### PR TITLE
docs(contributing): grant maintainer dual-license rights over contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,3 +109,9 @@ the project license.
 ## License
 
 By contributing, you agree your contributions are licensed under MPL-2.0.
+
+You also grant François Kiene, and his successors and assigns, the right to license your
+contribution under any other license, including proprietary or commercial terms, so the
+project can relicense or offer a commercial dual-license later without contacting every
+contributor. You keep the copyright to your contribution. This is separate from your DCO
+sign-off, which only certifies the origin of your work.


### PR DESCRIPTION
Adds a relicensing grant to CONTRIBUTING.md so the project keeps the right to relicense or offer a commercial dual-license later without contacting every contributor.

## What changed
The License section now states that, alongside licensing their work under MPL-2.0, contributors also grant the right to relicense it under any other license (including commercial terms). The grant is explicitly decoupled from the DCO sign-off, which only certifies provenance. Contributors keep the copyright to their work.

## Why short
This is the lightweight, readable fallback. Reviewed by an IP-law pass: a CONTRIBUTING clause accepted "by contributing" is fine as cover for casual/current contributions, but it is **not** the foundation for actually selling a commercial license over outside contributions. Before commercializing, the plan is a proper CLA via a bot (cla-assistant, Apache-ICLA-style: patent verbs, employer reps, entity grantee), plus French-jurisdiction legal review for moral rights. The heavy legal text belongs in that CLA.md, not inline here.