### PR TITLE
docs(npm): pin install command to @latest

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ brew install --build-from-source ./Formula/llmtrim.rb
 ## With npm
 
 ```bash
-npm install -g @llmtrim/cli && llmtrim setup   # prebuilt binary for your platform (no Rust needed)
+npm install -g @llmtrim/cli@latest && llmtrim setup   # prebuilt binary for your platform (no Rust needed)
 ```
 
 `npx @llmtrim/cli compress < req.json` works for trying it without installing, but use the

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Default `auto` switches each stage on only where it pays. `safe` runs the lossle
 
 ```bash
 # 1. Install (any OS, prebuilt binary, no Rust needed)
-npm install -g @llmtrim/cli && llmtrim setup
+npm install -g @llmtrim/cli@latest && llmtrim setup
 
 # 2. Open a new shell. Your AI tools now route through llmtrim automatically.
 

--- a/crates/llmtrim-cli/README.md
+++ b/crates/llmtrim-cli/README.md
@@ -29,7 +29,7 @@ llmtrim setup           # configure the local interceptor + environment
 llmtrim doctor          # verify it
 ```
 
-Other channels (same binary): `brew install fkiene/tap/llmtrim` · `scoop install llmtrim` · `npm i -g @llmtrim/cli` · `docker run ghcr.io/fkiene/llmtrim`. See [INSTALL.md](https://github.com/fkiene/llmtrim/blob/main/INSTALL.md).
+Other channels (same binary): `brew install fkiene/tap/llmtrim` · `scoop install llmtrim` · `npm i -g @llmtrim/cli@latest` · `docker run ghcr.io/fkiene/llmtrim`. See [INSTALL.md](https://github.com/fkiene/llmtrim/blob/main/INSTALL.md).
 
 ## Use it
 

--- a/tools/npm/README.md
+++ b/tools/npm/README.md
@@ -10,7 +10,7 @@ Every cut is re-counted with the provider's real tokenizer and auto-reverted if 
 save, so it can never increase your bill or break a request.
 
 ```bash
-npm install -g @llmtrim/cli && llmtrim setup
+npm install -g @llmtrim/cli@latest && llmtrim setup
 # open a new shell, then watch the bill shrink:
 llmtrim status --watch
 ```


### PR DESCRIPTION
Make the npm install instructions consistent with what `llmtrim update` prints by pinning to `@latest`. This keeps the published command cache-proof.

Updated the install command in:
- `README.md`
- `INSTALL.md`
- `tools/npm/README.md` (copied verbatim into the published npm package)

Docs-only change. Package name, build scripts, and package identity are untouched.