### PR TITLE
feat(proxy): forward through an upstream proxy via LLMTRIM_UPSTREAM_PROXY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **`LLMTRIM_UPSTREAM_PROXY` env var** — set this in the daemon's launch environment
+  (launchd plist / systemd unit, not `.profile`) to route the daemon's own outbound
+  requests through a corporate or gateway proxy, or a local companion proxy such as
+  headroom on a different port (e.g. `http://127.0.0.1:9999`).
+  Accepts `http://host:port` or `http://user:pass@host:port`. Only upstreams that match
+  llmtrim's own listen address (same loopback host AND same port) are rejected at startup
+  to prevent infinite recursion; a different port on the same loopback interface is
+  allowed. Credentials in the URL are plaintext in the process environment — use a
+  credential-free URL with OS-level auth where possible.
+  Requested by @gkgoat1 ([#62](https://github.com/fkiene/llmtrim/issues/62)).
+
 ## [0.2.0] - 2026-06-18
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,6 +1573,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1696,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1723,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2125,6 +2167,9 @@ dependencies = [
  "dotenvy",
  "http-body-util",
  "hudsucker",
+ "hyper-http-proxy",
+ "hyper-rustls",
+ "hyper-util",
  "llm_providers",
  "llmtrim-core",
  "once_cell",

--- a/README.md
+++ b/README.md
@@ -318,9 +318,28 @@ Every stage is individually tunable via config flags; `preset` wins over individ
 | `dedup` | `true` | collapse duplicate lines (lossless) |
 | `quality_gate` | `true` | revert any lossy cut whose query-relevant coverage drops too far |
 
-Env: `LLMTRIM_PRESET` (preset), `LLMTRIM_CONFIG` (config-file path), `LLMTRIM_DB_PATH` (ledger location).
+Env: `LLMTRIM_PRESET` (preset), `LLMTRIM_CONFIG` (config-file path), `LLMTRIM_DB_PATH` (ledger location), `LLMTRIM_UPSTREAM_PROXY` (route egress through another proxy, see below).
 
 </details>
+
+### Chaining through an upstream proxy
+
+Set `LLMTRIM_UPSTREAM_PROXY=http://host:port` to make llmtrim send its outbound
+calls through another proxy instead of dialing the API directly. This covers two
+cases: a corporate or auth proxy that all egress must pass through, and running
+llmtrim alongside a second local tool such as [headroom](https://github.com/chopratejas/headroom)
+on a different port.
+
+The connection to the API is tunneled through the upstream with `CONNECT` and stays
+under verifying TLS, so the upstream sees only the encrypted stream. An upstream that
+points at llmtrim's own listen address (any spelling of localhost on the same port) is
+rejected, because it would loop traffic back into the daemon; a companion proxy on a
+different port is allowed. `http://user:pass@host:port` works for proxy auth, and those
+credentials are redacted from logs.
+
+Put the variable in the daemon's own launch environment (the launchd plist or systemd
+unit), not only your shell profile. Credentials written into a shell profile are stored
+there in plaintext.
 
 ## The numbers
 

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -67,6 +67,17 @@ reqwest = { version = "0.13", default-features = false, optional = true }
 tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "signal", "time"], optional = true }
 # The MITM interceptor (`serve`).
 hudsucker = { version = "0.24", default-features = false, features = ["rcgen-ca", "rustls-client", "http2"], optional = true }
+# Upstream-proxy connector for the MITM path — tunnels HTTPS origin connections via CONNECT.
+# `rustls-tls-native-roots` enables the `__rustls` internal feature, which causes ProxyConnector
+# to build a tokio-rustls TlsConnector for the ORIGIN leg of tunnelled connections (the part
+# that actually carries the API key). The inner connector only dials the proxy itself (http://),
+# so it needs no TLS. The tokio-rustls ClientConfig inherits whatever CryptoProvider is
+# installed at runtime; we call aws_lc_rs::default_provider() at startup, so origin TLS uses
+# aws-lc-rs throughout — no ring is pulled in as an active provider.
+hyper-http-proxy = { version = "1.1", default-features = false, features = ["rustls-tls-native-roots"], optional = true }
+# Direct dep so serve.rs can call HttpsConnectorBuilder if needed for non-proxy paths.
+hyper-rustls = { version = "0.27", default-features = false, features = ["native-tokio", "http1", "http2"], optional = true }
+hyper-util = { version = "0.1", default-features = false, features = ["client-legacy", "http2"], optional = true }
 async-trait = { version = "0.1", optional = true }
 http-body-util = { version = "0.1", optional = true }
 bytes = { version = "1", optional = true }
@@ -99,7 +110,7 @@ winreg = "0.56"
 # hudsucker/tokio stack intercept already pulls).
 default = ["intercept", "mcp"]
 live = ["dep:async-openai", "dep:reqwest", "dep:tokio"]
-intercept = ["dep:hudsucker", "dep:tokio", "dep:async-trait", "dep:http-body-util", "dep:bytes", "dep:llm_providers", "dep:time"]
+intercept = ["dep:hudsucker", "dep:tokio", "dep:async-trait", "dep:http-body-util", "dep:bytes", "dep:llm_providers", "dep:time", "dep:hyper-http-proxy", "dep:hyper-util", "dep:hyper-rustls"]
 mcp = ["dep:rmcp", "dep:schemars", "dep:tokio"]
 
 [lints]

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -533,7 +533,8 @@ fn run() -> Result<()> {
                 .transpose()?;
             let result = llmtrim_core::compress(&input, kind)?;
             let endpoint = Endpoint::from_env(result.provider)?;
-            let response = endpoint.send(&result.request_json)?;
+            let proxy_url = llmtrim::transport::upstream_proxy_url(None)?;
+            let response = endpoint.send(&result.request_json, proxy_url.as_deref())?;
 
             // Record to the savings ledger (best-effort: never block the user's output).
             if let Ok(counter) =

--- a/crates/llmtrim-cli/src/quality.rs
+++ b/crates/llmtrim-cli/src/quality.rs
@@ -235,7 +235,10 @@ impl HttpModel {
 
 impl Model for HttpModel {
     fn answer(&self, request_json: &str) -> Result<String> {
-        let response = self.endpoint.send(request_json)?;
+        // Pass None for bind_addr: bench runs are not daemon instances, so there is no
+        // listen port to guard against loopback recursion.
+        let proxy_url = crate::transport::upstream_proxy_url(None)?;
+        let response = self.endpoint.send(request_json, proxy_url.as_deref())?;
         let value: serde_json::Value =
             serde_json::from_str(&response).context("response is not valid JSON")?;
         self.provider

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -46,6 +46,8 @@ mod imp {
     use hudsucker::hyper::{Method, Request, Response, header};
     use hudsucker::rustls::crypto::aws_lc_rs;
     use hudsucker::{Body, HttpContext, HttpHandler, Proxy, RequestOrResponse};
+    use hyper_http_proxy::{Intercept, Proxy as UpstreamProxy, ProxyConnector};
+    use hyper_util::client::legacy::connect::HttpConnector;
 
     use crate::tracking::{Record, Tracker};
     use llmtrim_core::config::DenseConfig;
@@ -279,10 +281,11 @@ mod imp {
     /// Replay the original (uncompressed) request to the upstream — direct, all statuses
     /// relayed — and build a response for the client. `None` if the replay itself fails (in
     /// which case the caller keeps the compressed response's error).
-    fn replay_original(orig: &OriginalRequest) -> Option<Response<Body>> {
+    fn replay_original(orig: &OriginalRequest, proxy_url: Option<&str>) -> Option<Response<Body>> {
         use std::io::Read;
         let body = std::str::from_utf8(&orig.body).ok()?;
-        let mut up = crate::transport::forward_post(&orig.url, &orig.headers, body).ok()?;
+        let mut up =
+            crate::transport::forward_post(&orig.url, &orig.headers, body, proxy_url).ok()?;
         let mut buf = Vec::new();
         up.reader.read_to_end(&mut buf).ok()?;
         let mut builder = Response::builder().status(up.status);
@@ -397,6 +400,10 @@ mod imp {
         memo: Arc<Memo>,
         /// The compressed request awaiting its response (set in `handle_request`).
         pending: Option<Pending>,
+        /// Optional upstream proxy URL from `LLMTRIM_UPSTREAM_PROXY`. Used by the replay path
+        /// (`forward_post`). The primary MITM interception path honours this setting via the
+        /// `ProxyConnector` built at startup (see the `start` function in this module).
+        upstream_proxy: Option<String>,
     }
 
     impl Drop for Interceptor {
@@ -536,8 +543,13 @@ mod imp {
             let status = res.status();
             if should_replay(status.as_u16())
                 && let Some(original) = pending.original.clone()
-                && let Ok(Some(replayed)) =
-                    tokio::task::spawn_blocking(move || replay_original(&original)).await
+                && let Ok(Some(replayed)) = {
+                    let proxy = self.upstream_proxy.clone();
+                    tokio::task::spawn_blocking(move || {
+                        replay_original(&original, proxy.as_deref())
+                    })
+                    .await
+                }
             {
                 eprintln!(
                     "llmtrim: upstream {} on compressed request — replayed original (no compression this call)",
@@ -1241,17 +1253,6 @@ mod imp {
             }
         });
 
-        let handler = Interceptor {
-            config: Arc::new(DenseConfig::load_for_interceptor()),
-            ledger: tx,
-            // `ensure_ca` above just reconciled the CA + sidecar, so this is exactly what the
-            // live CA can sign for.
-            domains: Arc::new(covered_domains()),
-            // One process-wide turn-stability memo, shared across the per-request handler clones.
-            memo: Arc::new(Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY)),
-            pending: None,
-        };
-
         // Loopback by default — a MITM proxy must not be reachable off-host unless asked.
         // LLMTRIM_BIND=0.0.0.0 opts in (containers: port mapping can't reach loopback).
         let bind_ip: std::net::IpAddr = match std::env::var("LLMTRIM_BIND") {
@@ -1261,6 +1262,30 @@ mod imp {
             Err(_) => std::net::IpAddr::from([127, 0, 0, 1]),
         };
         let addr = SocketAddr::from((bind_ip, port));
+
+        // Validate and read the upstream proxy setting once at startup so a bad URL is a hard
+        // error before any traffic flows, not a surprise on the first replay. Pass the bind
+        // address so the guard can distinguish "same port = recursion" from "different port =
+        // legitimate companion proxy" (e.g. headroom on 127.0.0.1:9999).
+        let upstream_proxy = crate::transport::upstream_proxy_url(Some(addr))?;
+        if let Some(ref u) = upstream_proxy {
+            eprintln!(
+                "llmtrim: upstream proxy: {}",
+                crate::transport::redact_proxy_url(u)
+            );
+        }
+
+        let handler = Interceptor {
+            config: Arc::new(DenseConfig::load_for_interceptor()),
+            ledger: tx,
+            // `ensure_ca` above just reconciled the CA + sidecar, so this is exactly what the
+            // live CA can sign for.
+            domains: Arc::new(covered_domains()),
+            // One process-wide turn-stability memo, shared across the per-request handler clones.
+            memo: Arc::new(Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY)),
+            pending: None,
+            upstream_proxy: upstream_proxy.clone(),
+        };
         // Pre-flight bind: hudsucker's `Proxy::start` collapses a bind failure to a bare
         // "io error", hiding whether the port is in use or OS-reserved. Bind once ourselves
         // first so the real cause reaches the log, then drop it microseconds before hudsucker
@@ -1281,20 +1306,69 @@ mod imp {
         // the first call and skewed the latency metric). One-time, at boot, off the request path.
         warm_up(&handler.config);
 
-        let proxy = Proxy::builder()
-            .with_addr(addr)
-            .with_ca(ca)
-            .with_rustls_connector(aws_lc_rs::default_provider())
-            .with_http_handler(handler)
-            .with_graceful_shutdown(async {
-                let _ = tokio::signal::ctrl_c().await;
-            })
-            .build()
-            .map_err(|e| anyhow::anyhow!("failed to build proxy: {e}"))?;
-        proxy
-            .start()
-            .await
-            .map_err(|e| anyhow::anyhow!("proxy error: {e}"))?;
+        // When LLMTRIM_UPSTREAM_PROXY is set, wrap hudsucker's outbound connector in a
+        // hyper-http-proxy ProxyConnector that tunnels origin TLS connections via CONNECT
+        // through the upstream proxy. When the var is unset, fall back to the standard
+        // `.with_rustls_connector(...)` path — byte-identical behaviour to before this change.
+        //
+        // The two branches produce different generic Proxy<C, ...> types (rustls connector vs
+        // proxy connector), so each branch calls .start().await directly rather than binding
+        // a common variable.
+        if let Some(ref upstream_url) = upstream_proxy {
+            let upstream_uri =
+                upstream_url
+                    .parse::<hudsucker::hyper::Uri>()
+                    .with_context(|| {
+                        format!(
+                            "failed to parse upstream proxy URI `{}`",
+                            crate::transport::redact_proxy_url(upstream_url)
+                        )
+                    })?;
+            let upstream_proxy_spec = UpstreamProxy::new(Intercept::All, upstream_uri);
+            // ProxyConnector has two distinct connection roles:
+            //  - Its INNER connector dials the PROXY itself. The upstream proxy is http://,
+            //    so a plain HttpConnector is correct — no TLS to the proxy.
+            //  - Its `tls` field wraps the ORIGIN connection that is tunnelled THROUGH the
+            //    CONNECT. This must perform full verifying TLS against the real origin
+            //    (openrouter.ai etc.) so the API key is never sent over a cleartext or
+            //    unverified channel.
+            //
+            // `from_proxy` (with the `rustls-tls-native-roots` feature active) builds a
+            // tokio-rustls TlsConnector for the origin leg using native roots and full cert
+            // verification. The tokio-rustls ClientConfig uses whatever CryptoProvider is
+            // installed at process start — we call aws_lc_rs::default_provider() at startup,
+            // so origin TLS automatically uses aws-lc-rs throughout.
+            let proxy_connector =
+                ProxyConnector::from_proxy(HttpConnector::new(), upstream_proxy_spec)
+                    .map_err(|e| anyhow::anyhow!("failed to build upstream ProxyConnector: {e}"))?;
+            Proxy::builder()
+                .with_addr(addr)
+                .with_ca(ca)
+                .with_http_connector(proxy_connector)
+                .with_http_handler(handler)
+                .with_graceful_shutdown(async {
+                    let _ = tokio::signal::ctrl_c().await;
+                })
+                .build()
+                .map_err(|e| anyhow::anyhow!("failed to build proxy (upstream-proxy path): {e}"))?
+                .start()
+                .await
+                .map_err(|e| anyhow::anyhow!("proxy error: {e}"))?;
+        } else {
+            Proxy::builder()
+                .with_addr(addr)
+                .with_ca(ca)
+                .with_rustls_connector(aws_lc_rs::default_provider())
+                .with_http_handler(handler)
+                .with_graceful_shutdown(async {
+                    let _ = tokio::signal::ctrl_c().await;
+                })
+                .build()
+                .map_err(|e| anyhow::anyhow!("failed to build proxy: {e}"))?
+                .start()
+                .await
+                .map_err(|e| anyhow::anyhow!("proxy error: {e}"))?;
+        }
         Ok(())
     }
 
@@ -1948,6 +2022,7 @@ mod imp {
                 domains: Arc::new(intercept_domains().into_iter().collect()),
                 memo: Arc::new(Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY)),
                 pending: None,
+                upstream_proxy: None,
             };
             (handler, rx)
         }
@@ -2665,6 +2740,51 @@ mod imp {
             assert!(
                 rx.try_recv().is_err(),
                 "exactly one ledger record for an empty body"
+            );
+        }
+
+        // --- C1 regression: origin TLS is verified through the CONNECT tunnel ---
+        //
+        // `ProxyConnector::from_proxy` (with the `rustls-tls-native-roots` feature active)
+        // sets its internal `tls` field to `Some(TlsConnector)`, which is what hyper-http-proxy
+        // uses to TLS-wrap the ORIGIN connection that is tunnelled through CONNECT.
+        //
+        // `from_proxy_unsecured` leaves `tls: None`, which means the tunnelled origin stream
+        // would be returned as a PLAINTEXT, UNVERIFIED stream — the security bug this test
+        // guards against.
+        //
+        // The Debug output from hyper-http-proxy's `ProxyConnector` encodes this distinction:
+        //   - `tls: Some(_)` → `"ProxyConnector { proxies: ... }"` (no unsecured marker)
+        //   - `tls: None`    → `"ProxyConnector (unsecured) { proxies: ... }"`
+        //
+        // Coverage boundary: this test verifies the *construction* path (TLS connector is
+        // wired in), not a live TLS handshake. A live handshake against a self-signed cert
+        // that should fail certificate verification would require a full local CONNECT+TLS
+        // harness; that is considered integration-test territory and is not included here.
+        // What the test guarantees: if someone reverts `from_proxy` to `from_proxy_unsecured`,
+        // the test catches it immediately.
+        #[test]
+        fn proxy_connector_origin_tls_is_active() {
+            // ProxyConnector::from_proxy internally builds a tokio-rustls ClientConfig.
+            // tokio-rustls requires a CryptoProvider to be installed; we use the same
+            // aws-lc-rs provider that production installs at daemon startup.
+            let _ = aws_lc_rs::default_provider().install_default();
+
+            let proxy_uri: hudsucker::hyper::Uri = "http://proxy.example.test:3128"
+                .parse()
+                .expect("test proxy URI");
+            let upstream_proxy_spec = UpstreamProxy::new(Intercept::All, proxy_uri);
+            let connector = ProxyConnector::from_proxy(HttpConnector::new(), upstream_proxy_spec)
+                .expect("ProxyConnector::from_proxy must succeed");
+
+            // hyper-http-proxy's Debug impl emits "(unsecured)" only when `tls` is None.
+            // Assert its absence to confirm the origin leg has a verifying TLS connector.
+            let debug_str = format!("{connector:?}");
+            assert!(
+                !debug_str.contains("(unsecured)"),
+                "ProxyConnector must have a TLS connector for the origin leg \
+                 (built with from_proxy, not from_proxy_unsecured). \
+                 Debug output: {debug_str}"
             );
         }
     }

--- a/crates/llmtrim-cli/src/transport.rs
+++ b/crates/llmtrim-cli/src/transport.rs
@@ -3,12 +3,182 @@
 //! Blocking `ureq` (no async — a request/response round-trip needs no
 //! concurrency). The pure parts (`url`, `headers`) are unit-tested; the live
 //! `send` needs an API key + network, so it isn't exercised in the test suite.
+//!
+//! # Upstream proxy (`LLMTRIM_UPSTREAM_PROXY`)
+//!
+//! By default every outbound call sets `.proxy(None)` to suppress `HTTPS_PROXY` — without
+//! this, a shell with `HTTPS_PROXY=127.0.0.1:PORT` pointing at the llmtrim daemon would
+//! loop back through itself. If you need the daemon's own traffic to exit through a
+//! corporate or gateway proxy, set `LLMTRIM_UPSTREAM_PROXY=http://host:port` (or
+//! `http://user:pass@host:port`) in the daemon's launch environment **before** the daemon
+//! starts. Changing it while running has no effect.
+//!
+//! The env var is honoured by: `Endpoint::send` (CLI `send` command),
+//! `forward_post` (replay path), and the primary hudsucker MITM path
+//! (via a `hyper-http-proxy` `ProxyConnector` wrapping hudsucker's outbound connector).
+//! `forward_get` exists but currently has no call site — GET requests pass through
+//! hudsucker's ProxyConnector directly and do not route through this function.
+//!
+//! **Security notes**: credentials in the URL are plaintext in the daemon's environment
+//! (`/proc/<pid>/environ` on Linux); use a credential-free URL and OS-level auth where
+//! possible. Only upstreams that point at llmtrim's own listen address (same loopback host
+//! AND same port) are rejected — this prevents infinite recursion while allowing a companion
+//! proxy like headroom running on a different loopback port (e.g. `127.0.0.1:9999`) to be
+//! used as the upstream. `localhost`, `127.0.0.1`, `::1`, and `[::1]` are treated as
+//! equivalent when comparing the host, so `localhost:8788` is caught if the daemon binds
+//! `127.0.0.1:8788`.
 
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 
 use llmtrim_core::ir::ProviderKind;
+
+/// Redact the `user:pass@` userinfo from a proxy URL before logging or surfacing in errors.
+/// `http://alice:s3cr3t@proxy.corp:3128` → `http://proxy.corp:3128`.
+/// URLs without userinfo are returned unchanged.
+pub fn redact_proxy_url(url: &str) -> String {
+    // Find `://` then look for `@` before the next `/` or end. Strip everything between.
+    if let Some(scheme_end) = url.find("://") {
+        let after_scheme = &url[scheme_end + 3..];
+        // Only strip if there is a `@` before the path separator.
+        let path_start = after_scheme.find('/').unwrap_or(after_scheme.len());
+        let host_part = &after_scheme[..path_start];
+        if let Some(at_pos) = host_part.rfind('@') {
+            let scheme = &url[..scheme_end + 3];
+            let rest = &after_scheme[at_pos + 1..];
+            return format!("{scheme}{rest}");
+        }
+    }
+    url.to_string()
+}
+
+/// Parse and validate `LLMTRIM_UPSTREAM_PROXY` once at startup. Returns `None` if the var is
+/// unset, `Err` if it is set but invalid (points at llmtrim's own listen address, or
+/// unparseable). The `ureq::Proxy` is `Clone` only in newer ureq; we keep a `String` and
+/// reconstruct per-call (ureq 3 proxy construction is cheap — it just validates the URL).
+///
+/// `bind_addr` is llmtrim's own listen address (e.g. `127.0.0.1:8788`). When `Some`, an
+/// upstream that resolves to the same loopback host AND the same port is rejected. Pass
+/// `None` when the daemon bind address is unknown (e.g. the CLI `send` subcommand, which
+/// does not run a proxy server).
+pub fn upstream_proxy_url(bind_addr: Option<std::net::SocketAddr>) -> Result<Option<String>> {
+    let url = match std::env::var("LLMTRIM_UPSTREAM_PROXY") {
+        Ok(v) if !v.is_empty() => v,
+        _ => return Ok(None),
+    };
+    validate_proxy_url(&url, bind_addr)?;
+    Ok(Some(url))
+}
+
+/// Returns true if `host` (already extracted, without brackets) is any loopback alias.
+/// Note: only `127.0.0.1` is checked explicitly; `127.x.x.x` beyond `127.0.0.1` is also
+/// technically loopback on Linux, but those addresses are an unguarded edge case here —
+/// the risk is low because corporate proxies never live on loopback ranges other than
+/// `127.0.0.1`, so a false-negative means a mis-typed proxy URL, not an exploit path.
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1"
+}
+
+/// Reject upstreams that point at llmtrim's own listen address (same loopback host + same
+/// port), which would create infinite recursion. A companion proxy on a different loopback
+/// port is explicitly allowed.
+fn validate_proxy_url(url: &str, bind_addr: Option<std::net::SocketAddr>) -> Result<()> {
+    // Extract the host portion (between `://` and the first `:`, `/`, or end).
+    let host = proxy_host(url).with_context(|| {
+        format!(
+            "LLMTRIM_UPSTREAM_PROXY: cannot parse host from `{}`",
+            redact_proxy_url(url)
+        )
+    })?;
+
+    // The raw host:port segment (before path), lowercased — needed to detect `[::1]:port`.
+    let raw_host_segment = {
+        let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or("");
+        let without_userinfo = after_scheme
+            .rfind('@')
+            .map(|i| &after_scheme[i + 1..])
+            .unwrap_or(after_scheme);
+        without_userinfo
+            .split(['/', '?'])
+            .next()
+            .unwrap_or("")
+            .to_ascii_lowercase()
+    };
+
+    // Resolve whether the upstream host is a loopback alias, handling bracketed IPv6.
+    let upstream_is_loopback = is_loopback_host(host)
+        || raw_host_segment == "[::1]"
+        || raw_host_segment.starts_with("[::1]:");
+
+    if upstream_is_loopback {
+        // Extract the upstream port from the raw segment (e.g. "127.0.0.1:9999" → 9999).
+        // `rsplit(':').next()` yields the last colon-separated token, which is the port
+        // for both plain IPv4 (`127.0.0.1:9999` → `"9999"`) and bracketed IPv6
+        // (`[::1]:9999` → `"9999"`). For bare `[::1]` with no port it yields `"[::1]"`,
+        // which `parse::<u16>()` rejects, leaving `upstream_port` as `None`.
+        let upstream_port: Option<u16> = raw_host_segment
+            .rsplit(':')
+            .next()
+            .and_then(|p| p.parse().ok());
+
+        if let (Some(bind), Some(up_port)) = (bind_addr, upstream_port) {
+            // Only reject if the port matches llmtrim's own bind port. A different port on
+            // the same loopback interface is a legitimate companion proxy (e.g. headroom).
+            if up_port == bind.port() {
+                anyhow::bail!(
+                    "LLMTRIM_UPSTREAM_PROXY points at llmtrim's own listen address \
+                     (`{host}:{up_port}`), which would cause infinite recursion. \
+                     Use a different port or a non-loopback proxy address."
+                );
+            }
+        } else if bind_addr.is_none() {
+            // No bind address supplied (e.g. CLI `send` command) — loopback is allowed
+            // since there is no daemon to recurse through.
+        } else {
+            // Bind address known but no port parsed from upstream URL (bare host, no port).
+            // Reject conservatively: a loopback URL with no explicit port likely defaults
+            // to 80 or is malformed; either way it cannot be a useful corporate proxy.
+            anyhow::bail!(
+                "LLMTRIM_UPSTREAM_PROXY points at a loopback address (`{host}`) without an \
+                 explicit port — cannot verify it does not point at llmtrim itself. \
+                 Use a non-loopback proxy address or include the port explicitly."
+            );
+        }
+    }
+
+    // Ask ureq to validate the full URL (scheme, port, etc.).
+    ureq::Proxy::new(url).with_context(|| {
+        format!(
+            "LLMTRIM_UPSTREAM_PROXY: invalid proxy URL `{}`",
+            redact_proxy_url(url)
+        )
+    })?;
+    Ok(())
+}
+
+/// Extract just the host from a proxy URL like `http://user:pass@host:port/`.
+fn proxy_host(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://")?.1;
+    // Strip userinfo
+    let without_userinfo = after_scheme
+        .rfind('@')
+        .map(|i| &after_scheme[i + 1..])
+        .unwrap_or(after_scheme);
+    // Strip port and path
+    let host = without_userinfo.split([':', '/', '?']).next()?;
+    (!host.is_empty()).then_some(host)
+}
+
+/// Build a `ureq::Proxy` from a URL string. Cheap; ureq 3 proxy construction just parses.
+fn make_proxy(url: &str) -> Result<ureq::Proxy> {
+    ureq::Proxy::new(url).with_context(|| {
+        format!(
+            "failed to construct upstream proxy `{}`",
+            redact_proxy_url(url)
+        )
+    })
+}
 
 /// Hard ceiling on any single upstream round-trip. ureq has no default timeout, so a hung
 /// upstream would pin a blocking thread forever (and on the replay path, leak the daemon's
@@ -86,13 +256,17 @@ impl Endpoint {
     }
 
     /// POST the request body and return the raw response body. Blocking.
-    pub fn send(&self, request_json: &str) -> Result<String> {
+    pub fn send(&self, request_json: &str, proxy_url: Option<&str>) -> Result<String> {
         let url = self.url();
-        // Never route through an HTTP(S)_PROXY (ureq honors them by default) — that would loop
-        // a proxied shell's traffic back through the llmtrim daemon. And bound the round-trip.
+        // Suppress the ambient HTTPS_PROXY by default (it points at us — looping traffic back
+        // through the daemon). If the caller supplies an explicit upstream proxy, use that instead.
+        let proxy = match proxy_url {
+            Some(u) => Some(make_proxy(u)?),
+            None => None,
+        };
         let mut request = ureq::post(&url)
             .config()
-            .proxy(None)
+            .proxy(proxy)
             .timeout_global(Some(UPSTREAM_TIMEOUT))
             .build();
         for (name, value) in self.headers() {
@@ -121,13 +295,21 @@ pub struct Upstream {
 /// verbatim, and return the upstream response as a stream. Upstream HTTP errors (4xx/5xx)
 /// are RELAYED, not turned into transport errors — a proxy must hand the client the
 /// provider's real status and message.
-pub fn forward_post(url: &str, headers: &[(String, String)], body: &str) -> Result<Upstream> {
+pub fn forward_post(
+    url: &str,
+    headers: &[(String, String)],
+    body: &str,
+    proxy_url: Option<&str>,
+) -> Result<Upstream> {
+    // Suppress ambient HTTPS_PROXY (points at us) unless an explicit upstream proxy is set.
+    let proxy = match proxy_url {
+        Some(u) => Some(make_proxy(u)?),
+        None => None,
+    };
     let mut req = ureq::post(url)
         .config()
         .http_status_as_error(false)
-        // No proxy: the daemon's own replay must never loop back through the proxy it runs
-        // (HTTPS_PROXY in a proxied shell points at us → unbounded recursion). And bound it.
-        .proxy(None)
+        .proxy(proxy)
         .timeout_global(Some(UPSTREAM_TIMEOUT))
         .build();
     for (k, v) in headers {
@@ -151,11 +333,19 @@ pub fn forward_post(url: &str, headers: &[(String, String)], body: &str) -> Resu
 }
 
 /// Forward a GET (e.g. a client's `/v1/models` probe) — passthrough, no body, streamed.
-pub fn forward_get(url: &str, headers: &[(String, String)]) -> Result<Upstream> {
+pub fn forward_get(
+    url: &str,
+    headers: &[(String, String)],
+    proxy_url: Option<&str>,
+) -> Result<Upstream> {
+    let proxy = match proxy_url {
+        Some(u) => Some(make_proxy(u)?),
+        None => None,
+    };
     let mut req = ureq::get(url)
         .config()
         .http_status_as_error(false)
-        .proxy(None)
+        .proxy(proxy)
         .timeout_global(Some(UPSTREAM_TIMEOUT))
         .build();
     for (k, v) in headers {
@@ -216,5 +406,106 @@ mod tests {
             !h.iter().any(|(k, _)| *k == "authorization"),
             "no bearer for anthropic"
         );
+    }
+
+    // --- upstream proxy tests ---
+
+    fn bind(addr: &str) -> Option<std::net::SocketAddr> {
+        Some(addr.parse().expect("test bind addr"))
+    }
+
+    #[test]
+    fn redact_strips_userinfo() {
+        assert_eq!(
+            redact_proxy_url("http://alice:s3cr3t@proxy.corp:3128"),
+            "http://proxy.corp:3128"
+        );
+    }
+
+    #[test]
+    fn redact_no_userinfo_unchanged() {
+        assert_eq!(
+            redact_proxy_url("http://proxy.corp:3128"),
+            "http://proxy.corp:3128"
+        );
+    }
+
+    #[test]
+    fn redact_preserves_path() {
+        assert_eq!(
+            redact_proxy_url("http://u:p@proxy.corp:3128/path"),
+            "http://proxy.corp:3128/path"
+        );
+    }
+
+    // Same host + same port as the daemon bind address — infinite recursion, must reject.
+    #[test]
+    fn loopback_127_rejected() {
+        let err = validate_proxy_url("http://127.0.0.1:8788", bind("127.0.0.1:8788")).unwrap_err();
+        assert!(
+            err.to_string().contains("own listen address")
+                || err.to_string().contains("infinite recursion"),
+            "got: {err}"
+        );
+    }
+
+    // IPv6 loopback, same port — must reject.
+    #[test]
+    fn loopback_ipv6_rejected() {
+        let err = validate_proxy_url("http://[::1]:8788", bind("127.0.0.1:8788")).unwrap_err();
+        assert!(
+            err.to_string().contains("own listen address")
+                || err.to_string().contains("infinite recursion")
+                || err.to_string().contains("::1"),
+            "got: {err}"
+        );
+    }
+
+    // `localhost` spelling of the same bind port — must reject (loopback alias normalisation).
+    #[test]
+    fn loopback_localhost_rejected() {
+        let err = validate_proxy_url("http://localhost:8788", bind("127.0.0.1:8788")).unwrap_err();
+        assert!(
+            err.to_string().contains("own listen address")
+                || err.to_string().contains("infinite recursion"),
+            "got: {err}"
+        );
+    }
+
+    // Different port on the same loopback host — this is the headroom composition case, must pass.
+    #[test]
+    fn loopback_different_port_allowed() {
+        assert!(
+            validate_proxy_url("http://127.0.0.1:9999", bind("127.0.0.1:8788")).is_ok(),
+            "companion proxy on a different loopback port must be allowed"
+        );
+    }
+
+    // Non-loopback host — always allowed regardless of port.
+    #[test]
+    fn non_loopback_allowed() {
+        assert!(validate_proxy_url("http://proxy.corp:8788", bind("127.0.0.1:8788")).is_ok());
+    }
+
+    #[test]
+    fn valid_proxy_without_auth() {
+        // ureq validates the URL; a non-loopback host should parse fine.
+        assert!(validate_proxy_url("http://proxy.corp:3128", None).is_ok());
+    }
+
+    #[test]
+    fn valid_proxy_with_auth() {
+        assert!(validate_proxy_url("http://user:pass@proxy.corp:3128", None).is_ok());
+    }
+
+    #[test]
+    fn proxy_host_extraction() {
+        assert_eq!(
+            proxy_host("http://user:pass@proxy.corp:3128/"),
+            Some("proxy.corp")
+        );
+        assert_eq!(proxy_host("http://proxy.corp:3128"), Some("proxy.corp"));
+        assert_eq!(proxy_host("http://proxy.corp/"), Some("proxy.corp"));
+        assert_eq!(proxy_host("not-a-url"), None);
     }
 }


### PR DESCRIPTION
Closes #62.

## What

Set `LLMTRIM_UPSTREAM_PROXY=http://host:port` to route llmtrim's egress through another proxy instead of dialing the API directly. This enables composition with a local companion proxy such as [headroom](https://github.com/chopratejas/headroom) and corporate/auth-proxy workflows.

## Coverage

- **ureq paths** (CLI `send` and the replay path) honor the proxy via `ureq::Proxy`, with native CONNECT and `user:pass@` auth.
- **Primary hudsucker MITM path** forwards through the upstream by swapping its outbound connector for a `hyper-http-proxy` `ProxyConnector`. The proxy is dialed plain (it is `http://`); the origin is tunneled with CONNECT and wrapped in verifying TLS (`from_proxy` + `rustls-tls-native-roots`, aws-lc-rs provider, native roots). When the var is unset, the connector path is byte-identical to before.
- Bench (`HttpModel`) honors the var.

## Safety

- Rejects an upstream pointing at llmtrim's own listen address (any localhost spelling on the same port) to prevent infinite recursion; a companion proxy on a different port is allowed.
- Redacts `user:pass@` credentials from all logs and error messages.
- TLS verification stays on; no danger/NoVerify path is introduced. Reviewed at crate-source level to confirm the origin leg through the tunnel is certificate-verified.

## Notes

- New deps (`hyper-http-proxy`, `hyper-rustls`, `hyper-util`) are gated behind the `intercept` feature, CLI-only, unify with hudsucker's existing hyper/rustls stack (no duplicate majors), and are MPL-compatible.
- README Configuration section documents the feature, including the plaintext-credential caveat for shell profiles.

## Testing

`cargo clippy --features intercept` clean; `cargo nextest run --features intercept` 661/661 pass.