### PR TITLE
refactor(config): resolve every runtime setting env-first then config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ All notable changes to this project are documented here. The format follows
 - **`serve --force` / `start --force` / `setup --force`** replace an llmtrim daemon that's
   already holding the port (stops it first, waits for the port to free, then takes over)
   instead of refusing, no-opping, or leaving a healthy same-port daemon untouched.
+- **Custom intercept hosts.** Point llmtrim at a self-hosted or gateway OpenAI-compatible
+  endpoint with `LLMTRIM_EXTRA_HOSTS=host1,host2` (or an `extra_hosts` array in the config
+  file). The name-constrained CA regenerates automatically to cover them. Entries must be
+  exact hostnames; malformed or overly broad ones are dropped.
+- **Every runtime setting is now settable in the config file, not just via env.** The
+  proxy knobs (`upstream_proxy`, `db_path`, `capture_dir`, `capture_max_mb`, `bind`,
+  `no_update_check`) each now resolve env-first then from a top-level key in `config.toml`,
+  matching the existing `preset`/`retention_days` behavior. The matching `LLMTRIM_*` env vars
+  are unchanged and still win when set.
 
 ### Fixed
 - **`serve` fails fast when the port is taken.** A bind-in-use error no longer spins through

--- a/README.md
+++ b/README.md
@@ -330,7 +330,27 @@ Every stage is individually tunable via config flags; `preset` wins over individ
 | `dedup` | `true` | collapse duplicate lines (lossless) |
 | `quality_gate` | `true` | revert any lossy cut whose query-relevant coverage drops too far |
 
-Env: `LLMTRIM_PRESET` (preset), `LLMTRIM_CONFIG` (config-file path), `LLMTRIM_DB_PATH` (ledger location), `LLMTRIM_UPSTREAM_PROXY` (route egress through another proxy, see below).
+Env: `LLMTRIM_PRESET` (preset), `LLMTRIM_CONFIG` (config-file path).
+
+</details>
+
+<details>
+<summary><b>Runtime settings (env or config file)</b></summary>
+
+These knobs are orthogonal to compression. Each resolves env-first, then from the config file, so set whichever fits. The env var wins when both are present.
+
+| env var | config key | meaning |
+| --- | --- | --- |
+| `LLMTRIM_EXTRA_HOSTS` | `extra_hosts` | extra exact LLM-API hosts to intercept (comma-separated env / array in file), e.g. a self-hosted OpenAI-compatible endpoint |
+| `LLMTRIM_UPSTREAM_PROXY` | `upstream_proxy` | route egress through another proxy (see below) |
+| `LLMTRIM_DB_PATH` | `db_path` | ledger location |
+| `LLMTRIM_CAPTURE_DIR` | `capture_dir` | before/after QA capture directory |
+| `LLMTRIM_CAPTURE_MAX_MB` | `capture_max_mb` | capture corpus size ceiling (`0` disables) |
+| `LLMTRIM_BIND` | `bind` | listen IP (default loopback; `0.0.0.0` for containers) |
+| `LLMTRIM_RETENTION_DAYS` | `retention_days` | ledger age-retention in days |
+| `LLMTRIM_NO_UPDATE_CHECK` | `no_update_check` | disable the passive update check |
+
+`extra_hosts` entries must be exact hostnames (`llm.acme.com`, never a bare `acme.com`): each one widens the name-constrained MITM CA, which regenerates automatically on the next launch to cover them.
 
 </details>
 

