### PR TITLE
feat(mcp): add `llmtrim mcp` server over stdio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ All notable changes to this project are documented here. The format follows
   are handled correctly: a right "no answer" scores as a hit. A new `choice` (MC1) scorer
   grades TruthfulQA by the selected option letter, not by any letter the model mentions in
   passing.
+- **`llmtrim mcp` runs an MCP server over stdio.** Any MCP client (Claude Code, Cursor,
+  custom agents) can spawn `llmtrim mcp` and call the engine as tools: `llmtrim_compress`
+  (compress a full request body and report the token deltas, honoring your `~/.llmtrim`
+  config like the proxy and CLI), `llmtrim_compress_text` (shrink a single text blob with
+  the lossless `safe` preset, independent of config), and `llmtrim_stats` (read the savings
+  ledger, the same data `llmtrim status --json` shows). Every call records to the same
+  ledger, so MCP traffic shows up in `llmtrim status`. Behind the `mcp` feature, which ships
+  in the default build. `llmtrim mcp install` registers the server with Claude Code via its
+  `claude mcp add` CLI (idempotent); `llmtrim mcp install --print` emits the config block to
+  paste into any other client.
 
 ### Changed
 - **The benchmark commands are now one `bench` subcommand group.** `llmtrim bench` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1101,6 +1102,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -2124,7 +2131,9 @@ dependencies = [
  "owo-colors",
  "regex",
  "reqwest",
+ "rmcp",
  "rusqlite",
+ "schemars",
  "serde",
  "serde_json",
  "statrs",
@@ -2740,6 +2749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3243,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3310,6 +3345,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -3520,6 +3590,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +3720,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 </p>
 
 <p align="center">
+  <sub>Use it as a <b>proxy</b>, a <b>CLI</b>, an <b>MCP server</b>, or a <b>library</b> (Python · Ruby · Swift · Kotlin).</sub>
+</p>
+
+<p align="center">
   <a href="https://github.com/fkiene/llmtrim/actions/workflows/ci.yml"><img src="https://github.com/fkiene/llmtrim/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License: AGPL v3"></a>
   <a href="https://crates.io/crates/llmtrim"><img src="https://img.shields.io/crates/v/llmtrim" alt="crates.io"></a>
@@ -243,6 +247,23 @@ print(out.input_tokens_before, "->", out.input_tokens_after)
 
 > [!NOTE]
 > Every binding returns the compressed `request_json` plus the before/after token counts, and maps errors to native exceptions. Per-language install and usage live in [`crates/llmtrim-uniffi`](crates/llmtrim-uniffi).
+
+**MCP server.** `llmtrim mcp` speaks the [Model Context Protocol](https://modelcontextprotocol.io) over stdin/stdout, so any MCP client can compress payloads and read your savings without the proxy. It exposes three tools: `llmtrim_compress` (compress a full request body, honoring your `~/.llmtrim` config like the proxy), `llmtrim_compress_text` (shrink one text blob, lossless), and `llmtrim_stats` (your savings ledger). Every call records to the same ledger, so MCP traffic shows up in `llmtrim status`.
+
+```bash
+llmtrim mcp install          # register with Claude Code (one command)
+llmtrim mcp install --print  # or print the config to paste into any other client
+```
+
+The printed block is the standard MCP config; for a client you edit by hand it looks like:
+
+```json
+{
+  "mcpServers": {
+    "llmtrim": { "command": "llmtrim", "args": ["mcp"] }
+  }
+}
+```
 
 ## Works with
 

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -72,6 +72,16 @@ llm_providers = { version = "0.14", optional = true }
 # whose new blanket impl collides with rcgen 0.14's `impl<T: Into<String>> From<T>`
 # (E0119), breaking un-`--locked` `cargo install`. Drop when rcgen ships a fix.
 time = { version = ">=0.3.36, <0.3.48", default-features = false, optional = true }
+# MCP server over stdio (`mcp`). rmcp is the official Model Context Protocol Rust SDK;
+# `transport-io` is the stdio transport, `macros` derives each tool's JSON Schema.
+rmcp = { version = "1.7", default-features = false, features = ["server", "macros", "transport-io"], optional = true }
+schemars = { version = "1", optional = true }
+
+# The protocol-level MCP test (`tests/mcp_protocol.rs`, gated on the `mcp` feature) drives
+# the server through an in-memory client, which needs rmcp's `client` side. Dev-only —
+# the shipped binary keeps just the server features above.
+[dev-dependencies]
+rmcp = { version = "1.7", default-features = false, features = ["client", "transport-io"] }
 
 [target.'cfg(not(windows))'.dependencies]
 auto-launch = "0.6.0"
@@ -80,9 +90,14 @@ auto-launch = "0.6.0"
 winreg = "0.56"
 
 [features]
-default = ["intercept"]
+# `mcp` is in `default` (like `intercept`) because the release binaries are built with
+# default features only; the whole point of `llmtrim mcp` is that MCP clients can spawn the
+# shipped binary, so it must carry the command. Cost is rmcp + schemars (modest next to the
+# hudsucker/tokio stack intercept already pulls).
+default = ["intercept", "mcp"]
 live = ["dep:async-openai", "dep:reqwest", "dep:tokio"]
 intercept = ["dep:hudsucker", "dep:tokio", "dep:async-trait", "dep:http-body-util", "dep:bytes", "dep:llm_providers", "dep:time"]
+mcp = ["dep:rmcp", "dep:schemars", "dep:tokio"]
 
 [lints]
 workspace = true

--- a/crates/llmtrim-cli/README.md
+++ b/crates/llmtrim-cli/README.md
@@ -44,6 +44,8 @@ echo '{"model":"gpt-4o","messages":[...]}' | llmtrim send     --provider openai 
 
 **Zero config needed.** The default `auto` mode inspects each request and picks the right compressors for its shape (tool-heavy → `agent`, code → `code`, long context → `rag`, else `aggressive`). Force one with `LLMTRIM_PRESET=<name>`.
 
+Or expose the engine to an MCP client. `llmtrim mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io) server over stdin/stdout with three tools, `llmtrim_compress`, `llmtrim_compress_text`, and `llmtrim_stats`, recording to the same savings ledger as the proxy. Run `llmtrim mcp install` to register it with Claude Code, or `llmtrim mcp install --print` to get the config for any other client.
+
 ## As a library
 
 The compression engine is the [`llmtrim-core`](https://crates.io/crates/llmtrim-core) crate (no network, no async), with native bindings for **Python, Ruby, Swift and Kotlin** (see the [project README](https://github.com/fkiene/llmtrim)).

--- a/crates/llmtrim-cli/src/lib.rs
+++ b/crates/llmtrim-cli/src/lib.rs
@@ -10,6 +10,7 @@ pub mod autostart;
 pub mod bench;
 pub mod daemon;
 pub mod doctor;
+pub mod mcp;
 pub mod monitor;
 pub mod quality;
 pub mod serve;

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -199,6 +199,17 @@ enum Commands {
         #[arg(long, short, conflicts_with_all = ["watch", "daily", "weekly", "monthly", "json", "csv"])]
         quiet: bool,
     },
+    /// Run an MCP server over stdio (or `mcp install` to register it with a client)
+    ///
+    /// Exposes llmtrim's compression and savings stats as Model Context Protocol
+    /// tools, so any MCP client (Claude Code, Cursor, custom agents) can compress a
+    /// request and read the ledger directly. Speaks JSON-RPC over stdin/stdout — point
+    /// a client at `command: llmtrim, args: ["mcp"]`. Honors your ~/.llmtrim config like
+    /// the proxy and CLI do. Run `llmtrim mcp install` to register it for you.
+    Mcp {
+        #[command(subcommand)]
+        action: Option<McpAction>,
+    },
     /// Check the install end-to-end and explain anything broken
     ///
     /// Read-only diagnosis: binary, daemon, port, env wiring (persisted + this shell),
@@ -278,6 +289,22 @@ enum BenchCmd {
     Latency(LatencyArgs),
     /// Head-to-head vs a third-party compressor (Python comparators).
     Compare(CompareArgs),
+}
+
+#[derive(Subcommand)]
+enum McpAction {
+    /// Register the llmtrim MCP server with your MCP client
+    ///
+    /// Installs it into Claude Code via its `claude mcp add` CLI (idempotent — re-running
+    /// is a no-op). For any other client, `--print` emits the config block to paste.
+    Install {
+        /// Print the client config JSON instead of installing it.
+        #[arg(long)]
+        print: bool,
+        /// Overwrite an existing `llmtrim` server entry that differs.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(clap::Args)]
@@ -588,6 +615,10 @@ fn run() -> Result<()> {
             ),
         },
         Commands::Update => llmtrim::update::run()?,
+        Commands::Mcp { action } => match action {
+            None => llmtrim::mcp::run()?,
+            Some(McpAction::Install { print, force }) => llmtrim::mcp::install(print, force)?,
+        },
         Commands::Monitor {
             watch,
             interval,
@@ -1565,68 +1596,10 @@ fn daemon_view(summary: &llmtrim::tracking::Summary) -> monitor::DaemonView {
     }
 }
 
-fn monitor_cost(tracker: &Tracker) -> Option<monitor::Cost> {
-    let models = tracker.by_model().ok()?;
-    cost_estimate(&models)
-}
-
-/// Per-model rows for the breakdown, top 8 by request volume, priced where the registry
-/// knows the model.
-fn model_views(tracker: &Tracker) -> Result<Vec<monitor::ModelView>> {
-    let mut models: Vec<monitor::ModelView> = tracker
-        .by_model()?
-        .into_iter()
-        .filter(|m| m.events > 0)
-        .map(|m| {
-            // Per-model USD figures where the registry prices the model — used to project the
-            // round-trip the same way the hero does.
-            let priced = m.model.as_deref().and_then(llm_prices);
-            // Frozen-zone meter, per model: the saving over the compressible surface
-            // (metered rows only). `None` until traffic recorded the meter.
-            let new_before = m.metered_input_before - m.frozen_input_tokens;
-            let new_pct = (m.frozen_input_tokens > 0 && new_before > 0).then(|| {
-                ui::saved_pct(
-                    new_before as f64,
-                    (m.metered_input_after - m.frozen_input_tokens) as f64,
-                )
-            });
-            let cost_saved = priced
-                .map(|(inp, _)| (m.input_before - m.input_after).max(0) as f64 / 1_000_000.0 * inp);
-            let out_spend = priced.map(|(_, outp)| m.output_after as f64 / 1_000_000.0 * outp);
-            let spend = priced.map(|(inp, outp)| {
-                m.input_after as f64 / 1_000_000.0 * inp
-                    + m.output_after as f64 / 1_000_000.0 * outp
-            });
-            monitor::ModelView {
-                name: m
-                    .model
-                    .unwrap_or_else(|| format!("{} · unknown model", m.provider)),
-                events: m.events,
-                saved_pct: ui::saved_pct(m.input_before as f64, m.input_after as f64),
-                cost_saved,
-                spend,
-                out_spend,
-                cached: m.cache_read > 0,
-                new_pct,
-            }
-        })
-        .collect();
-    models.sort_unstable_by_key(|b| std::cmp::Reverse(b.events));
-    models.truncate(8);
-    Ok(models)
-}
-
-/// Today's priced saving (UTC), for the hero's recency anchor. `None` when nothing
-/// priced ran today — the dashboard hides the figure rather than showing $0.00.
-fn today_saved_usd(tracker: &Tracker) -> Option<f64> {
-    let models = tracker.by_model_today().ok()?;
-    cost_estimate(&models).map(|c| c.saved)
-}
-
 fn render_snapshot(tracker: &Tracker, color: bool) -> Result<(String, monitor::Health)> {
     let summary = tracker.summary()?;
-    let models = model_views(tracker)?;
-    let cost = monitor_cost(tracker);
+    let models = monitor::model_views(tracker)?;
+    let cost = monitor::monitor_cost(tracker);
     let daemon = daemon_view(&summary);
     let health = monitor::health(&daemon);
     let mut out = monitor::snapshot(
@@ -1635,7 +1608,7 @@ fn render_snapshot(tracker: &Tracker, color: bool) -> Result<(String, monitor::H
         &summary,
         &models,
         cost.as_ref(),
-        today_saved_usd(tracker),
+        monitor::today_saved_usd(tracker),
     );
     // Passive, cached (≤24h), opt-out update notice (LLMTRIM_NO_UPDATE_CHECK to disable).
     if let Some(v) = llmtrim::update::check(false) {
@@ -1756,14 +1729,14 @@ fn run_monitor(
             print!("{}", monitor::export_csv(&rows));
         } else if json {
             let s = tracker.summary()?;
-            let models = model_views(&tracker)?;
+            let models = monitor::model_views(&tracker)?;
             let daemon = daemon_view(&s);
             println!(
                 "{}",
                 monitor::export_json(
                     &s,
                     &models,
-                    monitor_cost(&tracker).as_ref(),
+                    monitor::monitor_cost(&tracker).as_ref(),
                     &rows,
                     Some(&daemon)
                 )
@@ -1779,23 +1752,12 @@ fn run_monitor(
 
     // Whole-snapshot export (no period selected).
     if json || csv {
-        let rows = tracker.by_period(Period::Day)?;
         if csv {
+            let rows = tracker.by_period(Period::Day)?;
             print!("{}", monitor::export_csv(&rows));
         } else {
-            let s = tracker.summary()?;
-            let models = model_views(&tracker)?;
-            let daemon = daemon_view(&s);
-            println!(
-                "{}",
-                monitor::export_json(
-                    &s,
-                    &models,
-                    monitor_cost(&tracker).as_ref(),
-                    &rows,
-                    Some(&daemon)
-                )
-            );
+            let daemon = daemon_view(&tracker.summary()?);
+            println!("{}", monitor::stats_json(&tracker, Some(&daemon))?);
         }
         return Ok(());
     }
@@ -1821,111 +1783,6 @@ fn run_monitor(
 /// prompt tokens at 50% (no write surcharge); Gemini implicit caching discounts cached
 /// tokens 75%. Unknown providers assume no discount, which collapses the net figure to
 /// the list-rate one instead of inventing a discount.
-fn cache_multipliers(provider: &str) -> (f64, f64) {
-    match provider {
-        "anthropic" => (0.10, 1.25),
-        "openai" => (0.50, 0.0),
-        "google" => (0.25, 0.0),
-        _ => (1.0, 0.0),
-    }
-}
-
-/// USD cost figures priced per model via [`llm_prices`], `None` when no recorded model
-/// is priced.
-///
-/// - `saved`/`spend` value tokens at **list input rates** (tokens cut × input price; the
-///   compressed input_after + measured output). Consistent numerator/denominator — the
-///   headline basis.
-/// - `net_saved` re-prices the same measured saving against the **real bill**: the
-///   provider-reported usage split (fresh × 1.0 + cache writes × 1.25 + cache reads ×
-///   0.1, per provider) gives the actual input bill, and the counterfactual bill scales
-///   it by the measured compression ratio (same cache mix, prompt larger by `pct`):
-///   `net_saved = net_bill × pct / (1 − pct)`. On traffic with no cache usage this
-///   degrades exactly to the list-rate figure.
-/// - `out_spend_shaped` is the output spend from requests that actually carried the
-///   output-shaping instruction — the only spend the benchmark factor may be projected on.
-fn cost_estimate(models: &[llmtrim::tracking::ModelRow]) -> Option<monitor::Cost> {
-    let mut cost = monitor::Cost {
-        saved: 0.0,
-        spend: 0.0,
-        out_spend: 0.0,
-        net_saved: 0.0,
-        out_spend_shaped: 0.0,
-        live_saved: 0.0,
-    };
-    let mut matched = false;
-    for m in models {
-        let Some(model_id) = m.model.as_deref() else {
-            continue;
-        };
-        if let Some((input_price, output_price)) = llm_prices(model_id) {
-            let delta = (m.input_before - m.input_after).max(0) as f64;
-            cost.saved += delta / 1_000_000.0 * input_price;
-            let out = m.output_after as f64 / 1_000_000.0 * output_price;
-            cost.spend += m.input_after as f64 / 1_000_000.0 * input_price + out;
-            cost.out_spend += out;
-            cost.out_spend_shaped += m.output_after_shaped as f64 / 1_000_000.0 * output_price;
-
-            let (read_mult, write_mult) = cache_multipliers(&m.provider);
-            let net_bill = (m.fresh_input_est as f64
-                + m.cache_write as f64 * write_mult
-                + m.cache_read as f64 * read_mult)
-                / 1_000_000.0
-                * input_price;
-            let pct = if m.input_before > 0 {
-                (delta / m.input_before as f64).min(0.95)
-            } else {
-                0.0
-            };
-            cost.net_saved += net_bill * pct / (1.0 - pct);
-            // Live-zone attribution: the cut happens in the compressible zone, billed as
-            // fresh (1×) + cache writes (1.25× on Anthropic) — never at the ~10% read rate
-            // the net blend assumes — so price the cut at that mix. No usage split recorded
-            // → rate 1.0, degrading to the list figure.
-            let live_used = m.fresh_input_est + m.cache_write;
-            let live_rate = if live_used > 0 {
-                (m.fresh_input_est as f64 + m.cache_write as f64 * write_mult.max(1.0))
-                    / live_used as f64
-            } else {
-                1.0
-            };
-            cost.live_saved += delta / 1_000_000.0 * input_price * live_rate;
-            matched = true;
-        }
-    }
-    matched.then_some(cost)
-}
-
-/// Per-1M-token `(input, output)` price for a model: the `llm_providers` registry first,
-/// matched across every provider (the ledger records the wire-shape provider, not the
-/// upstream brand), then the embedded models.dev snapshot for models the registry hasn't
-/// shipped yet (e.g. day-one releases like claude-fable-5 on 0.14.3).
-fn llm_prices(model_id: &str) -> Option<(f64, f64)> {
-    #[cfg(feature = "intercept")]
-    for &provider_id in llm_providers::get_providers_data().keys() {
-        if let Some(model) = llm_providers::get_model_ref(provider_id, model_id) {
-            return Some((model.input_price, model.output_price));
-        }
-    }
-    snapshot_prices(model_id)
-}
-
-/// Fallback table: the pinned models.dev snapshot the bench prices from, embedded at
-/// compile time (the package re-includes bench/pricing.json for this). Exact id first,
-/// then with the `provider/` prefix stripped, mirroring [`bench::resolve_pricing`] — but
-/// zero-priced rows (free tiers, parse gaps) return `None` so an unknown model shows a
-/// blank cost cell rather than a misleading $0.00.
-fn snapshot_prices(model_id: &str) -> Option<(f64, f64)> {
-    static TABLE: once_cell::sync::Lazy<bench::PriceTable> =
-        once_cell::sync::Lazy::new(|| bench::load_pricing(include_str!("../bench/pricing.json")));
-    let p = TABLE.get(model_id).or_else(|| {
-        let (_, bare) = model_id.split_once('/')?;
-        TABLE.get(bare)
-    })?;
-    let (input, output) = (p.input_per_1k * 1000.0, p.output_per_1k * 1000.0);
-    (input > 0.0 || output > 0.0).then_some((input, output))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/llmtrim-cli/src/mcp.rs
+++ b/crates/llmtrim-cli/src/mcp.rs
@@ -1,0 +1,749 @@
+//! `mcp` — Model Context Protocol server over stdio.
+//!
+//! A fourth way to reach the engine, next to the proxy, the CLI, and the language
+//! bindings: any MCP client (Claude Code, Cursor, custom agents) spawns `llmtrim mcp`
+//! and calls llmtrim's compression and savings stats as MCP tools. The transport is
+//! JSON-RPC 2.0 over stdin/stdout — the form clients spawn by default.
+//!
+//! Like [`crate::serve`], the real implementation is feature-gated (`mcp`); a build
+//! without it keeps the `mcp` subcommand but bails with a clear rebuild hint.
+
+#[cfg(not(feature = "mcp"))]
+pub fn run() -> anyhow::Result<()> {
+    anyhow::bail!("this build has no MCP server; rebuild with `--features mcp`")
+}
+
+#[cfg(not(feature = "mcp"))]
+pub fn install(_print: bool, _force: bool) -> anyhow::Result<()> {
+    anyhow::bail!("this build has no MCP server; rebuild with `--features mcp`")
+}
+
+#[cfg(feature = "mcp")]
+pub use imp::{install, run};
+
+/// The MCP handler the `mcp` command serves, for protocol-level tests that drive it over
+/// an in-memory transport instead of stdio. `db` is an isolated ledger path so the test
+/// never writes to the user's real savings DB. Not a stable API: it exists only for the
+/// `tests/mcp_protocol.rs` integration test (which can't reach the private `mod imp`).
+#[doc(hidden)]
+#[cfg(feature = "mcp")]
+pub fn test_server(db: std::path::PathBuf) -> impl rmcp::ServerHandler + Clone {
+    imp::server_at(db)
+}
+
+#[cfg(feature = "mcp")]
+mod imp {
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use anyhow::{Context, Result};
+    use rmcp::handler::server::wrapper::Parameters;
+    use rmcp::model::{CallToolResult, Content};
+    use rmcp::{
+        ErrorData as McpError, ServerHandler, ServiceExt, schemars, tool, tool_handler,
+        tool_router, transport::stdio,
+    };
+    use serde::Deserialize;
+    use serde_json::{Value, json};
+
+    use crate::tracking::{Record, Tracker};
+    use llmtrim_core::CompressResult;
+    use llmtrim_core::config::DenseConfig;
+    use llmtrim_core::ir::ProviderKind;
+    use llmtrim_core::tokenizer;
+
+    /// The model `llmtrim_compress_text` wraps a blob under. Arbitrary (the request is
+    /// synthetic and never sent); it only selects the tokenizer for the reported counts.
+    const TEXT_WRAP_MODEL: &str = "gpt-4o";
+
+    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    struct CompressArgs {
+        /// The provider request body (OpenAI, Anthropic, or Google shape). Accepts either the
+        /// JSON object itself or a JSON string of it; the whole body is compressed and
+        /// returned in the same shape.
+        request: RequestArg,
+        /// Provider hint: `openai`, `anthropic`, or `google`. Leave unset to detect it
+        /// from the request shape.
+        #[serde(default)]
+        provider: Option<String>,
+    }
+
+    /// A request body passed as either a JSON object (the natural form an agent emits) or a
+    /// JSON string of one. Both reduce to the string the engine takes.
+    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    #[serde(untagged)]
+    enum RequestArg {
+        Text(String),
+        Json(serde_json::Map<String, Value>),
+    }
+
+    impl RequestArg {
+        fn into_body(self) -> String {
+            match self {
+                RequestArg::Text(s) => s,
+                RequestArg::Json(map) => Value::Object(map).to_string(),
+            }
+        }
+    }
+
+    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    struct CompressTextArgs {
+        /// A single text blob to shrink (a tool output, a document, a message). It is
+        /// wrapped in a one-message request, compressed, and the shrunk text is returned.
+        text: String,
+    }
+
+    // `llmtrim_stats` takes no parameters, but the `#[tool]` macro still wants a typed args
+    // struct, so this is an empty one (the advertised input schema is `{}`).
+    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    struct StatsArgs {}
+
+    /// The MCP handler. `db` selects the ledger: `None` is the real one (`Tracker::open`,
+    /// honoring `LLMTRIM_DB_PATH`/XDG like every other front-end); `Some(path)` is an
+    /// isolated ledger for tests, so the protocol test never writes to the user's real DB.
+    #[derive(Clone)]
+    pub(super) struct LlmtrimServer {
+        db: Option<PathBuf>,
+    }
+
+    pub(super) fn server() -> LlmtrimServer {
+        LlmtrimServer { db: None }
+    }
+
+    pub(super) fn server_at(db: PathBuf) -> LlmtrimServer {
+        LlmtrimServer { db: Some(db) }
+    }
+
+    impl LlmtrimServer {
+        fn tracker(&self) -> Result<Tracker> {
+            match &self.db {
+                Some(p) => Tracker::open_at(p),
+                None => Tracker::open(),
+            }
+        }
+
+        /// Record a savings row best-effort: a ledger failure must never fail the tool call.
+        fn record(&self, r: &Record) {
+            if let Ok(tracker) = self.tracker() {
+                let _ = tracker.record(r);
+            }
+        }
+    }
+
+    #[tool_router]
+    impl LlmtrimServer {
+        #[tool(
+            description = "Compress an LLM request body and report the token savings. Pass the raw request JSON; get back the compressed request in the same shape plus before/after token counts and the per-stage breakdown."
+        )]
+        fn llmtrim_compress(
+            &self,
+            Parameters(args): Parameters<CompressArgs>,
+        ) -> Result<CallToolResult, McpError> {
+            let result = compress(&args.request.into_body(), args.provider.as_deref())?;
+            self.record(&ledger_record(&result));
+            ok_json(&compress_payload(&result))
+        }
+
+        #[tool(
+            description = "Compress a single text blob and report the token savings. Use this to shrink one chunk (a tool output, a document) rather than a whole request. The text is wrapped in a minimal request, compressed, and the shrunk text is returned."
+        )]
+        fn llmtrim_compress_text(
+            &self,
+            Parameters(args): Parameters<CompressTextArgs>,
+        ) -> Result<CallToolResult, McpError> {
+            let (payload, record) = compress_text(&args.text)?;
+            self.record(&record);
+            ok_json(&payload)
+        }
+
+        #[tool(
+            description = "Report recent savings from the local ledger: tokens trimmed, dollars saved, and a per-model breakdown. The same data the `llmtrim status --json` dashboard shows."
+        )]
+        fn llmtrim_stats(
+            &self,
+            Parameters(_args): Parameters<StatsArgs>,
+        ) -> Result<CallToolResult, McpError> {
+            let tracker = self.tracker().map_err(internal)?;
+            let stats = crate::monitor::stats_json(&tracker, None).map_err(internal)?;
+            Ok(CallToolResult::success(vec![Content::text(stats)]))
+        }
+    }
+
+    #[tool_handler(
+        name = "llmtrim",
+        instructions = "llmtrim compresses LLM request payloads with no extra model calls. Use llmtrim_compress for a full request body, llmtrim_compress_text for a single text blob, and llmtrim_stats to read the savings ledger."
+    )]
+    impl ServerHandler for LlmtrimServer {}
+
+    /// Run the engine once, honoring `~/.llmtrim` config like the proxy and CLI. Pure: the
+    /// caller records the savings. A bad provider hint or malformed request comes back as a
+    /// JSON-RPC error, never a panic.
+    fn compress(request: &str, provider: Option<&str>) -> Result<CompressResult, McpError> {
+        let kind = provider
+            .map(ProviderKind::from_str)
+            .transpose()
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let config = DenseConfig::load().map_err(internal)?;
+        llmtrim_core::compress_with_config(request, kind, &config)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))
+    }
+
+    /// Ledger row for a `compress_text` blob: the content saving with no model attribution,
+    /// since no model call happened. Matches the proxy/CLI schema (the unknown fields are
+    /// `None`, exactly as the one-shot `compress` path leaves them).
+    fn text_ledger_record(tokenizer: &str, exact: bool, before: usize, after: usize) -> Record {
+        Record {
+            provider: ProviderKind::OpenAi.as_str().to_string(),
+            model: None,
+            tokenizer: tokenizer.to_string(),
+            exact,
+            input_before: before as i64,
+            input_after: after as i64,
+            output_before: None,
+            output_after: None,
+            compress_micros: None,
+            cache_read_tokens: None,
+            fresh_input_tokens: None,
+            cache_write_tokens: None,
+            output_shaped: Some(false),
+            frozen_input_tokens: Some(0),
+        }
+    }
+
+    fn compress_payload(result: &CompressResult) -> Value {
+        let stages: Vec<Value> = result
+            .stages
+            .iter()
+            .map(|s| {
+                json!({
+                    "name": s.name,
+                    "applied": s.applied,
+                    "tokens_before": s.tokens_before.0,
+                    "tokens_after": s.tokens_after.0,
+                    "note": s.note,
+                })
+            })
+            .collect();
+        json!({
+            "request_json": result.request_json,
+            "provider": result.provider.as_str(),
+            "model": result.model,
+            "tokenizer_label": result.tokenizer_label,
+            "tokenizer_exact": result.tokenizer_exact,
+            "input_tokens_before": result.input_tokens_before.0,
+            "input_tokens_after": result.input_tokens_after.0,
+            // Signed: `output_control` (Stage F) can add a terse-output instruction that grows
+            // the input to buy a larger output saving, so this goes negative on small requests.
+            // `output_shaped` below says when that tradeoff is in play.
+            "tokens_saved": result.input_tokens_before.0 as i64 - result.input_tokens_after.0 as i64,
+            "frozen_input_tokens": result.frozen_input_tokens.0,
+            "output_shaped": result.output_shaped,
+            "stages": stages,
+        })
+    }
+
+    /// Shrink a single text blob. The blob is wrapped in a one-message OpenAI request only so
+    /// the engine has something to operate on; we then run a **content-only** config (the
+    /// lossless `safe` preset) so the request-envelope stages never fire: `output_control`
+    /// would inject an instruction meant for a model answering a prompt, and `cache` a
+    /// `prompt_cache_key` for an API call — neither applies to a bare blob, and the caller
+    /// only gets the text back. The reported token counts are of the text itself (in vs out),
+    /// not the synthetic wrapper, so the numbers describe exactly what's returned. Pure: the
+    /// caller records the returned `Record`.
+    fn compress_text(text: &str) -> Result<(Value, Record), McpError> {
+        let body = json!({
+            "model": TEXT_WRAP_MODEL,
+            "messages": [{ "role": "user", "content": text }],
+        })
+        .to_string();
+        let config = DenseConfig::preset("safe").expect("built-in preset");
+        let result = llmtrim_core::compress_with_config(&body, Some(ProviderKind::OpenAi), &config)
+            .map_err(internal)?;
+        let out = user_content(&result.request_json);
+
+        let counter = tokenizer::counter_for(ProviderKind::OpenAi, Some(TEXT_WRAP_MODEL))
+            .map_err(internal)?;
+        let before = counter.count(text);
+        let after = counter.count(&out);
+
+        let record = text_ledger_record(counter.label(), counter.is_exact(), before, after);
+        let payload = json!({
+            "text": out,
+            "input_tokens_before": before,
+            "input_tokens_after": after,
+            "tokens_saved": before as i64 - after as i64,
+        });
+        Ok((payload, record))
+    }
+
+    /// Mirror the ledger row the CLI `compress` path writes, so MCP-driven traffic shows
+    /// up in `llmtrim status`/monitor identically — output/cache/timing fields are unknown
+    /// here (no upstream round-trip), exactly as in the one-shot CLI.
+    fn ledger_record(result: &CompressResult) -> Record {
+        Record {
+            provider: result.provider.as_str().to_string(),
+            model: result.model.clone(),
+            tokenizer: result.tokenizer_label.clone(),
+            exact: result.tokenizer_exact,
+            input_before: result.input_tokens_before.0 as i64,
+            input_after: result.input_tokens_after.0 as i64,
+            output_before: None,
+            output_after: None,
+            compress_micros: None,
+            cache_read_tokens: None,
+            fresh_input_tokens: None,
+            cache_write_tokens: None,
+            output_shaped: Some(result.output_shaped),
+            frozen_input_tokens: Some(result.frozen_input_tokens.0 as i64),
+        }
+    }
+
+    /// Pull the first user message's text back out of a compressed request, for
+    /// `llmtrim_compress_text`. Content may be a plain string or an array of typed blocks
+    /// (any provider, any language); concatenate the text parts. Falls back to the whole
+    /// compressed JSON if the shape is unexpected.
+    fn user_content(request_json: &str) -> String {
+        let parsed: Value = match serde_json::from_str(request_json) {
+            Ok(v) => v,
+            Err(_) => return request_json.to_string(),
+        };
+        let Some(msg) = parsed
+            .get("messages")
+            .and_then(Value::as_array)
+            .and_then(|m| {
+                m.iter()
+                    .find(|m| m.get("role").and_then(Value::as_str) == Some("user"))
+            })
+        else {
+            return request_json.to_string();
+        };
+        match msg.get("content") {
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Array(blocks)) => {
+                let text: Vec<&str> = blocks
+                    .iter()
+                    .filter_map(|b| b.get("text").and_then(Value::as_str))
+                    .collect();
+                if text.is_empty() {
+                    request_json.to_string()
+                } else {
+                    text.join("")
+                }
+            }
+            _ => request_json.to_string(),
+        }
+    }
+
+    fn ok_json(payload: &Value) -> Result<CallToolResult, McpError> {
+        Ok(CallToolResult::success(vec![Content::text(
+            payload.to_string(),
+        )]))
+    }
+
+    fn internal(e: anyhow::Error) -> McpError {
+        McpError::internal_error(e.to_string(), None)
+    }
+
+    /// Serve the MCP protocol over stdio until the client disconnects. The async runtime
+    /// stays confined here so the command dispatch in `main.rs` stays synchronous, like the
+    /// proxy's `serve`. A single stdio client needs no parallelism, so this uses a
+    /// current-thread runtime (the proxy, fielding many connections, uses multi-thread).
+    pub fn run() -> Result<()> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("failed to start the MCP runtime")?;
+        rt.block_on(async {
+            let service = server()
+                .serve(stdio())
+                .await
+                .context("failed to start the MCP server")?;
+            service.waiting().await.context("MCP server error")?;
+            Ok(())
+        })
+    }
+
+    // ── `llmtrim mcp install`: register the server with a client ────────────────────────
+
+    /// The MCP-client config block for the llmtrim server, for clients configured by hand
+    /// (Cursor, custom agents). The server is launched as `llmtrim mcp`.
+    fn client_config_json() -> String {
+        serde_json::to_string_pretty(&json!({
+            "mcpServers": { "llmtrim": { "command": "llmtrim", "args": ["mcp"] } }
+        }))
+        .expect("static JSON serializes")
+    }
+
+    /// The `claude` CLI argv that registers the server at user scope. Kept separate so it can
+    /// be asserted in tests without spawning the real CLI.
+    fn claude_add_args() -> Vec<&'static str> {
+        vec![
+            "mcp", "add", "llmtrim", "-s", "user", "--", "llmtrim", "mcp",
+        ]
+    }
+
+    /// Run a `claude` subcommand. `Ok(None)` means the CLI isn't installed (spawn failed with
+    /// not-found); `Ok(Some(status))` carries its exit status.
+    /// Run a `claude` subcommand. `Ok(None)` means the CLI isn't installed (spawn failed with
+    /// not-found); `Ok(Some(success))` is whether it exited zero. This is the only real-IO
+    /// part of install; the orchestration in [`install_with`] takes it as a parameter so it
+    /// can be tested without spawning a process or touching the user's Claude config.
+    fn run_claude(args: &[&str]) -> Result<Option<bool>> {
+        use std::process::Command;
+        match Command::new("claude").args(args).output() {
+            Ok(out) => Ok(Some(out.status.success())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e).context("failed to run the `claude` CLI"),
+        }
+    }
+
+    /// Register the llmtrim MCP server with the user's client. Today that means Claude Code
+    /// via its own `claude mcp add` CLI (which owns the config file, so we don't hand-edit
+    /// it); idempotent, with `--force` to reinstall a stale entry. Any other client is served
+    /// the config block to paste. `--print` skips all writes and just emits that block.
+    pub fn install(print: bool, force: bool) -> Result<()> {
+        install_with(print, force, run_claude)
+    }
+
+    /// `install` with the `claude` runner injected (see [`run_claude`]).
+    fn install_with(
+        print: bool,
+        force: bool,
+        run: impl Fn(&[&str]) -> Result<Option<bool>>,
+    ) -> Result<()> {
+        if print {
+            println!("{}", client_config_json());
+            return Ok(());
+        }
+
+        // `claude mcp get` exits non-zero when the server is absent; `None` means no CLI on
+        // PATH, so fall back to the paste-this-config path.
+        let present = match run(&["mcp", "get", "llmtrim"])? {
+            None => {
+                eprintln!(
+                    "No `claude` CLI found on PATH. Paste this into your MCP client's config:\n"
+                );
+                println!("{}", client_config_json());
+                return Ok(());
+            }
+            Some(found) => found,
+        };
+
+        if present && !force {
+            println!(
+                "llmtrim is already registered with Claude Code (`llmtrim mcp install --force` to reinstall)."
+            );
+            return Ok(());
+        }
+        if present && force {
+            let _ = run(&["mcp", "remove", "llmtrim", "-s", "user"])?;
+        }
+
+        match run(&claude_add_args())? {
+            Some(true) => {
+                println!(
+                    "Registered llmtrim with Claude Code (user scope). Restart the client to pick it up."
+                );
+                Ok(())
+            }
+            Some(false) => anyhow::bail!("`claude mcp add` failed"),
+            None => anyhow::bail!("the `claude` CLI vanished between checks"),
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn req() -> String {
+            json!({
+                "model": "gpt-4o",
+                "messages": [
+                    { "role": "system", "content": "You are a helpful assistant.   " },
+                    { "role": "user", "content": "Hello   world\n\n\nthis  has   redundant     whitespace." }
+                ]
+            })
+            .to_string()
+        }
+
+        #[test]
+        fn compress_maps_result_to_payload() {
+            let result = llmtrim_core::compress_with_config(&req(), None, &DenseConfig::default())
+                .expect("compress should succeed on a valid request");
+            let payload = compress_payload(&result);
+
+            // Every documented field is present and correctly typed.
+            assert!(payload["request_json"].is_string());
+            assert_eq!(payload["provider"], "openai");
+            assert_eq!(payload["model"], "gpt-4o");
+            assert!(payload["tokenizer_label"].is_string());
+            assert!(payload["tokenizer_exact"].as_bool().unwrap());
+            assert!(payload["frozen_input_tokens"].as_u64().is_some());
+            assert_eq!(payload["output_shaped"], false); // default config shapes nothing
+            let before = payload["input_tokens_before"].as_u64().unwrap();
+            let after = payload["input_tokens_after"].as_u64().unwrap();
+            assert!(before > 0);
+            assert!(after <= before);
+            assert_eq!(
+                payload["tokens_saved"].as_i64().unwrap(),
+                before as i64 - after as i64
+            );
+            // Per-stage report carries name + before/after for each stage.
+            let stages = payload["stages"].as_array().expect("stages array");
+            assert!(!stages.is_empty());
+            assert!(stages.iter().all(|s| s["name"].is_string()
+                && s["tokens_before"].as_u64().is_some()
+                && s["tokens_after"].as_u64().is_some()));
+        }
+
+        #[test]
+        fn output_shaped_request_reports_signed_negative_savings() {
+            // A tiny request with output shaping on: Stage F injects a terse-output
+            // instruction that grows the input to buy an output saving, so tokens_saved goes
+            // negative and output_shaped flags the tradeoff.
+            let tiny =
+                json!({ "model": "gpt-4o", "messages": [{ "role": "user", "content": "hi" }] })
+                    .to_string();
+            let shaped = DenseConfig {
+                output_control: true,
+                ..DenseConfig::default()
+            };
+            let result =
+                llmtrim_core::compress_with_config(&tiny, Some(ProviderKind::OpenAi), &shaped)
+                    .expect("compress should succeed");
+            let payload = compress_payload(&result);
+
+            assert_eq!(payload["output_shaped"], true);
+            assert!(
+                payload["tokens_saved"].as_i64().unwrap() < 0,
+                "shaping a tiny request grows the input; tokens_saved must be honest about it"
+            );
+        }
+
+        #[test]
+        fn ledger_records_match_the_proxy_schema() {
+            // Full-request record carries the model and the result's token counts.
+            let result = llmtrim_core::compress_with_config(&req(), None, &DenseConfig::default())
+                .expect("compress should succeed");
+            let rec = ledger_record(&result);
+            assert_eq!(rec.provider, "openai");
+            assert_eq!(rec.model.as_deref(), Some("gpt-4o"));
+            assert_eq!(rec.input_before, result.input_tokens_before.0 as i64);
+            assert_eq!(rec.input_after, result.input_tokens_after.0 as i64);
+            assert!(rec.output_after.is_none() && rec.compress_micros.is_none());
+
+            // Blob record has no model attribution (no model call happened).
+            let blob = text_ledger_record("tiktoken", true, 100, 60);
+            assert_eq!(blob.provider, "openai");
+            assert_eq!(blob.model, None);
+            assert_eq!(blob.input_before, 100);
+            assert_eq!(blob.input_after, 60);
+            assert_eq!(blob.output_shaped, Some(false));
+        }
+
+        #[test]
+        fn bad_provider_is_invalid_params_not_panic() {
+            let err = compress(&req(), Some("not-a-provider")).unwrap_err();
+            assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        }
+
+        #[test]
+        fn malformed_request_is_an_error() {
+            let err = compress("{ not json", None).unwrap_err();
+            assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        }
+
+        #[test]
+        fn compress_text_reports_blob_level_deltas_and_shrinks() {
+            // An exact duplicate line: the lossless `safe` config collapses it via dedup.
+            let blob =
+                "the quick brown fox jumps\nthe quick brown fox jumps\nfoo bar baz qux quux corge";
+            let (payload, record) = compress_text(blob).expect("compress_text should succeed");
+
+            let before = payload["input_tokens_before"].as_u64().unwrap();
+            let after = payload["input_tokens_after"].as_u64().unwrap();
+            assert!(before > 0);
+            assert!(
+                after < before,
+                "safe dedup should shrink a blob with a repeated line"
+            );
+            assert_eq!(
+                payload["tokens_saved"].as_i64().unwrap(),
+                before as i64 - after as i64
+            );
+
+            // Content-only: no output-shaping instruction leaks into the returned text, and
+            // the numbers describe the blob (after is far below a wrapped request's token count).
+            let text = payload["text"].as_str().unwrap();
+            assert!(!text.to_lowercase().contains("be concise"));
+            assert!(
+                after < 40,
+                "reported tokens are the blob's, not the wrapper's"
+            );
+
+            // The ledger row mirrors the blob-level numbers, no model attribution.
+            assert_eq!(record.model, None);
+            assert_eq!(record.input_before, before as i64);
+            assert_eq!(record.input_after, after as i64);
+        }
+
+        #[test]
+        fn user_content_handles_string_and_blocks() {
+            let s = json!({ "messages": [{ "role": "user", "content": "café ☕ 日本語" }] })
+                .to_string();
+            assert_eq!(user_content(&s), "café ☕ 日本語");
+
+            let blocks = json!({
+                "messages": [{ "role": "user", "content": [
+                    { "type": "text", "text": "part one " },
+                    { "type": "text", "text": "part two" }
+                ] }]
+            })
+            .to_string();
+            assert_eq!(user_content(&blocks), "part one part two");
+        }
+
+        #[test]
+        fn request_arg_accepts_both_object_and_string() {
+            // An agent (and the MCP Inspector) passes `request` as a JSON object; a stricter
+            // client may stringify it. Both must reduce to the same engine input.
+            let body =
+                json!({ "model": "gpt-4o", "messages": [{ "role": "user", "content": "hi" }] });
+
+            let from_obj: CompressArgs =
+                serde_json::from_value(json!({ "request": body })).expect("object form");
+            let from_str: CompressArgs =
+                serde_json::from_value(json!({ "request": body.to_string() }))
+                    .expect("string form");
+
+            let obj_body = from_obj.request.into_body();
+            assert_eq!(obj_body, from_str.request.into_body());
+            // And it round-trips to a request the engine accepts.
+            assert!(
+                serde_json::from_str::<serde_json::Value>(&obj_body)
+                    .unwrap()
+                    .get("messages")
+                    .is_some()
+            );
+        }
+
+        #[test]
+        fn install_config_and_argv_launch_the_server() {
+            // The paste-this-config block and the claude argv must both launch `llmtrim mcp`,
+            // matching the command MCP clients spawn.
+            let cfg: serde_json::Value =
+                serde_json::from_str(&client_config_json()).expect("valid JSON");
+            assert_eq!(cfg["mcpServers"]["llmtrim"]["command"], "llmtrim");
+            assert_eq!(cfg["mcpServers"]["llmtrim"]["args"][0], "mcp");
+
+            let argv = claude_add_args();
+            assert_eq!(&argv[..4], &["mcp", "add", "llmtrim", "-s"]);
+            // Everything after `--` is the launch command, and it is `llmtrim mcp`.
+            let sep = argv.iter().position(|a| *a == "--").expect("-- separator");
+            assert_eq!(&argv[sep + 1..], &["llmtrim", "mcp"]);
+        }
+
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        type Calls = Rc<RefCell<Vec<String>>>;
+
+        // A fake `claude` runner: appends each subcommand it's asked to run to `log` and
+        // replies from a queue of canned results, so install's branches are tested without
+        // spawning anything.
+        fn fake_runner(
+            log: Calls,
+            replies: Vec<Result<Option<bool>>>,
+        ) -> impl Fn(&[&str]) -> Result<Option<bool>> {
+            let replies = RefCell::new(replies.into_iter());
+            move |args: &[&str]| {
+                log.borrow_mut().push(args.join(" "));
+                replies.borrow_mut().next().expect("a canned reply")
+            }
+        }
+
+        #[test]
+        fn install_print_writes_nothing() {
+            // print mode must never invoke the runner.
+            let run = |_: &[&str]| -> Result<Option<bool>> { panic!("runner must not be called") };
+            install_with(true, false, run).expect("print mode succeeds");
+        }
+
+        #[test]
+        fn install_without_claude_cli_falls_back() {
+            let calls: Calls = Rc::default();
+            install_with(false, false, fake_runner(calls.clone(), vec![Ok(None)]))
+                .expect("fallback succeeds");
+            assert_eq!(*calls.borrow(), vec!["mcp get llmtrim"]); // probed, then gave up
+        }
+
+        #[test]
+        fn install_is_idempotent_when_already_present() {
+            let calls: Calls = Rc::default();
+            install_with(
+                false,
+                false,
+                fake_runner(calls.clone(), vec![Ok(Some(true))]),
+            )
+            .expect("already-present is a no-op success");
+            assert_eq!(*calls.borrow(), vec!["mcp get llmtrim"]); // no add attempted
+        }
+
+        #[test]
+        fn install_adds_when_absent() {
+            let calls: Calls = Rc::default();
+            install_with(
+                false,
+                false,
+                fake_runner(calls.clone(), vec![Ok(Some(false)), Ok(Some(true))]),
+            )
+            .expect("registers");
+            let calls = calls.borrow();
+            assert_eq!(calls[0], "mcp get llmtrim");
+            assert_eq!(calls[1], "mcp add llmtrim -s user -- llmtrim mcp");
+        }
+
+        #[test]
+        fn install_force_reinstalls_present_entry() {
+            let calls: Calls = Rc::default();
+            install_with(
+                false,
+                true,
+                fake_runner(
+                    calls.clone(),
+                    vec![Ok(Some(true)), Ok(Some(true)), Ok(Some(true))],
+                ),
+            )
+            .expect("force reinstalls");
+            let calls = calls.borrow();
+            assert_eq!(calls[1], "mcp remove llmtrim -s user");
+            assert_eq!(calls[2], "mcp add llmtrim -s user -- llmtrim mcp");
+        }
+
+        #[test]
+        fn install_errors_when_add_fails() {
+            let calls: Calls = Rc::default();
+            let run = fake_runner(calls, vec![Ok(Some(false)), Ok(Some(false))]); // absent, add fails
+            assert!(install_with(false, false, run).is_err());
+        }
+
+        #[test]
+        fn user_content_falls_back_to_the_whole_json_on_odd_shapes() {
+            // Each defensive branch returns the input unchanged rather than losing data.
+            let malformed = "{ not json";
+            assert_eq!(user_content(malformed), malformed);
+
+            let no_user = json!({ "messages": [{ "role": "system", "content": "x" }] }).to_string();
+            assert_eq!(user_content(&no_user), no_user);
+
+            let empty_blocks =
+                json!({ "messages": [{ "role": "user", "content": [{ "type": "image" }] }] })
+                    .to_string();
+            assert_eq!(user_content(&empty_blocks), empty_blocks);
+
+            let odd_content =
+                json!({ "messages": [{ "role": "user", "content": 42 }] }).to_string();
+            assert_eq!(user_content(&odd_content), odd_content);
+        }
+    }
+}

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -6,9 +6,10 @@
 //! styling goes through `crate::ui`; colour is passed in by the caller, which disables
 //! it for non-TTY stdout or when `NO_COLOR` is set.
 
