### PR TITLE
test(setup): de-flake first_free_port port-acceptance check

### DIFF
--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -1582,13 +1582,11 @@ mod tests {
             "occupied port not rejected"
         );
 
-        // Release it; the same port is now bindable and the probe returns it.
-        drop(held);
-        assert_eq!(
-            first_free_port(taken, 0),
-            Some(taken),
-            "free port not accepted"
-        );
+        // With the port still held, a wider scan skips the occupied port and returns a free
+        // one further along. (Re-probing the *same* port after drop is racy: under parallel
+        // tests another thread can grab the freed ephemeral port before we rebind it.)
+        let found = first_free_port(taken, 64).expect("a free port exists in the span");
+        assert_ne!(found, taken, "scan returned the still-occupied port");
     }
 
     // ── Multi-profile sweep tests (POSIX only) ─────────────────────────────────────


### PR DESCRIPTION
## What

The macOS CI run [27618302530](https://github.com/fkiene/llmtrim/actions/runs/27618302530) failed on `setup::tests::first_free_port_rejects_occupied_accepts_free` (`setup.rs:1587`, "free port not accepted").

## Why

The test dropped a held listener, then asserted the *same* freed port was immediately re-bindable (`Some(taken)`). Under nextest's parallel execution, another thread can grab that just-freed ephemeral port in the drop/rebind window — likelier on a loaded macOS runner. The failure was flaky, not a real regression.

## Fix

Keep the deterministic occupied-port rejection (`span 0` → `None`). Verify acceptance without a rebind race: while the port is still held, a wider scan (`span 64`) must skip the occupied port and return a different free one.