### PR TITLE
fix(release-bindings): cross-compile x86_64-apple-darwin (drop macos-13)

### DIFF
--- a/.github/workflows/release-bindings.yml
+++ b/.github/workflows/release-bindings.yml
@@ -36,7 +36,7 @@ jobs:
         include:
           - { os: ubuntu-22.04,     target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04-arm,  target: aarch64-unknown-linux-gnu }
-          - { os: macos-13,          target: x86_64-apple-darwin }
+          - { os: macos-latest,      target: x86_64-apple-darwin }   # cross-compiled (Intel runners are scarce)
           - { os: macos-latest,      target: aarch64-apple-darwin }
           - { os: windows-latest,    target: x86_64-pc-windows-msvc }
     runs-on: ${{ matrix.os }}
@@ -53,8 +53,15 @@ jobs:
       # Builds the self-contained wheel (cdylib + injected UniFFI glue) for this runner's
       # platform; --release for the shipped artifact.
       - name: Build wheel
-        run: crates/llmtrim-uniffi/scripts/build-wheel.sh --release
+        env:
+          LLMTRIM_TARGET: ${{ matrix.target }}
+        run: |
+          rustup target add "$LLMTRIM_TARGET"
+          crates/llmtrim-uniffi/scripts/build-wheel.sh --release
+      # The x86_64 wheel is cross-built on an arm64 runner, so it can't run here — skip its
+      # smoke (the native-arch wheels still get tested).
       - name: Smoke-test the wheel before publishing
+        if: matrix.target != 'x86_64-apple-darwin'
         run: |
           pip install target/wheels/llmtrim-*.whl
           pytest crates/llmtrim-uniffi/tests/python -q
@@ -89,7 +96,7 @@ jobs:
         include:
           - { os: ubuntu-22.04,     target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04-arm,  target: aarch64-unknown-linux-gnu }
-          - { os: macos-13,          target: x86_64-apple-darwin }
+          - { os: macos-latest,      target: x86_64-apple-darwin }   # cross-compiled (Intel runners are scarce)
           - { os: macos-latest,      target: aarch64-apple-darwin }
           - { os: windows-latest,    target: x86_64-pc-windows-msvc }
     runs-on: ${{ matrix.os }}
@@ -105,7 +112,9 @@ jobs:
       - name: Build gem
         env:
           LLMTRIM_VERSION: ${{ github.ref_name }}
+          LLMTRIM_TARGET: ${{ matrix.target }}
         run: |
+          rustup target add "$LLMTRIM_TARGET"
           # gem versions use X.Y.Z (no leading v).
           export LLMTRIM_VERSION="${LLMTRIM_VERSION#v}"
           crates/llmtrim-uniffi/scripts/build-gem.sh
@@ -149,7 +158,7 @@ jobs:
         include:
           - { os: ubuntu-22.04,    target: x86_64-unknown-linux-gnu,  jna: linux-x86-64 }
           - { os: ubuntu-22.04-arm, target: aarch64-unknown-linux-gnu, jna: linux-aarch64 }
-          - { os: macos-13,         target: x86_64-apple-darwin,       jna: darwin-x86-64 }
+          - { os: macos-latest,     target: x86_64-apple-darwin,       jna: darwin-x86-64 }   # cross-compiled
           - { os: macos-latest,     target: aarch64-apple-darwin,      jna: darwin-aarch64 }
           - { os: windows-latest,   target: x86_64-pc-windows-msvc,    jna: win32-x86-64 }
           - { os: windows-11-arm,   target: aarch64-pc-windows-msvc,   jna: win32-aarch64 }
@@ -160,9 +169,10 @@ jobs:
       - name: Build release cdylib
         shell: bash
         run: |
-          cargo build --release -p llmtrim-uniffi
+          rustup target add ${{ matrix.target }}
+          cargo build --release -p llmtrim-uniffi --target ${{ matrix.target }}
           mkdir out
-          cp target/release/{libllmtrim_ffi.so,libllmtrim_ffi.dylib,llmtrim_ffi.dll} out/ 2>/dev/null || true
+          cp target/${{ matrix.target }}/release/{libllmtrim_ffi.so,libllmtrim_ffi.dylib,llmtrim_ffi.dll} out/ 2>/dev/null || true
       - uses: actions/upload-artifact@v4
         with:
           name: native-${{ matrix.jna }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **Language-binding publishes (PyPI / RubyGems / Maven Central) now build their
+  `x86_64-apple-darwin` artifacts by cross-compiling on an arm64 macOS runner** instead of
+  natively on a `macos-13` Intel runner. Intel macOS hosted runners are scarce and the
+  `v0.1.7` binding jobs stalled in the queue, blocking those publishes. The CLI/crate
+  release was unaffected. The build scripts now honor an optional `LLMTRIM_TARGET`.
+
 ## [0.1.7] - 2026-06-13
 
 ### Added

--- a/crates/llmtrim-uniffi/scripts/build-gem.sh
+++ b/crates/llmtrim-uniffi/scripts/build-gem.sh
@@ -31,8 +31,8 @@ dbg="$(find_cdylib target/debug)"
 cargo run -q --bin uniffi-bindgen -p llmtrim-uniffi -- generate --library "$dbg" --language ruby --out-dir "$lib_dir"
 
 echo "==> building the optimized cdylib to bundle"
-cargo build --release -p llmtrim-uniffi
-rel="$(find_cdylib target/release)"
+cargo build --release -p llmtrim-uniffi ${LLMTRIM_TARGET:+--target "$LLMTRIM_TARGET"}
+rel="$(find_cdylib "target/${LLMTRIM_TARGET:+$LLMTRIM_TARGET/}release")"
 [ -n "$rel" ] || { echo "error: no release cdylib in target/release/" >&2; exit 1; }
 base="$(basename "$rel")"
 cp "$rel" "$lib_dir/$base"

--- a/crates/llmtrim-uniffi/scripts/build-wheel.sh
+++ b/crates/llmtrim-uniffi/scripts/build-wheel.sh
@@ -23,8 +23,10 @@ py="$(command -v python3 || command -v python)"
 
 cd "$crate_dir"
 
-echo "==> maturin build (native cdylib in wheel)"
-maturin build $profile_flag -o "$dist_dir"
+echo "==> maturin build (cdylib in wheel)"
+# LLMTRIM_TARGET cross-compiles (e.g. x86_64-apple-darwin on an arm64 macOS runner), which
+# is how we avoid depending on scarce Intel-mac runners. Unset = native host build.
+maturin build $profile_flag ${LLMTRIM_TARGET:+--target "$LLMTRIM_TARGET"} -o "$dist_dir"
 
 wheel="$(ls -t "$dist_dir"/llmtrim-*.whl | head -1)"
 echo "==> base wheel: $wheel"


### PR DESCRIPTION
v0.1.7 binding publishes stalled on `macos-13` Intel-runner starvation (queued ~40min). Build x86_64-apple-darwin by cross-compiling on macos-latest (arm64), matching release.yml. Scripts honor optional `LLMTRIM_TARGET`; Python smoke skipped for the cross wheel. Native paths unchanged (verified locally). Apple cross-build first-validated on v0.1.8.