### PR TITLE
fix(wasm): skip wasm-opt so wasm-pack publish succeeds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,6 +379,7 @@ jobs:
             const j = JSON.parse(fs.readFileSync(p, "utf8"));
             j.name = "@llmtrim/js";
             j.version = process.env.TAG.replace(/^v/, "");
+            j.keywords = ["llm", "tokens", "compression", "proxy", "openai", "anthropic", "claude", "wasm", "webassembly"];
             fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
           '
           npm publish crates/llmtrim-wasm/pkg --access public
@@ -389,7 +390,9 @@ jobs:
             "name": "@llmtrim/wasm",
             "version": "$VER",
             "description": "Alias for @llmtrim/js, the llmtrim WebAssembly binding.",
+            "keywords": ["llm", "tokens", "compression", "proxy", "openai", "anthropic", "claude", "wasm", "webassembly"],
             "license": "MPL-2.0",
+            "homepage": "https://github.com/fkiene/llmtrim",
             "repository": { "type": "git", "url": "https://github.com/fkiene/llmtrim" },
             "type": "module",
             "main": "index.js",
@@ -400,6 +403,21 @@ jobs:
           JSON
           echo 'export * from "@llmtrim/js";' > alias/index.js
           echo 'export * from "@llmtrim/js";' > alias/index.d.ts
+          cat > alias/README.md <<'MD'
+          # @llmtrim/wasm
+
+          Alias for [`@llmtrim/js`](https://www.npmjs.com/package/@llmtrim/js) — the
+          WebAssembly/JS binding for the [llmtrim](https://github.com/fkiene/llmtrim)
+          compression engine. Installing this package pulls in `@llmtrim/js` at the same
+          version and re-exports it, so both names resolve to the identical API.
+
+          ```js
+          import { compress } from "@llmtrim/wasm"; // same as "@llmtrim/js"
+          ```
+
+          See the [`@llmtrim/js` README](https://www.npmjs.com/package/@llmtrim/js) for the
+          full API and usage.
+          MD
           npm publish ./alias --access public
           # Verify both channels resolve from the registry.
           sleep 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **`@llmtrim/js` / `@llmtrim/wasm` now publish to npm.** The v0.2.1 release built the
+  package but its `wasm-pack` publish step failed (`wasm-opt` rejected the post-MVP wasm
+  features recent rustc emits), so the packages never landed on npm. The redundant
+  `wasm-opt` pass is now skipped (rustc already optimizes under `--release`), so the
+  bindings publish.
+
 ## [0.2.1] - 2026-06-19
 
 ### Added

--- a/crates/llmtrim-wasm/Cargo.toml
+++ b/crates/llmtrim-wasm/Cargo.toml
@@ -10,6 +10,15 @@ license.workspace = true
 # Published to npm via wasm-pack, not to crates.io.
 publish = false
 
+# wasm-pack runs a wasm-opt pass after the build, but recent rustc emits post-MVP wasm
+# features (bulk-memory, sign-extension, ...) that wasm-opt's validator rejects unless every
+# one is explicitly enabled — a moving target that depends on the toolchain and wasm-opt
+# version. rustc already optimizes the module under `--release`, so skip the redundant pass
+# instead of chasing feature flags. (The CI smoke job builds with wasm-bindgen directly and
+# never runs wasm-opt, so it didn't catch the failure; the release publish-wasm job does.)
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/crates/llmtrim-wasm/README.md
+++ b/crates/llmtrim-wasm/README.md
@@ -1,4 +1,4 @@
-# llmtrim-wasm
+# @llmtrim/js
 
 WebAssembly/JS bindings for the [`llmtrim-core`](../llmtrim-core) compression engine, for
 running the static prompt/payload compressor in a browser, Node, Bun, Deno, or a Cloudflare


### PR DESCRIPTION
## Problem

The v0.2.1 release's `publish-wasm` job failed, so `@llmtrim/js` / `@llmtrim/wasm` never reached npm.

`wasm-pack build --release` runs a `wasm-opt` pass after the build, but recent rustc emits post-MVP wasm features (bulk-memory, sign-extension, ...) that wasm-opt's validator rejects unless each is explicitly enabled — a toolchain/wasm-opt-version moving target. The CI smoke job builds with `wasm-bindgen` directly and never runs wasm-opt, so it didn't catch this; the release job does.

## Fix

Set `wasm-opt = false` in the wasm crate's `[package.metadata.wasm-pack.profile.release]`. rustc already optimizes the module under `--release`, and the wasm-opt pass gives no meaningful gzip win here.

## Verification

Installed wasm-pack 0.13.1 (matches CI) and reproduced locally:
- `wasm-pack build --release --target bundler` now succeeds
- the bundler artifact validates and exports `compress` (the release job's smoke check)
- gzip size ≈1.16 MB with or without wasm-opt (within Cloudflare Workers Free)

Ships in v0.2.2 — npm tarballs are immutable but 0.2.1 never published, so no re-tag.