### PR TITLE
chore: strengthen the contributor frame

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,15 +4,22 @@
 
 <!-- What does this change do, and what problem does it solve? -->
 
+## Linked issue
+
+<!-- Large changes should be agreed in an issue first (see CONTRIBUTING.md). -->
+
+Closes #
+
 ## How it was verified
 
-<!-- Tests added/updated? `cargo test`, `cargo clippy`, `cargo fmt --check` all green? -->
+<!-- Tests added/updated? Did the check loop pass? -->
 
-- [ ] `cargo test` passes
-- [ ] `cargo clippy --all-targets -- -D warnings` is clean
-- [ ] `cargo fmt --all -- --check` is clean
+- [ ] `cargo fmt` is clean
+- [ ] `cargo clippy --features intercept` is clean
+- [ ] `cargo nextest run --features intercept` passes
 - [ ] New behavior is covered by a test
-- [ ] Commits are signed off (`git commit -s` — DCO, see CONTRIBUTING.md)
+- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]` (or the change is invisible to users)
+- [ ] Commits are signed off (`git commit -s`, DCO, see CONTRIBUTING.md)
 
 ## Notes
 

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,52 @@
+name: DCO
+
+# Verify every commit in a pull request carries a `Signed-off-by` line, certifying the
+# Developer Certificate of Origin (https://developercertificate.org/). CONTRIBUTING.md
+# states inbound=outbound (contributions are licensed under AGPL-3.0-only); this check
+# enforces that the sign-off is actually present rather than trusting the PR checkbox.
+
+on:
+  pull_request:
+
+# Least privilege: read the repo, nothing else.
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need the full PR commit range, not just the tip.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check Signed-off-by on every PR commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          # Require a well-formed Signed-off-by on every non-merge commit. Per the DCO, the
+          # sign-off only has to be present and well-formed; it need not match the commit
+          # author (sign-off email often differs after a rebase or a web-UI commit).
+          for sha in $(git rev-list --no-merges "$BASE_SHA".."$HEAD_SHA"); do
+            if git show -s --format='%(trailers:key=Signed-off-by)' "$sha" \
+              | grep -qiE '^Signed-off-by: .+ <[^@ ]+@[^@ ]+>'; then
+              continue
+            fi
+            if [ "$missing" -eq 0 ]; then
+              echo "Commits missing a well-formed 'Signed-off-by' line:"
+            fi
+            echo "  $(git show -s --format='%h %s' "$sha")"
+            missing=1
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo
+            echo "Sign off your commits with 'git commit -s' (see CONTRIBUTING.md)."
+            echo "To fix existing commits: git rebase --signoff $BASE_SHA && git push --force-with-lease"
+            exit 1
+          fi
+          echo "All PR commits are signed off."

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the maintainers by opening a [GitHub Security Advisory](https://github.com/fkiene/llmtrim/security/advisories/new) (use it as a private report channel; do not file a public issue). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,8 @@
 Thanks for your interest! llmtrim is a static, deterministic LLM prompt compressor:
 zero auxiliary model calls, every transform measured with the real target tokenizer.
 
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Ground rules
 
 Four principles guide every change:
@@ -15,15 +17,32 @@ Four principles guide every change:
 
 ## Development
 
+The standard check loop (run all three before pushing):
+
 ```bash
