### PR TITLE
fix(serve): fail fast on a busy port, add --force to replace a daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **`serve --force` / `start --force` / `setup --force`** replace an llmtrim daemon that's
+  already holding the port (stops it first, waits for the port to free, then takes over)
+  instead of refusing, no-opping, or leaving a healthy same-port daemon untouched.
+
 ### Fixed
+- **`serve` fails fast when the port is taken.** A bind-in-use error no longer spins through
+  the supervised restart loop five times; it reports once, naming the daemon already on the
+  port (`llmtrim stop` first, or `--force` to replace it) or the foreign process holding it.
+- **A recycled pid no longer reads as a running daemon.** Daemon liveness now verifies the
+  pid is actually llmtrim, not just that *some* process has that pid, so a stale pidfile
+  pointing at an unrelated reused pid is cleared instead of reported as running.
 - **`@llmtrim/js` / `@llmtrim/wasm` now publish to npm.** The v0.2.1 release built the
   package but its `wasm-pack` publish step failed (`wasm-opt` rejected the post-MVP wasm
   features recent rustc emits), so the packages never landed on npm. The redundant

--- a/crates/llmtrim-cli/src/daemon.rs
+++ b/crates/llmtrim-cli/src/daemon.rs
@@ -114,8 +114,21 @@ fn tasklist_reports_pid(stdout: &str, pid: u32) -> bool {
 fn pid_is_llmtrim(pid: u32) -> bool {
     #[cfg(target_os = "linux")]
     {
-        let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).unwrap_or_default();
-        comm.trim().starts_with("llmtrim")
+        // Prefer the `exe` symlink: it's the real binary filename, untruncated and immune to a
+        // process rewriting its `comm`/argv0 (the 15-char `comm` would also misjudge a longer
+        // installed name). A deleted binary shows up as "llmtrim (deleted)", still a match. Fall
+        // back to `comm`, then be permissive when neither is readable (e.g. EACCES) — better to
+        // attempt a stop on an uncertain match than to disown a real daemon.
+        if let Ok(path) = std::fs::read_link(format!("/proc/{pid}/exe")) {
+            return path
+                .file_name()
+                .map(|n| n.to_string_lossy().starts_with("llmtrim"))
+                .unwrap_or(true);
+        }
+        match std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+            Ok(comm) => comm.trim().starts_with("llmtrim"),
+            Err(_) => true,
+        }
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -152,10 +165,13 @@ pub fn is_alive(pid: u32) -> bool {
     }
 }
 
