### PR TITLE
docs(core): clarify that lossless is input-side, not response restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ These are surfaced by the same A/B that proves the savings:
 - **Anthropic / Gemini token counts are approximate.** There's no public exact tokenizer, so a BPE proxy is used and flagged in `status`. OpenAI is exact.
 - **Output savings aren't measured live.** The proxy compresses input; an output *saving* needs the A/B counterfactual, which only the offline benchmark runs. `status` "saved" is input-side.
 - **The default is quality-gated, not lossless.** Lossy stages run only where the eval shows quality holds. Want a byte-faithful round-trip? Use the `safe` preset.
+- **"Lossless" is input-side, not response restoration.** A lossless stage preserves the information the model reads (a folded log run, a TOON-encoded array, an abbreviation legend the model decodes in-prompt), and the token gate reverts any input cut that doesn't pay off. The engine does not transform the model's response back to an original form.
 
 ## Acknowledgments
 

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -2,7 +2,11 @@
 //!
 //! This crate is a zero-LLM-call middleware: it ingests a provider-shaped request
 //! body, compresses it with deterministic algorithms only (no auxiliary model, no
-//! embeddings), and can reverse the lossless transforms on the response. The
+//! embeddings). "Lossless" here means a stage preserves the information the model
+//! reads (a folded log run, a TOON-encoded array, an abbreviation legend the model
+//! decodes in-prompt), and the token gate reverts any input cut that doesn't pay off.
+//! It does not mean the engine transforms the response back: [`rehydrate`] is an inert
+//! passthrough today, reserved for a future output-side phase. The
 //! functions here are the **pure transform core** — no network calls live in this
 //! crate. The `llmtrim` CLI/proxy crate wraps them.
 //!


### PR DESCRIPTION
## What

Corrects a misleading claim about what "lossless" means in llmtrim.

- The crate-level doc said the engine "can reverse the lossless transforms on the response." It does not: `rehydrate()` is an inert passthrough (it ignores the plan it is handed; no stage records a reversible plan), reserved for a future output-side phase.
- "Lossless" here means a stage preserves the information the model reads (a folded log run, a TOON array, an in-prompt abbreviation legend), and the token gate reverts any input cut that doesn't pay off.

Touches the crate doc (`lib.rs`) and one README "Known limits" bullet. No behavior change.

## Review

Three independent reviewers (accuracy, scope/clarity, merge-readiness) cleared it: every claim verified against the code, only the two intended files committed, `cargo check` clean, the new `[`rehydrate`]` intra-doc link resolves.

Pre-existing and out of scope: `cargo doc` is already red on main (14 broken intra-doc links unrelated to this change).