+use anyhow::Result;
 use serde_json::json;
 
-use crate::tracking::{PeriodRow, Summary};
+use crate::tracking::{ModelRow, Period, PeriodRow, Summary, Tracker};
 use crate::ui::{self, Tone};
 
 // ── view models (built by main from the ledger/daemon/pricing) ──────────────────
@@ -693,6 +694,191 @@ pub fn export_csv(periods: &[PeriodRow]) -> String {
     o
 }
 
+// ── ledger → view models + pricing (the single source of truth shared by the `status`
+//    dashboard and the MCP `llmtrim_stats` tool) ─────────────────────────────────────
+
+/// Full machine-readable stats snapshot from the ledger: the same JSON `status --json`
+/// emits. The MCP server returns this verbatim so a tool call and the dashboard never
+/// disagree. `daemon` is `None` for callers that don't inspect the proxy (the MCP tool),
+/// which renders as `"daemon": null`.
+pub fn stats_json(tracker: &Tracker, daemon: Option<&DaemonView>) -> Result<String> {
+    let summary = tracker.summary()?;
+    let models = model_views(tracker)?;
+    let cost = monitor_cost(tracker);
+    let periods = tracker.by_period(Period::Day)?;
+    Ok(export_json(
+        &summary,
+        &models,
+        cost.as_ref(),
+        &periods,
+        daemon,
+    ))
+}
+
+pub fn monitor_cost(tracker: &Tracker) -> Option<Cost> {
+    let models = tracker.by_model().ok()?;
+    cost_estimate(&models)
+}
+
+/// Per-model rows for the breakdown, top 8 by request volume, priced where the registry
+/// knows the model.
+pub fn model_views(tracker: &Tracker) -> Result<Vec<ModelView>> {
+    let mut models: Vec<ModelView> = tracker
+        .by_model()?
+        .into_iter()
+        .filter(|m| m.events > 0)
+        .map(|m| {
+            // Per-model USD figures where the registry prices the model — used to project the
+            // round-trip the same way the hero does.
+            let priced = m.model.as_deref().and_then(llm_prices);
+            // Frozen-zone meter, per model: the saving over the compressible surface
+            // (metered rows only). `None` until traffic recorded the meter.
+            let new_before = m.metered_input_before - m.frozen_input_tokens;
+            let new_pct = (m.frozen_input_tokens > 0 && new_before > 0).then(|| {
+                ui::saved_pct(
+                    new_before as f64,
+                    (m.metered_input_after - m.frozen_input_tokens) as f64,
+                )
+            });
+            let cost_saved = priced
+                .map(|(inp, _)| (m.input_before - m.input_after).max(0) as f64 / 1_000_000.0 * inp);
+            let out_spend = priced.map(|(_, outp)| m.output_after as f64 / 1_000_000.0 * outp);
+            let spend = priced.map(|(inp, outp)| {
+                m.input_after as f64 / 1_000_000.0 * inp
+                    + m.output_after as f64 / 1_000_000.0 * outp
+            });
+            ModelView {
+                name: m
+                    .model
+                    .unwrap_or_else(|| format!("{} · unknown model", m.provider)),
+                events: m.events,
+                saved_pct: ui::saved_pct(m.input_before as f64, m.input_after as f64),
+                cost_saved,
+                spend,
+                out_spend,
+                cached: m.cache_read > 0,
+                new_pct,
+            }
+        })
+        .collect();
+    models.sort_unstable_by_key(|b| std::cmp::Reverse(b.events));
+    models.truncate(8);
+    Ok(models)
+}
+
+/// Today's priced saving (UTC), for the hero's recency anchor. `None` when nothing
+/// priced ran today — the dashboard hides the figure rather than showing $0.00.
+pub fn today_saved_usd(tracker: &Tracker) -> Option<f64> {
+    let models = tracker.by_model_today().ok()?;
+    cost_estimate(&models).map(|c| c.saved)
+}
+
+fn cache_multipliers(provider: &str) -> (f64, f64) {
+    match provider {
+        "anthropic" => (0.10, 1.25),
+        "openai" => (0.50, 0.0),
+        "google" => (0.25, 0.0),
+        _ => (1.0, 0.0),
+    }
+}
+
+/// USD cost figures priced per model via [`llm_prices`], `None` when no recorded model
+/// is priced.
+///
+/// - `saved`/`spend` value tokens at **list input rates** (tokens cut × input price; the
+///   compressed input_after + measured output). Consistent numerator/denominator — the
+///   headline basis.
+/// - `net_saved` re-prices the same measured saving against the **real bill**: the
+///   provider-reported usage split (fresh × 1.0 + cache writes × 1.25 + cache reads ×
+///   0.1, per provider) gives the actual input bill, and the counterfactual bill scales
+///   it by the measured compression ratio (same cache mix, prompt larger by `pct`):
+///   `net_saved = net_bill × pct / (1 − pct)`. On traffic with no cache usage this
+///   degrades exactly to the list-rate figure.
+/// - `out_spend_shaped` is the output spend from requests that actually carried the
+///   output-shaping instruction — the only spend the benchmark factor may be projected on.
+fn cost_estimate(models: &[ModelRow]) -> Option<Cost> {
+    let mut cost = Cost {
+        saved: 0.0,
+        spend: 0.0,
+        out_spend: 0.0,
+        net_saved: 0.0,
+        out_spend_shaped: 0.0,
+        live_saved: 0.0,
+    };
+    let mut matched = false;
+    for m in models {
+        let Some(model_id) = m.model.as_deref() else {
+            continue;
+        };
+        if let Some((input_price, output_price)) = llm_prices(model_id) {
+            let delta = (m.input_before - m.input_after).max(0) as f64;
+            cost.saved += delta / 1_000_000.0 * input_price;
+            let out = m.output_after as f64 / 1_000_000.0 * output_price;
+            cost.spend += m.input_after as f64 / 1_000_000.0 * input_price + out;
+            cost.out_spend += out;
+            cost.out_spend_shaped += m.output_after_shaped as f64 / 1_000_000.0 * output_price;
+
+            let (read_mult, write_mult) = cache_multipliers(&m.provider);
+            let net_bill = (m.fresh_input_est as f64
+                + m.cache_write as f64 * write_mult
+                + m.cache_read as f64 * read_mult)
+                / 1_000_000.0
+                * input_price;
+            let pct = if m.input_before > 0 {
+                (delta / m.input_before as f64).min(0.95)
+            } else {
+                0.0
+            };
+            cost.net_saved += net_bill * pct / (1.0 - pct);
+            // Live-zone attribution: the cut happens in the compressible zone, billed as
+            // fresh (1×) + cache writes (1.25× on Anthropic) — never at the ~10% read rate
+            // the net blend assumes — so price the cut at that mix. No usage split recorded
+            // → rate 1.0, degrading to the list figure.
+            let live_used = m.fresh_input_est + m.cache_write;
+            let live_rate = if live_used > 0 {
+                (m.fresh_input_est as f64 + m.cache_write as f64 * write_mult.max(1.0))
+                    / live_used as f64
+            } else {
+                1.0
+            };
+            cost.live_saved += delta / 1_000_000.0 * input_price * live_rate;
+            matched = true;
+        }
+    }
+    matched.then_some(cost)
+}
+
+/// Per-1M-token `(input, output)` price for a model: the `llm_providers` registry first,
+/// matched across every provider (the ledger records the wire-shape provider, not the
+/// upstream brand), then the embedded models.dev snapshot for models the registry hasn't
+/// shipped yet (e.g. day-one releases like claude-fable-5 on 0.14.3).
+fn llm_prices(model_id: &str) -> Option<(f64, f64)> {
+    #[cfg(feature = "intercept")]
+    for &provider_id in llm_providers::get_providers_data().keys() {
+        if let Some(model) = llm_providers::get_model_ref(provider_id, model_id) {
+            return Some((model.input_price, model.output_price));
+        }
+    }
+    snapshot_prices(model_id)
+}
+
+/// Fallback table: the pinned models.dev snapshot the bench prices from, embedded at
+/// compile time (the package re-includes bench/pricing.json for this). Exact id first,
+/// then with the `provider/` prefix stripped, mirroring [`crate::bench::resolve_pricing`]
+/// — but zero-priced rows (free tiers, parse gaps) return `None` so an unknown model
+/// shows a blank cost cell rather than a misleading $0.00.
+fn snapshot_prices(model_id: &str) -> Option<(f64, f64)> {
+    use crate::bench;
+    static TABLE: once_cell::sync::Lazy<bench::PriceTable> =
+        once_cell::sync::Lazy::new(|| bench::load_pricing(include_str!("../bench/pricing.json")));
+    let p = TABLE.get(model_id).or_else(|| {
+        let (_, bare) = model_id.split_once('/')?;
+        TABLE.get(bare)
+    })?;
+    let (input, output) = (p.input_per_1k * 1000.0, p.output_per_1k * 1000.0);
+    (input > 0.0 || output > 0.0).then_some((input, output))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -915,6 +1101,39 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["requests"], 1204);
         assert_eq!(v["cost"], serde_json::Value::Null);
