### PR TITLE
test: guard tests for BM25+ floor and log pre-masking

### DIFF
--- a/crates/llmtrim-core/src/stages/retrieve.rs
+++ b/crates/llmtrim-core/src/stages/retrieve.rs
@@ -1998,6 +1998,56 @@ mod tests {
         );
     }
 
+    #[test]
+    fn bm25_plus_does_not_change_kept_set_on_long_short_mix() {
+        // SELECTION-LEVEL EVIDENCE (the question the BM25+ proposal hinges on): does the δ floor
+        // change *which* chunks survive a top-k token budget on a realistic long/short mix?
+        //
+        // Setup designed to be maximally favorable to a flip: chunk 0 is the relevant long chunk
+        // holding the high-IDF query term "rollback" exactly once, drowned in 6× filler (heavy
+        // length penalty). Six short decoys each densely match the OTHER query term "procedure"
+        // but never "rollback". This is exactly the "long chunk over-penalized vs short chunks"
+        // case Lv & Zhai describe.
+        //
+        // Observed: plain BM25 already keeps chunk 0 (0.513 vs the decoys' 0.334) — the crate's
+        // length normalization never pushes a matched rare term below a different-term short
+        // match. δ then only RESCALES (chunk 0 → 2.187, decoys → 0.541), widening the gap
+        // monotonically; it never reorders. So on this mix BM25+ changes no selection.
+        let filler = "and the report further covered assorted routine operational matters across \
+                      the wider organisation in considerable repetitive and largely unremarkable \
+                      detail spanning many additional unrelated paragraphs of background prose \
+                      that nobody on the team ever actually reads in full at any point";
+        let long_relevant =
+            format!("rollback {filler} {filler} {filler} {filler} {filler} {filler}");
+        let mut chunks = vec![long_relevant];
+        for w in [
+            "onboarding",
+            "billing",
+            "cleanup",
+            "review",
+            "handover",
+            "intake",
+        ] {
+            chunks.push(format!("the {w} procedure"));
+        }
+        let query = lex_words("rollback procedure");
+        let keep = 3usize;
+
+        let plain_rank = argsort_desc(&bm25_scores(&chunks, &query, 0.0));
+        let plus_rank = argsort_desc(&bm25_scores(&chunks, &query, BM25_PLUS_DELTA));
+
+        let plain_kept: HashSet<usize> = plain_rank.iter().copied().take(keep).collect();
+        let plus_kept: HashSet<usize> = plus_rank.iter().copied().take(keep).collect();
+
+        // The relevant long chunk survives either way — plain BM25 was never the problem here.
+        assert!(plain_kept.contains(&0) && plus_kept.contains(&0));
+        // The kept set is IDENTICAL: BM25+ has no selection-level effect on this mix.
+        assert_eq!(
+            plain_kept, plus_kept,
+            "δ rescales scores but does not change which chunks survive the budget"
+        );
+    }
+
     // --- RM3 pseudo-relevance feedback (Lavrenko & Croft, SIGIR 2001) ------------------------
 
     /// Corpus where the true answer chunk shares vocabulary with the chunk the sparse query hits

--- a/crates/llmtrim-core/src/stages/toolout/template.rs
+++ b/crates/llmtrim-core/src/stages/toolout/template.rs
@@ -1430,6 +1430,77 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Evidence test for the Drain3 "regex pre-masking" proposal. The existing pipeline
+    /// already masks volatile tokens (timestamps, hex addresses, hashes, UUIDs, IPv4,
+    /// numbers) via [`VARIABLE`] before grouping. This measures what that pre-masking buys:
+    /// distinct templates and token savings WITH masking vs. a no-mask baseline (where each
+    /// line is its own group because the volatile fields differ).
+    #[test]
+    fn premasking_drives_grouping_and_savings() {
+        // Realistic repetitive tool output: a stack trace repeated by many worker threads,
+        // each frame differing only in volatile fields — a wall-clock timestamp, a hex
+        // return address, a thread id, and a line number. This is exactly the shape the
+        // Drain3 proposal targets.
+        let mut lines = Vec::new();
+        for i in 0..40 {
+            let addr = 0x7f00_0000u64 + (i as u64) * 0x40;
+            lines.push(format!(
+                "2026-06-13T10:{:02}:{:02}Z thread-{i} at 0x{addr:x} (worker.rs:{}) panicked: send failed",
+                i / 60,
+                i % 60,
+                120 + i
+            ));
+        }
+        let text = lines.join("\n");
+
+        // Baseline: distinct templates WITHOUT pre-masking = number of byte-distinct lines.
+        // Every line differs (timestamp/addr/id/line), so each is its own group → 40.
+        let distinct_unmasked = {
+            let mut set = std::collections::HashSet::new();
+            for l in text.lines() {
+                set.insert(l);
+            }
+            set.len()
+        };
+        assert_eq!(
+            distinct_unmasked, 40,
+            "no-mask baseline: every line is unique"
+        );
+
+        // With pre-masking: collapse the volatile fields, then count distinct templates.
+        let distinct_masked = {
+            let mut set = std::collections::HashSet::new();
+            for l in text.lines() {
+                set.insert(template_of(l).0);
+            }
+            set.len()
+        };
+        assert_eq!(
+            distinct_masked, 1,
+            "pre-masking folds all 40 lines into ONE template"
+        );
+
+        // The whole point: real token savings on this shape.
+        let (out, folded) = collapse(&text);
+        assert!(folded, "the masked run folds");
+        let saved = 100.0 - (count_tokens(&out) as f64 / count_tokens(&text) as f64 * 100.0);
+        assert!(
+            saved >= 60.0,
+            "expected >=60% token savings, got {saved:.1}%"
+        );
+
+        // Lossless: the line-number column is a regular sequence, so it range-folds to
+        // `120..159` (every value reconstructible from the notation) rather than listing all
+        // 40. Both endpoints survive verbatim, and the hex-address column keeps its explicit
+        // list — no value is dropped.
+        assert!(
+            out.contains("120..159"),
+            "line-number range preserved: {out}"
+        );
+        assert!(out.contains("0x7f000000"), "first address preserved: {out}");
+        assert!(out.contains("0x7f0009c0"), "last address preserved: {out}");
+    }
+
     #[test]
     fn end_to_end_collapse_range_folds_regular_run() {
         let text: String = (0..30)


### PR DESCRIPTION
These tests came out of a perspective-followup eval. They document that the BM25+ delta floor and the toolout pre-masking already ship and behave as expected.

- `bm25_plus_does_not_change_kept_set_on_long_short_mix` (retrieve.rs): selection-level evidence that the BM25+ delta floor rescales scores monotonically and never reorders the kept set on a long/short chunk mix.
- `premasking_drives_grouping_and_savings` (toolout/template.rs): evidence that the existing VARIABLE regex pre-masking collapses byte-distinct stack-trace lines into one template with >60% token savings, losslessly.

Test-only, no production change, no CHANGELOG entry needed.