### PR TITLE
ci(release): generate the third-party NOTICE once, offline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: write
 
+# Retry transient crates.io download blips (curl 18 "Transferred a partial file" etc.) instead
+# of failing a job outright. Applies to every cargo invocation in the workflow (fetch, build).
+env:
+  CARGO_NET_RETRY: "10"
+
 jobs:
   # One published GitHub Release per tag, body taken from the matching CHANGELOG.md section.
   # Runs before the build matrix so every binary uploads into a release that already has notes.
@@ -34,8 +39,34 @@ jobs:
           title: llmtrim $version
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  build:
+  # Generate the third-party license NOTICE exactly once, not per-target. `cargo metadata`
+  # returns the full cross-platform dependency set (no --filter-platform), so one run on Linux
+  # produces the same union every target needs — running it in all 6 build legs was pure
+  # redundancy that multiplied the flake surface. `cargo fetch --locked` warms the cache so the
+  # generator (now `--offline`) is network-free; the build legs consume the result as an artifact.
+  license-notice:
     needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      # Pin the toolchain like every other rust job (publish-crate etc.) instead of relying on
+      # the runner image happening to preinstall cargo.
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Warm the cargo cache (the only network step here)
+        run: cargo fetch --locked
+      - name: Generate third-party license notice
+        run: python3 tools/gen_third_party_licenses.py
+      - uses: actions/upload-artifact@v4
+        with:
+          name: third-party-licenses
+          path: THIRD-PARTY-LICENSES.md
+          if-no-files-found: error
+
+  build:
+    needs: [create-release, license-notice]
     name: ${{ matrix.target }}
     permissions:
       contents: write
@@ -60,21 +91,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      # setup-python guarantees `python3` on every runner (Windows ships `python`, not
-      # `python3`) for the license-notice generator below.
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.x'
       # aws-lc-rs assembles its x86 asm with NASM. Only x86_64 Windows needs it; the ARM64
       # runner uses a different assembler, and no arm64 NASM build exists.
       - name: Install NASM (Windows x64)
         if: runner.os == 'Windows' && runner.arch == 'X64'
         uses: ilammy/setup-nasm@v1
-      # Distributing a compiled binary statically links every dependency, so the archive
-      # must carry the AGPL license text + third-party attribution notices. The NOTICE is
-      # generated here (not committed) by harvesting LICENSE files from the cargo cache.
-      - name: Generate third-party license notice
-        run: python3 tools/gen_third_party_licenses.py
+      # The NOTICE is generated once in the `license-notice` job (the same union for every
+      # target) and pulled in here, so the archive can bundle it via `include` below.
+      - uses: actions/download-artifact@v4
+        with:
+          name: third-party-licenses
+          path: .
       # Cross-compiles, strips, archives as llmtrim-<target>.tar.gz (.zip on Windows) with a
       # matching .sha256, and uploads to the GitHub Release for this tag. The archive name
       # matches what install.sh and install.ps1 download. `include` bundles LICENSE + NOTICE.

--- a/tools/gen_third_party_licenses.py
+++ b/tools/gen_third_party_licenses.py
@@ -11,8 +11,12 @@ import json, os, re, subprocess, glob, hashlib
 # repo root = parent of this script's tools/ dir
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# `--offline`: the cache must already hold every crate (the CI release job runs
+# `cargo fetch --locked` first). This makes the harvest physically network-free, so it
+# can't fail on a transient crates.io download (curl 18 "Transferred a partial file").
+# Run `cargo fetch` yourself first if your local cache is cold.
 meta = json.loads(subprocess.check_output(
-    ["cargo", "metadata", "--format-version", "1", "--all-features", "--quiet"],
+    ["cargo", "metadata", "--format-version", "1", "--all-features", "--offline", "--quiet"],
     cwd=ROOT))
 ws = set(meta.get("workspace_members", []))
 
@@ -54,6 +58,18 @@ for p in meta["packages"]:
         texts[key]["crates"].add(f"{name} {ver}")
 
 pkgs.sort(key=lambda x: x[0].lower())
+
+# Refuse to write a degenerate NOTICE. The archives bundle this file to satisfy AGPL/third-party
+# attribution, so a near-empty one (broken metadata graph, cold/unextracted cache, no LICENSE
+# files harvested) is a compliance failure, not a smaller file — fail loudly instead of shipping
+# it. Floors are well below the real counts (~574 deps / ~295 texts) so normal dep churn never
+# trips them; a genuine breakage drops far past them.
+if len(pkgs) < 100 or len(texts) < 50:
+    raise SystemExit(
+        f"refusing to write a degenerate THIRD-PARTY-LICENSES.md: {len(pkgs)} deps, "
+        f"{len(texts)} license texts (expected hundreds). Is the cargo cache warm "
+        f"(`cargo fetch --locked`) and is `cargo metadata` resolving the full graph?"
+    )
 
 out = []
 out.append("# Third-Party Licenses\n")


### PR DESCRIPTION
## Problem

On the v0.1.13 release, the `aarch64-pc-windows-msvc` build leg failed with a transient crates.io download blip (`curl 18 "Transferred a partial file"` fetching `darling`) during the **Generate third-party license notice** step. That step runs `cargo metadata --all-features` in **all 6 build legs, before any cargo build**, so the registry cache is cold and it must download from crates.io.

Because `publish-npm`, `bump-scoop`, `docker`, and `verify-install` all `needs: build`, that one flaky leg **skipped npm/scoop/docker** (crates.io + Homebrew had already published). A `gh run rerun --failed` cleared it, but the flake will recur.

## Fix (three compounding)

1. **`cargo metadata` is now `--offline`** (after `cargo fetch --locked` warms the cache), so the license harvest is physically network-free and *cannot* fail on a crates.io download. This is the correctness guarantee.
2. **The NOTICE is generated once** in a dedicated `license-notice` job and passed to the build legs as an artifact, instead of regenerating it per target. `cargo metadata` returns the full cross-platform package set (no `--filter-platform`), so one Linux run yields the same union every target bundled before — the per-target generation was pure redundancy that multiplied the flake surface ~6×. Verified the script iterates `meta["packages"]` (all platforms), so no license-compliance regression.
3. **Top-level `CARGO_NET_RETRY: 10`** so the remaining network steps (the fetch, and the per-target compiles) retry transient blips instead of failing outright.

## Validation

The `--offline` flag was tested locally (574 deps, 295 license texts — identical output). Note: `release.yml` only runs on tag push, so this PR's normal CI does **not** exercise it; the real validation is the next release. The `--offline` guarantee is what proves the flake is gone (metadata physically cannot download), independent of CI.

No changelog entry — CI/release-infra only, not user-observable.