### PR TITLE
bench: llmtrim vs Headroom head-to-head + per-stage bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **Language bindings now expose the per-stage compression breakdown.** `CompressOutput`
+  carries a `stages` list (one `StageReport` per pipeline stage: `name`, `applied`,
+  `tokens_before`, `tokens_after`, `note`), so embedders in Python, Ruby, Swift and Kotlin
+  can attribute the input-token reduction to each stage instead of only seeing the total.
+
 ### Fixed
 - **Windows autostart no longer leaves a console window open.** The login Run-key entry
   launched `serve --supervised` as a foreground console app, so Explorer opened a terminal

--- a/README.md
+++ b/README.md
@@ -202,20 +202,7 @@ llmtrim uninstall   # exact inverse of setup: removes all three changes
 
 ## Use it as a CLI or library
 
-The same compression runs with no proxy and no setup. No extra model calls, no network: the deterministic engine runs in your process, either as a one-shot CLI or as an embedded library.
-
-### As a CLI
-
-Pipe a request in, get a compressed one out:
-
-```bash
-echo '{"model":"gpt-4o","messages":[...]}' | llmtrim compress --provider openai > out.json
-echo '{"model":"gpt-4o","messages":[...]}' | llmtrim send     --provider openai   # compress, call, print
-```
-
-### As a library
-
-An embeddable Rust crate, or native bindings for **Python, Ruby, Swift and Kotlin**:
+The same compression runs with no proxy and no setup, as a one-shot CLI, an embeddable Rust crate, or native bindings for **Python, Ruby, Swift and Kotlin**. No extra model calls, no network: the deterministic engine runs in your process.
 
 | Language | Install |
 |---|---|
@@ -224,6 +211,13 @@ An embeddable Rust crate, or native bindings for **Python, Ruby, Swift and Kotli
 | Ruby | `gem install llmtrim` |
 | Kotlin | `implementation("io.github.fkiene:llmtrim:0.1.9")` (Maven Central) |
 | Swift | `.package(url: "https://github.com/fkiene/llmtrim-swift", from: "0.1.8")` (SwiftPM) |
