### PR TITLE
fix(update): use 'npm install -g @pkg@latest' for the npm channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **`llmtrim update` now prints the correct npm upgrade command.** It printed
+  `npm update -g @llmtrim/cli`, which npm treats as a no-op for a globally installed package
+  already on a satisfying version; it now prints `npm install -g @llmtrim/cli@latest`.
 - **`status` no longer reports "stopped" while the proxy is serving.** Health was decided
   from the pidfile alone, so a daemon whose pidfile went missing (e.g. lost to a full disk)
   showed the loud "stopped — LLM calls will fail" banner even though the proxy was still

--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -194,7 +194,7 @@ pub fn run() -> Result<()> {
         Channel::Npm => instructions(
             "update via npm",
             &[
-                "npm update -g @llmtrim/cli",
+                "npm install -g @llmtrim/cli@latest",
                 "llmtrim setup    # restart the daemon on the new binary",
             ],
         ),


### PR DESCRIPTION
## Problem
The `Channel::Npm` arm of `llmtrim update` printed `npm update -g @llmtrim/cli`. npm respects the installed semver range for global packages, so this command frequently no-ops and leaves the user on an old version.

## Fix
Print `npm install -g @llmtrim/cli@latest` instead, which reliably installs the newest published version. The `llmtrim setup` restart line is unchanged.

Changelog entry added under `## [Unreleased]`.

Note: this edits `[Unreleased]`, which #30 and #31 also touch, so a changelog conflict on those merges is expected.