### PR TITLE
docs(assets): restyle status + frontier SVGs to the new dashboard

### DIFF
--- a/assets/frontier-dark.svg
+++ b/assets/frontier-dark.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="860" height="284" viewBox="0 0 860 284">
 <defs>
 <linearGradient id="bill" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#34506b"/><stop offset="100%" stop-color="#4d7aa3"/></linearGradient>
-<filter id="win" x="-45%" y="-65%" width="190%" height="230%"><feDropShadow dx="0" dy="0" stdDeviation="5" flood-color="#3fb950" flood-opacity="0.5"/></filter>
+<filter id="win" x="-45%" y="-65%" width="190%" height="230%"><feDropShadow dx="0" dy="0" stdDeviation="3" flood-color="#99ccff" flood-opacity="0.28"/></filter>
 </defs>
 <rect width="860" height="284" fill="#0d1117"/>
 <rect x="1" y="1" width="858" height="282" rx="12" fill="none" stroke="#30363d" stroke-width="1"/>
@@ -18,10 +18,10 @@
 <text x="367.9" y="178.0" font-size="17" font-weight="800" fill="#e6edf3" text-anchor="start" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">$0.0126</text>
 <text x="203.1" y="176.0" font-size="10.5" font-weight="600" fill="#c3d2de" text-anchor="middle" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="0.4">−31%</text>
 <text x="296.0" y="176.0" font-size="10.5" font-weight="600" fill="#eaf2f8" text-anchor="middle" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="0.4">−74%</text>
-<path d="M353.9,152 H702.0 A6,6 0 0 1 708.0,158 V186.0 A6,6 0 0 1 702.0,192 H353.9" fill="#3fb950" fill-opacity="0.09" stroke="#3fb950" stroke-opacity="0.55" stroke-width="1.4" stroke-dasharray="5 4"/>
-<text x="692.0" y="184.0" font-size="34" font-weight="800" fill="#3fb950" text-anchor="end" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="-1" filter="url(#win)">−66%</text>
-<text x="692.0" y="206.0" font-size="12.5" font-weight="600" fill="#56d364" text-anchor="end" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="0.2">round-trip cost you don't pay</text>
-<text x="44" y="240" font-size="14.5" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" fill="#8b949e">caveman cuts <tspan fill="#e6edf3">output</tspan> · rtk cuts <tspan fill="#e6edf3">tool output</tspan> · llmtrim cuts <tspan fill="#3fb950" font-weight="800">both ends</tspan></text>
+<path d="M353.9,152 H702.0 A6,6 0 0 1 708.0,158 V186.0 A6,6 0 0 1 702.0,192 H353.9" fill="#99ccff" fill-opacity="0.09" stroke="#99ccff" stroke-opacity="0.55" stroke-width="1.4" stroke-dasharray="5 4"/>
+<text x="692.0" y="184.0" font-size="34" font-weight="800" fill="#99ccff" text-anchor="end" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="-1" filter="url(#win)">−66%</text>
+<text x="692.0" y="206.0" font-size="12.5" font-weight="600" fill="#79c0ff" text-anchor="end" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="0.2">round-trip cost you don't pay</text>
+<text x="44" y="240" font-size="14.5" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" fill="#8b949e">caveman cuts <tspan fill="#e6edf3">output</tspan> · rtk cuts <tspan fill="#e6edf3">tool output</tspan> · llmtrim cuts <tspan fill="#99ccff" font-weight="800">both ends</tspan></text>
 <line x1="44" y1="258" x2="816" y2="258" stroke="#21262d" stroke-width="1"/>
 <text x="44.0" y="272.0" font-size="11" font-weight="400" fill="#7d8590" text-anchor="start" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">measured: 112 live A/B cases · qwen/qwen3-next-80b-a3b-instruct · full results in bench/README</text>
 </svg>

--- a/assets/frontier-light.svg
+++ b/assets/frontier-light.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="860" height="284" viewBox="0 0 860 284">
 <defs>
 <linearGradient id="bill" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#9fb8d2"/><stop offset="100%" stop-color="#6e93b6"/></linearGradient>