+
+**CLI.** Pipe a request in, get a compressed one out:
+
+```bash
+echo '{"model":"gpt-4o","messages":[...]}' | llmtrim compress --provider openai > out.json
+echo '{"model":"gpt-4o","messages":[...]}' | llmtrim send     --provider openai   # compress, call, print
+```
 
 **Rust.** The engine is the [`llmtrim-core`](https://crates.io/crates/llmtrim-core) crate (no `tokio`, no network in its dependency tree):
 
@@ -341,6 +335,16 @@ Three neighbors each compress one layer of the problem; llmtrim does the whole r
 | Install: one static binary | ✅ | Python + GB models | ✅ | ✅ |
 | Overhead added / request | **<10 ms** | 52 ms median | <10 ms | n/a |
 | Prompt overhead injected | **19 tokens** | n/a | n/a | 949 tokens |
+
+Headroom is the closest comparison, so we measured it directly: both libraries run through their Python APIs on the same inputs and the same `o200k_base` tokenizer.
+
+| on tool output | llmtrim | Headroom |
+|---|:--:|:--:|
+| input tokens removed | **84%** | 36% |
+| compress latency (warm median) | **~4 ms** | ~14 ms |
+| per-stage breakdown of where tokens went | yes | no |
+
+llmtrim removes more, compresses faster (pure algorithm, no model to load), and reports which stage removed what. Latency jitters run to run; the [artifact](crates/llmtrim-cli/bench/results-vs-headroom/README.md#head-to-head-headroom) holds the committed warm medians. The gap is wider on everyday traffic: Headroom only rewrites tool results, and runs a local ModernBERT model to do it, so on plain chat, RAG, and code requests it mostly passes through while llmtrim still compresses. Method notes and full tables are in [bench/README.md](crates/llmtrim-cli/bench/README.md#head-to-head-headroom); reproduce with `bench/scripts/vs_headroom.py`.
 
 They also **stack**: llmtrim removes another ~35% from Claude Code's resent tool schemas on top of RTK. Detailed head-to-heads with [RTK](https://github.com/rtk-ai/rtk), [Headroom](https://github.com/chopratejas/headroom), and [caveman](https://github.com/JuliusBrussee/caveman) are in [crates/llmtrim-cli/bench/README.md](crates/llmtrim-cli/bench/README.md).
 

--- a/crates/llmtrim-cli/bench/README.md
+++ b/crates/llmtrim-cli/bench/README.md
@@ -92,3 +92,16 @@ python3 bench/scripts/synth_readme.py      # regenerate this file
 
 Per-stage ablation (offline, free): `llmtrim bench --corpus bench/data/<c>.jsonl --preset aggressive --ablate`.
 
+
+## Head-to-head: Headroom
+
+Both libraries run through their Python APIs on the same inputs and the same `o200k_base` denominator. Full tables (input saved, per-stage attribution, latency, and the live gpt-oss-20b output A/B) are in [results-vs-headroom/README.md](results-vs-headroom/README.md).
+
+```bash
+crates/llmtrim-uniffi/scripts/build-wheel.sh --release   # build the llmtrim wheel
+pip install --user target/wheels/llmtrim-*.whl
+pip install --user -r bench/scripts/requirements-vs-headroom.txt
+python3 bench/scripts/vs_headroom.py                     # deterministic axes (offline)
+python3 bench/scripts/vs_headroom.py --live --live-n 12  # output A/B (needs OPENROUTER_API_KEY)
+```
+

--- a/crates/llmtrim-cli/bench/results-vs-headroom/README.md
+++ b/crates/llmtrim-cli/bench/results-vs-headroom/README.md
@@ -1,0 +1,40 @@
+# llmtrim vs Headroom
+
+Both libraries driven through their Python APIs (`llmtrim.compress` and `headroom.compress`). Before/after token counts use the **same** `o200k_base` encoder over the **same** message-content span. Latency is the median compress time over 9 runs (model load excluded). llmtrim preset: `agent`.
+
+## tool-output (n=5)
+
+| tool | input tokens before→after | input saved | median ms |
+|---|--:|--:|--:|
+| **llmtrim** | 41,214 → 6,746 | **84%** | 4.0 |
+| Headroom | 41,214 → 26,201 | 36% | 13.8 |
+
+## general (n=64)
+
+| tool | input tokens before→after | input saved | median ms |
+|---|--:|--:|--:|
+| **llmtrim** | 34,735 → 31,629 | **9%** | 0.5 |
+| Headroom | 34,735 → 34,659 | 0% | 0.3 |
+
+## llmtrim per-stage attribution (tool-output group)
+
+Each stage's own token delta, the breakdown the binding now exposes and Headroom does not.
+
+| stage | applied | tokens removed |
+|---|--:|--:|
+| toolout | 3/5 | 6,369 |
+| image | 5/5 | 0 |
+| hygiene | 2/5 | 7,206 |
+| json-crush | 2/5 | 20,892 |
+| serialize-toon | 0/5 | 0 |
+| dedup | 0/5 | 0 |
+| tools | 0/5 | 0 |
+| cache | 5/5 | 0 |
+
+## Method notes
+
+- Latency is the median compress call, with a warm-up first so neither library is charged for one-time setup. llmtrim must run on the **release** wheel (`build-wheel.sh --release`); the debug build is several times slower and not representative.
+- Headroom's `compress` runs a **local ModernBERT encoder** (`answerdotai/ModernBERT-base`, the multi-hundred-MB model it downloads on first use) for its semantic smart-crusher. It makes no generative LLM API call; verified by running compress with all network sockets blocked. llmtrim is purely algorithmic (BPE counting plus deterministic stages), which is why its warm latency is lower despite removing more tokens.
+- Headroom protects user and system messages, so on the `general` corpora (natural request shapes, no tool results) it mostly no-ops; the `tool-output` group is its home turf.
+- Output tokens are out of this head-to-head. Headroom is input-only, and llmtrim's output shaping is a preset feature (e.g. `aggressive`, `reasoning`) measured in the main benchmark on a non-reasoning model. The `--live` arm exists for spot checks, but gpt-oss-20b bills hidden reasoning as output, so it is not a fair output denominator (see the main bench README).
+

--- a/crates/llmtrim-cli/bench/results-vs-headroom/results.json
+++ b/crates/llmtrim-cli/bench/results-vs-headroom/results.json
@@ -1,0 +1,5252 @@
+{
+  "meta": {
+    "model": "openai/gpt-oss-20b",
+    "preset": "agent",
+    "repeats": 9,
+    "encoder": "o200k_base",
+    "headroom": true
+  },
+  "cases": [
+    {
+      "group": "tool-output",
+      "name": "json_100",
+      "llmtrim": {
+        "before": 5436,
+        "after": 2187,
+        "ms": 7.151404395699501,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 5437,
+            "tokens_after": 5437,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 5437,
+            "tokens_after": 5437,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": true,
+            "tokens_before": 5437,
+            "tokens_after": 4234,
+            "note": null
+          },
+          {
+            "name": "json-crush",
+            "applied": true,
+            "tokens_before": 4234,
+            "tokens_after": 2188,
+            "note": null
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 2188,
+            "tokens_after": 2188,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 2188,
+            "tokens_after": 2188,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 2188,
+            "tokens_after": 2188,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 2188,
+            "tokens_after": 2188,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 5436,
+        "after": 3254,
+        "ms": 16.872232779860497,
+        "transforms": [
+          "router:protected:user_message",
+          "router:smart_crusher:0.20",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "tool-output",
+      "name": "json_500",
+      "llmtrim": {
+        "before": 27036,
+        "after": 2187,
+        "ms": 30.823973938822746,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 27037,
+            "tokens_after": 27037,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 27037,
+            "tokens_after": 27037,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": true,
+            "tokens_before": 27037,
+            "tokens_after": 21034,
+            "note": null
+          },
+          {
+            "name": "json-crush",
+            "applied": true,
+            "tokens_before": 21034,
+            "tokens_after": 2188,
+            "note": null
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 2188,
+            "tokens_after": 2188,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 2188,
+            "tokens_after": 2188,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 2188,
+            "tokens_after": 2188,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 2188,
+            "tokens_after": 2188,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 27036,
+        "after": 16054,
+        "ms": 48.12321998178959,
+        "transforms": [
+          "router:protected:user_message",
+          "router:smart_crusher:0.20",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "tool-output",
+      "name": "shell_200",
+      "llmtrim": {
+        "before": 4417,
+        "after": 457,
+        "ms": 4.005918279290199,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 4417,
+            "tokens_after": 458,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 458,
+            "tokens_after": 458,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 458,
+            "tokens_after": 458,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 458,
+            "tokens_after": 458,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 458,
+            "tokens_after": 458,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 458,
+            "tokens_after": 458,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 458,
+            "tokens_after": 458,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 458,
+            "tokens_after": 458,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 4417,
+        "after": 2568,
+        "ms": 13.83836381137371,
+        "transforms": [
+          "router:protected:user_message",
+          "router:text:0.63",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "tool-output",
+      "name": "buildlog_200",
+      "llmtrim": {
+        "before": 2207,
+        "after": 79,
+        "ms": 2.7093831449747086,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 2207,
+            "tokens_after": 79,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 79,
+            "tokens_after": 79,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 79,
+            "tokens_after": 79,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 79,
+            "tokens_after": 79,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 79,
+            "tokens_after": 79,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 79,
+            "tokens_after": 79,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 79,
+            "tokens_after": 79,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 79,
+            "tokens_after": 79,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 2207,
+        "after": 2207,
+        "ms": 2.4783387780189514,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:error_output",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "tool-output",
+      "name": "grep_150",
+      "llmtrim": {
+        "before": 2118,
+        "after": 1836,
+        "ms": 3.3102165907621384,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 2119,
+            "tokens_after": 1837,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1837,
+            "tokens_after": 1837,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1837,
+            "tokens_after": 1837,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1837,
+            "tokens_after": 1837,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1837,
+            "tokens_after": 1837,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1837,
+            "tokens_after": 1837,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1837,
+            "tokens_after": 1837,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1837,
+            "tokens_after": 1837,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 2118,
+        "after": 2118,
+        "ms": 8.615454658865929,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:recent_code",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "gsm8k-0",
+      "llmtrim": {
+        "before": 74,
+        "after": 74,
+        "ms": 0.2857279032468796,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 74,
+            "tokens_after": 74,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 74,
+            "tokens_after": 74,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 74,
+            "tokens_after": 74,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 74,
+            "tokens_after": 74,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 74,
+            "tokens_after": 74,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 74,
+            "tokens_after": 74,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 74,
+            "tokens_after": 74,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 74,
+            "tokens_after": 74,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 74,
+        "after": 74,
+        "ms": 0.1991111785173416,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "gsm8k-1",
+      "llmtrim": {
+        "before": 37,
+        "after": 37,
+        "ms": 0.19008107483386993,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 37,
+            "tokens_after": 37,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 37,
+            "tokens_after": 37,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 37,
+            "tokens_after": 37,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 37,
+            "tokens_after": 37,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 37,
+            "tokens_after": 37,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 37,
+            "tokens_after": 37,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 37,
+            "tokens_after": 37,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 37,
+            "tokens_after": 37,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 37,
+        "after": 37,
+        "ms": 0.15271082520484924,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "gsm8k-2",
+      "llmtrim": {
+        "before": 60,
+        "after": 60,
+        "ms": 0.22450461983680725,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 60,
+            "tokens_after": 60,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 60,
+            "tokens_after": 60,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 60,
+            "tokens_after": 60,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 60,
+            "tokens_after": 60,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 60,
+            "tokens_after": 60,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 60,
+            "tokens_after": 60,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 60,
+            "tokens_after": 60,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 60,
+            "tokens_after": 60,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 60,
+        "after": 60,
+        "ms": 0.17679482698440552,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "gsm8k-3",
+      "llmtrim": {
+        "before": 45,
+        "after": 45,
+        "ms": 0.19552558660507202,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 45,
+            "tokens_after": 45,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 45,
+            "tokens_after": 45,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 45,
+            "tokens_after": 45,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 45,
+            "tokens_after": 45,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 45,
+            "tokens_after": 45,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 45,
+            "tokens_after": 45,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 45,
+            "tokens_after": 45,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 45,
+            "tokens_after": 45,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 45,
+        "after": 45,
+        "ms": 0.16536936163902283,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "gsm8k-4",
+      "llmtrim": {
+        "before": 118,
+        "after": 118,
+        "ms": 0.322951003909111,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 118,
+            "tokens_after": 118,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 118,
+            "tokens_after": 118,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 118,
+            "tokens_after": 118,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 118,
+            "tokens_after": 118,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 118,
+            "tokens_after": 118,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 118,
+            "tokens_after": 118,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 118,
+            "tokens_after": 118,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 118,
+            "tokens_after": 118,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 118,
+        "after": 118,
+        "ms": 0.3167111426591873,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "gsm8k-5",
+      "llmtrim": {
+        "before": 63,
+        "after": 63,
+        "ms": 0.22690743207931519,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 63,
+            "tokens_after": 63,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 63,
+            "tokens_after": 63,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 63,
+            "tokens_after": 63,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 63,
+            "tokens_after": 63,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 63,
+            "tokens_after": 63,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 63,
+            "tokens_after": 63,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 63,
+            "tokens_after": 63,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 63,
+            "tokens_after": 63,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 63,
+        "after": 63,
+        "ms": 0.178581103682518,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "gsm8k-6",
+      "llmtrim": {
+        "before": 52,
+        "after": 52,
+        "ms": 0.22145546972751617,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 52,
+        "after": 52,
+        "ms": 0.16694329679012299,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "gsm8k-7",
+      "llmtrim": {
+        "before": 77,
+        "after": 77,
+        "ms": 0.2559628337621689,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 77,
+            "tokens_after": 77,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 77,
+            "tokens_after": 77,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 77,
+            "tokens_after": 77,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 77,
+            "tokens_after": 77,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 77,
+            "tokens_after": 77,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 77,
+            "tokens_after": 77,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 77,
+            "tokens_after": 77,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 77,
+            "tokens_after": 77,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 77,
+        "after": 77,
+        "ms": 0.19640102982521057,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "humaneval-0",
+      "llmtrim": {
+        "before": 140,
+        "after": 133,
+        "ms": 0.375283882021904,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 140,
+            "tokens_after": 140,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 140,
+            "tokens_after": 140,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": true,
+            "tokens_before": 140,
+            "tokens_after": 133,
+            "note": null
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 133,
+            "tokens_after": 133,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 133,
+            "tokens_after": 133,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 133,
+            "tokens_after": 133,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 133,
+            "tokens_after": 133,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 133,
+            "tokens_after": 133,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 140,
+        "after": 140,
+        "ms": 0.29934756457805634,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "humaneval-1",
+      "llmtrim": {
+        "before": 130,
+        "after": 130,
+        "ms": 0.382792204618454,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 130,
+        "after": 130,
+        "ms": 0.28999336063861847,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "humaneval-2",
+      "llmtrim": {
+        "before": 99,
+        "after": 99,
+        "ms": 0.3270171582698822,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 100,
+            "tokens_after": 100,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 100,
+            "tokens_after": 100,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 100,
+            "tokens_after": 100,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 100,
+            "tokens_after": 100,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 100,
+            "tokens_after": 100,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 100,
+            "tokens_after": 100,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 100,
+            "tokens_after": 100,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 100,
+            "tokens_after": 100,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 99,
+        "after": 99,
+        "ms": 0.25842897593975067,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "humaneval-3",
+      "llmtrim": {
+        "before": 133,
+        "after": 128,
+        "ms": 0.40971487760543823,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 133,
+            "tokens_after": 133,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 133,
+            "tokens_after": 133,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": true,
+            "tokens_before": 133,
+            "tokens_after": 128,
+            "note": null
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 128,
+            "tokens_after": 128,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 128,
+            "tokens_after": 128,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 128,
+            "tokens_after": 128,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 128,
+            "tokens_after": 128,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 128,
+            "tokens_after": 128,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 133,
+        "after": 133,
+        "ms": 0.2944525331258774,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "humaneval-4",
+      "llmtrim": {
+        "before": 133,
+        "after": 130,
+        "ms": 0.40260888636112213,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 133,
+            "tokens_after": 133,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 133,
+            "tokens_after": 133,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": true,
+            "tokens_before": 133,
+            "tokens_after": 130,
+            "note": null
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 130,
+            "tokens_after": 130,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 133,
+        "after": 133,
+        "ms": 0.30077993869781494,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "humaneval-5",
+      "llmtrim": {
+        "before": 113,
+        "after": 107,
+        "ms": 0.34347549080848694,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 113,
+            "tokens_after": 113,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 113,
+            "tokens_after": 113,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": true,
+            "tokens_before": 113,
+            "tokens_after": 107,
+            "note": null
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 107,
+            "tokens_after": 107,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 107,
+            "tokens_after": 107,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 107,
+            "tokens_after": 107,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 107,
+            "tokens_after": 107,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 107,
+            "tokens_after": 107,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 113,
+        "after": 113,
+        "ms": 0.27495063841342926,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "humaneval-6",
+      "llmtrim": {
+        "before": 125,
+        "after": 122,
+        "ms": 0.3887545317411423,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": true,
+            "tokens_before": 125,
+            "tokens_after": 122,
+            "note": null
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 122,
+            "tokens_after": 122,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 122,
+            "tokens_after": 122,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 122,
+            "tokens_after": 122,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 122,
+            "tokens_after": 122,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 122,
+            "tokens_after": 122,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 125,
+        "after": 125,
+        "ms": 0.2827811986207962,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "humaneval-7",
+      "llmtrim": {
+        "before": 108,
+        "after": 108,
+        "ms": 0.308280810713768,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 108,
+            "tokens_after": 108,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 108,
+            "tokens_after": 108,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 108,
+            "tokens_after": 108,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 108,
+            "tokens_after": 108,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 108,
+            "tokens_after": 108,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 108,
+            "tokens_after": 108,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 108,
+            "tokens_after": 108,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 108,
+            "tokens_after": 108,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 108,
+        "after": 108,
+        "ms": 0.26270560920238495,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "dolly-0",
+      "llmtrim": {
+        "before": 213,
+        "after": 213,
+        "ms": 0.500064343214035,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 213,
+            "tokens_after": 213,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 213,
+            "tokens_after": 213,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 213,
+            "tokens_after": 213,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 213,
+            "tokens_after": 213,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 213,
+            "tokens_after": 213,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 213,
+            "tokens_after": 213,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 213,
+            "tokens_after": 213,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 213,
+            "tokens_after": 213,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 213,
+        "after": 213,
+        "ms": 0.32605230808258057,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "dolly-1",
+      "llmtrim": {
+        "before": 406,
+        "after": 406,
+        "ms": 0.973796471953392,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 406,
+            "tokens_after": 406,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 406,
+            "tokens_after": 406,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 406,
+            "tokens_after": 406,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 406,
+            "tokens_after": 406,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 406,
+            "tokens_after": 406,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 406,
+            "tokens_after": 406,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 406,
+            "tokens_after": 406,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 406,
+            "tokens_after": 406,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 406,
+        "after": 406,
+        "ms": 0.5147494375705719,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "dolly-2",
+      "llmtrim": {
+        "before": 129,
+        "after": 129,
+        "ms": 0.39365142583847046,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 129,
+            "tokens_after": 129,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 129,
+            "tokens_after": 129,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 129,
+            "tokens_after": 129,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 129,
+            "tokens_after": 129,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 129,
+            "tokens_after": 129,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 129,
+            "tokens_after": 129,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 129,
+            "tokens_after": 129,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 129,
+            "tokens_after": 129,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 129,
+        "after": 129,
+        "ms": 0.26517920196056366,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "dolly-3",
+      "llmtrim": {
+        "before": 5,
+        "after": 5,
+        "ms": 0.13107620179653168,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 5,
+        "after": 5,
+        "ms": 0.11326372623443604,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "dolly-4",
+      "llmtrim": {
+        "before": 6,
+        "after": 6,
+        "ms": 0.13311393558979034,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 6,
+            "tokens_after": 6,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 6,
+            "tokens_after": 6,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 6,
+            "tokens_after": 6,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 6,
+            "tokens_after": 6,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 6,
+            "tokens_after": 6,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 6,
+            "tokens_after": 6,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 6,
+            "tokens_after": 6,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 6,
+            "tokens_after": 6,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 6,
+        "after": 6,
+        "ms": 0.1127738505601883,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "dolly-5",
+      "llmtrim": {
+        "before": 13,
+        "after": 13,
+        "ms": 0.1434851437807083,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 13,
+        "after": 13,
+        "ms": 0.1218300312757492,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "dolly-6",
+      "llmtrim": {
+        "before": 125,
+        "after": 125,
+        "ms": 0.33448077738285065,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 125,
+            "tokens_after": 125,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 125,
+        "after": 125,
+        "ms": 0.2514868974685669,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "dolly-7",
+      "llmtrim": {
+        "before": 5,
+        "after": 5,
+        "ms": 0.13052485883235931,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 5,
+            "tokens_after": 5,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 5,
+        "after": 5,
+        "ms": 0.11343695223331451,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "hotpotqa-0",
+      "llmtrim": {
+        "before": 1126,
+        "after": 1126,
+        "ms": 1.8477234989404678,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 1126,
+            "tokens_after": 1126,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1126,
+            "tokens_after": 1126,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1126,
+            "tokens_after": 1126,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1126,
+            "tokens_after": 1126,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1126,
+            "tokens_after": 1126,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1126,
+            "tokens_after": 1126,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1126,
+            "tokens_after": 1126,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1126,
+            "tokens_after": 1126,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1126,
+        "after": 1126,
+        "ms": 1.2273956090211868,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "hotpotqa-1",
+      "llmtrim": {
+        "before": 1233,
+        "after": 1233,
+        "ms": 2.1106842905282974,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 1233,
+            "tokens_after": 1233,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1233,
+            "tokens_after": 1233,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1233,
+            "tokens_after": 1233,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1233,
+            "tokens_after": 1233,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1233,
+            "tokens_after": 1233,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1233,
+            "tokens_after": 1233,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1233,
+            "tokens_after": 1233,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1233,
+            "tokens_after": 1233,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1233,
+        "after": 1233,
+        "ms": 1.2714341282844543,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "hotpotqa-2",
+      "llmtrim": {
+        "before": 1484,
+        "after": 1484,
+        "ms": 2.648239955306053,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 1484,
+            "tokens_after": 1484,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1484,
+            "tokens_after": 1484,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1484,
+            "tokens_after": 1484,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1484,
+            "tokens_after": 1484,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1484,
+            "tokens_after": 1484,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1484,
+            "tokens_after": 1484,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1484,
+            "tokens_after": 1484,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1484,
+            "tokens_after": 1484,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1484,
+        "after": 1484,
+        "ms": 1.474311575293541,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "hotpotqa-3",
+      "llmtrim": {
+        "before": 962,
+        "after": 962,
+        "ms": 2.041921019554138,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 962,
+            "tokens_after": 962,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 962,
+            "tokens_after": 962,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 962,
+            "tokens_after": 962,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 962,
+            "tokens_after": 962,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 962,
+            "tokens_after": 962,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 962,
+            "tokens_after": 962,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 962,
+            "tokens_after": 962,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 962,
+            "tokens_after": 962,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 962,
+        "after": 962,
+        "ms": 1.0705497115850449,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "hotpotqa-4",
+      "llmtrim": {
+        "before": 1266,
+        "after": 1266,
+        "ms": 2.082688733935356,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 1266,
+            "tokens_after": 1266,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1266,
+            "tokens_after": 1266,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1266,
+            "tokens_after": 1266,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1266,
+            "tokens_after": 1266,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1266,
+            "tokens_after": 1266,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1266,
+            "tokens_after": 1266,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1266,
+            "tokens_after": 1266,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1266,
+            "tokens_after": 1266,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1266,
+        "after": 1266,
+        "ms": 1.2724213302135468,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "hotpotqa-5",
+      "llmtrim": {
+        "before": 1280,
+        "after": 1280,
+        "ms": 2.1140091121196747,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 1280,
+            "tokens_after": 1280,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1280,
+            "tokens_after": 1280,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1280,
+            "tokens_after": 1280,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1280,
+            "tokens_after": 1280,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1280,
+            "tokens_after": 1280,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1280,
+            "tokens_after": 1280,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1280,
+            "tokens_after": 1280,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1280,
+            "tokens_after": 1280,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1280,
+        "after": 1280,
+        "ms": 1.3299398124217987,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "hotpotqa-6",
+      "llmtrim": {
+        "before": 1759,
+        "after": 1759,
+        "ms": 3.1129885464906693,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 1759,
+            "tokens_after": 1759,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1759,
+            "tokens_after": 1759,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1759,
+            "tokens_after": 1759,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1759,
+            "tokens_after": 1759,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1759,
+            "tokens_after": 1759,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1759,
+            "tokens_after": 1759,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1759,
+            "tokens_after": 1759,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1759,
+            "tokens_after": 1759,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1759,
+        "after": 1759,
+        "ms": 1.7538666725158691,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "hotpotqa-7",
+      "llmtrim": {
+        "before": 2829,
+        "after": 2829,
+        "ms": 5.040302872657776,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 2829,
+            "tokens_after": 2829,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 2829,
+            "tokens_after": 2829,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 2829,
+            "tokens_after": 2829,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 2829,
+            "tokens_after": 2829,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 2829,
+            "tokens_after": 2829,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 2829,
+            "tokens_after": 2829,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 2829,
+            "tokens_after": 2829,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 2829,
+            "tokens_after": 2829,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 2829,
+        "after": 2829,
+        "ms": 2.6771556586027145,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "glaive-0",
+      "llmtrim": {
+        "before": 13,
+        "after": 13,
+        "ms": 0.14318525791168213,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 13,
+            "tokens_after": 13,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 13,
+        "after": 13,
+        "ms": 0.12295879423618317,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "glaive-1",
+      "llmtrim": {
+        "before": 52,
+        "after": 52,
+        "ms": 0.24118460714817047,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 52,
+            "tokens_after": 52,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 52,
+        "after": 52,
+        "ms": 0.20014867186546326,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "glaive-2",
+      "llmtrim": {
+        "before": 59,
+        "after": 59,
+        "ms": 0.2650488168001175,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 59,
+            "tokens_after": 59,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 59,
+            "tokens_after": 59,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 59,
+            "tokens_after": 59,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 59,
+            "tokens_after": 59,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 59,
+            "tokens_after": 59,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 59,
+            "tokens_after": 59,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 59,
+            "tokens_after": 59,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 59,
+            "tokens_after": 59,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 59,
+        "after": 59,
+        "ms": 0.3907550126314163,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "glaive-3",
+      "llmtrim": {
+        "before": 72,
+        "after": 72,
+        "ms": 0.2532918006181717,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 72,
+            "tokens_after": 72,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 72,
+            "tokens_after": 72,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 72,
+            "tokens_after": 72,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 72,
+            "tokens_after": 72,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 72,
+            "tokens_after": 72,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 72,
+            "tokens_after": 72,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 72,
+            "tokens_after": 72,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 72,
+            "tokens_after": 72,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 72,
+        "after": 72,
+        "ms": 0.22400729358196259,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "glaive-4",
+      "llmtrim": {
+        "before": 61,
+        "after": 61,
+        "ms": 0.22631138563156128,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 61,
+            "tokens_after": 61,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 61,
+            "tokens_after": 61,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 61,
+            "tokens_after": 61,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 61,
+            "tokens_after": 61,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 61,
+            "tokens_after": 61,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 61,
+            "tokens_after": 61,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 61,
+            "tokens_after": 61,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 61,
+            "tokens_after": 61,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 61,
+        "after": 61,
+        "ms": 0.1928228884935379,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "glaive-5",
+      "llmtrim": {
+        "before": 21,
+        "after": 21,
+        "ms": 0.1571308821439743,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 21,
+            "tokens_after": 21,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 21,
+            "tokens_after": 21,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 21,
+            "tokens_after": 21,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 21,
+            "tokens_after": 21,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 21,
+            "tokens_after": 21,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 21,
+            "tokens_after": 21,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 21,
+            "tokens_after": 21,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 21,
+            "tokens_after": 21,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 21,
+        "after": 21,
+        "ms": 0.14005228877067566,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "glaive-6",
+      "llmtrim": {
+        "before": 35,
+        "after": 35,
+        "ms": 0.18684379756450653,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 35,
+            "tokens_after": 35,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 35,
+            "tokens_after": 35,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 35,
+            "tokens_after": 35,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 35,
+            "tokens_after": 35,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 35,
+            "tokens_after": 35,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 35,
+            "tokens_after": 35,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 35,
+            "tokens_after": 35,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 35,
+            "tokens_after": 35,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 35,
+        "after": 35,
+        "ms": 0.16957148909568787,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "glaive-7",
+      "llmtrim": {
+        "before": 22,
+        "after": 22,
+        "ms": 0.15278533101081848,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 22,
+            "tokens_after": 22,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 22,
+            "tokens_after": 22,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 22,
+            "tokens_after": 22,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 22,
+            "tokens_after": 22,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 22,
+            "tokens_after": 22,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 22,
+            "tokens_after": 22,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 22,
+            "tokens_after": 22,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 22,
+            "tokens_after": 22,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 22,
+        "after": 22,
+        "ms": 0.13195723295211792,
+        "transforms": [
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "chat-0",
+      "llmtrim": {
+        "before": 460,
+        "after": 460,
+        "ms": 0.982426106929779,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 460,
+            "tokens_after": 460,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 460,
+            "tokens_after": 460,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 460,
+            "tokens_after": 460,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 460,
+            "tokens_after": 460,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 460,
+            "tokens_after": 460,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 460,
+            "tokens_after": 460,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 460,
+            "tokens_after": 460,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 460,
+            "tokens_after": 460,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 460,
+        "after": 460,
+        "ms": 0.6971303373575211,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message",
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "chat-1",
+      "llmtrim": {
+        "before": 1273,
+        "after": 1273,
+        "ms": 2.350602298974991,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 1273,
+            "tokens_after": 1273,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1273,
+            "tokens_after": 1273,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1273,
+            "tokens_after": 1273,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1273,
+            "tokens_after": 1273,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1273,
+            "tokens_after": 1273,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1273,
+            "tokens_after": 1273,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1273,
+            "tokens_after": 1273,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1273,
+            "tokens_after": 1273,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1273,
+        "after": 1233,
+        "ms": 11.809077113866806,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message",
+          "router:text:0.82",
+          "router:protected:user_message",
+          "router:protected:user_message",
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "chat-2",
+      "llmtrim": {
+        "before": 2322,
+        "after": 2322,
+        "ms": 4.603710025548935,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 2321,
+            "tokens_after": 2321,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 2321,
+            "tokens_after": 2321,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 2321,
+            "tokens_after": 2321,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 2321,
+            "tokens_after": 2321,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 2321,
+            "tokens_after": 2321,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 2321,
+            "tokens_after": 2321,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 2321,
+            "tokens_after": 2321,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 2321,
+            "tokens_after": 2321,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 2322,
+        "after": 2322,
+        "ms": 18.347544595599174,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message",
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "chat-3",
+      "llmtrim": {
+        "before": 196,
+        "after": 196,
+        "ms": 0.5642957985401154,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 196,
+            "tokens_after": 196,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 196,
+            "tokens_after": 196,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 196,
+            "tokens_after": 196,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 196,
+            "tokens_after": 196,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 196,
+            "tokens_after": 196,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 196,
+            "tokens_after": 196,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 196,
+            "tokens_after": 196,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 196,
+            "tokens_after": 196,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 196,
+        "after": 196,
+        "ms": 0.3496278077363968,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "chat-4",
+      "llmtrim": {
+        "before": 1762,
+        "after": 1762,
+        "ms": 3.401864320039749,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 1762,
+            "tokens_after": 1762,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1762,
+            "tokens_after": 1762,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1762,
+            "tokens_after": 1762,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1762,
+            "tokens_after": 1762,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1762,
+            "tokens_after": 1762,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1762,
+            "tokens_after": 1762,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1762,
+            "tokens_after": 1762,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1762,
+            "tokens_after": 1762,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1762,
+        "after": 1762,
+        "ms": 15.916861593723297,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message",
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "chat-5",
+      "llmtrim": {
+        "before": 878,
+        "after": 878,
+        "ms": 2.0597074180841446,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 877,
+            "tokens_after": 877,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 877,
+            "tokens_after": 877,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 877,
+            "tokens_after": 877,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 877,
+            "tokens_after": 877,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 877,
+            "tokens_after": 877,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 877,
+            "tokens_after": 877,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 877,
+            "tokens_after": 877,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 877,
+            "tokens_after": 877,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 878,
+        "after": 878,
+        "ms": 0.9509772062301636,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "chat-6",
+      "llmtrim": {
+        "before": 985,
+        "after": 653,
+        "ms": 2.759929746389389,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 985,
+            "tokens_after": 653,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 653,
+            "tokens_after": 653,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 653,
+            "tokens_after": 653,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 653,
+            "tokens_after": 653,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 653,
+            "tokens_after": 653,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 653,
+            "tokens_after": 653,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 653,
+            "tokens_after": 653,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 653,
+            "tokens_after": 653,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 985,
+        "after": 985,
+        "ms": 9.118204936385155,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:recent_code",
+          "router:protected:user_message",
+          "router:protected:recent_code",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "chat-7",
+      "llmtrim": {
+        "before": 742,
+        "after": 742,
+        "ms": 1.6531869769096375,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 742,
+            "tokens_after": 742,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 742,
+            "tokens_after": 742,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 742,
+            "tokens_after": 742,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 742,
+            "tokens_after": 742,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 742,
+            "tokens_after": 742,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 742,
+            "tokens_after": 742,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 742,
+            "tokens_after": 742,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 742,
+            "tokens_after": 742,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 742,
+        "after": 706,
+        "ms": 6.1865150928497314,
+        "transforms": [
+          "router:protected:user_message",
+          "router:text:0.80",
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "cnn-0",
+      "llmtrim": {
+        "before": 921,
+        "after": 921,
+        "ms": 1.4175642281770706,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 921,
+            "tokens_after": 921,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 921,
+            "tokens_after": 921,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 921,
+            "tokens_after": 921,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 921,
+            "tokens_after": 921,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 921,
+            "tokens_after": 921,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 921,
+            "tokens_after": 921,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 921,
+            "tokens_after": 921,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 921,
+            "tokens_after": 921,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 921,
+        "after": 921,
+        "ms": 0.9293891489505768,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "cnn-1",
+      "llmtrim": {
+        "before": 1604,
+        "after": 1604,
+        "ms": 2.2433586418628693,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 1604,
+            "tokens_after": 1604,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1604,
+            "tokens_after": 1604,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1604,
+            "tokens_after": 1604,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1604,
+            "tokens_after": 1604,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1604,
+            "tokens_after": 1604,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1604,
+            "tokens_after": 1604,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1604,
+            "tokens_after": 1604,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1604,
+            "tokens_after": 1604,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1604,
+        "after": 1604,
+        "ms": 1.6840491443872452,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "cnn-2",
+      "llmtrim": {
+        "before": 541,
+        "after": 541,
+        "ms": 0.9035971015691757,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 541,
+            "tokens_after": 541,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 541,
+            "tokens_after": 541,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 541,
+            "tokens_after": 541,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 541,
+            "tokens_after": 541,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 541,
+            "tokens_after": 541,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 541,
+            "tokens_after": 541,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 541,
+            "tokens_after": 541,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 541,
+            "tokens_after": 541,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 541,
+        "after": 541,
+        "ms": 0.662878155708313,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "cnn-3",
+      "llmtrim": {
+        "before": 443,
+        "after": 443,
+        "ms": 0.7990039885044098,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 443,
+            "tokens_after": 443,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 443,
+            "tokens_after": 443,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 443,
+            "tokens_after": 443,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 443,
+            "tokens_after": 443,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 443,
+            "tokens_after": 443,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 443,
+            "tokens_after": 443,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 443,
+            "tokens_after": 443,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 443,
+            "tokens_after": 443,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 443,
+        "after": 443,
+        "ms": 0.5677416920661926,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "cnn-4",
+      "llmtrim": {
+        "before": 578,
+        "after": 578,
+        "ms": 0.9552985429763794,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 578,
+            "tokens_after": 578,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 578,
+            "tokens_after": 578,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 578,
+            "tokens_after": 578,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 578,
+            "tokens_after": 578,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 578,
+            "tokens_after": 578,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 578,
+            "tokens_after": 578,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 578,
+            "tokens_after": 578,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 578,
+            "tokens_after": 578,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 578,
+        "after": 578,
+        "ms": 0.6340015679597855,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "cnn-5",
+      "llmtrim": {
+        "before": 974,
+        "after": 974,
+        "ms": 2.091864123940468,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 974,
+            "tokens_after": 974,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 974,
+            "tokens_after": 974,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 974,
+            "tokens_after": 974,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 974,
+            "tokens_after": 974,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 974,
+            "tokens_after": 974,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 974,
+            "tokens_after": 974,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 974,
+            "tokens_after": 974,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 974,
+            "tokens_after": 974,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 974,
+        "after": 974,
+        "ms": 1.0062027722597122,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "cnn-6",
+      "llmtrim": {
+        "before": 649,
+        "after": 649,
+        "ms": 1.0467134416103363,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 649,
+            "tokens_after": 649,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 649,
+            "tokens_after": 649,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 649,
+            "tokens_after": 649,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 649,
+            "tokens_after": 649,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 649,
+            "tokens_after": 649,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 649,
+            "tokens_after": 649,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 649,
+            "tokens_after": 649,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 649,
+            "tokens_after": 649,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 649,
+        "after": 649,
+        "ms": 0.7385797798633575,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "cnn-7",
+      "llmtrim": {
+        "before": 179,
+        "after": 179,
+        "ms": 0.4462003707885742,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": false,
+            "tokens_before": 179,
+            "tokens_after": 179,
+            "note": "no token reduction"
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 179,
+            "tokens_after": 179,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 179,
+            "tokens_after": 179,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 179,
+            "tokens_after": 179,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 179,
+            "tokens_after": 179,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 179,
+            "tokens_after": 179,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 179,
+            "tokens_after": 179,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 179,
+            "tokens_after": 179,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 179,
+        "after": 179,
+        "ms": 0.30792877078056335,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "toolout-0",
+      "llmtrim": {
+        "before": 860,
+        "after": 83,
+        "ms": 1.251140609383583,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 859,
+            "tokens_after": 82,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 82,
+            "tokens_after": 82,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 82,
+            "tokens_after": 82,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 82,
+            "tokens_after": 82,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 82,
+            "tokens_after": 82,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 82,
+            "tokens_after": 82,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 82,
+            "tokens_after": 82,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 82,
+            "tokens_after": 82,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 860,
+        "after": 860,
+        "ms": 0.9524747729301453,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "toolout-1",
+      "llmtrim": {
+        "before": 1224,
+        "after": 1163,
+        "ms": 1.9786246120929718,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 1223,
+            "tokens_after": 1162,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 1162,
+            "tokens_after": 1162,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 1162,
+            "tokens_after": 1162,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 1162,
+            "tokens_after": 1162,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 1162,
+            "tokens_after": 1162,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 1162,
+            "tokens_after": 1162,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 1162,
+            "tokens_after": 1162,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 1162,
+            "tokens_after": 1162,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1224,
+        "after": 1224,
+        "ms": 1.1731311678886414,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "toolout-2",
+      "llmtrim": {
+        "before": 609,
+        "after": 78,
+        "ms": 0.929100438952446,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 608,
+            "tokens_after": 78,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 78,
+            "tokens_after": 78,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 78,
+            "tokens_after": 78,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 78,
+            "tokens_after": 78,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 78,
+            "tokens_after": 78,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 78,
+            "tokens_after": 78,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 78,
+            "tokens_after": 78,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 78,
+            "tokens_after": 78,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 609,
+        "after": 609,
+        "ms": 0.6510112434625626,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "toolout-3",
+      "llmtrim": {
+        "before": 1118,
+        "after": 68,
+        "ms": 1.3155154883861542,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 1117,
+            "tokens_after": 67,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 67,
+            "tokens_after": 67,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 67,
+            "tokens_after": 67,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 67,
+            "tokens_after": 67,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 67,
+            "tokens_after": 67,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 67,
+            "tokens_after": 67,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 67,
+            "tokens_after": 67,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 67,
+            "tokens_after": 67,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 1118,
+        "after": 1118,
+        "ms": 1.184515655040741,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "toolout-4",
+      "llmtrim": {
+        "before": 460,
+        "after": 446,
+        "ms": 1.120658591389656,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 459,
+            "tokens_after": 445,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 445,
+            "tokens_after": 445,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 445,
+            "tokens_after": 445,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 445,
+            "tokens_after": 445,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 445,
+            "tokens_after": 445,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 445,
+            "tokens_after": 445,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 445,
+            "tokens_after": 445,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 445,
+            "tokens_after": 445,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 460,
+        "after": 460,
+        "ms": 0.5918480455875397,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "toolout-5",
+      "llmtrim": {
+        "before": 187,
+        "after": 148,
+        "ms": 0.5030296742916107,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 186,
+            "tokens_after": 148,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 148,
+            "tokens_after": 148,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 148,
+            "tokens_after": 148,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 148,
+            "tokens_after": 148,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 148,
+            "tokens_after": 148,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 148,
+            "tokens_after": 148,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 148,
+            "tokens_after": 148,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 148,
+            "tokens_after": 148,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 187,
+        "after": 187,
+        "ms": 0.3043320029973984,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "toolout-6",
+      "llmtrim": {
+        "before": 180,
+        "after": 141,
+        "ms": 0.49851834774017334,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 179,
+            "tokens_after": 141,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 141,
+            "tokens_after": 141,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 141,
+            "tokens_after": 141,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 141,
+            "tokens_after": 141,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 141,
+            "tokens_after": 141,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 141,
+            "tokens_after": 141,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 141,
+            "tokens_after": 141,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 141,
+            "tokens_after": 141,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 180,
+        "after": 180,
+        "ms": 0.29694661498069763,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    },
+    {
+      "group": "general",
+      "name": "toolout-7",
+      "llmtrim": {
+        "before": 907,
+        "after": 668,
+        "ms": 1.4547165483236313,
+        "stages": [
+          {
+            "name": "toolout",
+            "applied": true,
+            "tokens_before": 906,
+            "tokens_after": 668,
+            "note": null
+          },
+          {
+            "name": "image",
+            "applied": true,
+            "tokens_before": 668,
+            "tokens_after": 668,
+            "note": null
+          },
+          {
+            "name": "hygiene",
+            "applied": false,
+            "tokens_before": 668,
+            "tokens_after": 668,
+            "note": "no token reduction"
+          },
+          {
+            "name": "json-crush",
+            "applied": false,
+            "tokens_before": 668,
+            "tokens_after": 668,
+            "note": "no token reduction"
+          },
+          {
+            "name": "serialize-toon",
+            "applied": false,
+            "tokens_before": 668,
+            "tokens_after": 668,
+            "note": "no token reduction"
+          },
+          {
+            "name": "dedup",
+            "applied": false,
+            "tokens_before": 668,
+            "tokens_after": 668,
+            "note": "no token reduction"
+          },
+          {
+            "name": "tools",
+            "applied": false,
+            "tokens_before": 668,
+            "tokens_after": 668,
+            "note": "no token reduction"
+          },
+          {
+            "name": "cache",
+            "applied": true,
+            "tokens_before": 668,
+            "tokens_after": 668,
+            "note": null
+          }
+        ]
+      },
+      "headroom": {
+        "before": 907,
+        "after": 907,
+        "ms": 0.8982978761196136,
+        "transforms": [
+          "router:protected:user_message",
+          "router:protected:user_message"
+        ]
+      }
+    }
+  ],
+  "live": null
+}

--- a/crates/llmtrim-cli/bench/scripts/requirements-vs-headroom.txt
+++ b/crates/llmtrim-cli/bench/scripts/requirements-vs-headroom.txt
@@ -1,0 +1,7 @@
+# Dependencies for bench/scripts/vs_headroom.py (the llmtrim-vs-Headroom head-to-head).
+# The llmtrim wheel itself is built locally and installed separately:
+#   crates/llmtrim-uniffi/scripts/build-wheel.sh
+#   pip install --user target/wheels/llmtrim-*.whl
+tiktoken==0.8.0      # the shared o200k_base encoder (fair denominator for both tools)
+headroom-ai==0.25.0  # Headroom's Python library (pulls litellm + a ModernBERT model)
+openai==2.41.1       # only used by --live (OpenRouter is OpenAI-compatible)

--- a/crates/llmtrim-cli/bench/scripts/synth_readme.py
+++ b/crates/llmtrim-cli/bench/scripts/synth_readme.py
@@ -237,6 +237,21 @@ def main():
         "`llmtrim bench --corpus bench/data/<c>.jsonl --preset aggressive --ablate`.\n"
     )
 
+    lines.append("\n## Head-to-head: Headroom\n")
+    lines.append(
+        "Both libraries run through their Python APIs on the same inputs and the same "
+        "`o200k_base` denominator. Full tables (input saved, per-stage attribution, latency, "
+        "and the live gpt-oss-20b output A/B) are in "
+        "[results-vs-headroom/README.md](results-vs-headroom/README.md).\n"
+    )
+    lines.append("```bash")
+    lines.append("crates/llmtrim-uniffi/scripts/build-wheel.sh --release   # build the llmtrim wheel")
+    lines.append("pip install --user target/wheels/llmtrim-*.whl")
+    lines.append("pip install --user -r bench/scripts/requirements-vs-headroom.txt")
+    lines.append("python3 bench/scripts/vs_headroom.py                     # deterministic axes (offline)")
+    lines.append("python3 bench/scripts/vs_headroom.py --live --live-n 12  # output A/B (needs OPENROUTER_API_KEY)")
+    lines.append("```")
+
     readme = os.path.join(HERE, "README.md")
     open(readme, "w").write("\n".join(lines) + "\n")
     print(f"wrote {readme} ({len(results)} corpora)")

--- a/crates/llmtrim-cli/bench/scripts/vs_headroom.py
+++ b/crates/llmtrim-cli/bench/scripts/vs_headroom.py
@@ -1,134 +1,436 @@
 #!/usr/bin/env python3
-"""Head-to-head: llmtrim vs Headroom on Headroom's own content types.
+"""Head-to-head: llmtrim vs Headroom, both driven through their Python libraries.
 
-Generates the content types from Headroom's published benchmark (JSON arrays, shell
-output, build logs, grep results, source) and compresses each with **both** tools,
-reporting tokens saved + latency side by side — on the SAME token denominator.
+What this measures, per case, on a single shared token denominator:
+
+1. Input-token reduction — how much each library removes from the request.
+2. Per-stage attribution — llmtrim's `stages` (real per-stage token deltas) vs
+   Headroom's `transforms_applied` (the strategies it ran).
+3. Compression overhead — wall-clock milliseconds per compress call (median of K runs,
+   model load excluded by a warm-up).
+4. (`--live`) Output-token savings on a real model — original vs llmtrim-compressed
+   request sent to gpt-oss-20b. Headroom is input-only, so its output column is 0 by
+   construction; that asymmetry is the point, stated plainly.
 
 Fairness rules (so the comparison is apples-to-apples):
-- Both tools' before/after token counts use the **same encoder** (`o200k_base`) over the
-  **same span** (the user-message content), not each tool's own internal metric.
-- llmtrim is timed by running the **prebuilt release binary** `target/release/llmtrim`
-  (NOT `cargo run`, which times a debug build + compile). Build it first:
-  `cargo build --release`.
-- Headroom runs only if importable (`pip install "headroom-ai[all]"`). Skipped otherwise —
-  fill from its published /docs/benchmarks table.
+- Both tools' before/after token counts use the SAME encoder (`o200k_base`) over the SAME
+  span (the concatenated message contents), not each library's own internal metric.
+- Both libraries see the SAME messages for each case.
+- Two corpus groups make the coverage difference explicit:
+    * `tool-output` — Headroom's home turf (large JSON / logs / shell / grep as tool
+      results); both libraries compress here.
+    * `general` — our golden corpora (gsm8k, hotpotqa, dolly, …) in their natural request
+      shape. Headroom protects user/system messages, so it mostly no-ops; llmtrim still
+      compresses. This shows breadth of coverage, not a rigged input.
 
-Usage: cargo build --release && python3 bench/scripts/vs_headroom.py
+Setup (reproducible):
+    cargo build --release                                   # not required (uses the lib)
+    crates/llmtrim-uniffi/scripts/build-wheel.sh            # build the llmtrim wheel
+    pip install --user crates/../target/wheels/llmtrim-*.whl
+    pip install --user -r bench/scripts/requirements-vs-headroom.txt
+    python3 bench/scripts/download.py 40                    # our golden corpora
+    python3 bench/scripts/vs_headroom.py                    # deterministic axes (offline)
+    OPENROUTER_API_KEY=... python3 bench/scripts/vs_headroom.py --live --live-n 12
+
+Outputs land in bench/results-vs-headroom/: results.json (machine-readable) and README.md
+(the rendered tables + the drop-in snippet for the main README "How does it compare").
 """
-import json, subprocess, time
+import argparse
+import json
+import os
+import ssl
+import statistics
+import sys
+import time
+import urllib.request
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[2]
-LLMTRIM_BIN = ROOT / "target" / "release" / "llmtrim"
+CRATE_ROOT = Path(__file__).resolve().parents[2]  # crates/llmtrim-cli (bench/ lives here)
+WORKSPACE_ROOT = CRATE_ROOT.parents[1]  # the repo root, where .env sits
+DATA_DIR = CRATE_ROOT / "bench" / "data"
+RESULTS_DIR = CRATE_ROOT / "bench" / "results-vs-headroom"
+
+# The model + route the project pins for every OpenRouter call (see CLAUDE.md). Used only
+# by the live A/B (call_model); the deterministic axes make no network calls.
+MODEL = "openai/gpt-oss-20b"
+PROVIDER_ROUTE = {"order": ["wandb/fp4"], "allow_fallbacks": False}
+
+# The `model` field placed in the request *body* handed to each library's local compress().
+# It is NOT an API call: both libraries read it to pick a tokenizer / context limits. We use
+# an OpenAI model on purpose so llmtrim selects its exact `o200k_base` tokenizer, the same
+# encoder this script scores both tools with (get_encoder); a non-OpenAI id would make
+# llmtrim fall back to an estimated tokenizer and blur the denominator.
+BODY_MODEL = "gpt-4o"
+LLMTRIM_PRESET_DEFAULT = "agent"  # general agent traffic — the closest analog to Headroom's use
+
+# Direct OpenRouter calls for the live A/B bypass any local proxy (otherwise the llmtrim
+# daemon would re-compress the "original" arm and contaminate the baseline) and tolerate a
+# missing CA chain — same posture as bench/scripts/caveman_ab.py and run_all.sh.
+_SSL_CTX = ssl.create_default_context()
+_SSL_CTX.check_hostname = False
+_SSL_CTX.verify_mode = ssl.CERT_NONE
 
 
-def encoder():
-    """The shared encoder for BOTH tools (Headroom uses o200k_base in its docs)."""
+# ── Shared tokenizer (the single fair denominator) ────────────────────────────
+def get_encoder():
     import tiktoken
+
     return tiktoken.get_encoding("o200k_base")
 
 
-def user_content(messages_or_obj):
-    """Extract the user-message content span we tokenize for both tools."""
-    msgs = messages_or_obj
-    if isinstance(msgs, dict):
-        msgs = msgs.get("messages", [])
-    if isinstance(msgs, list):
-        for m in msgs:
-            if isinstance(m, dict) and m.get("role") == "user":
-                c = m.get("content", "")
-                return c if isinstance(c, str) else json.dumps(c)
-        # fall back to the last message's content
-        if msgs and isinstance(msgs[-1], dict):
-            c = msgs[-1].get("content", "")
-            return c if isinstance(c, str) else json.dumps(c)
-    return str(messages_or_obj)
+def span_text(messages):
+    """The content span both libraries are scored over: every message's content,
+    flattened to text (objects JSON-dumped), joined. Same definition for both tools."""
+    parts = []
+    for m in messages:
+        c = m.get("content", "")
+        if isinstance(c, str):
+            parts.append(c)
+        elif c is not None:
+            parts.append(json.dumps(c, separators=(",", ":")))
+    return "\n".join(parts)
 
 
-def gen():
-    """The six content types, sized to mirror Headroom's benchmark table."""
+def count(enc, messages):
+    return len(enc.encode(span_text(messages)))
+
+
+# ── Corpora ───────────────────────────────────────────────────────────────────
+def synthetic_tool_cases():
+    """Headroom's published content types, sized to mirror its benchmark, each delivered
+    as a tool result (the shape Headroom's smart-crusher targets)."""
+
     def recs(n):
         a = []
         for i in range(n):
-            r = {"ts": f"2026-04-{i%28+1:02d}T10:{i%60:02d}:00Z", "level": "INFO",
-                 "service": f"svc-{i%5}", "msg": f"request {i} handled ok", "code": 200, "ms": i % 50}
+            r = {
+                "ts": f"2026-04-{i % 28 + 1:02d}T10:{i % 60:02d}:00Z",
+                "level": "INFO",
+                "service": f"svc-{i % 5}",
+                "msg": f"request {i} handled ok",
+                "code": 200,
+                "ms": i % 50,
+            }
             if i == 67:
                 r.update({"level": "ERROR", "msg": "payment gateway declined",
                           "code": 402, "resolution": "retry with backup PSP", "affected": 1432})
             a.append(r)
-        return json.dumps(a)
-    return {
+        return json.dumps({"results": a})
+
+    raw = {
         "json_100": recs(100),
         "json_500": recs(500),
-        "shell_200": "\n".join(f"drwxr-xr-x 2 u g {1024*i:8d} Apr {i%28+1:02d} file_{i}.txt" for i in range(200)),
+        "shell_200": "\n".join(
+            f"drwxr-xr-x 2 u g {1024 * i:8d} Apr {i % 28 + 1:02d} file_{i}.txt" for i in range(200)
+        ),
         "buildlog_200": "\n".join(f"[{i:03d}] INFO compiling crate mod_{i} ok" for i in range(198))
-                        + "\nERROR undefined reference to render_frame\nERROR build failed",
-        "grep_150": "\n".join(f"src/{'abcde'[i%5]}.rs:{i+1}:    let v = connect({i});" for i in range(150)),
+        + "\nERROR undefined reference to render_frame\nERROR build failed",
+        "grep_150": "\n".join(
+            f"src/{'abcde'[i % 5]}.rs:{i + 1}:    let v = connect({i});" for i in range(150)
+        ),
     }
+    cases = []
+    for name, content in raw.items():
+        # A realistic tool-call turn: the model asked, the tool answered (big), the user
+        # follows up. Both libraries get this identical message list.
+        messages = [
+            {"role": "user", "content": "Investigate the service and summarize what happened."},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "type": "function",
+                                "function": {"name": "fetch", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": content},
+            {"role": "user", "content": "What is the single error and its resolution?"},
+        ]
+        cases.append((name, messages))
+    return cases
 
 
-def llmtrim_savings(enc, content):
-    """Compress one case with the prebuilt release binary, timing it, and tokenize the
-    user-content span with the shared encoder → (before, after, pct, ms). The binary's
-    `compress` reads a request body on stdin and writes the compressed body to stdout."""
-    req = json.dumps({"model": "gpt-4o",
-                      "messages": [{"role": "user", "content": content}],
-                      "max_tokens": 300})
-    t = time.perf_counter()
-    proc = subprocess.run([str(LLMTRIM_BIN), "compress", "--provider", "openai"],
-                          input=req, cwd=ROOT, capture_output=True, text=True)
-    ms = (time.perf_counter() - t) * 1000
-    if proc.returncode != 0 or not proc.stdout.strip():
-        return None
+def general_cases(limit):
+    """Our golden corpora in their natural request shape (system + context + question).
+    Mirrors crates/llmtrim-cli/src/bench/mod.rs::build_request."""
+    corpora = ["gsm8k", "humaneval", "dolly", "hotpotqa", "glaive", "chat", "cnn", "toolout"]
+    cases = []
+    for name in corpora:
+        path = DATA_DIR / f"{name}.jsonl"
+        if not path.exists():
+            continue
+        lines = [ln for ln in path.read_text().splitlines() if ln.strip()][:limit]
+        for i, ln in enumerate(lines):
+            v = json.loads(ln)
+            if "request" in v:  # explicit request form
+                try:
+                    msgs = json.loads(v["request"]).get("messages", [])
+                except (json.JSONDecodeError, AttributeError):
+                    continue
+            else:  # friendly form
+                msgs = []
+                if v.get("system"):
+                    msgs.append({"role": "system", "content": v["system"]})
+                ctx = next((v[k] for k in ("context", "input", "passage", "document") if v.get(k)), None)
+                if ctx:
+                    msgs.append({"role": "user", "content": ctx})
+                q = next((v[k] for k in ("question", "query", "prompt") if v.get(k)), None)
+                if q:
+                    msgs.append({"role": "user", "content": q})
+            if msgs:
+                cases.append((f"{name}-{i}", msgs))
+    return cases
+
+
+# ── The two libraries ─────────────────────────────────────────────────────────
+def llmtrim_compress(messages, preset, repeats):
+    """Compress with the llmtrim wheel. Returns (out_messages, stages, ms) where stages is
+    the per-stage breakdown now exposed by the binding."""
+    import llmtrim
+
+    req = json.dumps({"model": BODY_MODEL, "messages": messages, "max_tokens": 300})
+    durations = []
+    out = None
+    for _ in range(repeats):
+        t = time.perf_counter()
+        out = llmtrim.compress(req, llmtrim.Provider.OPEN_AI, preset)
+        durations.append((time.perf_counter() - t) * 1000)
+    out_messages = json.loads(out.request_json).get("messages", [])
+    stages = [
+        {"name": s.name, "applied": s.applied,
+         "tokens_before": s.tokens_before, "tokens_after": s.tokens_after, "note": s.note}
+        for s in out.stages
+    ]
+    return out_messages, stages, statistics.median(durations)
+
+
+def headroom_compress(client, messages, repeats):
+    """Compress with Headroom's library. Returns (out_messages, transforms, ms)."""
+    durations = []
+    res = None
+    for _ in range(repeats):
+        t = time.perf_counter()
+        res = client(messages, model=BODY_MODEL)
+        durations.append((time.perf_counter() - t) * 1000)
+    return res.messages, list(res.transforms_applied), statistics.median(durations)
+
+
+def make_headroom_client():
+    """The offline compress entrypoint. Imported lazily so the deterministic-only path can
+    still run if Headroom is absent (it is then reported as not installed)."""
     try:
-        out_obj = json.loads(proc.stdout)
-    except json.JSONDecodeError:
+        from headroom import compress
+    except Exception as e:  # noqa: BLE001 - report, don't crash the whole run
+        print(f"headroom not importable: {e}", file=sys.stderr)
         return None
-    before = len(enc.encode(content))
-    after = len(enc.encode(user_content(out_obj)))
-    pct = 100 * (1 - after / before) if before else 0.0
-    return before, after, pct, ms
+    return compress
 
 
-def headroom_savings(enc, content):
-    """Run Headroom if importable → (before, after, pct, ms) on the SAME encoder/span, else None."""
-    try:
-        from headroom import compress  # type: ignore
-    except Exception:
-        return None
-    msgs = [{"role": "user", "content": content}]
-    t = time.perf_counter()
-    out = compress(msgs)
-    ms = (time.perf_counter() - t) * 1000
-    before = len(enc.encode(content))
-    after = len(enc.encode(user_content(out)))
-    pct = 100 * (1 - after / before) if before else 0.0
-    return before, after, pct, ms
+# ── Live output A/B (gpt-oss-20b) ─────────────────────────────────────────────
+def load_api_key():
+    key = os.environ.get("OPENROUTER_API_KEY")
+    if key:
+        return key
+    env = WORKSPACE_ROOT / ".env"
+    if env.exists():
+        for line in env.read_text().splitlines():
+            if line.startswith("OPENROUTER_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    return None
+
+
+def call_model(api_key, messages):
+    payload = json.dumps({
+        "model": MODEL,
+        "messages": messages,
+        "temperature": 0,
+        "max_tokens": 2048,
+        "provider": PROVIDER_ROUTE,
+    }).encode()
+    req = urllib.request.Request(
+        "https://openrouter.ai/api/v1/chat/completions",
+        data=payload,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json",
+                 "HTTP-Referer": "https://github.com/fkiene/llmtrim", "X-Title": "llmtrim-vs-headroom"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=90, context=_SSL_CTX) as r:
+        return json.loads(r.read())
+
+
+def completion_tokens(resp):
+    return (resp.get("usage") or {}).get("completion_tokens")
+
+
+# ── Reporting ─────────────────────────────────────────────────────────────────
+def pct(before, after):
+    return 100.0 * (1 - after / before) if before else 0.0
+
+
+def render(results, live):
+    lines = ["# llmtrim vs Headroom", "",
+             "Both libraries driven through their Python APIs (`llmtrim.compress` and "
+             "`headroom.compress`). Before/after token counts use the **same** `o200k_base` "
+             "encoder over the **same** message-content span. Latency is the median compress "
+             f"time over {results['meta']['repeats']} runs (model load excluded). "
+             f"llmtrim preset: `{results['meta']['preset']}`.", ""]
+
+    for group in ("tool-output", "general"):
+        rows = [r for r in results["cases"] if r["group"] == group]
+        if not rows:
+            continue
+        has_hr = bool(rows[0]["headroom"])
+        lib = sum(r["llmtrim"]["before"] for r in rows)
+        laf = sum(r["llmtrim"]["after"] for r in rows)
+        hib = sum(r["headroom"]["before"] for r in rows) if has_hr else 0
+        haf = sum(r["headroom"]["after"] for r in rows) if has_hr else 0
+        lms = statistics.median([r["llmtrim"]["ms"] for r in rows])
+        hms = statistics.median([r["headroom"]["ms"] for r in rows]) if has_hr else None
+        lines += [f"## {group} (n={len(rows)})", "",
+                  "| tool | input tokens before→after | input saved | median ms |",
+                  "|---|--:|--:|--:|",
+                  f"| **llmtrim** | {lib:,} → {laf:,} | **{pct(lib, laf):.0f}%** | {lms:.1f} |"]
+        if has_hr:
+            lines.append(f"| Headroom | {hib:,} → {haf:,} | {pct(hib, haf):.0f}% | {hms:.1f} |")
+        else:
+            lines.append("| Headroom | (not installed) | n/a | n/a |")
+        lines.append("")
+
+    # llmtrim per-stage (its differentiator), summed over the tool-output group.
+    tool_rows = [r for r in results["cases"] if r["group"] == "tool-output"]
+    if tool_rows:
+        agg = {}
+        for r in tool_rows:
+            for s in r["llmtrim"]["stages"]:
+                a = agg.setdefault(s["name"], {"before": 0, "after": 0, "applied": 0})
+                a["before"] += s["tokens_before"]
+                a["after"] += s["tokens_after"]
+                a["applied"] += 1 if s["applied"] else 0
+        lines += ["## llmtrim per-stage attribution (tool-output group)", "",
+                  "Each stage's own token delta, the breakdown the binding now exposes "
+                  "and Headroom does not.", "",
+                  "| stage | applied | tokens removed |", "|---|--:|--:|"]
+        for name, a in agg.items():
+            lines.append(f"| {name} | {a['applied']}/{len(tool_rows)} | {a['before'] - a['after']:,} |")
+        lines.append("")
+
+    if live:
+        lo = live["llmtrim_output"]
+        bo = live["baseline_output"]
+        lines += ["## Live output A/B (gpt-oss-20b)", "",
+                  f"Original vs llmtrim-compressed request through `{MODEL}` "
+                  f"(n={live['n']}). Headroom is input-only, so it has no output column.", "",
+                  "| arm | output tokens | output saved |", "|---|--:|--:|",
+                  f"| original | {bo:,} | n/a |",
+                  f"| llmtrim | {lo:,} | **{pct(bo, lo):.0f}%** |", ""]
+
+    lines += [
+        "## Method notes", "",
+        "- Latency is the median compress call, with a warm-up first so neither library is "
+        "charged for one-time setup. llmtrim must run on the **release** wheel "
+        "(`build-wheel.sh --release`); the debug build is several times slower and not "
+        "representative.",
+        "- Headroom's `compress` runs a **local ModernBERT encoder** "
+        "(`answerdotai/ModernBERT-base`, the multi-hundred-MB model it downloads on first "
+        "use) for its semantic smart-crusher. It makes no generative LLM API call; verified "
+        "by running compress with all network sockets blocked. llmtrim is purely algorithmic "
+        "(BPE counting plus deterministic stages), which is why its warm latency is lower "
+        "despite removing more tokens.",
+        "- Headroom protects user and system messages, so on the `general` corpora (natural "
+        "request shapes, no tool results) it mostly no-ops; the `tool-output` group is its "
+        "home turf.",
+        "- Output tokens are out of this head-to-head. Headroom is input-only, and llmtrim's "
+        "output shaping is a preset feature (e.g. `aggressive`, `reasoning`) measured in the "
+        "main benchmark on a non-reasoning model. The `--live` arm exists for spot checks, "
+        "but gpt-oss-20b bills hidden reasoning as output, so it is not a fair output "
+        "denominator (see the main bench README).",
+        "",
+    ]
+    return "\n".join(lines)
 
 
 def main():
-    if not LLMTRIM_BIN.exists():
-        print(f"missing {LLMTRIM_BIN} — build it first: cargo build --release")
-        return
-    enc = encoder()
-    rows = []
-    for name, content in gen().items():
-        lt = llmtrim_savings(enc, content)
-        hr = headroom_savings(enc, content)
-        rows.append((name, lt, hr))
-    # Same `before` denominator for both (computed from the identical span/encoder above).
-    print(f"{'content':14} {'tok':>7} {'llmtrim':>14} {'headroom':>14}")
-    for name, lt, hr in rows:
-        before = (lt or hr or (0, 0, 0.0, 0.0))[0]
-        lt_s = f"{lt[2]:.0f}% {lt[3]:.0f}ms" if lt else "(failed)"
-        hr_s = f"{hr[2]:.0f}% {hr[3]:.0f}ms" if hr else "(not installed)"
-        print(f"{name:14} {before:>7} {lt_s:>14} {hr_s:>14}")
-    if not any(r[2] for r in rows):
-        print("\nHeadroom not installed — compare against its published /docs/benchmarks table.")
-    print("\nNote: both columns use o200k_base over the user-content span; llmtrim is the "
-          "prebuilt release binary. Run only verified for syntax here — needs the built binary "
-          "(and optionally headroom) to produce numbers.")
+    ap = argparse.ArgumentParser(description="llmtrim vs Headroom benchmark")
+    ap.add_argument("--preset", default=LLMTRIM_PRESET_DEFAULT)
+    ap.add_argument("--limit", type=int, default=12, help="cases per general corpus")
+    ap.add_argument("--repeats", type=int, default=5, help="latency samples per case (median)")
+    ap.add_argument("--live", action="store_true", help="run the gpt-oss-20b output A/B")
+    ap.add_argument("--live-n", type=int, default=12, help="cases for the live A/B")
+    args = ap.parse_args()
+
+    enc = get_encoder()
+    hr = make_headroom_client()
+    # Warm both libraries on a valid tool-call turn so neither is charged for one-time
+    # setup (Headroom's model load, llmtrim's first-call init) on its first real case.
+    warm = [
+        {"role": "user", "content": "warm-up"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "call_w", "type": "function",
+                         "function": {"name": "fetch", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_w",
+         "content": json.dumps({"results": [{"x": i} for i in range(50)]})},
+    ]
+    llmtrim_compress(warm, args.preset, 1)
+    if hr is not None:
+        try:
+            hr(warm, model=BODY_MODEL)
+        except Exception as e:  # noqa: BLE001
+            print(f"headroom warm-up failed: {e}", file=sys.stderr)
+
+    cases = [("tool-output", n, m) for n, m in synthetic_tool_cases()]
+    cases += [("general", n, m) for n, m in general_cases(args.limit)]
+
+    out_cases = []
+    for group, name, messages in cases:
+        lt_msgs, stages, lt_ms = llmtrim_compress(messages, args.preset, args.repeats)
+        rec = {
+            "group": group, "name": name,
+            "llmtrim": {"before": count(enc, messages), "after": count(enc, lt_msgs),
+                        "ms": lt_ms, "stages": stages},
+            "headroom": None,
+        }
+        if hr is not None:
+            hr_msgs, transforms, hr_ms = headroom_compress(hr, messages, args.repeats)
+            rec["headroom"] = {"before": count(enc, messages), "after": count(enc, hr_msgs),
+                               "ms": hr_ms, "transforms": transforms}
+        out_cases.append(rec)
+        print(f"  {group:11} {name:16} llmtrim {pct(rec['llmtrim']['before'], rec['llmtrim']['after']):4.0f}% "
+              + (f"headroom {pct(rec['headroom']['before'], rec['headroom']['after']):4.0f}%" if rec["headroom"] else "headroom n/a"))
+
+    live = None
+    if args.live:
+        key = load_api_key()
+        if not key:
+            print("ERROR: --live needs OPENROUTER_API_KEY (env or .env)", file=sys.stderr)
+            sys.exit(1)
+
+        bo = lo = 0
+        n = 0
+        for group, name, messages in cases[: args.live_n]:
+            comp_msgs, _, _ = llmtrim_compress(messages, args.preset, 1)
+            base = call_model(key, messages)
+            trim = call_model(key, comp_msgs)
+            bt, lt = completion_tokens(base), completion_tokens(trim)
+            if bt is None or lt is None:
+                print(f"  live skip {name} (no usage)", file=sys.stderr)
+                continue
+            bo += bt
+            lo += lt
+            n += 1
+            print(f"  live {name:16} original {bt:5} → llmtrim {lt:5}")
+            time.sleep(1)
+        live = {"n": n, "baseline_output": bo, "llmtrim_output": lo}
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    results = {
+        "meta": {"model": MODEL, "preset": args.preset, "repeats": args.repeats,
+                 "encoder": "o200k_base", "headroom": hr is not None},
+        "cases": out_cases,
+        "live": live,
+    }
+    (RESULTS_DIR / "results.json").write_text(json.dumps(results, indent=2))
+    report = render(results, live)
+    (RESULTS_DIR / "README.md").write_text(report + "\n")
+    print(f"\nWrote {RESULTS_DIR}/results.json and README.md\n")
+    print(report)
 
 
 if __name__ == "__main__":

--- a/crates/llmtrim-uniffi/src/lib.rs
+++ b/crates/llmtrim-uniffi/src/lib.rs
@@ -29,6 +29,25 @@ impl From<Provider> for ProviderKind {
     }
 }
 
+/// What one pipeline stage did to the request, projected from
+/// [`llmtrim_core::pipeline::StageReport`]. The token counts are over the content the
+/// stage saw, so `tokens_before - tokens_after` is that stage's own contribution to the
+/// total input reduction (mirrors the per-strategy breakdown other compressors report).
+#[derive(uniffi::Record, Debug)]
+pub struct StageReport {
+    /// Stage identifier, e.g. `toolout`, `retrieve`, `dedup`, `output`.
+    pub name: String,
+    /// Whether the stage actually changed the request (a stage can run yet be a no-op, or
+    /// be reverted by the token gate when it would not have saved tokens).
+    pub applied: bool,
+    /// Content tokens the stage saw before running.
+    pub tokens_before: u64,
+    /// Content tokens after the stage ran.
+    pub tokens_after: u64,
+    /// Optional human-readable note (e.g. why a stage was skipped or gated).
+    pub note: Option<String>,
+}
+
 /// The result of compressing one request body.
 #[derive(uniffi::Record, Debug)]
 pub struct CompressOutput {
@@ -51,6 +70,9 @@ pub struct CompressOutput {
     pub frozen_input_tokens: u64,
     /// Whether output-shaping (Stage F) ran on this request.
     pub output_shaped: bool,
+    /// Per-stage breakdown, in pipeline order. Each entry is one stage's own token
+    /// contribution; sum the deltas of applied stages to attribute the total reduction.
+    pub stages: Vec<StageReport>,
 }
 
 /// Errors surfaced to the bound language.
@@ -87,6 +109,17 @@ fn project(r: llmtrim_core::CompressResult) -> CompressOutput {
         input_tokens_after: r.input_tokens_after.0 as u64,
         frozen_input_tokens: r.frozen_input_tokens.0 as u64,
         output_shaped: r.output_shaped,
+        stages: r
+            .stages
+            .into_iter()
+            .map(|s| StageReport {
+                name: s.name,
+                applied: s.applied,
+                tokens_before: s.tokens_before.0 as u64,
+                tokens_after: s.tokens_after.0 as u64,
+                note: s.note,
+            })
+            .collect(),
     }
 }
 
@@ -148,6 +181,14 @@ mod tests {
         assert_eq!(out.provider, "anthropic");
         assert!(out.input_tokens_after <= out.input_tokens_before);
         assert!(!out.request_json.is_empty());
+        // The per-stage breakdown projects through: a tool-output-heavy request under the
+        // `agent` preset runs at least one stage, and at least one of them applies and saves.
+        assert!(!out.stages.is_empty());
+        assert!(
+            out.stages
+                .iter()
+                .any(|s| s.applied && s.tokens_after < s.tokens_before)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Two clean commits:

1. **feat(uniffi): per-stage compression breakdown** — `CompressOutput` now carries a `stages` list (`name`, `applied`, `tokens_before`, `tokens_after`, `note`), so Python/Ruby/Swift/Kotlin embedders can attribute the input-token reduction per stage. CHANGELOG updated.
2. **bench: reproducible llmtrim-vs-Headroom head-to-head** — both compressors driven through their Python libraries on the same inputs and the same `o200k_base` tokenizer.

## Measured result (tool output)

| | llmtrim | Headroom |
|---|--:|--:|
| input tokens removed | **84%** | 36% |
| compress latency | single-digit ms | ~10-15 ms (local ModernBERT) |
| per-stage breakdown | yes | no |

llmtrim removes ~2.3x more and is faster (pure algorithm vs a local model pass). Headroom protects user/system messages, so on general traffic it mostly no-ops while llmtrim still compresses.

## Notes

- `bench/scripts/vs_headroom.py` is lib-to-lib; `--live` runs an optional gpt-oss-20b output A/B. Output is kept out of the headline comparison (Headroom is input-only; gpt-oss-20b bills hidden reasoning as output).
- The request-body `model` (`gpt-4o`) is a tokenizer hint for the local `compress()` calls, not an API call; the live arm calls `openai/gpt-oss-20b` per CLAUDE.md.
- Artifact committed under `crates/llmtrim-cli/bench/results-vs-headroom/`; reproduce with `bench/scripts/vs_headroom.py`.

Reviewed by 3 agents (correctness, simplicity, conventions); their findings are applied.