### PR TITLE
fix(autostart): resolve the port instead of hardcoding the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ All notable changes to this project are documented here. The format follows
   flags "no pidfile … re-run `llmtrim setup`") instead of the false "stopped". The
   supervised daemon also re-records its own pidfile on restart, so a transient loss
   self-heals.
+- **`llmtrim autostart` no longer hardcodes the default port.** Run with no `--port`, the
+  command wrote the default port into the login entry regardless of the port your daemon
+  and `HTTPS_PROXY` were actually on, so a reboot could bring the interceptor up on a port
+  the environment wasn't wired to (LLM calls then fail until re-fixed). It now resolves the
+  port the same way `setup`/`start` do — explicit `--port`, else the running daemon, else
+  the configured env — and only falls back to the default when nothing is pinned.
 
 ## [0.1.11] - 2026-06-14
 

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -222,9 +222,11 @@ enum Commands {
         /// Disable autostart instead of enabling it.
         #[arg(long)]
         off: bool,
-        /// Port the autostarted interceptor listens on.
-        #[arg(long, default_value_t = llmtrim::setup::DEFAULT_PORT)]
-        port: u16,
+        /// Port the autostarted interceptor listens on. Omit to reuse the port already
+        /// wired into your environment / the running daemon (only a first install with
+        /// nothing pinned falls back to the default port).
+        #[arg(long)]
+        port: Option<u16>,
     },
     /// Print the local CA certificate path and how to trust it
     ///
@@ -637,11 +639,20 @@ fn run() -> Result<()> {
             }
         }
         Commands::Autostart { off, port } => {
-            llmtrim::autostart::configure(!off, port)?;
             let color = ui::color_stdout();
             if off {
+                // Port is unused when disabling; pass the default to match `uninstall`.
+                llmtrim::autostart::configure(false, llmtrim::setup::DEFAULT_PORT)?;
                 println!("{}", ui::ok(color, "Autostart disabled."));
             } else {
+                // Match the daemon/env so login doesn't come up on a port the env isn't
+                // wired to. `resolve_port` prefers an explicit `--port`, then the running
+                // daemon, then the configured env, and only scans from the default when
+                // nothing is pinned (a first install).
+                let running = llmtrim::daemon::running().map(|s| s.port);
+                let port = llmtrim::setup::resolve_port(port, running)
+                    .context("llmtrim autostart: could not pick a port — pass --port explicitly")?;
+                llmtrim::autostart::configure(true, port)?;
                 println!(
                     "{}",
                     ui::ok(

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -1400,6 +1400,19 @@ mod tests {
         );
     }
 
+    /// The public boundary `llmtrim autostart` resolves through. A running daemon's port must
+    /// win over any default — this is the regression `fix/autostart-port-resolve` locks in
+    /// (bare `autostart` used to hardcode the default). Deterministic: `running` short-circuits
+    /// `choose_port` before `configured_port()` reads any real env.
+    #[test]
+    fn resolve_port_prefers_running_over_default() {
+        assert_eq!(resolve_port(None, Some(9001)).expect("running port"), 9001);
+        assert_eq!(
+            resolve_port(Some(7000), Some(9001)).expect("explicit"),
+            7000
+        );
+    }
+
     #[test]
     fn parse_proxy_port_reads_the_wired_port() {
         assert_eq!(parse_proxy_port("http://127.0.0.1:8787"), Some(8787));


### PR DESCRIPTION
## Problem
`llmtrim autostart` with no `--port` wrote `DEFAULT_PORT` into the login entry regardless of the port the daemon and `HTTPS_PROXY` were actually on (e.g. 8788). A reboot then brings the interceptor up on a port the environment isn't wired to → the "env points at :X but daemon listens on :Y" mismatch breaks every LLM HTTPS call until refixed. Hit live: `setup` reused the existing 8788 wiring while bare `autostart` wrote 43117.

## Fix
The `--port` arg is now `Option<u16>`. When enabling, the handler resolves the port via `setup::resolve_port(port, running)` — explicit `--port`, else the running daemon, else the configured env, else scan from the default — matching `setup`/`start`.

## Review fixes applied
- Disable path passes `DEFAULT_PORT` (unused on disable) to match `uninstall`, avoiding a stale `--port 0` in the macOS `auto-launch` args.
- The `resolve_port` failure carries an autostart-specific hint ("pass --port explicitly").
- Added `resolve_port_prefers_running_over_default` test locking the running-over-default precedence at the public boundary.

Tests: `choose_port_precedence`, `resolve_port_prefers_running_over_default`, autostart suite; fmt + clippy clean.