### PR TITLE
docs(serve): attribute the cert-verify failure to Python 3.13's strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
-- **Strict-TLS (OpenSSL 3.x) clients can now use the proxy.** The MITM leaf certificates
-  llmtrim minted lacked the Authority Key Identifier (and Key Usage / Extended Key Usage)
-  extensions, so OpenSSL 3.x rejected them with "Missing Authority Key Identifier", breaking
-  every Python `httpx` / OpenAI-SDK client
-  behind the proxy (e.g. Hermes Agent, litellm). `curl` and Node TLS are lenient, so this went
-  unnoticed. Minted leaves now include the Authority Key Identifier plus Key Usage and Extended
-  Key Usage (serverAuth). The local CA is unchanged, so no re-trust is needed.
+- **Strict-TLS clients can now use the proxy.** The MITM leaf certificates llmtrim minted
+  lacked the Authority Key Identifier (and Key Usage / Extended Key Usage) extensions. Python
+  3.13 turns on OpenSSL's `VERIFY_X509_STRICT` mode by default, which enforces RFC 5280 and
+  rejects such a leaf with "Missing Authority Key Identifier", breaking every Python `httpx` /
+  OpenAI-SDK client behind the proxy (e.g. Hermes Agent, litellm). `curl` and Node TLS don't run
+  the strict checks, so this went unnoticed. Minted leaves now include the Authority Key
+  Identifier plus Key Usage and Extended Key Usage (serverAuth). The local CA is unchanged, so
+  no re-trust is needed.
 
 ### Added
 - **`serve --force` / `start --force` / `setup --force`** replace an llmtrim daemon that's

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1623,10 +1623,12 @@ mod imp {
 
     /// MITM leaf-certificate authority: a drop-in for hudsucker's `RcgenAuthority` that adds the
     /// X.509 extensions strict TLS stacks require on a leaf but hudsucker 0.24 omits. Without the
-    /// Authority Key Identifier, OpenSSL 3.x rejects the cert with "Missing Authority Key
-    /// Identifier", which breaks every httpx / OpenAI-SDK Python client behind the proxy (curl
-    /// and Node TLS are lenient, so this went unnoticed). We also set Key Usage + Extended Key
-    /// Usage (serverAuth). Otherwise identical to `RcgenAuthority`: a per-host leaf signed by our
+    /// Authority Key Identifier, OpenSSL's strict verification (`VERIFY_X509_STRICT`, which Python
+    /// 3.13 enables by default in `ssl.create_default_context()`) rejects the cert with "Missing
+    /// Authority Key Identifier", which breaks every httpx / OpenAI-SDK Python client behind the
+    /// proxy (curl and Node TLS skip the strict checks, so this went unnoticed). We also set Key
+    /// Usage + Extended Key Usage (serverAuth). Otherwise identical to `RcgenAuthority`: a
+    /// per-host leaf signed by our
     /// CA, cached in memory. `RcgenAuthority::new` exposes no hook for these extensions and 0.24
     /// is the latest published version, and llmtrim publishes to crates.io (so a git-patched
     /// hudsucker is not an option), hence the small in-tree copy.


### PR DESCRIPTION
Follow-up to #74. A fact-check found the trigger wording was overstated: the "Missing Authority Key Identifier" rejection is not OpenSSL 3.x enforcing AKI on its own. It comes from OpenSSL's `VERIFY_X509_STRICT` verification, which **Python 3.13** turns on by default in `ssl.create_default_context()`. Plain OpenSSL, curl, and Node TLS skip the strict checks.

Tightens the `LeafCertAuthority` doc comment and the CHANGELOG entry accordingly. Doc-comment + changelog only; no behavior change.

Refs: openssl/openssl#28391, python/cpython#138193, urllib3/urllib3#3665.