-/// The running daemon, if the pidfile points at a live process. Clears a stale pidfile.
+/// The running daemon, if the pidfile points at a live llmtrim process. Clears a stale pidfile.
+/// The identity check (not just liveness) matters because the OS recycles pids: a pidfile left
+/// by a crashed daemon can name a pid the OS later handed to something unrelated. Without it,
+/// callers would treat that foreign process as our daemon — and `--force` would try to stop it.
 pub fn running() -> Option<DaemonState> {
     let state = read_state()?;
-    if is_alive(state.pid) {
+    if is_alive(state.pid) && pid_is_llmtrim(state.pid) {
         Some(state)
     } else {
         let _ = std::fs::remove_file(pidfile().ok()?);
@@ -293,6 +309,38 @@ pub fn stop() -> Result<Option<u32>> {
     Ok(Some(state.pid))
 }
 
+/// Stop the running daemon, then block until `port` is actually free. `stop` already waits for
+/// the process to exit, but the kernel can hold the listening socket a beat longer; a caller
+/// about to rebind the same port must wait for that gap to close or it loses the bind race.
+/// Returns `true` if the port freed, `false` on a 5s timeout.
+pub fn stop_and_wait_free(port: u16) -> Result<bool> {
+    stop()?;
+    Ok(wait_until_free(
+        port,
+        probe_port,
+        50,
+        std::time::Duration::from_millis(100),
+    ))
+}
+
+/// Poll until `probe` reports `port` free, up to `iters` times spaced `step` apart; `true` if it
+/// freed, `false` on timeout. `probe`/`iters`/`step` are parameters so the timeout path is
+/// unit-testable in microseconds without a real socket or a real 5s wait.
+fn wait_until_free(
+    port: u16,
+    probe: impl Fn(u16) -> bool,
+    iters: u32,
+    step: std::time::Duration,
+) -> bool {
+    for _ in 0..iters {
+        if !probe(port) {
+            return true;
+        }
+        std::thread::sleep(step);
+    }
+    false
+}
+
 /// Format a duration in seconds as `3h12m` / `5m` / `42s`.
 pub fn human_uptime(secs: i64) -> String {
     let (h, m, s) = (secs / 3600, (secs % 3600) / 60, secs % 60);
@@ -316,6 +364,36 @@ pub fn human_age(rfc3339: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wait_until_free_returns_true_once_the_port_frees() {
+        // Busy on the first probe, free on the second.
+        let calls = std::cell::Cell::new(0);
+        assert!(wait_until_free(
+            0,
+            |_| {
+                calls.set(calls.get() + 1);
+                calls.get() < 2
+            },
+            50,
+            std::time::Duration::ZERO,
+        ));
+    }
+
+    #[test]
+    fn wait_until_free_times_out_on_a_port_that_stays_held() {
+        // A port that never frees must report timeout, not hang — the `--force stopped it but
+        // the socket lingered` path. Tiny iters/step so this runs in microseconds.
+        assert!(!wait_until_free(0, |_| true, 3, std::time::Duration::ZERO));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn pid_one_is_not_identified_as_llmtrim() {
+        // pid 1 (init/systemd) is always alive but never llmtrim — guards the identity check
+        // that lets `running()` clear a pidfile naming a recycled foreign pid.
+        assert!(!pid_is_llmtrim(1));
+    }
 
     #[test]
     fn human_uptime_formats() {

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -118,6 +118,10 @@ enum Commands {
         /// Port to listen on (127.0.0.1).
         #[arg(long, default_value_t = llmtrim::setup::DEFAULT_PORT)]
         port: u16,
+        /// Replace an llmtrim daemon already holding the port (stops it first) instead of
+        /// refusing to start.
+        #[arg(long)]
+        force: bool,
         /// Internal: run with crash-restart supervision (used by `start`/autostart).
         #[arg(long, hide = true)]
         supervised: bool,
@@ -137,6 +141,10 @@ enum Commands {
         /// Interceptor port. Omit to auto-select a free port starting at 43117.
         #[arg(long)]
         port: Option<u16>,
+        /// Restart the daemon even if a healthy one is already on the chosen port (e.g. to pick
+        /// up a new binary). By default setup leaves a healthy same-port daemon running.
+        #[arg(long)]
+        force: bool,
     },
     /// Undo everything `setup` did
     ///
@@ -160,6 +168,10 @@ enum Commands {
         /// Port to listen on. Omit to reuse the configured port (or 43117).
         #[arg(long)]
         port: Option<u16>,
+        /// Restart a running daemon: by default `start` is a no-op when one is already up;
+        /// `--force` stops it first and starts a fresh one.
+        #[arg(long)]
+        force: bool,
     },
     /// Run an agent, guaranteeing its traffic routes through llmtrim
     ///
@@ -568,6 +580,7 @@ fn run() -> Result<()> {
         }
         Commands::Serve {
             port,
+            force,
             supervised,
             hide_console,
         } => {
@@ -581,17 +594,35 @@ fn run() -> Result<()> {
                 // a foreground `llmtrim serve` must not rewrite the user's shell profiles.
                 // Best-effort: never let it stop the proxy coming up.
                 let _ = llmtrim::setup::heal_managed_env();
-                llmtrim::serve::run_supervised(port)?;
+                llmtrim::serve::run_supervised(port, force)?;
             } else {
-                llmtrim::serve::run(port)?;
+                llmtrim::serve::run(port, force)?;
             }
         }
-        Commands::Setup { port } => llmtrim::setup::run(port)?,
+        Commands::Setup { port, force } => llmtrim::setup::run(port, force)?,
         Commands::Uninstall { purge, keep_binary } => {
             llmtrim::setup::uninstall(purge, keep_binary)?
         }
-        Commands::Start { port } => {
+        Commands::Start { port, force } => {
             let color = ui::color_stdout();
+            if force && let Some(state) = llmtrim::daemon::running() {
+                println!(
+                    "{}",
+                    ui::ok(
+                        color,
+                        &format!("Stopping existing daemon · pid {} (--force)", state.pid)
+                    )
+                );
+                // Wait for the port to actually free before spawning, so the new daemon doesn't
+                // lose the bind race and crash on EADDRINUSE.
+                if !llmtrim::daemon::stop_and_wait_free(state.port)? {
+                    anyhow::bail!(
+                        "--force stopped pid {} but port {} was still held after 5s",
+                        state.pid,
+                        state.port
+                    );
+                }
+            }
             if let Some(state) = llmtrim::daemon::running() {
                 println!(
                     "{}",

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -9,12 +9,12 @@
 //! because they all speak HTTPS to a known set of API hosts.
 
 #[cfg(not(feature = "intercept"))]
-pub fn run(_port: u16) -> anyhow::Result<()> {
+pub fn run(_port: u16, _force: bool) -> anyhow::Result<()> {
     anyhow::bail!("this build has no interceptor; rebuild with `--features intercept`")
 }
 
 #[cfg(not(feature = "intercept"))]
-pub fn run_supervised(_port: u16) -> anyhow::Result<()> {
+pub fn run_supervised(_port: u16, _force: bool) -> anyhow::Result<()> {
     anyhow::bail!("this build has no interceptor; rebuild with `--features intercept`")
 }
 
@@ -1159,9 +1159,84 @@ mod imp {
         }
     }
 
+    /// A port already in use. Carried as a typed error so the supervisor can recognize a
+    /// permanent bind failure (don't retry) and the dispatcher can word the hint.
+    #[derive(Debug)]
+    pub struct PortInUse {
+        port: u16,
+        /// The llmtrim daemon already holding it, if the pidfile names a live one.
+        by_llmtrim_pid: Option<u32>,
+    }
+
+    impl std::fmt::Display for PortInUse {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self.by_llmtrim_pid {
+                Some(pid) => write!(
+                    f,
+                    "port {} is already served by llmtrim (pid {pid}) — `llmtrim stop` first, \
+                     or rerun with --force to replace it",
+                    self.port
+                ),
+                None => write!(
+                    f,
+                    "cannot bind port {} — already in use by another process; free it or pass \
+                     a different --port",
+                    self.port
+                ),
+            }
+        }
+    }
+
+    impl std::error::Error for PortInUse {}
+
+    /// Refuse (or, with `force`, clear) a port already held before we try to bind it. Turns the
+    /// retry-looping `EADDRINUSE` crash into one actionable error, and lets `--force` take over a
+    /// stale daemon the way `start`/`stop` already manage one. A daemon whose pidfile names *our
+    /// own* pid (the supervised loop adopted it) is not a conflict — skip it.
+    fn preflight_port(port: u16, force: bool) -> Result<()> {
+        if let Some(state) = crate::daemon::running()
+            && state.port == port
+            && state.pid != std::process::id()
+        {
+            if !force {
+                return Err(PortInUse {
+                    port,
+                    by_llmtrim_pid: Some(state.pid),
+                }
+                .into());
+            }
+            eprintln!(
+                "llmtrim: --force: stopping existing daemon (pid {})",
+                state.pid
+            );
+            // `stop` waits for the process to exit; wait_free closes the lingering-socket gap so
+            // the bind below doesn't lose the race. A timeout here is its own error (the daemon
+            // didn't release the port), not the foreign-process case below, so the message stays
+            // accurate.
+            if !crate::daemon::stop_and_wait_free(port)? {
+                anyhow::bail!(
+                    "--force stopped the daemon (pid {}) but port {port} was still held after 5s",
+                    state.pid
+                );
+            }
+            return Ok(());
+        }
+        // An untracked process on the port (no llmtrim pidfile, or one naming a different port):
+        // `--force` can't safely kill a foreign process, so refuse immediately either way.
+        if crate::daemon::probe_port(port) {
+            return Err(PortInUse {
+                port,
+                by_llmtrim_pid: None,
+            }
+            .into());
+        }
+        Ok(())
+    }
+
     /// Run the interceptor on `127.0.0.1:port`, blocking until Ctrl-C. Sets up its own
     /// Tokio runtime so the rest of the CLI stays synchronous.
-    pub fn run(port: u16) -> Result<()> {
+    pub fn run(port: u16, force: bool) -> Result<()> {
+        preflight_port(port, force)?;
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
@@ -1173,18 +1248,28 @@ mod imp {
     /// `setup` points `HTTPS_PROXY` at us, a dead proxy breaks the client's HTTPS entirely —
     /// so on an unexpected exit/panic we restart. Gives up only if it fails fast 5× in a row
     /// (a real misconfig, not a transient), so it never spins forever.
-    pub fn run_supervised(port: u16) -> Result<()> {
+    pub fn run_supervised(port: u16, force: bool) -> Result<()> {
         use std::time::{Duration, Instant};
         let mut fast_fails = 0u32;
+        // `--force` is a one-time take-over: apply it only on the first start. On a crash-restart
+        // the daemon we'd be replacing is ourselves (the pidfile now holds our own pid), so there
+        // is nothing to force, and re-forcing could stop a freshly adopted sibling.
+        let mut force = force;
         loop {
             // Adopt the pidfile if it's missing (a manually-launched supervised daemon, or
             // one whose pidfile was lost to a transient full disk). Best-effort: never let a
             // bookkeeping write stop the proxy from serving.
             let _ = crate::daemon::write_state_if_absent(std::process::id(), port);
             let started = Instant::now();
-            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run(port)));
+            let outcome =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run(port, force)));
+            force = false;
             match outcome {
                 Ok(Ok(())) => return Ok(()), // graceful shutdown (Ctrl-C)
+                // A bind failure is permanent (the port is taken or OS-reserved), not the
+                // transient crash the restart loop exists for — retrying just spins. Surface
+                // it once and give up so the operator sees the actionable message immediately.
+                Ok(Err(e)) if e.downcast_ref::<PortInUse>().is_some() => return Err(e),
                 Ok(Err(e)) => eprintln!("llmtrim: interceptor exited: {e}"),
                 Err(_) => eprintln!("llmtrim: interceptor panicked"),
             }
@@ -1289,10 +1374,20 @@ mod imp {
         // Pre-flight bind: hudsucker's `Proxy::start` collapses a bind failure to a bare
         // "io error", hiding whether the port is in use or OS-reserved. Bind once ourselves
         // first so the real cause reaches the log, then drop it microseconds before hudsucker
-        // rebinds the same addr.
+        // rebinds the same addr. Only an in-use port maps to PortInUse (so the supervisor fails
+        // fast on it); a permission/transient error keeps its OS cause and stays retryable.
         drop(
-            std::net::TcpListener::bind(addr)
-                .with_context(|| format!("cannot bind {addr} — port in use or reserved"))?,
+            std::net::TcpListener::bind(addr).map_err(|e| -> anyhow::Error {
+                if e.kind() == std::io::ErrorKind::AddrInUse {
+                    PortInUse {
+                        port,
+                        by_llmtrim_pid: None,
+                    }
+                    .into()
+                } else {
+                    anyhow::Error::new(e).context(format!("cannot bind {addr}"))
+                }
+            })?,
         );
         eprintln!("llmtrim: MITM interceptor on http://{addr}");
         eprintln!("  export HTTPS_PROXY=http://{addr}");
@@ -1499,6 +1594,75 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::*;
+
+        #[test]
+        fn port_in_use_message_points_to_force_when_llmtrim_owns_it() {
+            let msg = PortInUse {
+                port: 43117,
+                by_llmtrim_pid: Some(616982),
+            }
+            .to_string();
+            assert!(msg.contains("43117"), "names the port: {msg}");
+            assert!(msg.contains("616982"), "names the pid: {msg}");
+            assert!(msg.contains("--force"), "points to --force: {msg}");
+        }
+
+        #[test]
+        fn port_in_use_message_for_foreign_process_does_not_promise_force() {
+            // --force can't kill a foreign process, so the message must not suggest it.
+            let msg = PortInUse {
+                port: 9999,
+                by_llmtrim_pid: None,
+            }
+            .to_string();
+            assert!(msg.contains("9999"), "names the port: {msg}");
+            assert!(
+                msg.contains("another process"),
+                "blames a foreign owner: {msg}"
+            );
+            assert!(!msg.contains("--force"), "must not promise --force: {msg}");
+        }
+
+        #[test]
+        fn preflight_refuses_a_busy_port_immediately() {
+            // Bind an ephemeral port so something is listening, then confirm preflight refuses
+            // it (no daemon pidfile names this port, so it reads as a foreign process). The
+            // ephemeral port avoids clashing with any real daemon's configured port.
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let port = listener.local_addr().unwrap().port();
+
+            let start = std::time::Instant::now();
+            let err = preflight_port(port, false).expect_err("busy port must be refused");
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(2),
+                "foreign-port refusal must be fast, took {:?}",
+                start.elapsed()
+            );
+            assert!(
+                err.downcast_ref::<PortInUse>().is_some(),
+                "must surface PortInUse, got: {err}"
+            );
+            // It must be attributed to a foreign owner, not to llmtrim — otherwise the user is
+            // told to `llmtrim stop` a process llmtrim can't stop.
+            let msg = err.to_string();
+            assert!(
+                msg.contains("another process") && !msg.contains("--force"),
+                "foreign port must read as foreign, got: {msg}"
+            );
+        }
+
+        #[test]
+        fn port_in_use_survives_anyhow_wrapping_for_the_supervisor() {
+            // run_supervised fails fast only if it can downcast the error back to PortInUse.
+            // Guard the core invariant: a regression that double-wraps or renames the type would
+            // silently restore the 5× retry-spin this fix removes.
+            let e: anyhow::Error = PortInUse {
+                port: 1234,
+                by_llmtrim_pid: None,
+            }
+            .into();
+            assert!(e.downcast_ref::<PortInUse>().is_some());
+        }
 
         #[test]
         fn capture_cap_evicts_oldest_until_under_limit() {

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -295,7 +295,7 @@ fn heal_profiles_in(base: &std::path::Path, proxy: &str, ca: &str) -> Result<Vec
     Ok(healed)
 }
 
-pub fn run(requested: Option<u16>) -> Result<()> {
+pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
     let color = ui::color_stdout();
 
     // 0. Resolve the port *once*, here, before anything is wired. The port is a contract
@@ -450,7 +450,9 @@ pub fn run(requested: Option<u16>) -> Result<()> {
     //    changing (explicit `--port`, or self-healing a drifted state) or the daemon is gone —
     //    that also picks up a new binary after an update (the silent-stale-update trap).
     let daemon_ok = match &running {
-        Some(state) if state.port == port => {
+        // `--force` falls through to the restart arm even on a matching port (e.g. to pick up a
+        // freshly installed binary); without it a healthy same-port daemon is left untouched.
+        Some(state) if state.port == port && !force => {
             rows.push((
                 ui::OK,
                 "Interceptor".into(),
@@ -459,7 +461,16 @@ pub fn run(requested: Option<u16>) -> Result<()> {
             true
         }
         _ => {
-            let _ = crate::daemon::stop(); // clear a dead/old-port daemon + its pidfile first
+            // Clear a dead/old-port daemon (or the --force target) and wait for the port to free
+            // before respawning, so the new daemon doesn't lose the bind race. A timeout here is
+            // surfaced (not silently swallowed) so a confusing spawn failure isn't a mystery.
+            if let Ok(false) = crate::daemon::stop_and_wait_free(port) {
+                rows.push((
+                    ui::WARN,
+                    "Interceptor".into(),
+                    format!("port {port} still held 5s after stop; starting anyway"),
+                ));
+            }
             match crate::daemon::spawn_detached(port) {
                 Ok(pid) => {
                     rows.push((


### PR DESCRIPTION
## What

`serve --supervised` treated a port-in-use bind failure as a transient crash and spun through the restart loop 5× before giving up, even though the port being taken is permanent. This makes the proxy fail fast with an actionable message, and adds `--force` to take over a daemon already on the port.

## Changes

- **Fail fast on a busy port.** Pre-flight the listen port. A live llmtrim daemon on it → refuse with `port N is already served by llmtrim (pid X) — llmtrim stop first, or rerun with --force to replace it`; a foreign process → say so. Only `AddrInUse` maps to the non-transient `PortInUse` (supervisor surfaces it once instead of retrying); `EACCES`/transient bind errors keep their OS cause and stay retryable.
- **`--force` on `serve`, `start`, `setup`.** Stops the existing daemon first (via the guarded `daemon::stop`, which never kills a foreign process), waits for the port to actually free (shared `daemon::stop_and_wait_free`), then takes over. In the supervised loop `--force` applies only to the first start, never a crash-restart. `setup --force` restarts even a healthy same-port daemon (e.g. to pick up a new binary).
- **Robust daemon identity.** `daemon::running()` now verifies the pid is llmtrim (via `/proc/<pid>/exe`, not just liveness), so a stale pidfile naming an OS-recycled pid is cleared rather than mistaken for a running daemon.

## Review

Two rounds of 3 parallel reviewers (correctness/concurrency, API/UX/conventions, tests/coverage). All findings triaged and either fixed or declined with reason (see commit). Notable fixes: AddrInUse-only error mapping, `start --force` wait-for-free before spawn, `/proc/exe` identity check to avoid a false-negative double-daemon.

## Tests

676 pass (`cargo nextest run --features intercept`). New: `PortInUse` Display (both arms), busy-port fast-refusal, supervisor downcast survival, `wait_until_free` free+timeout (injectable, <1ms), `pid_is_llmtrim(1)`. `fmt` + `clippy --features intercept` clean.