### PR TITLE
fix(uninstall): name the env vars still live in the current shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ All notable changes to this project are documented here. The format follows
   the environment wasn't wired to (LLM calls then fail until re-fixed). It now resolves the
   port the same way `setup`/`start` do — explicit `--port`, else the running daemon, else
   the configured env — and only falls back to the default when nothing is pinned.
+- **`uninstall`'s closing message now names the leftover env vars and gives a remedy that
+  works.** It said only "open a new shell", which never told you what was left behind and
+  read as optional. It now spells out that the current shell still has `HTTPS_PROXY`,
+  `HTTP_PROXY`, and `NODE_EXTRA_CA_CERTS` exported (the exact set `setup` writes) and that
+  clearing them means a new shell or `unset HTTPS_PROXY HTTP_PROXY NODE_EXTRA_CA_CERTS` —
+  not re-sourcing the profile, which leaves an already-exported var set.
 
 ## [0.1.11] - 2026-06-14
 

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -752,7 +752,9 @@ pub fn uninstall(purge: bool, keep_binary: bool) -> Result<()> {
         ui::paint(
             color,
             Tone::Bold,
-            "Done. Open a new shell so the environment changes take effect."
+            "Done. Your current shell still has HTTPS_PROXY, HTTP_PROXY, and \
+             NODE_EXTRA_CA_CERTS exported. Open a new shell to clear them, or run: \
+             unset HTTPS_PROXY HTTP_PROXY NODE_EXTRA_CA_CERTS"
         )
     );
     // The env is gone from disk, but processes that were already running inherited it at


### PR DESCRIPTION
## What

`uninstall` removes the managed profile block but cannot mutate the parent shell, so the current session keeps the exported proxy/CA vars. The closing message said only "open a new shell so the environment changes take effect" without naming what was left behind.

It now spells out that this shell still has `HTTPS_PROXY`, `HTTP_PROXY`, and `NODE_EXTRA_CA_CERTS` exported (the exact set `setup` writes, per `ENV_KEYS` in setup.rs) and that you open a new shell or re-source your profile to clear them.

## Scope

- Message string only. No change to the env logic.
- `stop` deliberately left untouched: it is a temporary pause, the env stays wired so `start` resumes cleanly.

## Verify

`cargo fmt` + `cargo clippy --features intercept` clean; `cargo nextest run --features intercept` 618 passed.

Note: the `[Unreleased]` changelog entry may overlap other open PRs.