### PR TITLE
fix(update): print tap-qualified brew upgrade command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to this project are documented here. The format follows
 - **`llmtrim update` now prints the correct npm upgrade command.** It printed
   `npm update -g @llmtrim/cli`, which npm treats as a no-op for a globally installed package
   already on a satisfying version; it now prints `npm install -g @llmtrim/cli@latest`.
+- **`llmtrim update` on a Homebrew install now prints a command that works.** The Homebrew
+  arm told you to run `brew upgrade llmtrim`, but the formula is tapped as
+  `fkiene/tap/llmtrim`. On a machine that never added the tap, that errors with "no
+  available formula named llmtrim" and you stay on the old binary. It now prints the
+  tap-qualified, idempotent form (`brew tap fkiene/tap` then
+  `brew upgrade fkiene/tap/llmtrim`).
 - **`status` no longer reports "stopped" while the proxy is serving.** Health was decided
   from the pidfile alone, so a daemon whose pidfile went missing (e.g. lost to a full disk)
   showed the loud "stopped — LLM calls will fail" banner even though the proxy was still

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,7 +126,7 @@ llmtrim update
 
 - **Binary** (`curl | sh`): re-runs the installer to fetch the latest release, then restarts.
 - **Cargo / Homebrew**: prints the right command (`cargo install --locked llmtrim --force` /
-  `brew upgrade llmtrim`), then run `llmtrim setup` to restart the daemon on it.
+  `brew upgrade fkiene/tap/llmtrim`), then run `llmtrim setup` to restart the daemon on it.
 
 `status` shows a one-line notice when a newer release exists (checked at most once a day,
 cached; set `LLMTRIM_NO_UPDATE_CHECK=1` to disable, and it's skipped offline). Pin a version

--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -187,7 +187,8 @@ pub fn run() -> Result<()> {
         Channel::Homebrew => instructions(
             "update via Homebrew",
             &[
-                "brew upgrade llmtrim",
+                "brew tap fkiene/tap",
+                "brew upgrade fkiene/tap/llmtrim",
                 "llmtrim setup    # restart the daemon on the new binary",
             ],
         ),


### PR DESCRIPTION
## Problem

`llmtrim update` on a Homebrew install prints `brew upgrade llmtrim`. The formula is tapped as `fkiene/tap/llmtrim` (release.yml: `brew tap fkiene/tap` then `brew install fkiene/tap/llmtrim`). On a machine that never added the tap, `brew upgrade llmtrim` errors with "no available formula named llmtrim" and the user silently stays un-upgraded — the same class we just fixed for npm.

## Fix

Print the tap-qualified, idempotent form:

```
brew tap fkiene/tap
brew upgrade fkiene/tap/llmtrim
llmtrim setup    # restart the daemon on the new binary
```

Verify loop green (618 tests pass); coverage of `update.rs` unchanged (string lives in the real-IO `run()` entrypoint).