### PR TITLE
fix(tools): prune tools only on the first turn to keep the cache prefix stable (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,26 @@ All notable changes to this project are documented here. The format follows
   command and its install paths are unchanged. `rehydrate` is now `pub` (the CLI's
   interceptor calls it across the crate boundary).
 
+### Fixed
+- **Tool selection no longer churns the cached prompt prefix on agent loops** (#9): tool
+  *selection* keeps only the tools its relevance ranking scores against the conversation,
+  so the kept subset changes from turn to turn. Providers fold the `tools[]` block into the
+  cached prompt prefix, so a changing block invalidated the prefix on every turn of an agent
+  loop — provider prompt-cache reads dropped and the prefix was rebilled as fresh input,
+  which on a cache-warm loop can cost *more* than not compressing at all. Selection now runs
+  **only on the first turn** of a conversation (where there is no prior prefix to bust and the
+  saving is free); from the second turn on the tool set is left intact, and only the
+  deterministic description-trim and schema-minify stages shrink the block — they are pure
+  functions of the toolset, so the block stays byte-identical turn to turn (regression-tested).
+  Applies to every preset that selects tools (`agent`, `aggressive`). A single-shot request with
+  a large toolset still gets the full pruning saving. On a cache-warm multi-turn loop this keeps
+  the tool prefix reusable instead of rebilling it each turn (an exploratory `gpt-4o-mini` run
+  showed it roughly halving freshly-billed input once the prefix is warm — indicative, not a
+  committed benchmark). The first turn ships the pruned set and turn two the full set, so there is
+  a one-time prefix change at that boundary (a single extra cache write, ~25% on Anthropic) before
+  it stays warm. This stabilizes the *tool block* on its own; keeping earlier-turn *message
+  content* byte-stable across turns still relies on the turn-stability memo (`memo = true`, default).
+
 ## [0.1.6] - 2026-06-12
 
 ### Added

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -349,6 +349,11 @@ impl DenseConfig {
                 c.strip_base64 = true;
             }
             "agent" => {
+                // Tool selection is first-turn-only (see `stages::tools::select_tools`): pruning
+                // the `tools[]` block on later turns would churn the cached prompt prefix and
+                // raise cost on an agent loop (issue #9). It still prunes the opening single-shot
+                // request, where the saving is free. Trim + minify below are deterministic, so
+                // they shrink the block without changing it turn-to-turn.
                 c.tool_select = true;
                 c.tool_trim_desc = true;
                 // Minify tool schemas in place (API-safe TSCG subset): semantics-preserving, so
@@ -397,6 +402,8 @@ impl DenseConfig {
                 c.dedup_near = true;
                 c.ngram = true;
                 c.normalize_unicode = true;
+                // First-turn-only, like `agent` — `select_tools` never prunes mid-loop, so the
+                // cached prefix stays stable even under this preset's heavier compression (#9).
                 c.tool_select = true;
                 c.tool_trim_desc = true;
                 c.tool_minify_schema = true; // API-safe TSCG schema minify (rides with trim)
@@ -581,6 +588,20 @@ mod tests {
         }
         // Default (= `safe`) is off.
         assert!(!DenseConfig::default().tool_minify_schema);
+    }
+
+    #[test]
+    fn agent_shrinks_the_tool_block_without_per_turn_churn() {
+        // Issue #9: the tool block is part of the cached prompt prefix, so it must not change
+        // turn-to-turn on an agent loop. The agent preset keeps the deterministic trim/minify
+        // (cache-stable) and gates selection to the first turn only (byte-stability is proven
+        // end-to-end by `agent_tool_block_is_byte_stable_across_turns` in the crate root). Lock
+        // the flag lineup here.
+        let agent = DenseConfig::preset("agent").unwrap();
+        assert!(
+            agent.tool_select && agent.tool_trim_desc && agent.tool_minify_schema,
+            "agent shrinks the tool block (selection is first-turn-only; trim/minify are cache-stable)"
+        );
     }
 
     #[test]

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -490,6 +490,57 @@ mod tests {
     }
 
     #[test]
+    fn agent_tool_block_is_byte_stable_across_turns() {
+        // Issue #9: on an agent loop the `tools[]` block is part of the cached prompt prefix, so
+        // it must be byte-identical turn-to-turn or the provider prompt cache is busted. Two
+        // consecutive mid-loop turns (a tool was already invoked, so selection is skipped) must
+        // compress to the exact same tools block.
+        let tools = serde_json::json!([
+            {"type":"function","function":{"name":"read_file","description":"Read a file from disk by path.","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}},
+            {"type":"function","function":{"name":"grep_search","description":"Search files with a regex.","parameters":{"type":"object","properties":{"pattern":{"type":"string"}}}}},
+            {"type":"function","function":{"name":"run_bash","description":"Run a shell command.","parameters":{"type":"object","properties":{"command":{"type":"string"}}}}},
+            {"type":"function","function":{"name":"web_search","description":"Search the web.","parameters":{"type":"object","properties":{"query":{"type":"string"}}}}}
+        ]);
+        let turn_a = serde_json::json!({
+            "model": "gpt-4o-mini", "tools": tools,
+            "messages": [
+                {"role": "system", "content": "You are a coding agent."},
+                {"role": "user", "content": "read main.rs"},
+                {"role": "assistant", "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"main.rs\"}"}}]},
+                {"role": "tool", "tool_call_id": "c1", "content": "fn main() {}"},
+                {"role": "user", "content": "now grep for the word transform"}
+            ]
+        })
+        .to_string();
+        // Turn B = turn A + the grep call/result + a new ask (the agent-loop shape).
+        let turn_b = serde_json::json!({
+            "model": "gpt-4o-mini", "tools": tools,
+            "messages": [
+                {"role": "system", "content": "You are a coding agent."},
+                {"role": "user", "content": "read main.rs"},
+                {"role": "assistant", "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{\"path\":\"main.rs\"}"}}]},
+                {"role": "tool", "tool_call_id": "c1", "content": "fn main() {}"},
+                {"role": "user", "content": "now grep for the word transform"},
+                {"role": "assistant", "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "grep_search", "arguments": "{\"pattern\":\"transform\"}"}}]},
+                {"role": "tool", "tool_call_id": "c2", "content": "main.rs:1: transform()"},
+                {"role": "user", "content": "now run the tests with bash"}
+            ]
+        })
+        .to_string();
+
+        let cfg = config::DenseConfig::preset("agent").expect("agent preset");
+        let ra = compress_with_config(&turn_a, Some(ProviderKind::OpenAi), &cfg).unwrap();
+        let rb = compress_with_config(&turn_b, Some(ProviderKind::OpenAi), &cfg).unwrap();
+        let tools_of =
+            |json: &str| -> Value { serde_json::from_str::<Value>(json).unwrap()["tools"].clone() };
+        assert_eq!(
+            tools_of(&ra.request_json),
+            tools_of(&rb.request_json),
+            "the agent preset must emit a byte-identical tools[] block across turns (cache prefix stays warm)"
+        );
+    }
+
+    #[test]
     fn repeated_tool_invocation_ships_full_output() {
         // Rail: repeat → passthrough. The agent re-ran a tool because its first result
         // was compressed — the newest occurrence must ship byte-identical (this is the

--- a/crates/llmtrim-core/src/stages/tools.rs
+++ b/crates/llmtrim-core/src/stages/tools.rs
@@ -247,6 +247,19 @@ const BM25_B: f64 = 0.75;
 /// lets a query that names a tool outrank one that only mentions the term in a long description,
 /// which flat overlap (and flat BM25) cannot distinguish.
 fn select_tools(req: &mut Request, provider: &dyn Provider) {
+    // Cache-safety gate (issue #9): prune only on the FIRST turn of a conversation. The kept
+    // tool subset depends on the conversation, so it changes as an agent loop grows — and
+    // providers fold the `tools[]` block into the cached prompt prefix, so a changing block
+    // busts the prefix every turn (cache reads collapse, the prefix is rebilled as fresh input,
+    // costing more than the few schema tokens pruning saved). On the first turn there is no
+    // prior prefix to bust, so pruning is a free saving; from the second turn on the block must
+    // stay byte-stable, so we leave it intact and rely on the deterministic trim/minify stages
+    // to shrink it without churning it. (This also keeps `aggressive`, which likewise enables
+    // the cache stage, from busting its own prefix.)
+    if !is_first_turn(req) {
+        return;
+    }
+
     let descriptors = provider.tool_descriptors(req);
     if descriptors.len() < 2 {
         return; // nothing meaningful to prune
@@ -288,18 +301,14 @@ fn select_tools(req: &mut Request, provider: &dyn Provider) {
         .collect();
     let scores = bm25f_scores(&docs, &query);
 
-    // Never drop a tool the agent already invoked earlier in the conversation: its `tool_use`
-    // block would dangle (and the agent clearly needs it). Multi-turn safety — independent of
-    // the BM25F score.
-    let used = tools_used_in_history(req);
-
     // Explicit-mention rail: a tool whose exact name appears as a standalone token anywhere in
-    // the conversation's content text is kept regardless of score. The BM25F query above is
-    // bounded to the most-recent TOOL_QUERY_MAX_BYTES, so a tool referenced only by an early
-    // instruction ("use ToolSearch before calling deferred tools") would otherwise score 0 and
-    // be dropped — guaranteeing an invalid tool call if the model obeys that instruction. A
-    // false keep costs a few schema tokens; a false drop breaks a tool call, so bias to keep.
-    // One pass over the full content text (cheap substring scan), independent of the query cap.
+    // the (first-turn) content text is kept regardless of score. This is a case-SENSITIVE
+    // exact-name match (`contains_standalone`), so it catches a tool the lowercased BM25F query
+    // tokenizes away — e.g. an underscore-joined `mcp__server__thing`, or a name referenced only
+    // by an instruction ("use ToolSearch before calling deferred tools") whose split doesn't
+    // score the tool. A false keep costs a few schema tokens; a false drop breaks a tool call,
+    // so bias to keep. (The former "keep already-invoked tools" rail is gone: selection now only
+    // runs on the first turn — see the `is_first_turn` gate — where no tool has been invoked yet.)
     let mut mentioned: HashSet<&str> = HashSet::new();
     for p in pointers.iter() {
         if mentioned.len() == descriptors.len() {
@@ -317,7 +326,7 @@ fn select_tools(req: &mut Request, provider: &dyn Provider) {
     let keep: Vec<bool> = descriptors
         .iter()
         .zip(&scores)
-        .map(|((name, _), &s)| used.contains(name) || mentioned.contains(name.as_str()) || s > 0.0)
+        .map(|((name, _), &s)| mentioned.contains(name.as_str()) || s > 0.0)
         .collect();
     if keep.iter().any(|&k| k) {
         provider.retain_tools(req, &keep);
@@ -489,20 +498,52 @@ fn bm25f_scores(docs: &[ToolDoc], query: &HashSet<&str>) -> Vec<f64> {
         .collect()
 }
 
-/// Names of tools already invoked in the conversation — OpenAI `tool_calls[].function.name`,
-/// Anthropic `{type: tool_use, name}` content blocks, and Google `parts[].functionCall.name`.
+/// True when the request is the first turn of a conversation — at most one non-system message
+/// and no tool invoked yet. Tool selection prunes only here (see `select_tools`): later turns
+/// must keep the `tools[]` block byte-stable so the provider prompt-cache prefix stays warm.
+/// Cross-wire-shape: counts non-system turns in `messages` / `input` / `contents` (Anthropic
+/// keeps `system` out of the array, so its first turn is one `user` message; OpenAI's is
+/// `system` + `user`), and treats any already-invoked tool as proof of a live loop.
+fn is_first_turn(req: &Request) -> bool {
+    if !tools_used_in_history(req).is_empty() {
+        return false;
+    }
+    let raw = req.raw();
+    let non_system_turns = ["messages", "input", "contents"]
+        .iter()
+        .filter_map(|k| raw.get(*k).and_then(Value::as_array))
+        .map(|a| {
+            a.iter()
+                .filter(|m| m.get("role").and_then(Value::as_str) != Some("system"))
+                .count()
+        })
+        .max()
+        .unwrap_or(0);
+    non_system_turns <= 1
+}
+
+/// Names of tools already invoked in the conversation — OpenAI Chat `tool_calls[].function.name`,
+/// OpenAI Responses `input[]` items of `{type: function_call, name}`, Anthropic `{type: tool_use,
+/// name}` content blocks, and Google `parts[].functionCall.name`.
 fn tools_used_in_history(req: &Request) -> HashSet<String> {
     let mut used = HashSet::new();
     let raw = req.raw();
-    // OpenAI/Anthropic use "messages"; Google uses "contents".
+    // OpenAI Chat / Anthropic use "messages"; Google uses "contents"; OpenAI Responses uses "input".
     let turns = raw
         .get("messages")
         .or_else(|| raw.get("contents"))
+        .or_else(|| raw.get("input"))
         .and_then(Value::as_array);
     let Some(turns) = turns else {
         return used;
     };
     for m in turns {
+        // OpenAI Responses: a tool call is an input item `{type: function_call, name, ...}`.
+        if m.get("type").and_then(Value::as_str) == Some("function_call")
+            && let Some(n) = m.get("name").and_then(Value::as_str)
+        {
+            used.insert(n.to_string());
+        }
         // OpenAI: tool_calls[].function.name
         if let Some(calls) = m.get("tool_calls").and_then(Value::as_array) {
             for c in calls {
@@ -718,10 +759,11 @@ mod tests {
     }
 
     #[test]
-    fn selection_keeps_tools_invoked_earlier() {
-        // `run_sql` was called earlier; the latest turn is about weather. Multi-turn safety:
-        // a tool already invoked must survive even when irrelevant to the current turn,
-        // else its `tool_use` dangles and the agent loses it.
+    fn selection_skipped_once_a_tool_was_invoked() {
+        // `run_sql` was called earlier, so the conversation is a live agent loop. Selection is
+        // skipped (issue #9): pruning the `tools[]` block now would change the cached prompt
+        // prefix every turn. The full toolset ships unchanged — which also can't dangle the
+        // earlier `tool_use`.
         let body = json!({
             "model":"gpt-4o",
             "messages":[
@@ -732,12 +774,13 @@ mod tests {
         });
         let mut req = Request::from_value(ProviderKind::OpenAi, body);
         let counter = counter_for(ProviderKind::OpenAi, Some("gpt-4o")).unwrap();
-        let _ = pipeline::run(
+        let out = pipeline::run(
             &mut req,
             &OpenAiProvider,
             counter.as_ref(),
             &[select_stage()],
         );
+        assert!(!out.stages[0].applied, "selection skipped mid-loop");
         let names: Vec<&str> = req
             .raw()
             .get("tools")
@@ -746,14 +789,10 @@ mod tests {
             .iter()
             .filter_map(|t| t.pointer("/function/name").and_then(Value::as_str))
             .collect();
-        assert!(names.contains(&"get_weather"), "relevant tool kept");
-        assert!(
-            names.contains(&"run_sql"),
-            "tool invoked earlier kept despite being irrelevant now"
-        );
-        assert!(
-            !names.contains(&"send_email"),
-            "unused irrelevant tool dropped"
+        assert_eq!(
+            names,
+            vec!["get_weather", "send_email", "run_sql"],
+            "the full toolset ships unchanged mid-loop: {names:?}"
         );
     }
 
@@ -1033,29 +1072,78 @@ mod tests {
         );
     }
 
-    // ── Explicit-mention keep rail ──────────────────────────────────────────────────────
+    // ── Mid-conversation: selection is skipped to keep the cached prefix stable ──────────
 
-    /// Regression (live capture 1781204413588398-27117d): a tool whose only reference is an
-    /// instruction in an early message — beyond the TOOL_QUERY_MAX_BYTES recent window — must
-    /// survive selection. The negative half: an unmentioned, irrelevant tool is still pruned,
-    /// so the stage keeps saving tokens.
+    /// Regression (live capture 1781204413588398-27117d) + issue #9: a deferred tool referenced
+    /// only by an early instruction must not be dropped. Selection is first-turn-only, so on this
+    /// multi-turn conversation it is skipped entirely — the whole toolset (including the
+    /// early-mentioned `ToolSearch`) ships unchanged, both keeping the tool call valid and leaving
+    /// the cached `tools[]` prefix byte-stable.
     #[test]
-    fn explicitly_mentioned_tool_survives_beyond_query_window() {
-        let mut messages = vec![json!({
-            "role":"user",
-            "content":"Use ToolSearch with query select:<name> to load tool schemas before calling them."
-        })];
-        // >16KB of filler prose between the instruction and the recent turn, so the
-        // instruction falls outside the BM25F query window.
-        let filler = "the quiet meadow stretched beneath a pale sky while distant hills slept. ";
-        for _ in 0..12 {
-            messages.push(json!({"role":"user","content": filler.repeat(30)}));
-        }
-        messages
-            .push(json!({"role":"user","content":"what is the weather forecast in Paris today?"}));
+    fn is_first_turn_across_wire_shapes() {
+        use ProviderKind::{Anthropic, Google, OpenAi};
+        let ft = |kind, body: Value| is_first_turn(&Request::from_value(kind, body));
+
+        // OpenAI Chat: leading system + one user message is the first turn.
+        assert!(ft(
+            OpenAi,
+            json!({"messages":[{"role":"system","content":"s"},{"role":"user","content":"hi"}]})
+        ));
+        assert!(!ft(
+            OpenAi,
+            json!({"messages":[
+                {"role":"system","content":"s"},{"role":"user","content":"hi"},
+                {"role":"assistant","tool_calls":[{"function":{"name":"f"}}]},
+                {"role":"tool","tool_call_id":"1","content":"x"},
+                {"role":"user","content":"again"}]})
+        ));
+
+        // Anthropic: `system` is top-level, so the first turn is a single `user` message.
+        assert!(ft(
+            Anthropic,
+            json!({"system":"s","messages":[{"role":"user","content":"hi"}]})
+        ));
+        assert!(!ft(
+            Anthropic,
+            json!({"system":"s","messages":[
+                {"role":"user","content":"hi"},
+                {"role":"assistant","content":[{"type":"tool_use","name":"f","input":{}}]}]})
+        ));
+
+        // Gemini: `contents` with user/model roles; tool calls are `parts[].functionCall`.
+        assert!(ft(
+            Google,
+            json!({"contents":[{"role":"user","parts":[{"text":"hi"}]}]})
+        ));
+        assert!(!ft(
+            Google,
+            json!({"contents":[
+                {"role":"user","parts":[{"text":"hi"}]},
+                {"role":"model","parts":[{"functionCall":{"name":"f"}}]}]})
+        ));
+
+        // OpenAI Responses: `instructions` is system, turns live in `input`.
+        assert!(ft(
+            OpenAi,
+            json!({"instructions":"s","input":[{"role":"user","content":"hi"}]})
+        ));
+        // A lone `function_call` item counts as one turn, but the loop guard
+        // (`tools_used_in_history` scanning `input`) still marks it mid-loop.
+        assert!(!ft(
+            OpenAi,
+            json!({"instructions":"s","input":[
+                {"type":"function_call","name":"f","arguments":"{}","call_id":"1"}]})
+        ));
+    }
+
+    #[test]
+    fn multi_turn_conversation_is_not_pruned() {
         let body = json!({
             "model":"gpt-4o",
-            "messages": messages,
+            "messages":[
+                {"role":"user","content":"Use ToolSearch with query select:<name> to load tool schemas before calling them."},
+                {"role":"user","content":"what is the weather forecast in Paris today?"}
+            ],
             "tools":[
                 {"type":"function","function":{"name":"get_weather","description":"Get the weather forecast for a city","parameters":{}}},
                 {"type":"function","function":{"name":"ToolSearch","description":"Load deferred tool schemas","parameters":{}}},
@@ -1064,11 +1152,15 @@ mod tests {
         });
         let mut req = Request::from_value(ProviderKind::OpenAi, body);
         let counter = counter_for(ProviderKind::OpenAi, Some("gpt-4o")).unwrap();
-        let _ = pipeline::run(
+        let out = pipeline::run(
             &mut req,
             &OpenAiProvider,
             counter.as_ref(),
             &[select_stage()],
+        );
+        assert!(
+            !out.stages[0].applied,
+            "selection is skipped past the first turn (no churn of the cached tool block)"
         );
         let names: Vec<&str> = req
             .raw()
@@ -1078,14 +1170,10 @@ mod tests {
             .iter()
             .filter_map(|t| t.pointer("/function/name").and_then(Value::as_str))
             .collect();
-        assert!(
-            names.contains(&"ToolSearch"),
-            "tool mentioned only in an early instruction must be kept: {names:?}"
-        );
-        assert!(names.contains(&"get_weather"), "relevant tool kept");
-        assert!(
-            !names.contains(&"send_email"),
-            "unmentioned irrelevant tool still pruned: {names:?}"
+        assert_eq!(
+            names,
+            vec!["get_weather", "ToolSearch", "send_email"],
+            "the full toolset ships unchanged mid-conversation: {names:?}"
         );
     }
 


### PR DESCRIPTION
Fixes #9.

## Problem

On an OpenAI-compatible agent loop the `agent` preset could **raise** the bill versus baseline: the prompt got smaller but provider prompt-cache reuse got worse, so tokens were rebilled as fresh input.

Root cause: per-turn tool **selection** (`select_tools`) keeps only the tools its relevance ranking scores against the conversation. The kept subset changes turn-to-turn (it *grows* as the loop introduces new tool needs). Providers fold the `tools[]` block into the cached prompt prefix, so a changing block invalidates the prefix every turn — cache reads collapse, the prefix is rebilled fresh. The turn-stability `memo` only freezes conversation message content, never `tools[]`, so it can't catch this.

## Fix

Gate `select_tools` to the **first turn** of a conversation (≤1 non-system message, no tool invoked yet). There the saving is free — no prior prefix to bust. From the second turn on, the tool set is left intact and only the deterministic `trim_desc`/`minify_schema` stages shrink it, keeping the block byte-identical turn to turn. Applies to every preset that selects tools (`agent`, `aggressive` — both also enable the cache stage).

## Why not other approaches

- **Make selection monotonic** (score over the whole conversation so a kept tool stays kept): live-tested on `gpt-4o-mini` and it did **not** help — the churn is *growth-driven* (turn 1 "weather"→1 tool, turn 2 +"currency"→4 tools), and a growing block still busts the cache every growth step.
- **Freeze the tool set via the `memo`** / **reorder the tool block after volatile content**: infeasible (can't pre-freeze a superset on a stateless turn-1; provider prefix order isn't caller-controllable).

## Verification (live, `gpt-4o-mini`, identical scripted agent loop)

Per-turn `cached_tokens` and total freshly-billed input:

| condition | turn-2 cached | fresh-billed (4 turns) |
|-----------|--------------:|-----------------------:|
| `safe` (no tool stage) | 1920 | 2293 |
| `agent` with per-turn selection (before) | **0** | **4738** |
| tool block left intact / first-turn-only (this PR) | 2176 | 2365 |

- End-to-end test `agent_tool_block_is_byte_stable_across_turns` (crate root): two mid-loop turns compress to a **byte-identical** `tools[]` block under the agent preset.
- Multi-turn selection tests now assert pruning is **skipped** mid-loop.
- Full suite green (572 tests).

## Trade-off (called out)

First-turn-only keeps the full tool block on every later turn, which is the right call when the prefix cache pays out (the dominant agent case). On providers *without* implicit prefix caching, or very large static toolsets, this conserves more tokens than per-turn pruning would have on those turns — an accepted, documented heuristic. Single-shot tool requests still get the full pruning saving.

## Review note

This PR was iterated after two independent peer reviews (one proposing alternatives, one stress-testing). Their consensus drove: (a) replacing the original "drop tool_select from agent" with the first-turn guard so single-shot pruning is preserved, (b) the real end-to-end byte-stability test (the earlier test only checked a config flag), and (c) extending the guard to `aggressive`.

`cache` preset was **not** changed: live testing showed it was the strongest cache performer (its `prompt_cache_key` stabilizes routing), so the report's `cache` regression looks like single-run trajectory noise.