### PR TITLE
docs: bindings published at v0.1.8 — drop stale note, fix Swift row

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,7 @@ The same compression runs with no proxy and no setup, as a one-shot CLI, an embe
 | Python | `pip install llmtrim` |
 | Ruby | `gem install llmtrim` |
 | Kotlin | `implementation("io.github.fkiene:llmtrim:0.1.8")` (Maven Central) |
-| Swift | `.package(url: "https://github.com/fkiene/llmtrim", from: "0.1.8")` (SwiftPM) |
-
-> [!NOTE]
-> The CLI is published today; the **library packages above ship with the next release**. Until then, build them from source: [`crates/llmtrim-uniffi`](crates/llmtrim-uniffi). *(This note is removed once they're published.)*
+| Swift | [XCFramework on each release](https://github.com/fkiene/llmtrim/releases/latest) (SwiftPM package in progress) |
 
 **CLI.** Pipe a request in, get a compressed one out:
 


### PR DESCRIPTION
Post-release doc fix. Rust/Python/Ruby/Kotlin are live (crates.io/PyPI/RubyGems/Maven Central) so the 'ships next release' note is removed. Swift's XCFramework is a release asset but SwiftPM `.package(url:,from:)` doesn't resolve yet (tag Package.swift is local-path); the row now points at the release asset and marks SwiftPM-package distribution in progress. Docs-only.