-cargo build                  # debug build
-cargo test                   # run the suite (deterministic, no network)
-cargo clippy --all-targets -- -D warnings
-cargo fmt --all
-cargo build --features live  # the bench network path (async-openai + tokio)
+cargo fmt
+cargo clippy --features intercept
+cargo nextest run --features intercept
 ```
 
-CI runs fmt, clippy (`-D warnings`), and the test suite on Linux, macOS, and Windows. Keep all three green.
+Notes:
+
+- Use `cargo nextest run`, not `cargo test`: it runs in parallel and prints compact output.
+- Do not pass `-- -D warnings` to clippy. `warnings = "deny"` is already set in the
+  workspace `[lints.rust]`, and adding the flag forks the build cache between clippy and test.
+- Keep `--features intercept` consistent across commands so the incremental cache is reused.
+
+The suite is deterministic and hits no network. `cargo build --features live` builds the
+optional bench network path (async-openai + tokio); async is confined to that path and is
+not allowed in the core compression stages.
+
+Before the first push that opens a PR, also check coverage of the files you changed:
+
+```bash
+cargo llvm-cov --features intercept,mcp --summary-only
+```
+
+CI runs fmt, clippy, and the test suite on Linux, macOS, and Windows. Keep all three green.
 
 Enable the local git hooks (mirror of CI plus a gitleaks secret scan; needs `gitleaks` or Docker):
 
@@ -45,12 +64,35 @@ Stages implement the `Transform` trait (`src/gate.rs`) and are assembled in
 
 Lossy stages stay **off by default** and are quality-checked offline (see README §6).
 
+## Before a large change
+
+Open an issue first for anything beyond a small fix. Describe the problem and the approach
+you have in mind, and wait for a maintainer to confirm the direction. A short agreement up
+front saves a large PR from a redesign in review. New user-facing surfaces (a CLI mode, an
+MCP tool, an output channel) and any change to the published `llmtrim-core` public API need
+this step.
+
 ## Pull requests
 
 - One logical change per PR; every changed line should trace to the stated goal.
+- Link the issue the PR addresses (`Closes #123`).
 - Add or update tests for new behavior.
-- Run fmt + clippy + tests before pushing.
+- Add a `CHANGELOG.md` entry under `## [Unreleased]` for any user-observable change, written
+  for users. Skip it only for invisible changes (cosmetic, docs, tests, no-op refactors).
+- Run the check loop above before pushing.
 - Fill in the PR template.
+
+## Commit hygiene
+
+One coherent change per commit, with a message that explains it for a reviewer. Fold every
+fixup, "wip", or review-fix tweak into the commit it belongs to before you push. Force-push a
+rewritten branch with `--force-with-lease`, never a bare `--force`.
+
+## Review
+
+A maintainer reviews each PR and may ask you to split a large change into smaller pieces or to
+move ecosystem-specific logic out of `llmtrim-core`. Expect a first response within a week. A
+request for changes is about the code, not about you.
 
 ## Sign your commits (DCO)
 


### PR DESCRIPTION
## What & why

Strengthens the contributor frame so external contributions arrive on a fair, accurate footing. This is housekeeping prompted by reviewing #45, kept off that contributor's thread.

## Changes

- **CONTRIBUTING.md**: corrects the check loop to the real one (`cargo fmt` + clippy/nextest with `--features intercept`) and drops the forbidden `-- -D warnings`. Adds an issue-first step for large changes and new core/public-API surfaces, the changelog expectation, a commit-hygiene section, a review section (one-week response, may ask to split), and the coverage-gate command. Confines the async note to the `--features live` path.
- **.github/PULL_REQUEST_TEMPLATE.md**: adds a `Closes #` linked-issue prompt and a changelog checkbox, and corrects the verification commands.
- **.github/workflows/dco.yml** (new): enforces a well-formed `Signed-off-by` on every non-merge PR commit, so the inbound=outbound AGPL basis is verified rather than trusted. Self-contained (no third-party action), least privilege, injection-safe via env vars.
- **CODE_OF_CONDUCT.md** (new): Contributor Covenant 2.1 with a private GitHub Security Advisory report channel, linked from CONTRIBUTING.

## How it was verified

- [x] `cargo fmt`, clippy, nextest unaffected (docs/CI only, no Rust changed)
- [x] `dco.yml` validated as YAML and smoke-tested against real history (accepts a signed-off commit, well-formed-trailer match)
- [x] Prose run through the avoid-ai-writing pass: no em dashes, no placeholders
- [x] Commit signed off (DCO)

## Notes

The CODE_OF_CONDUCT.md covenant text is the verbatim 2.1 standard fetched from the canonical source; only the reporting-contact line was customized.
