### PR TITLE
fix(setup): correct the caveman warning's reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **`setup`'s caveman warning no longer claims llmtrim shapes output the same way caveman
+  does.** caveman users run coding agents, which route to the `agent` preset where `auto`
+  deliberately leaves output unshaped, so the old "llmtrim already does this (Stage F)" reason
+  was wrong for exactly the people who saw it. The warning now explains that `auto` already
+  shapes output where it pays (code, long context, plain prose) and skips tool-call traffic
+  because terse shaping saves no tokens on short replies (bench: quality neutral), so caveman
+  is redundant either way.
+
 ## [0.1.10] - 2026-06-14
 
 ### Added

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -440,20 +440,25 @@ pub fn run(requested: Option<u16>) -> Result<()> {
         )
     );
 
-    // caveman (the output-compression skill) shapes replies the same way Stage F does;
-    // stacked, the two inject competing style instructions into the same prompt, and our
-    // A/B measured telegraphic output hurting quality. Warn and print caveman's *own*
-    // uninstall commands — never run them ourselves: removing another tool is the
-    // user's call, not setup's.
+    // caveman (the output-compression skill) shapes model output on every request. llmtrim's
+    // `auto` already shapes output where it pays (code / long context / plain prose), and
+    // deliberately skips it on agent traffic — tool-call replies are already short,
+    // so terse shaping there saves no tokens (bench/README glaive: cost ~-5%, quality +0pp).
+    // So caveman is redundant where output shaping helps and a no-op win where it doesn't.
+    // Warn and print caveman's *own* uninstall commands — never run them ourselves: removing
+    // another tool is the user's call, not setup's.
     if caveman_installed() {
         println!();
         println!(
             "{}",
             ui::warn(
                 color,
-                "caveman detected — it compresses model output, which llmtrim already does \
-                 (Stage F). Stacked, the two inject competing style instructions; our A/B \
-                 measured telegraphic output hurting answer quality. Consider removing it:"
+                "caveman detected. It shapes model output on every request. llmtrim's auto \
+                 mode already shapes output where it pays (code, long context, plain prose) \
+                 and skips it on tool-calling agent traffic on purpose: tool-call replies are \
+                 already short, so terse shaping there saves no tokens (our bench measured \
+                 quality neutral). So caveman adds nothing llmtrim does not already do where \
+                 it helps. To remove it:"
             )
         );
         #[cfg(not(windows))]

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -364,8 +364,9 @@ impl DenseConfig {
                 c.serialize_flatten = true; // dot-flatten nested tool-result JSON
                 c.serialize_buckets = true; // bucket heterogeneous record arrays
                 c.json_crush = true; // sample huge record arrays to representatives
-                // No terse output here: on tool-calling traffic it gave ~no cost benefit
-                // (glaive cost 7%) and a quality dip (100→92 at n=12) — see bench/README.
+                // No terse output here: short tool-call replies leave nothing to trim, so it
+                // gave ~no cost benefit (glaive cost 5%) at neutral quality (n=39 +0.0pp,
+                // CI ±5.2 — the n=12 -8pp was noise; see bench/README).
                 c.multimodal = true; // downscale images to the provider cap (see `rag` note)
                 c.strip_base64 = true; // elide base64 blobs (measured +0.0pp, see `rag` note)
                 // ngram dropped: ~10–106 tok on agent traffic (bench) for an injected


### PR DESCRIPTION
## What

The `setup` caveman warning told users "caveman compresses model output, which llmtrim already does (Stage F)." That reasoning is wrong for the exact users who see it: caveman runs on coding agents, whose requests carry `tools[]` and route to the `agent` preset, where `auto` deliberately leaves output unshaped.

## Why it's correct now

`auto` shapes output where it pays (code, long context, plain prose) and skips tool-call traffic on purpose: tool-call replies are already short, so terse shaping there saves no tokens (bench/README glaive: cost ~-5%, quality +0pp). So caveman is redundant where shaping helps and a no-op win where it doesn't. The warning now says that.

Also fixes the stale `agent`-arm comment in `config.rs` that cited a "100->92 at n=12" quality dip. The bench README records that as noise (+0.0pp at n=39); the dip belongs to the reasoning shape, not agent traffic.

## Notes

The branch name mentions an `auto-terse` preset that was explored and then dropped: `auto` already terses everywhere terseness pays, so a knob to force it onto tool-calls had no value. Only the warning/comment fixes remain.

## Verification

582 tests pass, clippy clean, fmt applied. Prose checked with avoid-ai-writing (main pass + independent subagent reviewer).