### PR TITLE
docs(readme): add npm version + downloads badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 <p align="center">
   <a href="https://github.com/fkiene/llmtrim/actions/workflows/ci.yml"><img src="https://github.com/fkiene/llmtrim/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License: AGPL v3"></a>
-  <a href="https://crates.io/crates/llmtrim"><img src="https://img.shields.io/crates/v/llmtrim" alt="crates.io"></a>
+  <a href="https://crates.io/crates/llmtrim"><img src="https://img.shields.io/crates/v/llmtrim?logo=rust" alt="crates.io"></a>
+  <a href="https://www.npmjs.com/package/@llmtrim/cli"><img src="https://img.shields.io/npm/v/@llmtrim/cli?logo=npm" alt="npm"></a>
+  <a href="https://www.npmjs.com/package/@llmtrim/cli"><img src="https://img.shields.io/npm/dm/@llmtrim/cli" alt="npm downloads"></a>
   <img src="https://img.shields.io/badge/rust-1.88%2B-orange" alt="Rust 1.88+">
 </p>
 


### PR DESCRIPTION
Adds two npm badges next to the existing crates.io badge:
- npm version (`@llmtrim/cli`, currently 0.1.11 — confirmed published)
- npm monthly downloads (~1,147/month — a flattering, real adoption signal)

Also adds `?logo=rust`/`?logo=npm` to distinguish the two version badges. Deliberately **omits** a crates.io downloads badge (139 all-time undersells next to the npm number) and keeps the crates.io version badge (it shows the version, not the low count, and crates.io is the native channel for a Rust tool).

Docs-only, no changelog per CLAUDE.md.