--- a/crates/llmtrim-cli/src/discover.rs
+++ b/crates/llmtrim-cli/src/discover.rs
@@ -119,10 +119,11 @@ fn resolve_dir(dir: Option<PathBuf>) -> Result<PathBuf> {
     if let Some(d) = dir {
         return Ok(d);
     }
-    if let Ok(d) = std::env::var("LLMTRIM_CAPTURE_DIR")
-        && !d.is_empty()
+    if let Some(d) = llmtrim_core::config::RuntimeConfig::get()
+        .capture_dir
+        .clone()
     {
-        return Ok(PathBuf::from(d));
+        return Ok(d);
     }
     Ok(crate::daemon::home_dir()?.join("capture"))
 }

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -50,7 +50,7 @@ mod imp {
     use hyper_util::client::legacy::connect::HttpConnector;
 
     use crate::tracking::{Record, Tracker};
-    use llmtrim_core::config::DenseConfig;
+    use llmtrim_core::config::{DenseConfig, RuntimeConfig};
     use llmtrim_core::ir::ProviderKind;
     use llmtrim_core::memo::Memo;
 
@@ -104,21 +104,52 @@ mod imp {
         "ai-gateway.vercel.sh",
     ];
 
-    /// True if `host` is one of `EXTRA_HOSTS` (exact, or a subdomain of one).
+    /// User-configured extra hosts (env `LLMTRIM_EXTRA_HOSTS` / file `extra_hosts`), already
+    /// normalized + validated by [`RuntimeConfig`]. Beyond the curated `EXTRA_HOSTS`, so a
+    /// self-hosted or gateway OpenAI-compatible endpoint can be intercepted without a code
+    /// change. Each widens the name-constrained CA, exactly like `EXTRA_HOSTS`.
+    ///
+    /// Note one asymmetry: a user host `llm.acme.com` enters the CA's permitted subtrees as
+    /// `DnsName("llm.acme.com")`, which by RFC 5280 also lets the CA sign for its *subdomains*
+    /// (`api.llm.acme.com`). Interception is narrower — [`extra_host_match`] matches user hosts
+    /// *exactly*, never their subdomains — so the proxy never MITMs a host it wasn't told to.
+    /// The wider CA scope is unused and low-risk (the CA is local-only and regenerated when the
+    /// host set changes), but list exact hosts, not bare apexes, to keep the CA narrow.
+    fn user_extra_hosts() -> &'static [String] {
+        &RuntimeConfig::get().extra_hosts
+    }
+
+    /// True if `host` is a curated `EXTRA_HOSTS` entry or a user-configured extra host.
     fn is_extra_host(host: &str) -> bool {
+        extra_host_match(host, user_extra_hosts())
+    }
+
+    /// Pure host-match used by [`is_extra_host`]: a curated `EXTRA_HOSTS` entry matches exactly
+    /// or as a parent of `host` (subdomain), but a user-configured host matches **exactly only**
+    /// — never its subdomains. So a mistakenly broad user entry (e.g. an apex) can't silently
+    /// widen what gets intercepted beyond the exact host named.
+    fn extra_host_match(host: &str, user_hosts: &[String]) -> bool {
         EXTRA_HOSTS
             .iter()
             .any(|s| host == *s || host.ends_with(&format!(".{s}")))
+            || user_hosts.iter().any(|s| host == s)
     }
 
     /// Every name-constraint domain the CA should permit: the registry parent domains plus the
     /// curated extra hosts, sorted + deduped. The single source of truth for what we intend to
     /// intercept; compared byte-for-byte against the CA's sidecar to decide whether to regenerate.
     fn intercept_domains() -> Vec<String> {
+        intercept_domains_with(user_extra_hosts())
+    }
+
+    /// Pure body of [`intercept_domains`]: the registry parents + curated extras + the given
+    /// user hosts, sorted + deduped. Split out so the user-host → CA-sidecar flow is testable.
+    fn intercept_domains_with(user_hosts: &[String]) -> Vec<String> {
         let mut v: Vec<String> = LLM_DOMAINS
             .iter()
             .cloned()
             .chain(EXTRA_HOSTS.iter().map(|h| (*h).to_string()))
+            .chain(user_hosts.iter().cloned())
             .collect();
         v.sort();
         v.dedup();
@@ -690,9 +721,9 @@ mod imp {
         Some((result.request_json, pending))
     }
 
-    /// Opt-in QA capture: when `LLMTRIM_CAPTURE_DIR` is set, write the before/after request
-    /// bodies of each compressed request as one JSON file so an external reviewer can audit
-    /// compression quality. Off (zero work beyond one env read) unless the var is set; any
+    /// Opt-in QA capture: when a capture dir is set (`LLMTRIM_CAPTURE_DIR` env or `capture_dir`
+    /// in the config file), write the before/after request bodies of each compressed request as
+    /// one JSON file so an external reviewer can audit compression quality. Off unless set; any
     /// write failure is logged and swallowed — capture must never break proxying.
     fn capture_pair(
         before: &str,
@@ -700,12 +731,9 @@ mod imp {
         pending: &Pending,
         stages: &[llmtrim_core::pipeline::StageReport],
     ) {
-        let Ok(dir) = std::env::var("LLMTRIM_CAPTURE_DIR") else {
+        let Some(dir_path) = RuntimeConfig::get().capture_dir.clone() else {
             return;
         };
-        if dir.is_empty() {
-            return;
-        }
         // The names of the stages that actually rewrote this request — what an external auditor
         // needs to tell a lossless run that dropped content (a bug) from a lossy stage doing its
         // job. `plan` below is the output-rehydration plan (reversible response-side transforms),
@@ -732,10 +760,9 @@ mod imp {
             chrono::Utc::now().timestamp_micros(),
             std::process::id()
         );
-        let dir_path = std::path::Path::new(&dir);
         let path = dir_path.join(name);
-        if let Err(e) =
-            std::fs::create_dir_all(&dir).and_then(|_| std::fs::write(&path, record.to_string()))
+        if let Err(e) = std::fs::create_dir_all(&dir_path)
+            .and_then(|_| std::fs::write(&path, record.to_string()))
         {
             eprintln!("llmtrim: capture failed ({}): {e}", path.display());
         }
@@ -751,9 +778,8 @@ mod imp {
             .fetch_add(1, Ordering::Relaxed)
             .is_multiple_of(CHECK_EVERY)
         {
-            let max_bytes = std::env::var("LLMTRIM_CAPTURE_MAX_MB")
-                .ok()
-                .and_then(|s| s.trim().parse::<u64>().ok())
+            let max_bytes = RuntimeConfig::get()
+                .capture_max_mb
                 .unwrap_or(1024)
                 .saturating_mul(1024 * 1024);
             if max_bytes > 0 {
@@ -1340,11 +1366,11 @@ mod imp {
 
         // Loopback by default — a MITM proxy must not be reachable off-host unless asked.
         // LLMTRIM_BIND=0.0.0.0 opts in (containers: port mapping can't reach loopback).
-        let bind_ip: std::net::IpAddr = match std::env::var("LLMTRIM_BIND") {
-            Ok(s) => s
+        let bind_ip: std::net::IpAddr = match RuntimeConfig::get().bind.clone() {
+            Some(s) => s
                 .parse()
-                .with_context(|| format!("LLMTRIM_BIND is not a valid IP address: {s}"))?,
-            Err(_) => std::net::IpAddr::from([127, 0, 0, 1]),
+                .with_context(|| format!("bind address is not a valid IP: {s}"))?,
+            None => std::net::IpAddr::from([127, 0, 0, 1]),
         };
         let addr = SocketAddr::from((bind_ip, port));
 
@@ -1968,6 +1994,42 @@ mod imp {
                 d.windows(2).all(|w| w[0] <= w[1]),
                 "must be sorted for sidecar compare"
             );
+        }
+
+        #[test]
+        fn user_extra_hosts_flow_into_intercept_domains() {
+            // A user-configured host must reach the CA sidecar set so it is actually intercepted.
+            let user = vec!["llm.acme.com".to_string()];
+            let d = intercept_domains_with(&user);
+            assert!(d.contains(&"llm.acme.com".to_string()));
+            assert!(
+                d.contains(&"api.openai.com".to_string()),
+                "registry still present"
+            );
+            assert!(
+                d.windows(2).all(|w| w[0] <= w[1]),
+                "stays sorted for sidecar compare"
+            );
+        }
+
+        #[test]
+        fn user_extra_hosts_match_exactly_not_by_subdomain() {
+            // Curated EXTRA_HOSTS match a host and its subdomains; user hosts match ONLY the exact
+            // host named, so a typo'd apex can't widen interception to its siblings/subdomains.
+            let user = vec!["llm.acme.com".to_string()];
+            assert!(
+                extra_host_match("llm.acme.com", &user),
+                "exact user host matches"
+            );
+            assert!(
+                !extra_host_match("api.llm.acme.com", &user),
+                "a subdomain of a user host is NOT intercepted"
+            );
+            assert!(!extra_host_match("acme.com", &user));
+            assert!(!extra_host_match("notllm.acme.com", &user));
+            // Curated extras keep subdomain matching.
+            assert!(extra_host_match("api.groq.com", &[]));
+            assert!(extra_host_match("foo.api.groq.com", &[]));
         }
 
         #[test]

--- a/crates/llmtrim-cli/src/tracking.rs
+++ b/crates/llmtrim-cli/src/tracking.rs
@@ -593,8 +593,8 @@ pub fn db_path() -> Result<PathBuf> {
 }
 
 fn default_db_path() -> Result<PathBuf> {
-    if let Ok(p) = std::env::var("LLMTRIM_DB_PATH") {
-        return Ok(PathBuf::from(p));
+    if let Some(p) = llmtrim_core::config::RuntimeConfig::get().db_path.clone() {
+        return Ok(p);
     }
     let base = if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
         PathBuf::from(xdg)

--- a/crates/llmtrim-cli/src/transport.rs
+++ b/crates/llmtrim-cli/src/transport.rs
@@ -63,9 +63,11 @@ pub fn redact_proxy_url(url: &str) -> String {
 /// `None` when the daemon bind address is unknown (e.g. the CLI `send` subcommand, which
 /// does not run a proxy server).
 pub fn upstream_proxy_url(bind_addr: Option<std::net::SocketAddr>) -> Result<Option<String>> {
-    let url = match std::env::var("LLMTRIM_UPSTREAM_PROXY") {
-        Ok(v) if !v.is_empty() => v,
-        _ => return Ok(None),
+    let Some(url) = llmtrim_core::config::RuntimeConfig::get()
+        .upstream_proxy
+        .clone()
+    else {
+        return Ok(None);
     };
     validate_proxy_url(&url, bind_addr)?;
     Ok(Some(url))

--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -108,7 +108,7 @@ fn write_cache(latest: &str) {
 /// opt out with `LLMTRIM_NO_UPDATE_CHECK`; silent on any failure. Used for the passive
 /// `monitor` banner — `force` bypasses the cache (used by the `update` command).
 pub fn check(force: bool) -> Option<String> {
-    if std::env::var_os("LLMTRIM_NO_UPDATE_CHECK").is_some() {
+    if llmtrim_core::config::RuntimeConfig::get().no_update_check {
         return None;
     }
     if !force

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -276,13 +276,15 @@ impl DenseConfig {
         if let Some(name) = value.get("preset").and_then(toml::Value::as_str) {
             return Self::preset(name).with_context(|| format!("unknown preset '{name}'"));
         }
-        // A file with no *compression* keys (empty, or only orthogonal keys like
-        // `retention_days`) keeps the shipped `auto` shape-routing default. Otherwise adding
-        // e.g. `retention_days = 30` would silently fall through to the bare flag set
-        // (`auto = false`, everything-but-lossless off) and disable shape-routing — a
-        // surprising downgrade for a key that has nothing to do with compression.
+        // A file with no *compression* keys (empty, or only orthogonal keys like the
+        // `RuntimeConfig` runtime settings) keeps the shipped `auto` shape-routing default.
+        // Otherwise a file that sets only e.g. `capture_dir` would silently fall through to the
+        // bare flag set (`auto = false`, everything-but-lossless off) and disable shape-routing —
+        // a surprising downgrade for a key that has nothing to do with compression.
         if let Some(table) = value.as_table()
-            && !table.keys().any(|k| k != "retention_days" && k != "preset")
+            && !table
+                .keys()
+                .any(|k| !RUNTIME_ONLY_KEYS.contains(&k.as_str()) && k != "preset")
         {
             return Ok(Self::auto());
         }
@@ -454,30 +456,174 @@ fn config_path() -> Option<PathBuf> {
     Some(base.join("llmtrim").join("config.toml"))
 }
 
-/// Ledger age-retention in days, resolved **independently** of [`DenseConfig`] so selecting a
-/// preset never resets it (presets rebuild `DenseConfig` from `default()`). Resolution:
-/// `LLMTRIM_RETENTION_DAYS` (env) wins over a top-level `retention_days` key in the config
-/// file. `None` when unset or ≤ 0 — age retention off, leaving only the row cap to bound the
-/// ledger. The key is ignored by the compression config (no `deny_unknown_fields`).
-pub fn retention_days() -> Option<i64> {
-    if let Ok(v) = std::env::var("LLMTRIM_RETENTION_DAYS")
-        && let Ok(days) = v.trim().parse::<i64>()
-    {
-        return (days > 0).then_some(days);
-    }
-    let path = config_path().filter(|p| p.exists())?;
-    let text = std::fs::read_to_string(&path).ok()?;
-    let value: toml::Value = toml::from_str(&text).ok()?;
-    retention_days_from_toml(&value)
+/// Config-file keys that belong to [`RuntimeConfig`], not the compression pipeline. Listed so
+/// [`DenseConfig::from_toml_value`] treats a file that sets only these as "no compression keys"
+/// and keeps the `auto` default, instead of silently downgrading shape-routing.
+pub(crate) const RUNTIME_ONLY_KEYS: &[&str] = &[
+    "extra_hosts",
+    "upstream_proxy",
+    "capture_dir",
+    "db_path",
+    "no_update_check",
+    "bind",
+    "capture_max_mb",
+    "retention_days",
+];
+
+/// Runtime settings orthogonal to the compression pipeline ([`DenseConfig`]). Each value
+/// resolves **env-first, then a top-level key in the same config TOML, then a default** — the
+/// generalized form of the original `retention_days` rule, so every runtime knob is settable
+/// either way ("always handle both"). These keys are ignored by `DenseConfig` (it has no
+/// `deny_unknown_fields`), so they coexist in the one config file. Parsed once via
+/// [`RuntimeConfig::get`].
+///
+/// Intentionally *not* covered (env-only): `LLMTRIM_CONFIG` (points at this file — chicken/egg),
+/// `LLMTRIM_HOME` (base dir resolved before config loads), `LLMTRIM_PROFILE` (dev timing
+/// toggle), `LLMTRIM_VERSION` (internal updater handoff). None are persistable user settings.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeConfig {
+    /// Extra exact LLM-API hosts to intercept beyond the built-in registry. Env
+    /// `LLMTRIM_EXTRA_HOSTS` (comma-separated) replaces the file `extra_hosts` array.
+    /// Normalized to lowercase plain hostnames; malformed/overbroad entries are dropped.
+    /// Each entry widens the name-constrained MITM CA, so keep them exact (`llm.acme.com`,
+    /// never a bare apex like `acme.com`).
+    pub extra_hosts: Vec<String>,
+    /// Upstream HTTP proxy URL (env `LLMTRIM_UPSTREAM_PROXY` / file `upstream_proxy`).
+    pub upstream_proxy: Option<String>,
+    /// QA capture corpus directory (env `LLMTRIM_CAPTURE_DIR` / file `capture_dir`).
+    pub capture_dir: Option<PathBuf>,
+    /// Ledger DB path (env `LLMTRIM_DB_PATH` / file `db_path`).
+    pub db_path: Option<PathBuf>,
+    /// Disable the passive update check. The env var is **presence-only**: setting
+    /// `LLMTRIM_NO_UPDATE_CHECK` to *any* value (including `0` or empty) disables the check;
+    /// leaving it unset is the only way to keep the check on. The config key `no_update_check`
+    /// is a normal bool. (Preserves the prior `var_os(...).is_some()` behavior.)
+    pub no_update_check: bool,
+    /// Listen bind address, left unparsed (env `LLMTRIM_BIND` / file `bind`); the caller
+    /// parses + validates it as an IP.
+    pub bind: Option<String>,
+    /// Capture corpus size ceiling in MB (env `LLMTRIM_CAPTURE_MAX_MB` / file
+    /// `capture_max_mb`); `Some(0)` disables the cap, `None` means use the default.
+    pub capture_max_mb: Option<u64>,
+    /// Ledger age-retention in days (env `LLMTRIM_RETENTION_DAYS` / file `retention_days`);
+    /// positive only (`None` = age retention off, row cap alone bounds the ledger).
+    pub retention_days: Option<i64>,
 }
 
-/// The `retention_days` key from a parsed config (positive only). Factored out so the
-/// file-parsing is unit-testable without touching env or the real config path.
-fn retention_days_from_toml(value: &toml::Value) -> Option<i64> {
-    value
-        .get("retention_days")
-        .and_then(toml::Value::as_integer)
-        .filter(|d| *d > 0)
+impl RuntimeConfig {
+    /// Process-wide instance, loaded once from env + the config file on first use. Env vars
+    /// don't change mid-process, so caching is safe and keeps per-request paths (the capture
+    /// cap) off the filesystem. Because it is cached for the process lifetime, **tests must use
+    /// [`resolve`](Self::resolve), never `get`** — the first caller fixes the value for the
+    /// whole test binary, so `get` can't observe a per-test environment.
+    pub fn get() -> &'static RuntimeConfig {
+        static CACHE: std::sync::OnceLock<RuntimeConfig> = std::sync::OnceLock::new();
+        CACHE.get_or_init(Self::load)
+    }
+
+    /// Load from the real environment and config file (the one parse of the TOML).
+    fn load() -> RuntimeConfig {
+        let file = config_path()
+            .filter(|p| p.exists())
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|t| toml::from_str::<toml::Value>(&t).ok());
+        Self::resolve(|k| std::env::var(k).ok(), file.as_ref())
+    }
+
+    /// Pure resolver: `env` looks up an environment variable, `file` is the parsed config TOML
+    /// (if any). Factored out so the env-over-file precedence is unit-testable without touching
+    /// the real environment or filesystem.
+    fn resolve(env: impl Fn(&str) -> Option<String>, file: Option<&toml::Value>) -> RuntimeConfig {
+        let env_set = |k: &str| env(k).filter(|s| !s.is_empty());
+        let fstr = |key: &str| {
+            file.and_then(|v| v.get(key))
+                .and_then(toml::Value::as_str)
+                .map(str::to_string)
+        };
+        let fint = |key: &str| {
+            file.and_then(|v| v.get(key))
+                .and_then(toml::Value::as_integer)
+        };
+        let fbool = |key: &str| file.and_then(|v| v.get(key)).and_then(toml::Value::as_bool);
+        let positive = |v: Option<i64>| v.filter(|n| *n > 0);
+
+        // extra_hosts: env (comma-split) replaces the file array; both normalized + validated.
+        let raw_hosts: Vec<String> = match env_set("LLMTRIM_EXTRA_HOSTS") {
+            Some(s) => s.split(',').map(str::to_string).collect(),
+            None => file
+                .and_then(|v| v.get("extra_hosts"))
+                .and_then(toml::Value::as_array)
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|e| e.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        };
+        let mut extra_hosts: Vec<String> =
+            raw_hosts.iter().filter_map(|h| normalize_host(h)).collect();
+        extra_hosts.sort();
+        extra_hosts.dedup();
+
+        RuntimeConfig {
+            extra_hosts,
+            upstream_proxy: env_set("LLMTRIM_UPSTREAM_PROXY").or_else(|| fstr("upstream_proxy")),
+            capture_dir: env_set("LLMTRIM_CAPTURE_DIR")
+                .or_else(|| fstr("capture_dir"))
+                .map(PathBuf::from),
+            db_path: env_set("LLMTRIM_DB_PATH")
+                .or_else(|| fstr("db_path"))
+                .map(PathBuf::from),
+            no_update_check: env("LLMTRIM_NO_UPDATE_CHECK").is_some()
+                || fbool("no_update_check").unwrap_or(false),
+            bind: env_set("LLMTRIM_BIND").or_else(|| fstr("bind")),
+            capture_max_mb: env_set("LLMTRIM_CAPTURE_MAX_MB")
+                .and_then(|s| s.trim().parse::<u64>().ok())
+                .or_else(|| fint("capture_max_mb").and_then(|n| u64::try_from(n).ok())),
+            retention_days: positive(
+                env_set("LLMTRIM_RETENTION_DAYS")
+                    .and_then(|s| s.trim().parse::<i64>().ok())
+                    .or_else(|| fint("retention_days")),
+            ),
+        }
+    }
+}
+
+/// Normalize + validate a user-supplied intercept host: trim a trailing dot, lowercase, and
+/// accept only a plain multi-label DNS hostname (no scheme/path/port/wildcard/whitespace, at
+/// least one dot so a bare TLD can't widen the CA, and not a numeric IP literal). Returns `None`
+/// for anything unusable, which is silently dropped — a typo'd host simply isn't intercepted
+/// (visible in captures), and the name-constrained CA is never widened by a malformed or
+/// overbroad entry.
+fn normalize_host(raw: &str) -> Option<String> {
+    let h = raw.trim().trim_end_matches('.').to_ascii_lowercase();
+    if h.is_empty()
+        || h.starts_with('.')
+        || h.starts_with('-')
+        || !h.contains('.')
+        || h.contains(['/', ':', ' ', '\t', '*', '@', '?'])
+    {
+        return None;
+    }
+    // Each dot-separated label: non-empty, ASCII alphanumeric or hyphen only.
+    if !h
+        .split('.')
+        .all(|l| !l.is_empty() && l.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-'))
+    {
+        return None;
+    }
+    // Reject IPv4 literals (all labels numeric): an IP in a DNS name-constraint is undefined
+    // across TLS stacks, so it must never reach the CA's permitted subtrees.
+    if h.split('.').all(|l| l.bytes().all(|b| b.is_ascii_digit())) {
+        return None;
+    }
+    Some(h)
+}
+
+/// Ledger age-retention in days. Thin accessor over [`RuntimeConfig`] kept for the call sites
+/// that only need this one value.
+pub fn retention_days() -> Option<i64> {
+    RuntimeConfig::get().retention_days
 }
 
 #[cfg(test)]
@@ -666,20 +812,125 @@ mod tests {
         assert_eq!(c.serialize_min_rows, 2);
     }
 
+    /// Resolve with no env set (every lookup returns `None`) against the given file TOML.
+    fn resolve_file(toml_src: &str) -> RuntimeConfig {
+        let value: toml::Value = toml::from_str(toml_src).unwrap();
+        RuntimeConfig::resolve(|_| None, Some(&value))
+    }
+
+    /// Resolve with an explicit env map and the given file TOML.
+    fn resolve_env(env: &[(&str, &str)], toml_src: &str) -> RuntimeConfig {
+        let value: toml::Value = toml::from_str(toml_src).unwrap();
+        let env: std::collections::HashMap<String, String> = env
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        RuntimeConfig::resolve(|k| env.get(k).cloned(), Some(&value))
+    }
+
     #[test]
     fn retention_days_parses_positive_only() {
-        let p: toml::Value = toml::from_str("retention_days = 30").unwrap();
-        assert_eq!(retention_days_from_toml(&p), Some(30));
-        let zero: toml::Value = toml::from_str("retention_days = 0").unwrap();
+        assert_eq!(resolve_file("retention_days = 30").retention_days, Some(30));
         assert_eq!(
-            retention_days_from_toml(&zero),
+            resolve_file("retention_days = 0").retention_days,
             None,
             "0 disables age retention"
         );
-        let neg: toml::Value = toml::from_str("retention_days = -5").unwrap();
-        assert_eq!(retention_days_from_toml(&neg), None);
-        let absent: toml::Value = toml::from_str("hygiene = true").unwrap();
-        assert_eq!(retention_days_from_toml(&absent), None);
+        assert_eq!(resolve_file("retention_days = -5").retention_days, None);
+        assert_eq!(resolve_file("hygiene = true").retention_days, None);
+    }
+
+    #[test]
+    fn env_wins_over_file_for_every_runtime_setting() {
+        let file = "\
+            upstream_proxy = \"http://file:3128\"\n\
+            capture_dir = \"/file/cap\"\n\
+            db_path = \"/file/db.sqlite\"\n\
+            no_update_check = false\n\
+            bind = \"127.0.0.1\"\n\
+            capture_max_mb = 10\n\
+            retention_days = 7\n";
+        let c = resolve_env(
+            &[
+                ("LLMTRIM_UPSTREAM_PROXY", "http://env:8080"),
+                ("LLMTRIM_CAPTURE_DIR", "/env/cap"),
+                ("LLMTRIM_DB_PATH", "/env/db.sqlite"),
+                ("LLMTRIM_NO_UPDATE_CHECK", "1"),
+                ("LLMTRIM_BIND", "0.0.0.0"),
+                ("LLMTRIM_CAPTURE_MAX_MB", "99"),
+                ("LLMTRIM_RETENTION_DAYS", "14"),
+            ],
+            file,
+        );
+        assert_eq!(c.upstream_proxy.as_deref(), Some("http://env:8080"));
+        assert_eq!(c.capture_dir, Some(PathBuf::from("/env/cap")));
+        assert_eq!(c.db_path, Some(PathBuf::from("/env/db.sqlite")));
+        assert!(c.no_update_check);
+        assert_eq!(c.bind.as_deref(), Some("0.0.0.0"));
+        assert_eq!(c.capture_max_mb, Some(99));
+        assert_eq!(c.retention_days, Some(14));
+    }
+
+    #[test]
+    fn file_used_when_env_absent() {
+        let c = resolve_file(
+            "upstream_proxy = \"http://file:3128\"\nbind = \"::1\"\ncapture_max_mb = 0\n",
+        );
+        assert_eq!(c.upstream_proxy.as_deref(), Some("http://file:3128"));
+        assert_eq!(c.bind.as_deref(), Some("::1"));
+        assert_eq!(c.capture_max_mb, Some(0), "0 from file disables the cap");
+    }
+
+    #[test]
+    fn no_update_check_true_on_env_presence_even_empty() {
+        // var_os-style presence: any value (incl. empty) means "set".
+        let c = resolve_env(
+            &[("LLMTRIM_NO_UPDATE_CHECK", "")],
+            "no_update_check = false",
+        );
+        assert!(c.no_update_check);
+    }
+
+    #[test]
+    fn extra_hosts_env_replaces_file_and_normalizes() {
+        // Env comma list wins over the file array; entries are lowercased, sorted, deduped.
+        let c = resolve_env(
+            &[(
+                "LLMTRIM_EXTRA_HOSTS",
+                "LLM.Acme.com, api.acme.com, llm.acme.com",
+            )],
+            "extra_hosts = [\"ignored.example\"]",
+        );
+        assert_eq!(c.extra_hosts, vec!["api.acme.com", "llm.acme.com"]);
+    }
+
+    #[test]
+    fn extra_hosts_from_file_when_env_absent() {
+        let c = resolve_file("extra_hosts = [\"llm.acme.com\", \"gw.example.net\"]");
+        assert_eq!(c.extra_hosts, vec!["gw.example.net", "llm.acme.com"]);
+    }
+
+    #[test]
+    fn extra_hosts_drops_malformed_and_overbroad() {
+        // No dot (bare TLD), scheme/path/port, wildcard, leading dot/hyphen, whitespace → dropped.
+        for bad in [
+            "com",
+            "https://llm.acme.com",
+            "llm.acme.com/v1",
+            "llm.acme.com:443",
+            "*.acme.com",
+            ".acme.com",
+            "-acme.com",
+            "ac me.com",
+            "1.2.3.4",   // IPv4 literal: undefined as a DNS name-constraint
+            "127.0.0.1", // loopback IPv4
+        ] {
+            let c = resolve_env(&[("LLMTRIM_EXTRA_HOSTS", bad)], "");
+            assert!(c.extra_hosts.is_empty(), "expected `{bad}` to be dropped");
+        }
+        // A trailing dot (FQDN form) is normalized away, not rejected.
+        let c = resolve_env(&[("LLMTRIM_EXTRA_HOSTS", "llm.acme.com.")], "");
+        assert_eq!(c.extra_hosts, vec!["llm.acme.com"]);
     }
 
     #[test]
@@ -691,6 +942,32 @@ mod tests {
         assert!(
             c.hygiene && c.serialize,
             "retention_days is ignored by DenseConfig"
+        );
+    }
+
+    #[test]
+    fn runtime_only_keys_keep_auto_shape_routing() {
+        // A config that sets only RuntimeConfig keys (no compression keys) must keep the `auto`
+        // shape-routing default, not silently fall through to the bare `auto = false` flag set.
+        for src in [
+            "capture_dir = \"/tmp/cap\"",
+            "bind = \"0.0.0.0\"",
+            "upstream_proxy = \"http://p:3128\"",
+            "extra_hosts = [\"llm.acme.com\"]",
+            "no_update_check = true",
+            "db_path = \"/tmp/db\"\ncapture_max_mb = 100\nretention_days = 7",
+        ] {
+            let c = DenseConfig::from_toml_value(toml::from_str(src).unwrap()).unwrap();
+            assert!(c.auto, "runtime-only config `{src}` must keep auto routing");
+        }
+        // A compression key alongside a runtime key still selects explicit flags (auto off).
+        let c = DenseConfig::from_toml_value(
+            toml::from_str("capture_dir = \"/tmp/cap\"\nhygiene = false").unwrap(),
+        )
+        .unwrap();
+        assert!(
+            !c.auto && !c.hygiene,
+            "a compression key opts into explicit flags"
         );
     }
 }

--- a/crates/llmtrim-core/src/stages/toolout/template.rs
+++ b/crates/llmtrim-core/src/stages/toolout/template.rs
@@ -387,12 +387,14 @@ fn render_ts(epoch: i64, sep: char, suffix: &str) -> String {
 
 // ── Missed-fold telemetry (shape-registry stage 1) ──────────────────────────────────
 
-/// Capture directory for QA telemetry — the same opt-in `LLMTRIM_CAPTURE_DIR` the proxy's
-/// before/after capture uses. Read once; `None` (the default) costs nothing per fold.
+/// Capture directory for QA telemetry — the same opt-in capture dir the proxy's before/after
+/// capture uses (`LLMTRIM_CAPTURE_DIR` env or `capture_dir` in the config file). Read once;
+/// `None` (the default) costs nothing per fold.
 static CAPTURE_DIR: Lazy<Option<String>> = Lazy::new(|| {
-    std::env::var("LLMTRIM_CAPTURE_DIR")
-        .ok()
-        .filter(|d| !d.is_empty())
+    crate::config::RuntimeConfig::get()
+        .capture_dir
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned())
 });
 
 /// Loosely datetime-shaped: a `H:M`-style time, an ISO `YYYY-MM` date prefix, or a


### PR DESCRIPTION
## What

Generalizes the old `retention_days` "env wins over a top-level config key" rule into a single `RuntimeConfig` loader, so **every persistable runtime setting is settable both ways** (env var or `config.toml`), not just `preset`/`retention_days`.

Adds a new `extra_hosts` setting that lets you intercept a self-hosted or gateway OpenAI-compatible endpoint without a code change (the motivating case: routing a Hermes/`custom:` upstream through llmtrim).

## Changes

- **`RuntimeConfig`** (`llmtrim-core/src/config.rs`): parses the config TOML once and resolves each knob env-first, then file, then default. Pure `resolve()` core is unit-tested without touching env/FS; `get()` caches via `OnceLock` (env is process-stable).
- **`extra_hosts`** (env `LLMTRIM_EXTRA_HOSTS`, comma-separated / file `extra_hosts` array): feeds both proxy interception gates in `serve.rs`. `normalize_host` validates entries as exact lowercase hostnames and drops malformed/overbroad/IP-literal ones. User hosts match **exactly** (no subdomain expansion); curated `EXTRA_HOSTS` keep subdomain matching.
- **Mirrored to the config file**: `upstream_proxy`, `db_path`, `capture_dir` (proxy capture + discover + core toolout telemetry), `capture_max_mb`, `bind`, `no_update_check` (plus `retention_days` folded in).
- **Left env-only** (not persistable): `LLMTRIM_CONFIG`, `LLMTRIM_HOME`, `LLMTRIM_PROFILE`, `LLMTRIM_VERSION`.
- Docs: README "Runtime settings" table pairing each env var with its config key; CHANGELOG entries.

## Safety

The `from_toml_value` auto-preset guard now treats all `RUNTIME_ONLY_KEYS` as orthogonal, so a config that sets only a runtime key (e.g. `capture_dir`) keeps `auto` shape-routing instead of silently downgrading to the bare flag set.

## Tests

fmt + clippy clean; 685 tests pass (`--features intercept`). New coverage: env-over-file precedence for every knob, host normalization (incl. IPv4/apex/wildcard rejection), the runtime-key auto-preset guard, and the user-host → CA-sidecar flow with the exact-vs-subdomain distinction.

Reviewed by three independent agents across two passes; all findings (auto-preset guard regression, IPv4 in name-constraints, user-host subdomain over-match, doc accuracy) addressed.