+    }
+
+    // stats_json is the single source the `status --json` dashboard and the MCP llmtrim_stats
+    // tool both read; assert it assembles real ledger rows into the export shape.
+    #[test]
+    fn stats_json_reads_the_ledger() {
+        use crate::tracking::Record;
+        let tracker = Tracker::open_in_memory().unwrap();
+        for _ in 0..2 {
+            tracker
+                .record(&Record {
+                    provider: "openai".into(),
+                    model: Some("gpt-4o".into()),
+                    tokenizer: "tiktoken".into(),
+                    exact: true,
+                    input_before: 1000,
+                    input_after: 600,
+                    output_before: None,
+                    output_after: None,
+                    compress_micros: None,
+                    cache_read_tokens: None,
+                    fresh_input_tokens: None,
+                    cache_write_tokens: None,
+                    output_shaped: Some(false),
+                    frozen_input_tokens: Some(0),
+                })
+                .unwrap();
+        }
+        let out = stats_json(&tracker, None).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["requests"], 2);
+        assert_eq!(v["daemon"], serde_json::Value::Null);
+        assert!(v["by_model"].as_array().is_some_and(|m| !m.is_empty()));
     }
 
     #[test]

--- a/crates/llmtrim-cli/tests/mcp_protocol.rs
+++ b/crates/llmtrim-cli/tests/mcp_protocol.rs
@@ -1,0 +1,108 @@
+//! Protocol-level test: drive the MCP stdio handler through a real JSON-RPC exchange
+//! (`initialize` → `tools/list` → `tools/call`) over an in-memory duplex pipe, the same
+//! way an MCP client would over stdio, and assert the responses are well-formed and the
+//! tools run.
+#![cfg(feature = "mcp")]
+
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use serde_json::json;
+
+#[tokio::test]
+async fn initialize_list_and_call_over_jsonrpc() {
+    // Isolate the ledger so the recording tools never write to the user's real savings DB.
+    let db = std::env::temp_dir().join(format!("llmtrim_mcp_proto_{}.db", std::process::id()));
+
+    let (server_transport, client_transport) = tokio::io::duplex(8192);
+
+    // The server side: spawn the real handler the `llmtrim mcp` command serves. We start
+    // it through the same public entry the binary uses, over the duplex instead of stdio.
+    let server = tokio::spawn(async move {
+        let service = llmtrim::mcp::test_server(db)
+            .serve(server_transport)
+            .await
+            .expect("server handshake");
+        service.waiting().await.expect("server run");
+    });
+
+    // The client side: `()` is a no-op ClientHandler. `serve` performs `initialize` for us.
+    let client = ().serve(client_transport).await.expect("client initialize");
+
+    // tools/list advertises exactly the three documented tools, each with an input schema.
+    let tools = client.list_all_tools().await.expect("tools/list");
+    let mut names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    names.sort_unstable();
+    assert_eq!(
+        names,
+        ["llmtrim_compress", "llmtrim_compress_text", "llmtrim_stats"]
+    );
+    assert!(
+        tools.iter().all(|t| !t.input_schema.is_empty()),
+        "every tool advertises an input schema"
+    );
+    // The documented input fields show up in the advertised schemas.
+    let schema = |name: &str| {
+        let t = tools.iter().find(|t| t.name == name).unwrap();
+        t.input_schema["properties"].clone()
+    };
+    assert!(schema("llmtrim_compress")["request"].is_object());
+    assert!(schema("llmtrim_compress")["provider"].is_object());
+    assert!(schema("llmtrim_compress_text")["text"].is_object());
+
+    // Helper: call a tool over JSON-RPC and parse its single text result as JSON.
+    async fn call(
+        client: &rmcp::service::RunningService<rmcp::RoleClient, ()>,
+        name: &'static str,
+        args: serde_json::Map<String, serde_json::Value>,
+    ) -> serde_json::Value {
+        let mut params = CallToolRequestParams::new(name);
+        params.arguments = Some(args);
+        let result = client.call_tool(params).await.expect("tools/call");
+        assert_ne!(result.is_error, Some(true), "{name} must not error");
+        let text = result
+            .content
+            .first()
+            .and_then(|c| c.as_text())
+            .map(|t| t.text.clone())
+            .expect("text content");
+        serde_json::from_str(&text).expect("tool result is JSON")
+    }
+
+    // llmtrim_compress: a real-shaped request comes back compressed with token deltas. We
+    // don't assert the input shrinks (the server honors ~/.llmtrim config, whose `auto`
+    // default may add an output-shaping instruction); the deterministic mapping is unit-tested.
+    let request_body = json!({
+        "model": "gpt-4o",
+        "messages": [
+            { "role": "system", "content": "You are a helpful assistant.    " },
+            { "role": "user", "content": "Hello    world\n\n\nwith   redundant    whitespace." }
+        ]
+    })
+    .to_string();
+    let mut args = serde_json::Map::new();
+    args.insert("request".into(), json!(request_body));
+    let payload = call(&client, "llmtrim_compress", args).await;
+    assert!(payload["request_json"].is_string());
+    assert!(payload["input_tokens_before"].as_u64().unwrap() > 0);
+    assert!(payload["stages"].as_array().is_some_and(|s| !s.is_empty()));
+    assert_eq!(payload["provider"], "openai");
+
+    // llmtrim_compress_text: a blob comes back as shrunk text with blob-level deltas.
+    let mut args = serde_json::Map::new();
+    args.insert(
+        "text".into(),
+        json!("repeat me\nrepeat me\ntail words here"),
+    );
+    let payload = call(&client, "llmtrim_compress_text", args).await;
+    assert!(payload["text"].is_string());
+    assert!(payload["input_tokens_before"].as_u64().unwrap() > 0);
+    assert!(payload["tokens_saved"].as_i64().is_some());
+
+    // llmtrim_stats: returns the ledger snapshot as well-formed JSON.
+    let payload = call(&client, "llmtrim_stats", serde_json::Map::new()).await;
+    assert!(payload["requests"].as_u64().is_some());
+    assert!(payload["by_model"].is_array());
+
+    client.cancel().await.ok();
+    server.abort();
+}


