### PR TITLE
docs: Swift install -> llmtrim-swift repo + finish em-dash cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The same compression runs with no proxy and no setup, as a one-shot CLI, an embe
 | Python | `pip install llmtrim` |
 | Ruby | `gem install llmtrim` |
 | Kotlin | `implementation("io.github.fkiene:llmtrim:0.1.8")` (Maven Central) |
-| Swift | [XCFramework on each release](https://github.com/fkiene/llmtrim/releases/latest) (SwiftPM package in progress) |
+| Swift | `.package(url: "https://github.com/fkiene/llmtrim-swift", from: "0.1.8")` (SwiftPM) |
 
 **CLI.** Pipe a request in, get a compressed one out:
 

--- a/crates/llmtrim-uniffi/packaging/kotlin/README.md
+++ b/crates/llmtrim-uniffi/packaging/kotlin/README.md
@@ -1,7 +1,7 @@
 # llmtrim (Kotlin / JVM)
 
 Native, in-process bindings to the [llmtrim](https://github.com/fkiene/llmtrim)
-compression engine for the JVM — cut LLM input tokens 30–90%, no network, no extra model
+compression engine for the JVM, cutting LLM input tokens 30–90%, no network, no extra model
 calls. The compiled engine is bundled in the jar (loaded via JNA from the classpath), so
 no Rust toolchain is needed at runtime.
 
@@ -15,7 +15,7 @@ println("${out.inputTokensBefore} -> ${out.inputTokensAfter}")
 // send out.requestJson to the provider
 ```
 
-`compress(input, provider, preset)` — `provider` is `Provider.OPEN_AI`/`ANTHROPIC`/`GOOGLE`
+`compress(input, provider, preset)`: `provider` is `Provider.OPEN_AI`/`ANTHROPIC`/`GOOGLE`
 or `null` to auto-detect; `preset` is a workload name or `null` for the environment config.
 Throws `LlmtrimException.Compress` / `UnknownPreset`.
 

--- a/crates/llmtrim-uniffi/packaging/ruby/README.md
+++ b/crates/llmtrim-uniffi/packaging/ruby/README.md
@@ -1,7 +1,7 @@
 # llmtrim (Ruby)
 
 Native, in-process bindings to the [llmtrim](https://github.com/fkiene/llmtrim)
-compression engine — cut LLM input tokens 30–90% with zero extra model calls, no network,
+compression engine, cutting LLM input tokens 30–90% with zero extra model calls, no network,
 no server. The compiled engine is bundled in the gem, so no Rust toolchain is needed.
 
 ```ruby
@@ -15,7 +15,7 @@ puts "#{out.input_tokens_before} -> #{out.input_tokens_after}"
 # send out.request_json to the provider
 ```
 
-`compress(input, provider, preset)` — `provider` is `Llmtrim::Provider::OPEN_AI` /
+`compress(input, provider, preset)`: `provider` is `Llmtrim::Provider::OPEN_AI` /
 `ANTHROPIC` / `GOOGLE` or `nil` to auto-detect; `preset` is a workload name
 (`"aggressive"`, `"agent"`, `"code"`, `"rag"`, `"safe"`, …) or `nil` for the environment
 config. Raises `Llmtrim::LlmtrimError::Compress` / `UnknownPreset` on error.

--- a/crates/llmtrim-uniffi/packaging/swift/README.md
+++ b/crates/llmtrim-uniffi/packaging/swift/README.md
@@ -1,7 +1,7 @@
 # llmtrim (Swift / SwiftPM)
 
 Native, in-process bindings to the [llmtrim](https://github.com/fkiene/llmtrim)
-compression engine for Apple platforms (macOS, iOS) — cut LLM input tokens 30–90%, no
+compression engine for Apple platforms (macOS, iOS), cutting LLM input tokens 30–90%, no
 network, no extra model calls. The engine ships as a binary XCFramework, so consumers
 build no Rust.
 
@@ -14,7 +14,7 @@ print("\(out.inputTokensBefore) -> \(out.inputTokensAfter)")
 // send out.requestJson to the provider
 ```
 
-`compress(input:provider:preset:)` — `provider` is `.openAi`/`.anthropic`/`.google` or
+`compress(input:provider:preset:)`: `provider` is `.openAi`/`.anthropic`/`.google` or
 `nil` to auto-detect; `preset` is a workload name or `nil` for the environment config.
 Throws `LlmtrimError.Compress` / `.unknownPreset`.
 
@@ -28,5 +28,5 @@ swift build --package-path crates/llmtrim-uniffi/packaging/swift
 The script builds a release static lib per Apple target (macOS arm64/x86_64, iOS device,
 iOS simulator), generates the Swift API + FFI header/modulemap, and assembles
 `llmtrimFFI.xcframework`. For release distribution, attach `llmtrimFFI.xcframework.zip` to
-the GitHub release and switch `Package.swift` to the remote `binaryTarget` (url + checksum)
-— see the comment in `Package.swift`. License: AGPL-3.0-only.
+the GitHub release and switch `Package.swift` to the remote `binaryTarget` (url + checksum;
+see the comment in `Package.swift`). License: AGPL-3.0-only.


### PR DESCRIPTION
Swift now has a real SwiftPM home (github.com/fkiene/llmtrim-swift wrapping the published XCFramework); the install row points there. Also finishes the avoid-ai-writing pass: the packaging READMEs (ruby/kotlin/swift) are now em-dash-free like the rest. Docs-only.