### PR TITLE
fix(ci): let docs-only PRs satisfy required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,16 @@
 name: CI
 
 on:
+  # No workflow-level paths-ignore: a workflow skipped that way leaves required status
+  # contexts stuck "Pending", which permanently blocks docs-only PRs (branch protection on
+  # main requires the job contexts below). Instead the workflow always runs and the heavy
+  # jobs are gated per-job on the `changes` filter — a job skipped via its `if:` reports
+  # "Success" and satisfies the required check, while still running for real on any code
+  # change. A workflow skipped by paths-ignore, by contrast, leaves the context pending
+  # forever.
   push:
     branches: [main, master]
-    # Docs/assets don't affect the build — skip the whole matrix. Secrets in these files
-    # are still covered by the pre-commit/pre-push gitleaks hooks and GitHub push protection.
-    paths-ignore: ["**.md", "**.svg", "LICENSE", ".gitignore", ".gitattributes"]
   pull_request:
-    paths-ignore: ["**.md", "**.svg", "LICENSE", ".gitignore", ".gitattributes"]
 
 # Rapid pushes stack runs that all execute to completion — cancel the superseded one.
 # Tag/release runs are unaffected (separate workflow, no shared group).
@@ -24,8 +27,45 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  # Detect whether anything other than docs/assets changed. The heavy jobs below gate on
+  # `needs.changes.outputs.code` and skip (reporting "Success", which satisfies the required
+  # status check) on docs-only PRs. The gate is fail-safe: jobs run unless `code` is
+  # explicitly "false", so a docs-only change skips them, but if the `changes` job itself
+  # fails or is skipped (empty output), the heavy jobs still run rather than letting code
+  # through untested. A docs-only push to main likewise skips the matrix (nothing to test).
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    # paths-filter reads the PR file list via the API on pull_request events.
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # `code` is true when the push/PR touches anything that is NOT a doc/asset.
+          # `every` makes a file count toward `code` only when it matches ALL patterns (the
+          # `**` catch-all and every `!` exclusion) — the documented idiom for "any non-doc
+          # file". The filter is still true if at least one changed file qualifies, so a
+          # mixed code+docs PR is correctly treated as code.
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.svg'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.gitattributes'
+
   test:
     name: Test (${{ matrix.os }})
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -65,6 +105,8 @@ jobs:
   # the FFI surface actually loads and compresses from each host language.
   bindings:
     name: UniFFI bindings
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -97,6 +139,8 @@ jobs:
   # SwiftPM package); full xcframework/SwiftPM packaging is a later step.
   bindings-swift:
     name: Swift binding (smoke)
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -120,6 +164,8 @@ jobs:
   # Compile-and-load verification for the Kotlin target; full Gradle/Maven packaging later.
   bindings-kotlin:
     name: Kotlin binding (smoke)
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -153,6 +199,8 @@ jobs:
   # release-only if macOS minutes get tight.
   bindings-swift-package:
     name: Swift package (xcframework)
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -167,6 +215,8 @@ jobs:
   # outside deny.toml's allow-list (e.g. GPL/proprietary) or an unknown source.
   license-check:
     name: License compliance
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -191,6 +241,8 @@ jobs:
   # Homebrew formula must stay valid Ruby (a lowercase class name once broke `brew install`).
   formula:
     name: Formula syntax
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -200,6 +252,8 @@ jobs:
   # adopt a newer-than-1.88 API; this job fails when that happens.
   msrv:
     name: MSRV (1.88)
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` used workflow-level `paths-ignore` on both `push` and `pull_request`. Branch protection on `main` requires 10 status contexts (`Test (ubuntu/macos/windows-latest)`, `License compliance`, `MSRV (1.88)`, `Secret scan (gitleaks)`, `Formula syntax`, `UniFFI bindings`, `Kotlin binding (smoke)`, `Swift binding (smoke)`). On a docs-only PR the entire workflow was skipped at the workflow level, so those contexts never reported and the PR was blocked forever. #33 and #36 had to be admin-merged because of this.

## Confirmed GitHub behavior

Per GitHub's docs, a workflow skipped via workflow-level `paths`/`paths-ignore` leaves its associated required status contexts in a "Pending" state, and "you won't be able to merge the pull request if your repository is configured to require specific checks to pass first" ([skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs)). A job skipped via a job-level `if:` condition inside a workflow that did run behaves differently: it reports its status as Success and does not prevent a pull request from merging even when it is a required check ([using conditions to control job execution](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution)). Branch protection accepts a `successful`, `skipped`, or `neutral` status for a required check. So moving the path filtering from the workflow level to a per-job `if:` is the fix that lets the required contexts report on docs-only PRs while still running for real on code changes.

## Approach

- Remove the workflow-level `paths-ignore` so the workflow always runs and every required context always reports.
- Add a `changes` job using `dorny/paths-filter@v3` that outputs `code = true` when the diff touches any non-doc/non-asset file (the same path set the old `paths-ignore` listed). `predicate-quantifier: every` plus a `**` catch-all minus the doc exclusions means `code` is true iff at least one non-doc file changed.
- Gate the heavy jobs with `if: needs.changes.outputs.code == 'true'`. On a docs-only PR they skip and report Success, satisfying branch protection. On any code change they run for real, so gating cannot be weakened for code PRs. Pushes to `main` get the full matrix (paths-filter diffs against the default branch / treats everything as added with no common ancestor).
- `Secret scan (gitleaks)` stays ungated so it runs on every change (cheap and security-relevant).
- All job `name:` values are unchanged, so the required-context names still match branch protection exactly.

This PR edits a workflow file (not docs), so it triggers full CI and self-verifies the code-PR path before merging.

## Manual branch-protection change required

None. The 10 required context names are preserved verbatim; no branch-protection settings need to change.
