### PR TITLE
docs(contributing): clarify reporting vs. implementing an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,11 @@ assignees: ""
 
 <!-- If it's a compression stage: roughly what does it save, and what's the quality risk?
      llmtrim stages are token-gated and quality-checked offline (see README §6). -->
+
+## Are you willing to contribute this?
+
+<!-- No obligation either way. This just tells us whether to leave it for you
+     or pick it up ourselves. -->
+
+- [ ] I'd like to implement this myself and open a PR
+- [ ] I'm reporting the idea; happy for a maintainer or someone else to build it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,18 @@ front saves a large PR from a redesign in review. New user-facing surfaces (a CL
 MCP tool, an output channel) and any change to the published `llmtrim-core` public API need
 this step.
 
+## Reporting vs. implementing
+
+Filing an issue does not commit you to writing the code. Tell us which you mean: the
+feature-request template has a checkbox, or just say so in the issue.
+
+If you want to implement it, comment to claim it and a maintainer will assign you; an
+assigned issue is yours until it goes quiet for about two weeks. If you only want to
+report it, a maintainer or another contributor may pick it up. Either way, for a feature
+we agree the approach in the issue before a PR is opened, so a maintainer implementing
+your request will post the intended design on the issue first and give you a chance to
+respond.
+
 ## Pull requests
 
 - One logical change per PR; every changed line should trace to the stated goal.


### PR DESCRIPTION
## What

Adds a "Reporting vs. implementing" section to `CONTRIBUTING.md` and an intent checkbox to the feature-request template.

## Why

A reporter who files a feature request may want to implement it themselves, or may just want to flag the idea. Today there is no place for them to say which, so a maintainer either guesses or claims the work without asking. This adds:

- A checkbox on the feature-request form: implement it myself, or just reporting it.
- A short CONTRIBUTING section recording the claim/assign convention (comment to claim, maintainer assigns, an assigned issue goes stale after about two weeks) and the design-first rule for a maintainer-implemented request (post the intended approach on the issue before opening a PR).

Docs only; no code changes.