### PR TITLE
fix(capture): report ToolStage as 'tool_trim' when description trimming is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to this project are documented here. The format follows
   llmtrim in the current shell, so a wrapped agent can't silently bypass compression. Starts
   the daemon for you if the environment is wired but the interceptor is down.
 
+### Fixed
+- **`tool_trim` stage now appears as `"tool_trim"` in capture `stages` lists** (was `"tools"`).
+  When description trimming is active (`agent`/`aggressive` presets), the `ToolStage` stage name
+  is now `"tool_trim"` instead of `"tools"`. This lets QA auditors correctly identify
+  description-trimming runs as lossy and not flag them as category-4 bugs (lossless-only runs
+  that dropped content). Lossless-only uses (selection + schema minification without trimming)
+  continue to appear as `"tools"`.
+
 ## [0.1.12] - 2026-06-15
 
 ### Added

--- a/crates/llmtrim-core/src/stages/tools.rs
+++ b/crates/llmtrim-core/src/stages/tools.rs
@@ -31,7 +31,10 @@ pub struct ToolStage {
 
 impl Transform for ToolStage {
     fn name(&self) -> &str {
-        "tools"
+        // When description trimming is active the stage is lossy (content is dropped from tool
+        // descriptions). Use a distinct name so captures — and the audit protocol that reads the
+        // `stages` list to distinguish lossless from lossy runs — can tell the difference.
+        if self.trim_desc { "tool_trim" } else { "tools" }
     }
 
     fn gate_kind(&self) -> GateKind {
@@ -726,6 +729,26 @@ mod tests {
             minify_schema: false,
             max_desc_chars: 200,
         })
+    }
+
+    #[test]
+    fn stage_name_reflects_lossy_trim() {
+        // trim_desc drops description content, so it must report a distinct, lossy stage name
+        // for captures and the audit protocol; lossless selection/minification stays "tools".
+        let trimming = ToolStage {
+            select: false,
+            trim_desc: true,
+            minify_schema: false,
+            max_desc_chars: 200,
+        };
+        assert_eq!(trimming.name(), "tool_trim");
+        let lossless = ToolStage {
+            select: true,
+            trim_desc: false,
+            minify_schema: true,
+            max_desc_chars: 200,
+        };
+        assert_eq!(lossless.name(), "tools");
     }
 
     #[test]


### PR DESCRIPTION
## Why

The `ToolStage` reported its stage name as `"tools"` regardless of whether it was doing lossless work (tool selection + schema minification) or **lossy** description trimming (`trim_desc`, active in the `agent`/`aggressive` presets). The capture's `stages` list is what the compression-QA audit protocol reads to tell lossless runs from lossy ones, so the mislabel caused every `agent`/`aggressive` capture to be flagged as a category-4 false positive (a "lossless-only run that dropped content").

## What

`ToolStage::name()` now returns `"tool_trim"` when `trim_desc` is true, and `"tools"` otherwise. This is a label-only change — the compression output is unchanged; only the reported stage name becomes honest about lossiness.

- Lossless-only uses (selection + schema minification, `trim_desc=false`) still report `"tools"`.
- Added `stage_name_reflects_lossy_trim` unit test locking the contract.
- All `"tools"` references in the codebase are JSON request-body keys, not stage-name gating, so nothing selects/enables the stage by name — the rename only affects the captured `stages` list and logging.

## Verification

`cargo fmt --check`, `cargo clippy --features intercept`, and `cargo nextest run --features intercept` all green (636 tests).