### PR TITLE
feat(serve): record applied stage names in LLMTRIM_CAPTURE_DIR captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Added
+- **`LLMTRIM_CAPTURE_DIR` records the applied stages.** Each capture JSON now carries a
+  `stages` array — the names of the compression stages that actually rewrote the request.
+  Previously only `plan` (the output-rehydration plan, a different axis and usually empty)
+  was recorded, so an external auditor could not tell a lossless run that dropped content
+  (a bug) from a lossy stage doing its job.
 - **UniFFI bindings (`llmtrim-uniffi`) + Python wheel.** A new binding crate exposes
   `llmtrim-core` to Python, Ruby, Swift and Kotlin from one Rust definition: a flat
   `compress(input, provider, preset) -> CompressOutput` call with errors mapped to native

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -673,7 +673,7 @@ mod imp {
             output_shaped: result.output_shaped,
             frozen_input_tokens: Some(result.frozen_input_tokens.0 as i64),
         };
-        capture_pair(text, &result.request_json, &pending);
+        capture_pair(text, &result.request_json, &pending, &result.stages);
         Some((result.request_json, pending))
     }
 
@@ -681,13 +681,27 @@ mod imp {
     /// bodies of each compressed request as one JSON file so an external reviewer can audit
     /// compression quality. Off (zero work beyond one env read) unless the var is set; any
     /// write failure is logged and swallowed — capture must never break proxying.
-    fn capture_pair(before: &str, after: &str, pending: &Pending) {
+    fn capture_pair(
+        before: &str,
+        after: &str,
+        pending: &Pending,
+        stages: &[llmtrim_core::pipeline::StageReport],
+    ) {
         let Ok(dir) = std::env::var("LLMTRIM_CAPTURE_DIR") else {
             return;
         };
         if dir.is_empty() {
             return;
         }
+        // The names of the stages that actually rewrote this request — what an external auditor
+        // needs to tell a lossless run that dropped content (a bug) from a lossy stage doing its
+        // job. `plan` below is the output-rehydration plan (reversible response-side transforms),
+        // a different axis, so both are recorded.
+        let stages_applied: Vec<&str> = stages
+            .iter()
+            .filter(|s| s.applied)
+            .map(|s| s.name.as_str())
+            .collect();
         let record = serde_json::json!({
             "ts": chrono::Utc::now().to_rfc3339(),
             "provider": pending.provider.as_str(),
@@ -695,6 +709,7 @@ mod imp {
             "input_before": pending.input_before,
             "input_after": pending.input_after,
             "output_shaped": pending.output_shaped,
+            "stages": stages_applied,
             "plan": pending.plan,
             "before": before,
             "after": after,


### PR DESCRIPTION
## What & why

`LLMTRIM_CAPTURE_DIR` captures now record a `stages` array — the names of the compression stages that actually rewrote each request (`StageReport.applied`). Previously only `plan` (the output-rehydration plan, a different axis, usually empty) was recorded, so an external auditor couldn't tell a **lossless run that dropped content (a bug)** from a **lossy stage doing its job**.

`capture_pair` now takes the pipeline's per-stage reports and projects the applied ones. Zero extra work when `LLMTRIM_CAPTURE_DIR` is unset.

## How it was verified

- [x] `cargo build -p llmtrim` (the `serve` interceptor compiles)
- [x] `cargo clippy -p llmtrim` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Commit signed off (DCO)

## Notes

Small, self-contained change to the capture/audit path; no behavior change to compression or proxying.