### PR TITLE
docs(readme): split conflated submodular citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Every compressor is a deterministic implementation of published research: the id
 <details>
 <summary><b>Papers + crates behind each stage</b></summary>
 
-**Retrieval & context:** BM25 (Robertson & Zaragoza 2009, [`bm25`](https://crates.io/crates/bm25)); BM25+ (Lv & Zhai, CIKM 2011); RM3 (Lavrenko & Croft, SIGIR 2001); TextTiling (Hearst, CL 1997); TextRank (Mihalcea & Tarau, EMNLP 2004); MMR (Carbonell & Goldstein, SIGIR 1998); Submodular selection (Lin & Bilmes, ACL 2011, [arXiv:2008.05391](https://arxiv.org/abs/2008.05391)); DPP diverse sampling (Chen et al., NeurIPS 2018); Lost in the Middle ([arXiv:2307.03172](https://arxiv.org/abs/2307.03172)); DSLR ([arXiv:2407.03627](https://arxiv.org/abs/2407.03627)).
+**Retrieval & context:** BM25 (Robertson & Zaragoza 2009, [`bm25`](https://crates.io/crates/bm25)); BM25+ (Lv & Zhai, CIKM 2011); RM3 (Lavrenko & Croft, SIGIR 2001); TextTiling (Hearst, CL 1997); TextRank (Mihalcea & Tarau, EMNLP 2004); MMR (Carbonell & Goldstein, SIGIR 1998); Submodular objective (Lin & Bilmes, ACL 2011); modified-greedy knapsack maximizer (Tang et al., SIGMETRICS 2021, [arXiv:2008.05391](https://arxiv.org/abs/2008.05391)); DPP diverse sampling (Chen et al., NeurIPS 2018); Lost in the Middle ([arXiv:2307.03172](https://arxiv.org/abs/2307.03172)); DSLR ([arXiv:2407.03627](https://arxiv.org/abs/2407.03627)).
 
 **Code:** RepoCoder ([arXiv:2303.12570](https://arxiv.org/abs/2303.12570)); Hierarchical Context Pruning ([arXiv:2406.18294](https://arxiv.org/abs/2406.18294)); The Hidden Cost of Readability ([arXiv:2508.13666](https://arxiv.org/abs/2508.13666)); Minification token accounting ([arXiv:2606.01326](https://arxiv.org/abs/2606.01326)).
 


### PR DESCRIPTION
The **Retrieval & context** acknowledgment merged two distinct papers into a single citation, attaching arXiv:2008.05391 to Lin & Bilmes.

`crates/llmtrim-core/src/select.rs` actually combines two papers:

- **Objective:** Lin & Bilmes, "A Class of Submodular Functions for Document Summarization", ACL 2011. This paper has no arXiv id, so the arXiv link did not belong here.
- **Maximizer:** Tang et al., "Revisiting Modified Greedy Algorithm for Monotone Submodular Maximization with a Knapsack Constraint", arXiv:2008.05391. This is the modified-greedy knapsack maximizer carrying the 0.405 guarantee.

This splits the citation so each paper is attributed correctly. Docs-only, single line.