### PR TITLE
docs: drop em-dash overuse from the READMEs (AI-writing audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,27 +202,27 @@ llmtrim uninstall   # exact inverse of setup: removes all three changes
 
 ## Use it as a CLI or library
 
-The same compression runs with no proxy and no setup — as a one-shot CLI, an embeddable Rust crate, or native bindings for **Python, Ruby, Swift and Kotlin**. No extra model calls, no network: the deterministic engine runs in your process.
+The same compression runs with no proxy and no setup, as a one-shot CLI, an embeddable Rust crate, or native bindings for **Python, Ruby, Swift and Kotlin**. No extra model calls, no network: the deterministic engine runs in your process.
 
 | Language | Install |
 |---|---|
 | Rust | `cargo add llmtrim-core` |
 | Python | `pip install llmtrim` |
 | Ruby | `gem install llmtrim` |
-| Kotlin | `implementation("io.github.fkiene:llmtrim:0.1.7")` — Maven Central |
-| Swift | `.package(url: "https://github.com/fkiene/llmtrim", from: "0.1.7")` — SwiftPM |
+| Kotlin | `implementation("io.github.fkiene:llmtrim:0.1.7")` (Maven Central) |
+| Swift | `.package(url: "https://github.com/fkiene/llmtrim", from: "0.1.7")` (SwiftPM) |
 
 > [!NOTE]
-> The CLI is published today; the **library packages above ship with the next release**. Until then, build them from source — see [`crates/llmtrim-uniffi`](crates/llmtrim-uniffi). *(This note is removed once they're published.)*
+> The CLI is published today; the **library packages above ship with the next release**. Until then, build them from source: [`crates/llmtrim-uniffi`](crates/llmtrim-uniffi). *(This note is removed once they're published.)*
 
-**CLI** — pipe a request in, get a compressed one out:
+**CLI.** Pipe a request in, get a compressed one out:
 
 ```bash
 echo '{"model":"gpt-4o","messages":[...]}' | llmtrim compress --provider openai > out.json
 echo '{"model":"gpt-4o","messages":[...]}' | llmtrim send     --provider openai   # compress, call, print
 ```
 
-**Rust** — the engine is the [`llmtrim-core`](https://crates.io/crates/llmtrim-core) crate (no `tokio`, no network in its dependency tree):
+**Rust.** The engine is the [`llmtrim-core`](https://crates.io/crates/llmtrim-core) crate (no `tokio`, no network in its dependency tree):
 
 ```rust
 use llmtrim_core::{compress, compress_with_config, config::DenseConfig, ir::ProviderKind};
@@ -235,7 +235,7 @@ println!("{} -> {} input tokens", out.input_tokens_before, out.input_tokens_afte
 let out = compress_with_config(request_json, Some(ProviderKind::OpenAi), &DenseConfig::preset("agent").unwrap())?;
 ```
 
-**Python / Ruby / Swift / Kotlin** — one flat `compress(input, provider, preset)` call, generated from the same Rust engine via [UniFFI](https://mozilla.github.io/uniffi-rs/). The compiled engine is bundled in each package, so there's no Rust toolchain to install:
+**Python / Ruby / Swift / Kotlin.** One flat `compress(input, provider, preset)` call, generated from the same Rust engine via [UniFFI](https://mozilla.github.io/uniffi-rs/). The compiled engine is bundled in each package, so there's no Rust toolchain to install:
 
 ```python
 import llmtrim

--- a/crates/llmtrim-cli/README.md
+++ b/crates/llmtrim-cli/README.md
@@ -2,7 +2,7 @@
 
 <strong>llmtrim is a local proxy that compresses your LLM API requests so you pay less, with no change to the answers.</strong>
 
-It sits between your AI tools and the provider, strips the wasted tokens out of every request, and forwards it on — same answers, smaller bill. **−31% input and −74% output tokens**, measured live across 112 A/B cases, with no change in answer quality.
+It sits between your AI tools and the provider, strips the wasted tokens out of every request, and forwards it on. Same answers, smaller bill. **−31% input and −74% output tokens**, measured live across 112 A/B cases, with no change in answer quality.
 
 [![crates.io](https://img.shields.io/crates/v/llmtrim)](https://crates.io/crates/llmtrim)
 [![license](https://img.shields.io/badge/license-AGPL--3.0-blue)](https://www.gnu.org/licenses/agpl-3.0.txt)
@@ -33,7 +33,7 @@ Other channels (same binary): `brew install fkiene/tap/llmtrim` · `scoop instal
 
 ## Use it
 
-After `llmtrim setup`, any tool that honors `HTTPS_PROXY` routes through it automatically — Claude Code, Codex, Cursor, Aider, Gemini CLI, your own app. (GitHub Copilot pins its certificates and can't be intercepted.)
+After `llmtrim setup`, any tool that honors `HTTPS_PROXY` routes through it automatically: Claude Code, Codex, Cursor, Aider, Gemini CLI, your own app. (GitHub Copilot pins its certificates and can't be intercepted.)
 
 Or run the compression directly, no proxy:
 
@@ -42,11 +42,11 @@ echo '{"model":"gpt-4o","messages":[...]}' | llmtrim compress --provider openai 
 echo '{"model":"gpt-4o","messages":[...]}' | llmtrim send     --provider openai   # compress, call, print
 ```
 
-**Zero config needed** — the default `auto` mode inspects each request and picks the right compressors for its shape (tool-heavy → `agent`, code → `code`, long context → `rag`, else `aggressive`). Force one with `LLMTRIM_PRESET=<name>`.
+**Zero config needed.** The default `auto` mode inspects each request and picks the right compressors for its shape (tool-heavy → `agent`, code → `code`, long context → `rag`, else `aggressive`). Force one with `LLMTRIM_PRESET=<name>`.
 
 ## As a library
 
-The compression engine is the [`llmtrim-core`](https://crates.io/crates/llmtrim-core) crate (no network, no async), with native bindings for **Python, Ruby, Swift and Kotlin** — see the [project README](https://github.com/fkiene/llmtrim).
+The compression engine is the [`llmtrim-core`](https://crates.io/crates/llmtrim-core) crate (no network, no async), with native bindings for **Python, Ruby, Swift and Kotlin** (see the [project README](https://github.com/fkiene/llmtrim)).
 
 ## License
 

--- a/crates/llmtrim-core/README.md
+++ b/crates/llmtrim-core/README.md
@@ -1,8 +1,8 @@
 # llmtrim-core
 
-<strong>The static, deterministic compression engine behind [llmtrim](https://github.com/fkiene/llmtrim) — as an embeddable Rust library.</strong>
+<strong>The static, deterministic compression engine behind [llmtrim](https://github.com/fkiene/llmtrim), packaged as an embeddable Rust library.</strong>
 
-It takes a provider-shaped LLM request (OpenAI, Anthropic or Google JSON), strips the wasted tokens out of it with deterministic algorithms only — **no auxiliary model, no embeddings, no network, no `tokio`** — and hands you back a smaller request plus the measured token delta. Typical savings are **30–90% of input tokens**, with no change to the answer.
+It takes a provider-shaped LLM request (OpenAI, Anthropic or Google JSON), strips the wasted tokens out of it with deterministic algorithms only (**no auxiliary model, no embeddings, no network, no `tokio`**), and hands you back a smaller request plus the measured token delta. Typical savings are **30–90% of input tokens**, with no change to the answer.
 
 [![crates.io](https://img.shields.io/crates/v/llmtrim-core)](https://crates.io/crates/llmtrim-core)
 [![docs.rs](https://img.shields.io/docsrs/llmtrim-core)](https://docs.rs/llmtrim-core)
@@ -19,7 +19,7 @@ use llmtrim_core::{compress, compress_with_config, config::DenseConfig, ir::Prov
 // Auto-detect the provider from the request shape (pass Some(ProviderKind::…) to force it).
 let out = compress(&request_json, None)?;
 println!("{} -> {} input tokens", out.input_tokens_before, out.input_tokens_after);
-// `out.request_json` is the compressed body — send it to the provider unchanged.
+// `out.request_json` is the compressed body. Send it to the provider unchanged.
 
 // Or compress with an explicit workload preset:
 let cfg = DenseConfig::preset("agent").unwrap();
@@ -31,7 +31,7 @@ let out = compress_with_config(&request_json, Some(ProviderKind::Anthropic), &cf
 
 ## What it compresses
 
-Each compressor fires only where it pays — `auto` (the default) picks the right ones from the request's shape:
+Each compressor fires only where it pays. `auto` (the default) picks the right ones from the request's shape:
 
 | Where the waste is | What the engine does |
 |---|---|
@@ -46,16 +46,16 @@ Presets: `auto` (shape-routed, default), `aggressive`, `agent`, `code`, `rag`, `
 
 ## API
 
-- `compress` — load configuration from the environment / config file, optionally auto-detect the provider.
-- `compress_with_config` — compress with an explicit `config::DenseConfig`; no environment access, fully deterministic (used by tests and embedders).
-- `route` — pick the workload preset for a request from its structure alone.
-- `CompressResult` — the compressed body, the per-stage report, and the before/after token counts.
+- `compress`: load configuration from the environment / config file, optionally auto-detect the provider.
+- `compress_with_config`: compress with an explicit `config::DenseConfig`; no environment access, fully deterministic (used by tests and embedders).
+- `route`: pick the workload preset for a request from its structure alone.
+- `CompressResult`: the compressed body, the per-stage report, and the before/after token counts.
 
 Full reference on [docs.rs](https://docs.rs/llmtrim-core).
 
 ## Other languages
 
-The same engine is exposed to **Python, Ruby, Swift and Kotlin** via [UniFFI](https://mozilla.github.io/uniffi-rs/) — see [`llmtrim-uniffi`](../llmtrim-uniffi). The [`llmtrim`](https://crates.io/crates/llmtrim) crate is the CLI and drop-in compressing proxy built on this engine.
+The same engine is exposed to **Python, Ruby, Swift and Kotlin** via [UniFFI](https://mozilla.github.io/uniffi-rs/) (see [`llmtrim-uniffi`](../llmtrim-uniffi)). The [`llmtrim`](https://crates.io/crates/llmtrim) crate is the CLI and drop-in compressing proxy built on this engine.
 
 ## License
 

--- a/crates/llmtrim-uniffi/README.md
+++ b/crates/llmtrim-uniffi/README.md
@@ -1,6 +1,6 @@
 # llmtrim-uniffi
 
-[UniFFI](https://mozilla.github.io/uniffi-rs/) bindings over [`llmtrim-core`] — one Rust
+[UniFFI](https://mozilla.github.io/uniffi-rs/) bindings over [`llmtrim-core`]: one Rust
 definition, idiomatic in-process bindings for **Python, Ruby, Swift and Kotlin**. The
 compression runs natively in the caller's process (no server, no async).
 
@@ -49,7 +49,7 @@ print(out.input_tokens_before, "->", out.input_tokens_after)
 
 ## Ruby / Swift / Kotlin
 
-All targets generate from the same built library — no extra Rust. The generated glue is a
+All targets generate from the same built library, no extra Rust. The generated glue is a
 build artifact (its checksums are pinned to the library ABI), so it is regenerated per
 release rather than committed:
 
@@ -60,11 +60,11 @@ crates/llmtrim-uniffi/scripts/generate-bindings.sh out/   # python, ruby, swift,
 > **Generation needs an unstripped library.** Library-mode `uniffi-bindgen` reads metadata
 > symbols from the cdylib, but the workspace release profile sets `strip = true`. The script
 > therefore generates from the (unstripped) debug build; the native library you *ship* can be
-> a stripped `cargo build --release -p llmtrim-uniffi` cdylib — the glue loads it by name.
+> a stripped `cargo build --release -p llmtrim-uniffi` cdylib; the glue loads it by name.
 
-Ruby (verified) — this is the **raw generated binding** (module `LlmtrimFfi`), for a
+Ruby (verified). This is the **raw generated binding** (module `LlmtrimFfi`), for a
 source build with `libllmtrim_ffi.so` on the load path. The published **gem** aliases it to
-`Llmtrim` (`require "llmtrim"` → `Llmtrim.compress(...)`) — see
+`Llmtrim` (`require "llmtrim"` then `Llmtrim.compress(...)`); see
 [`packaging/ruby`](packaging/ruby).
 
 ```ruby
@@ -78,8 +78,8 @@ puts "#{out.input_tokens_before} -> #{out.input_tokens_after}"
 
 Swift emits `llmtrim_ffi.swift` + an FFI header and modulemap; Kotlin emits
 `uniffi/.../llmtrim_ffi.kt` (which loads the cdylib via JNA). CI compiles and runs a smoke
-for both — Swift on macOS (`swiftc` against the modulemap), Kotlin on a JVM (`kotlinc` +
-JNA) — so a binding break is caught in all four languages (see `tests/swift`, `tests/kotlin`
+for both: Swift on macOS (`swiftc` against the modulemap), Kotlin on a JVM (`kotlinc` +
+JNA), so a binding break is caught in all four languages (see `tests/swift`, `tests/kotlin`
 and the `bindings*` jobs in `.github/workflows/ci.yml`).
 
 ## Publishable packages


### PR DESCRIPTION
Audited the READMEs I wrote against the avoid-ai-writing patterns. Vocabulary was clean (no delve/robust/seamless/leverage/ecosystem), but em-dashes were overused (llmtrim-core 10/460 words, uniffi 7, cli 4, + 7 in the root README's CLI/library section). Replaced with commas/periods/parens/colons; no vocabulary or structural rewrite. Version strings untouched so the release auto-stamp still matches.

Docs-only — `ci.yml` paths-ignores `**.md`, so the required checks won't run on this PR (admin-merge / 'merge without waiting' needed).