### PR TITLE
fix(packaging): PyPI README, Intel-mac gem platform, metadata em-dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **Python package now carries its README on PyPI.** The wheel set a summary but no long
+  description, so the PyPI project page showed "no project description". `pyproject.toml`
+  now points `readme` at the binding README.
+- **Intel-mac Ruby gem (`x86_64-darwin`) now publishes.** The cross-compiled gem inherited
+  the build host's platform (`Gem::Platform.local` -> `arm64-darwin`) and collided with the
+  native arm64 gem, so it never shipped. The gem platform is derived from the build target
+  instead.
+- **Package metadata reads cleanly.** Removed the em-dash from the shared description string
+  used by the PyPI summary, the Maven Central description, and the gem summary.
+
 ## [0.1.9] - 2026-06-13
 
 ### Added

--- a/crates/llmtrim-uniffi/packaging/kotlin/build.gradle.kts
+++ b/crates/llmtrim-uniffi/packaging/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 // Publishable JVM library for the llmtrim Kotlin bindings.
 //
 // The UniFFI-generated Kotlin (src/main/kotlin/uniffi/…) loads the native engine through
-// JNA, which resolves the library from the classpath at /<os-arch>/ — so the compiled
+// JNA, which resolves the library from the classpath at /<os-arch>/, so the compiled
 // cdylib is bundled under src/main/resources/<os-arch>/ and ends up inside the jar. Both
 // the generated sources and the native resources are placed by scripts/build-maven.sh and
 // are git-ignored build artifacts. A release jar bundles every platform's library.
@@ -47,7 +47,7 @@ mavenPublishing {
     coordinates("io.github.fkiene", "llmtrim", project.version.toString())
     pom {
         name.set("llmtrim")
-        description.set("Static, deterministic LLM prompt/payload compression — cut input tokens 30-90% with zero extra model calls.")
+        description.set("Static, deterministic LLM prompt/payload compression that cuts input tokens 30-90% with zero extra model calls.")
         url.set("https://github.com/fkiene/llmtrim")
         licenses {
             license {

--- a/crates/llmtrim-uniffi/packaging/ruby/llmtrim.gemspec
+++ b/crates/llmtrim-uniffi/packaging/ruby/llmtrim.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   # Platform-specific gem (bundled native lib). The build script sets this to the target
   # platform; unset means a generic gem (used only for local `gem build` smoke).
   s.platform = ENV["LLMTRIM_GEM_PLATFORM"] if ENV["LLMTRIM_GEM_PLATFORM"]
-  s.summary = "Static, deterministic LLM prompt/payload compression — cut input tokens 30-90%."
+  s.summary = "Static, deterministic LLM prompt/payload compression that cuts input tokens 30-90%."
   s.description = "Native in-process bindings to the llmtrim-core compression engine " \
                   "(no network, no extra model calls), generated via UniFFI."
   s.authors = ["François Kiene"]

--- a/crates/llmtrim-uniffi/pyproject.toml
+++ b/crates/llmtrim-uniffi/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "maturin"
 
 [project]
 name = "llmtrim"
-description = "Static, deterministic LLM prompt/payload compression — cut input tokens 30-90% with zero extra model calls."
+description = "Static, deterministic LLM prompt/payload compression that cuts input tokens 30-90% with zero extra model calls."
+readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "AGPL-3.0-only" }
 keywords = ["llm", "tokens", "compression", "openai", "anthropic"]

--- a/crates/llmtrim-uniffi/scripts/build-gem.sh
+++ b/crates/llmtrim-uniffi/scripts/build-gem.sh
@@ -24,6 +24,21 @@ find_cdylib() {
     done
 }
 
+# The gem's platform must describe the TARGET, not the build host. When cross-compiling
+# (x86_64-apple-darwin on an arm64 macOS runner) `Gem::Platform.local` returns the host
+# (arm64-darwin) and the gem collides with the native arm64 gem, so the Intel-mac gem never
+# ships. Derive it from LLMTRIM_TARGET; the version-agnostic darwin form installs on any
+# macOS version. Windows/linux host == target, so fall back to the local platform there.
+gem_platform() {
+    case "${LLMTRIM_TARGET:-}" in
+        x86_64-*-linux-gnu)   echo "x86_64-linux" ;;
+        aarch64-*-linux-gnu)  echo "aarch64-linux" ;;
+        x86_64-apple-darwin)  echo "x86_64-darwin" ;;
+        aarch64-apple-darwin) echo "arm64-darwin" ;;
+        *)                    ruby -e 'puts Gem::Platform.local' ;;
+    esac
+}
+
 echo "==> generating UniFFI Ruby glue (from the unstripped debug build)"
 cargo build -p llmtrim-uniffi
 dbg="$(find_cdylib target/debug)"
@@ -43,7 +58,8 @@ echo "==> patching ffi_lib to load the bundled library ($base)"
 perl -i -pe "s{ffi_lib 'llmtrim_ffi'}{ffi_lib File.expand_path('$base', __dir__)}" \
     "$lib_dir/llmtrim_ffi.rb"
 
-echo "==> gem build (platform: $(ruby -e 'puts Gem::Platform.local'))"
+plat="$(gem_platform)"
+echo "==> gem build (platform: $plat)"
 cd "$pkg_dir"
-LLMTRIM_GEM_PLATFORM="$(ruby -e 'puts Gem::Platform.local')" gem build llmtrim.gemspec
+LLMTRIM_GEM_PLATFORM="$plat" gem build llmtrim.gemspec
 echo "==> built: $(ls -t "$pkg_dir"/*.gem | head -1)"


### PR DESCRIPTION
Three packaging-metadata fixes surfaced from the published v0.1.9 artifacts (registries are immutable, so these land in whatever release comes next):

- **PyPI** showed no project description: the wheel set a summary but no long description. `pyproject.toml` now sets `readme`.
- **RubyGems** was missing the Intel-mac gem: the cross-compiled `x86_64-apple-darwin` gem inherited the arm64 build host's platform via `Gem::Platform.local` and collided with the native arm64 gem. `build-gem.sh` now derives the gem platform from the build target.
- **Metadata em-dash** removed from the shared description string (PyPI summary / Maven Central description / gem summary).

No version bump.