### PR DESCRIPTION
Adds an MCP server front-end so any MCP client (Claude Code, Cursor, custom agents) can call llmtrim's compression and savings directly, a distribution channel the proxy/CLI/bindings don't reach.

## What's in it
- `llmtrim mcp` runs a Model Context Protocol server over stdio (JSON-RPC 2.0) via the official `rmcp` 1.7 SDK, exposing three tools:
  - `llmtrim_compress` — compress a full request body (accepts the JSON object or a string of it), honoring `~/.llmtrim` config like the proxy; returns the compressed body, token deltas (signed: output shaping can grow input to save on output), and the per-stage report.
  - `llmtrim_compress_text` — shrink a single text blob with the lossless `safe` preset; reports blob-level token deltas.
  - `llmtrim_stats` — the savings ledger, the same JSON `status --json` emits.
- `llmtrim mcp install` registers the server with Claude Code via its `claude mcp add` CLI (idempotent, `--force` to reinstall); `--print` emits the config block for any other client.
- Every tool records to the same ledger as the proxy, so MCP traffic shows up in `llmtrim status`.

## Design notes
- Behind a new `mcp` feature in `default` (release binaries are built with default features, so the shipped binary must carry the command). The rmcp client side is a dev-dependency only.
- `monitor::stats_json` was extracted so the dashboard and the MCP stats tool share one source of truth; `status --json` output is unchanged.
- Bad input returns a JSON-RPC error, never a panic.

## Testing
- 607 tests pass; clippy clean (`--features intercept,mcp --all-targets`); `mcp.rs` line coverage 91.4%.
- Protocol-level test over an in-memory duplex transport (initialize -> tools/list -> tools/call for all three tools).
- Verified end-to-end against two real clients: the MCP Inspector CLI (which surfaced and led to the object-vs-string `request` fix) and Claude Code (`✔ Connected`, idempotent install, clean removal).