-<filter id="win" x="-45%" y="-65%" width="190%" height="230%"><feDropShadow dx="0" dy="0" stdDeviation="5" flood-color="#1a7f37" flood-opacity="0.18"/></filter>
+<filter id="win" x="-45%" y="-65%" width="190%" height="230%"><feDropShadow dx="0" dy="0" stdDeviation="3" flood-color="#0969da" flood-opacity="0.12"/></filter>
 </defs>
 <rect width="860" height="284" fill="#ffffff"/>
 <rect x="1" y="1" width="858" height="282" rx="12" fill="none" stroke="#d0d7de" stroke-width="1"/>
@@ -18,10 +18,10 @@
 <text x="367.9" y="178.0" font-size="17" font-weight="800" fill="#1f2328" text-anchor="start" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">$0.0126</text>
 <text x="203.1" y="176.0" font-size="10.5" font-weight="600" fill="#222b33" text-anchor="middle" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="0.4">−31%</text>
 <text x="296.0" y="176.0" font-size="10.5" font-weight="600" fill="#0d2942" text-anchor="middle" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="0.4">−74%</text>
-<path d="M353.9,152 H702.0 A6,6 0 0 1 708.0,158 V186.0 A6,6 0 0 1 702.0,192 H353.9" fill="#1a7f37" fill-opacity="0.13" stroke="#1a7f37" stroke-opacity="0.55" stroke-width="1.4" stroke-dasharray="5 4"/>
-<text x="692.0" y="184.0" font-size="34" font-weight="800" fill="#1a7f37" text-anchor="end" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="-1" filter="url(#win)">−66%</text>
-<text x="692.0" y="206.0" font-size="12.5" font-weight="600" fill="#1f883d" text-anchor="end" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="0.2">round-trip cost you don't pay</text>
-<text x="44" y="240" font-size="14.5" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" fill="#59636e">caveman cuts <tspan fill="#1f2328">output</tspan> · rtk cuts <tspan fill="#1f2328">tool output</tspan> · llmtrim cuts <tspan fill="#1a7f37" font-weight="800">both ends</tspan></text>
+<path d="M353.9,152 H702.0 A6,6 0 0 1 708.0,158 V186.0 A6,6 0 0 1 702.0,192 H353.9" fill="#0969da" fill-opacity="0.13" stroke="#0969da" stroke-opacity="0.55" stroke-width="1.4" stroke-dasharray="5 4"/>
+<text x="692.0" y="184.0" font-size="34" font-weight="800" fill="#0969da" text-anchor="end" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="-1" filter="url(#win)">−66%</text>
+<text x="692.0" y="206.0" font-size="12.5" font-weight="600" fill="#1f6feb" text-anchor="end" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" letter-spacing="0.2">round-trip cost you don't pay</text>
+<text x="44" y="240" font-size="14.5" font-family="ui-sans-serif,-apple-system,Segoe UI,Helvetica,Arial,sans-serif" fill="#59636e">caveman cuts <tspan fill="#1f2328">output</tspan> · rtk cuts <tspan fill="#1f2328">tool output</tspan> · llmtrim cuts <tspan fill="#0969da" font-weight="800">both ends</tspan></text>
 <line x1="44" y1="258" x2="816" y2="258" stroke="#d8dee4" stroke-width="1"/>
 <text x="44.0" y="272.0" font-size="11" font-weight="400" fill="#6a727c" text-anchor="start" font-family="ui-monospace,SFMono-Regular,Menlo,monospace">measured: 112 live A/B cases · qwen/qwen3-next-80b-a3b-instruct · full results in bench/README</text>
 </svg>

--- a/assets/status-watch-dark.svg
+++ b/assets/status-watch-dark.svg
@@ -1,71 +1,82 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="760" height="442" viewBox="0 0 760 442" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="15">
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="500" viewBox="0 0 760 500" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="15">
   <style>
-    .t{fill:#e6edf3}.dim{fill:#8b949e}.acc{fill:#3fb950}.bold{fill:#e6edf3;font-weight:bold}
-    .accb{fill:#3fb950;font-weight:bold}.bar{fill:#3fb950}.trk{fill:#30363d}
-    .fine{fill:#8b949e;font-size:13px}
+    .t{fill:#e6edf3}.dim{fill:#8b949e}.acc{fill:#99ccff}
+    .bold{fill:#e6edf3;font-weight:bold}.accb{fill:#99ccff;font-weight:bold}
+    .bar{fill:#99ccff}.trk{fill:#30363d}.warn{fill:#d29922}
+    .fine{fill:#8b949e;font-size:13px}.box{fill:none;stroke:#6e7681}
   </style>
   <!-- terminal chrome -->
-  <rect width="760" height="442" rx="10" fill="#0d1117" stroke="#6e7681"/>
+  <rect width="760" height="500" rx="10" fill="#0d1117" stroke="#6e7681"/>
   <circle cx="22" cy="20" r="6" fill="#ff5f57"/><circle cx="42" cy="20" r="6" fill="#febc2e"/><circle cx="62" cy="20" r="6" fill="#28c840"/>
   <text x="380" y="25" class="dim" text-anchor="middle" font-size="13">llmtrim status --watch</text>
 
-  <!-- header -->
-  <text x="24" y="58" class="t"><tspan class="acc">llmtrim ●</tspan> running :8443 · <tspan class="acc">✓</tspan> port <tspan class="acc">✓</tspan> env <tspan class="acc">✓</tspan> ca · traffic <tspan class="acc">✓</tspan></text>
+  <!-- header: wordmark · live dot · meta · health -->
+  <text x="24" y="56" class="t"><tspan class="dim">‹‹</tspan> <tspan class="bold">llmtrim</tspan> <tspan class="dim">››</tspan> <tspan class="acc">●</tspan> <tspan class="dim">running · :8443 · up 2h33m · v0.1.12</tspan></text>
+  <text x="736" y="56" class="acc" text-anchor="end">✓ healthy</text>
 
-  <!-- hero panel -->
-  <rect x="24" y="74" width="712" height="46" rx="6" fill="none" stroke="#6e7681"/>
+  <!-- hero box: measured real-bill dollars, two lines -->
+  <rect x="24" y="72" width="712" height="60" rx="6" class="box"/>
+  <text x="40" y="98"><tspan class="accb">$179.46</tspan><tspan class="dim"> off your real bill · </tspan><tspan class="acc">$60.63 saved today</tspan></text>
+  <text x="40" y="120" class="dim">110.6M tokens trimmed · 17,701 requests</text>
+  <!-- the logo promise, no brackets -->
+  <text x="40" y="154"><tspan class="acc">✓</tspan><tspan class="t"> same answers, smaller bill</tspan></text>
 
-  <!-- animated hero frames (8s loop, 4 steps, 3 loops then freeze) -->
-  <g>
-    <animate attributeName="opacity" calcMode="discrete" dur="8s" repeatCount="3" fill="freeze" keyTimes="0;0.25" values="1;0"/>
-    <text x="40" y="103"><tspan class="accb">45.0M tokens</tspan><tspan class="t"> trimmed</tspan><tspan class="dim"> · today $114.07 · </tspan><tspan class="bold">~$343.19 off your bill</tspan><tspan class="t"> · 7,268 req</tspan></text>
+  <!-- savings -->
+  <text x="28" y="188" class="dim">SAVINGS</text>
+  <text x="36" y="211" class="t">input</text>
+  <text x="104" y="211"><tspan class="dim">116.8M ─✂─▶ </tspan><tspan class="bold">38.2M</tspan></text>
+  <rect x="300" y="200" width="150" height="12" rx="3" class="trk"/>
+  <rect x="300" y="200" width="100" height="12" rx="3" class="bar"/>
+  <text x="470" y="211" class="accb">-67%</text>
+  <text x="540" y="211" class="fine">(cache excluded)</text>
+
+  <text x="36" y="235" class="t">output</text>
+  <text x="104" y="235"><tspan class="bold">13.1M</tspan><tspan class="dim"> billed</tspan></text>
+  <rect x="300" y="224" width="150" height="12" rx="3" class="trk"/>
+  <rect x="300" y="224" width="110" height="12" rx="3" class="bar" opacity="0.55"/>
+  <text x="470" y="235" class="accb">~-73%</text>
+  <text x="540" y="235" class="fine">(est · if output shaped)</text>
+
+  <!-- 7-day trend -->
+  <text x="28" y="267" class="dim">7-DAY TREND <tspan class="fine">tokens saved / day</tspan></text>
+  <g class="bar">
+    <rect x="36"  y="289" width="9" height="13" rx="1.5"/>
+    <rect x="49"  y="283" width="9" height="19" rx="1.5"/>
+    <rect x="62"  y="285" width="9" height="17" rx="1.5"/>
+    <rect x="75"  y="283" width="9" height="19" rx="1.5"/>
+    <rect x="88"  y="280" width="9" height="22" rx="1.5"/>
+    <rect x="101" y="283" width="9" height="19" rx="1.5"/>
+    <rect x="114" y="287" width="9" height="15" rx="1.5"/>
   </g>
-  <g opacity="0">
-    <animate attributeName="opacity" calcMode="discrete" dur="8s" repeatCount="3" fill="freeze" keyTimes="0;0.25;0.5" values="0;1;0"/>
-    <text x="40" y="103"><tspan class="accb">45.1M tokens</tspan><tspan class="t"> trimmed</tspan><tspan class="dim"> · today $114.26 · </tspan><tspan class="bold">~$343.71 off your bill</tspan><tspan class="t"> · 7,273 req</tspan></text>
-  </g>
-  <g opacity="0">
-    <animate attributeName="opacity" calcMode="discrete" dur="8s" repeatCount="3" fill="freeze" keyTimes="0;0.5;0.75" values="0;1;0"/>
-    <text x="40" y="103"><tspan class="accb">45.1M tokens</tspan><tspan class="t"> trimmed</tspan><tspan class="dim"> · today $114.48 · </tspan><tspan class="bold">~$344.30 off your bill</tspan><tspan class="t"> · 7,279 req</tspan></text>
-  </g>
-  <g opacity="0">
-    <animate attributeName="opacity" calcMode="discrete" dur="8s" repeatCount="3" fill="freeze" keyTimes="0;0.75" values="0;1"/>
-    <text x="40" y="103"><tspan class="accb">45.2M tokens</tspan><tspan class="t"> trimmed</tspan><tspan class="dim"> · today $114.71 · </tspan><tspan class="bold">~$344.88 off your bill</tspan><tspan class="t"> · 7,286 req</tspan></text>
-  </g>
-
-  <text x="32" y="144" class="fine">floor $84.22 measured off the bill · $307.48 at list value</text>
-
-  <!-- savings axes -->
-  <text x="28" y="178" class="dim">savings</text>
-  <text x="36" y="202" class="t">input</text>
-  <rect x="116" y="191" width="220" height="12" rx="3" class="trk"/>
-  <rect x="116" y="191" width="156" height="12" rx="3" class="bar">
-    <animate attributeName="width" dur="8s" repeatCount="3" fill="freeze" calcMode="discrete" keyTimes="0;0.25;0.5;0.75" values="155;156;156;157"/>
-  </rect>
-  <text x="350" y="202" class="accb">−71%</text>
-  <text x="416" y="202" class="t">18.7M → 5.4M</text>
-  <text x="540" y="202" class="fine">(cache excluded)</text>
-
-  <text x="36" y="228" class="t">output</text>
-  <rect x="116" y="217" width="220" height="12" rx="3" class="trk"/>
-  <rect x="116" y="217" width="161" height="12" rx="3" class="bar" opacity="0.55"/>
-  <text x="350" y="228" class="accb">~−73%</text>
-  <text x="416" y="228" class="t">6.9M billed</text>
-  <text x="522" y="228" class="fine">(est · if shaped)</text>
+  <text x="140" y="299" class="dim">peak 19.6M · last 11.6M · <tspan class="acc">▲ up</tspan></text>
 
   <!-- by model -->
-  <text x="28" y="262" class="dim">by model</text>
-  <text x="36" y="286" class="dim">model</text><text x="340" y="286" class="dim" text-anchor="end">requests</text><text x="436" y="286" class="dim" text-anchor="end">saved</text><text x="544" y="286" class="dim" text-anchor="end">$ saved</text>
-  <line x1="36" y1="294" x2="544" y2="294" stroke="#6e7681"/>
-  <text x="36" y="316" class="t">claude-opus-4-8</text><text x="340" y="316" class="t" text-anchor="end">2,782</text><text x="436" y="316" class="acc" text-anchor="end">−71%</text><text x="544" y="316" class="acc" text-anchor="end">$86.52</text>
-  <text x="36" y="340" class="t">claude-fable-5</text><text x="340" y="340" class="t" text-anchor="end">2,704</text><text x="436" y="340" class="acc" text-anchor="end">−69%</text><text x="544" y="340" class="acc" text-anchor="end">$199.29</text>
-  <text x="36" y="364" class="fine">saved % measured without the cached prefix</text>
+  <text x="28" y="331" class="dim">BY MODEL</text>
+  <rect x="24" y="345" width="560" height="94" rx="6" class="box"/>
+  <text x="40" y="368" class="dim">model</text>
+  <text x="360" y="368" class="dim" text-anchor="end">requests</text>
+  <text x="456" y="368" class="dim" text-anchor="end">saved</text>
+  <text x="564" y="368" class="dim" text-anchor="end">$ saved</text>
+  <line x1="40" y1="377" x2="568" y2="377" stroke="#30363d"/>
+  <text x="40" y="400" class="t">claude-fable-5</text>
+  <text x="360" y="400" class="t" text-anchor="end">2,704</text>
+  <text x="456" y="400" class="acc" text-anchor="end">-69%</text>
+  <text x="564" y="400" class="acc" text-anchor="end">$199.29</text>
+  <text x="40" y="422" class="t">claude-opus-4-8</text>
+  <text x="360" y="422" class="t" text-anchor="end">2,782</text>
+  <text x="456" y="422" class="acc" text-anchor="end">-71%</text>
+  <text x="564" y="422" class="acc" text-anchor="end">$86.52</text>
 
-  <text x="28" y="394" class="fine">added latency ~2.7 ms/req · llmtrim overhead</text>
+  <!-- the one cost line -->
+  <text x="28" y="462" class="fine">+ ~3 ms/req · compression overhead</text>
 
-  <!-- blinking watch cursor -->
-  <text x="28" y="422" class="fine">refreshing every 2s - Ctrl-C to exit</text>
-  <rect x="304" y="411" width="9" height="14" fill="#8b949e">
-    <animate attributeName="opacity" dur="1s" repeatCount="3" fill="freeze" values="1;1;0;0"/>
-  </rect>
+  <!-- live status bar: spinner · last request · rate · quit keycap -->
+  <g transform="translate(34,483)">
+    <circle r="6" fill="none" stroke="#30363d" stroke-width="2"/>
+    <path d="M0,-6 A6,6 0 0 1 6,0" fill="none" stroke="#99ccff" stroke-width="2" stroke-linecap="round">
+      <animateTransform attributeName="transform" type="rotate" from="0" to="360" dur="0.9s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <text x="50" y="488" class="dim">last request 3s ago · <tspan class="acc">+4.8K tok/s saved</tspan></text>
+  <text x="736" y="488" text-anchor="end"><tspan class="bold">Ctrl-C</tspan> <tspan class="dim">exit</tspan></text>
 </svg>

--- a/assets/status-watch-light.svg
+++ b/assets/status-watch-light.svg
@@ -1,71 +1,82 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="760" height="442" viewBox="0 0 760 442" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="15">
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="500" viewBox="0 0 760 500" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="15">
   <style>
-    .t{fill:#1f2328}.dim{fill:#57606a}.acc{fill:#1a7f37}.bold{fill:#1f2328;font-weight:bold}
-    .accb{fill:#1a7f37;font-weight:bold}.bar{fill:#1a7f37}.trk{fill:#d8dee4}
-    .fine{fill:#57606a;font-size:13px}
+    .t{fill:#1f2328}.dim{fill:#57606a}.acc{fill:#0969da}
+    .bold{fill:#1f2328;font-weight:bold}.accb{fill:#0969da;font-weight:bold}
+    .bar{fill:#0969da}.trk{fill:#d8dee4}.warn{fill:#9a6700}
+    .fine{fill:#57606a;font-size:13px}.box{fill:none;stroke:#d0d7de}
   </style>
   <!-- terminal chrome -->
-  <rect width="760" height="442" rx="10" fill="#ffffff" stroke="#d0d7de"/>
+  <rect width="760" height="500" rx="10" fill="#ffffff" stroke="#d0d7de"/>
   <circle cx="22" cy="20" r="6" fill="#ff5f57"/><circle cx="42" cy="20" r="6" fill="#febc2e"/><circle cx="62" cy="20" r="6" fill="#28c840"/>
   <text x="380" y="25" class="dim" text-anchor="middle" font-size="13">llmtrim status --watch</text>
 
-  <!-- header -->
-  <text x="24" y="58" class="t"><tspan class="acc">llmtrim ●</tspan> running :8443 · <tspan class="acc">✓</tspan> port <tspan class="acc">✓</tspan> env <tspan class="acc">✓</tspan> ca · traffic <tspan class="acc">✓</tspan></text>
+  <!-- header: wordmark · live dot · meta · health -->
+  <text x="24" y="56" class="t"><tspan class="dim">‹‹</tspan> <tspan class="bold">llmtrim</tspan> <tspan class="dim">››</tspan> <tspan class="acc">●</tspan> <tspan class="dim">running · :8443 · up 2h33m · v0.1.12</tspan></text>
+  <text x="736" y="56" class="acc" text-anchor="end">✓ healthy</text>
 
-  <!-- hero panel -->
-  <rect x="24" y="74" width="712" height="46" rx="6" fill="none" stroke="#d0d7de"/>
+  <!-- hero box: measured real-bill dollars, two lines -->
+  <rect x="24" y="72" width="712" height="60" rx="6" class="box"/>
+  <text x="40" y="98"><tspan class="accb">$179.46</tspan><tspan class="dim"> off your real bill · </tspan><tspan class="acc">$60.63 saved today</tspan></text>
+  <text x="40" y="120" class="dim">110.6M tokens trimmed · 17,701 requests</text>
+  <!-- the logo promise, no brackets -->
+  <text x="40" y="154"><tspan class="acc">✓</tspan><tspan class="t"> same answers, smaller bill</tspan></text>
 
-  <!-- animated hero frames (8s loop, 4 steps, 3 loops then freeze) -->
-  <g>
-    <animate attributeName="opacity" calcMode="discrete" dur="8s" repeatCount="3" fill="freeze" keyTimes="0;0.25" values="1;0"/>
-    <text x="40" y="103"><tspan class="accb">45.0M tokens</tspan><tspan class="t"> trimmed</tspan><tspan class="dim"> · today $114.07 · </tspan><tspan class="bold">~$343.19 off your bill</tspan><tspan class="t"> · 7,268 req</tspan></text>
+  <!-- savings -->
+  <text x="28" y="188" class="dim">SAVINGS</text>
+  <text x="36" y="211" class="t">input</text>
+  <text x="104" y="211"><tspan class="dim">116.8M ─✂─▶ </tspan><tspan class="bold">38.2M</tspan></text>
+  <rect x="300" y="200" width="150" height="12" rx="3" class="trk"/>
+  <rect x="300" y="200" width="100" height="12" rx="3" class="bar"/>
+  <text x="470" y="211" class="accb">-67%</text>
+  <text x="540" y="211" class="fine">(cache excluded)</text>
+
+  <text x="36" y="235" class="t">output</text>
+  <text x="104" y="235"><tspan class="bold">13.1M</tspan><tspan class="dim"> billed</tspan></text>
+  <rect x="300" y="224" width="150" height="12" rx="3" class="trk"/>
+  <rect x="300" y="224" width="110" height="12" rx="3" class="bar" opacity="0.55"/>
+  <text x="470" y="235" class="accb">~-73%</text>
+  <text x="540" y="235" class="fine">(est · if output shaped)</text>
+
+  <!-- 7-day trend -->
+  <text x="28" y="267" class="dim">7-DAY TREND <tspan class="fine">tokens saved / day</tspan></text>
+  <g class="bar">
+    <rect x="36"  y="289" width="9" height="13" rx="1.5"/>
+    <rect x="49"  y="283" width="9" height="19" rx="1.5"/>
+    <rect x="62"  y="285" width="9" height="17" rx="1.5"/>
+    <rect x="75"  y="283" width="9" height="19" rx="1.5"/>
+    <rect x="88"  y="280" width="9" height="22" rx="1.5"/>
+    <rect x="101" y="283" width="9" height="19" rx="1.5"/>
+    <rect x="114" y="287" width="9" height="15" rx="1.5"/>
   </g>
-  <g opacity="0">
-    <animate attributeName="opacity" calcMode="discrete" dur="8s" repeatCount="3" fill="freeze" keyTimes="0;0.25;0.5" values="0;1;0"/>
-    <text x="40" y="103"><tspan class="accb">45.1M tokens</tspan><tspan class="t"> trimmed</tspan><tspan class="dim"> · today $114.26 · </tspan><tspan class="bold">~$343.71 off your bill</tspan><tspan class="t"> · 7,273 req</tspan></text>
-  </g>
-  <g opacity="0">
-    <animate attributeName="opacity" calcMode="discrete" dur="8s" repeatCount="3" fill="freeze" keyTimes="0;0.5;0.75" values="0;1;0"/>
-    <text x="40" y="103"><tspan class="accb">45.1M tokens</tspan><tspan class="t"> trimmed</tspan><tspan class="dim"> · today $114.48 · </tspan><tspan class="bold">~$344.30 off your bill</tspan><tspan class="t"> · 7,279 req</tspan></text>
-  </g>
-  <g opacity="0">
-    <animate attributeName="opacity" calcMode="discrete" dur="8s" repeatCount="3" fill="freeze" keyTimes="0;0.75" values="0;1"/>
-    <text x="40" y="103"><tspan class="accb">45.2M tokens</tspan><tspan class="t"> trimmed</tspan><tspan class="dim"> · today $114.71 · </tspan><tspan class="bold">~$344.88 off your bill</tspan><tspan class="t"> · 7,286 req</tspan></text>
-  </g>
-
-  <text x="32" y="144" class="fine">floor $84.22 measured off the bill · $307.48 at list value</text>
-
-  <!-- savings axes -->
-  <text x="28" y="178" class="dim">savings</text>
-  <text x="36" y="202" class="t">input</text>
-  <rect x="116" y="191" width="220" height="12" rx="3" class="trk"/>
-  <rect x="116" y="191" width="156" height="12" rx="3" class="bar">
-    <animate attributeName="width" dur="8s" repeatCount="3" fill="freeze" calcMode="discrete" keyTimes="0;0.25;0.5;0.75" values="155;156;156;157"/>
-  </rect>
-  <text x="350" y="202" class="accb">−71%</text>
-  <text x="416" y="202" class="t">18.7M → 5.4M</text>
-  <text x="540" y="202" class="fine">(cache excluded)</text>
-
-  <text x="36" y="228" class="t">output</text>
-  <rect x="116" y="217" width="220" height="12" rx="3" class="trk"/>
-  <rect x="116" y="217" width="161" height="12" rx="3" class="bar" opacity="0.55"/>
-  <text x="350" y="228" class="accb">~−73%</text>
-  <text x="416" y="228" class="t">6.9M billed</text>
-  <text x="522" y="228" class="fine">(est · if shaped)</text>
+  <text x="140" y="299" class="dim">peak 19.6M · last 11.6M · <tspan class="acc">▲ up</tspan></text>
 
   <!-- by model -->
-  <text x="28" y="262" class="dim">by model</text>
-  <text x="36" y="286" class="dim">model</text><text x="340" y="286" class="dim" text-anchor="end">requests</text><text x="436" y="286" class="dim" text-anchor="end">saved</text><text x="544" y="286" class="dim" text-anchor="end">$ saved</text>
-  <line x1="36" y1="294" x2="544" y2="294" stroke="#d0d7de"/>
-  <text x="36" y="316" class="t">claude-opus-4-8</text><text x="340" y="316" class="t" text-anchor="end">2,782</text><text x="436" y="316" class="acc" text-anchor="end">−71%</text><text x="544" y="316" class="acc" text-anchor="end">$86.52</text>
-  <text x="36" y="340" class="t">claude-fable-5</text><text x="340" y="340" class="t" text-anchor="end">2,704</text><text x="436" y="340" class="acc" text-anchor="end">−69%</text><text x="544" y="340" class="acc" text-anchor="end">$199.29</text>
-  <text x="36" y="364" class="fine">saved % measured without the cached prefix</text>
+  <text x="28" y="331" class="dim">BY MODEL</text>
+  <rect x="24" y="345" width="560" height="94" rx="6" class="box"/>
+  <text x="40" y="368" class="dim">model</text>
+  <text x="360" y="368" class="dim" text-anchor="end">requests</text>
+  <text x="456" y="368" class="dim" text-anchor="end">saved</text>
+  <text x="564" y="368" class="dim" text-anchor="end">$ saved</text>
+  <line x1="40" y1="377" x2="568" y2="377" stroke="#d8dee4"/>
+  <text x="40" y="400" class="t">claude-fable-5</text>
+  <text x="360" y="400" class="t" text-anchor="end">2,704</text>
+  <text x="456" y="400" class="acc" text-anchor="end">-69%</text>
+  <text x="564" y="400" class="acc" text-anchor="end">$199.29</text>
+  <text x="40" y="422" class="t">claude-opus-4-8</text>
+  <text x="360" y="422" class="t" text-anchor="end">2,782</text>
+  <text x="456" y="422" class="acc" text-anchor="end">-71%</text>
+  <text x="564" y="422" class="acc" text-anchor="end">$86.52</text>
 
-  <text x="28" y="394" class="fine">added latency ~2.7 ms/req · llmtrim overhead</text>
+  <!-- the one cost line -->
+  <text x="28" y="462" class="fine">+ ~3 ms/req · compression overhead</text>
 
-  <!-- blinking watch cursor -->
-  <text x="28" y="422" class="fine">refreshing every 2s - Ctrl-C to exit</text>
-  <rect x="304" y="411" width="9" height="14" fill="#57606a">
-    <animate attributeName="opacity" dur="1s" repeatCount="3" fill="freeze" values="1;1;0;0"/>
-  </rect>
+  <!-- live status bar: spinner · last request · rate · quit keycap -->
+  <g transform="translate(34,483)">
+    <circle r="6" fill="none" stroke="#d8dee4" stroke-width="2"/>
+    <path d="M0,-6 A6,6 0 0 1 6,0" fill="none" stroke="#0969da" stroke-width="2" stroke-linecap="round">
+      <animateTransform attributeName="transform" type="rotate" from="0" to="360" dur="0.9s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <text x="50" y="488" class="dim">last request 3s ago · <tspan class="acc">+4.8K tok/s saved</tspan></text>
+  <text x="736" y="488" text-anchor="end"><tspan class="bold">Ctrl-C</tspan> <tspan class="dim">exit</tspan></text>
 </svg>


### PR DESCRIPTION
Updates the README illustration assets to the redesigned `status` dashboard and the new blue accent.

## What changed
- `status-watch-dark/light.svg`: redrawn to the new layout (wordmark header with a `✓ healthy` badge, the measured real-bill hero, shear savings axes with accent-filled bars, the `7-DAY TREND` sparkline, a sorted `BY MODEL` table with a light header rule, and a live status bar: spinner, `last request ago`, live rate, `Ctrl-C exit` keycap).
- `frontier-dark/light.svg`: accent recolored from green to the interface blue (`#99ccff` dark, `#0969da` light), with a softened glow on the `−66%`.

All four are valid XML and verified with headless-render screenshots. Docs/assets only, no code.
