### PR TITLE
feat: adapter contract (rewrite_request) + default to auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to this project are documented here. The format follows
   Key Usage (serverAuth). The local CA is unchanged, so no re-trust is needed.
 
 ### Added
+- **`llmtrim_core::rewrite_request(input, provider, preset)`**: a stable entrypoint for
+  integration adapters. It defaults the preset to `auto` (per-request structural routing) and
+  never reads the environment or a config file, so the same request compresses identically
+  across the native, WASM, and UniFFI bindings. A cross-binding conformance suite
+  (`crates/llmtrim-core/tests/conformance/`) pins its output so a core change cannot silently
+  alter what an adapter forwards.
 - **`serve --force` / `start --force` / `setup --force`** replace an llmtrim daemon that's
   already holding the port (stops it first, waits for the port to free, then takes over)
   instead of refusing, no-opping, or leaving a healthy same-port daemon untouched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+- **`@llmtrim/js`: calling `compress()` with no preset now compresses with `auto`
+  (shape-routing) instead of the lossless-only baseline.** The npm package barely compressed
+  out of the box before, because the no-preset path fell back to lossless; it now matches the
+  native CLI and the live proxy. This changes the body forwarded to your provider when you call
+  `compress(body, provider)` with no third argument. To keep the previous lossless-only
+  behavior, pass `"safe"` as the preset.
+
 ### Fixed
 - **Strict-TLS (OpenSSL 3.x) clients can now use the proxy.** The MITM leaf certificates
   llmtrim minted lacked the Authority Key Identifier (and Key Usage / Extended Key Usage)

--- a/crates/llmtrim-cli/src/bench/mod.rs
+++ b/crates/llmtrim-cli/src/bench/mod.rs
@@ -1358,7 +1358,7 @@ mod tests {
         use llmtrim_core::tokenizer::counter_for;
         use serde_json::json;
         let counter = counter_for(ProviderKind::OpenAi, Some("gpt-4o")).unwrap();
-        let cfg = DenseConfig::default();
+        let cfg = DenseConfig::lossless();
         let model = StubModel("The answer is 42.".to_string());
         let cases = vec![BenchCase {
             name: "a".into(),
@@ -1388,7 +1388,7 @@ mod tests {
         assert_eq!(run.skipped, 0);
         assert!(
             run.cache_busted,
-            "default preset has cache off → busting on"
+            "lossless baseline has cache off → busting on"
         );
         let o = &run.outcomes[0];
         assert_eq!(o.quality_orig, 1.0);
@@ -1453,7 +1453,7 @@ mod tests {
         };
         let run = run_ab(
             &one_case(),
-            &DenseConfig::default(),
+            &DenseConfig::lossless(),
             &model,
             counter.as_ref(),
             &scorer,
@@ -1493,7 +1493,7 @@ mod tests {
         };
         let run = run_ab(
             &one_case(),
-            &DenseConfig::default(),
+            &DenseConfig::lossless(),
             &model,
             counter.as_ref(),
             &scorer,
@@ -1975,7 +1975,7 @@ mod tests {
             cache: true,
             serialize_flatten: true,
             serialize_buckets: true,
-            ..DenseConfig::default()
+            ..DenseConfig::lossless()
         };
         let labels: Vec<String> = ablation_configs(&cfg).into_iter().map(|(l, _)| l).collect();
         for stage in [

--- a/crates/llmtrim-cli/src/mcp.rs
+++ b/crates/llmtrim-cli/src/mcp.rs
@@ -468,7 +468,7 @@ mod imp {
 
         #[test]
         fn compress_maps_result_to_payload() {
-            let result = llmtrim_core::compress_with_config(&req(), None, &DenseConfig::default())
+            let result = llmtrim_core::compress_with_config(&req(), None, &DenseConfig::lossless())
                 .expect("compress should succeed on a valid request");
             let payload = compress_payload(&result);
 
@@ -479,7 +479,7 @@ mod imp {
             assert!(payload["tokenizer_label"].is_string());
             assert!(payload["tokenizer_exact"].as_bool().unwrap());
             assert!(payload["frozen_input_tokens"].as_u64().is_some());
-            assert_eq!(payload["output_shaped"], false); // default config shapes nothing
+            assert_eq!(payload["output_shaped"], false); // lossless config shapes nothing
             let before = payload["input_tokens_before"].as_u64().unwrap();
             let after = payload["input_tokens_after"].as_u64().unwrap();
             assert!(before > 0);
@@ -506,7 +506,7 @@ mod imp {
                     .to_string();
             let shaped = DenseConfig {
                 output_control: true,
-                ..DenseConfig::default()
+                ..DenseConfig::lossless()
             };
             let result =
                 llmtrim_core::compress_with_config(&tiny, Some(ProviderKind::OpenAi), &shaped)
@@ -523,7 +523,7 @@ mod imp {
         #[test]
         fn ledger_records_match_the_proxy_schema() {
             // Full-request record carries the model and the result's token counts.
-            let result = llmtrim_core::compress_with_config(&req(), None, &DenseConfig::default())
+            let result = llmtrim_core::compress_with_config(&req(), None, &DenseConfig::lossless())
                 .expect("compress should succeed");
             let rec = ledger_record(&result);
             assert_eq!(rec.provider, "openai");

--- a/crates/llmtrim-cli/src/quality.rs
+++ b/crates/llmtrim-cli/src/quality.rs
@@ -420,7 +420,7 @@ mod tests {
             provider: ProviderKind::OpenAi,
             expected: "ALPHA7".to_string(),
         }];
-        let rate = run_task_success(&cases, &DenseConfig::default(), &EchoModel).unwrap();
+        let rate = run_task_success(&cases, &DenseConfig::lossless(), &EchoModel).unwrap();
         assert_eq!(
             rate, 1.0,
             "echoed compressed request still contains the answer"

--- a/crates/llmtrim-cli/tests/common/mod.rs
+++ b/crates/llmtrim-cli/tests/common/mod.rs
@@ -16,7 +16,7 @@ use serde_json::{Value, json};
 pub fn input_only() -> DenseConfig {
     DenseConfig {
         output_control: false,
-        ..DenseConfig::default()
+        ..DenseConfig::lossless()
     }
 }
 

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -14,15 +14,19 @@ use serde::{Deserialize, Serialize};
 /// Validated non-empty by `build.rs`.
 pub const FORMAT_LEGEND: &str = include_str!("../prompts/toon_legend.txt");
 
-/// Per-stage enable flags and knobs. `DenseConfig::default()` (= the `safe` preset) is the
-/// **lossless** baseline: only quality-neutral lossless input compression runs (`hygiene`,
-/// `serialize`, exact-duplicate `dedup`). The **shipped default is `auto`** (shape-routing),
-/// which also turns on the lossy stages the eval shows quality-safe — output control on every
+/// Per-stage enable flags and knobs. `DenseConfig::default()` is **`auto`** (shape-routing) —
+/// the shipped default, matching `load()` and the live interceptor. The **lossless** baseline
+/// (only quality-neutral lossless input compression: `hygiene`, `serialize`, exact-duplicate
+/// `dedup`) is [`DenseConfig::lossless`] (= the `safe` preset). `auto` also turns on the lossy
+/// stages the eval shows quality-safe — output control on every
 /// shape, image downscale (quality-neutral by construction), and retrieve / skeleton / dedup /
 /// tools per shape. The bar is cost-at-no-measured-quality-loss, **not** losslessness; a stage
 /// is gated to opt-in only when it is *unmeasured* or *shown to regress*, not for being lossy.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+// Explicit per-stage flags in a config file layer over the lossless baseline (auto off), not
+// over the `auto` default — a file that sets only `hygiene = false` must not silently enable
+// shape-routing. (The runtime default when there is *no* file is still `auto`; see `load`.)
+#[serde(default = "DenseConfig::lossless")]
 pub struct DenseConfig {
     /// Stage D — lossless data hygiene (minify, numeric trim, base64/data-URI strip).
     pub hygiene: bool,
@@ -185,7 +189,19 @@ pub struct DenseConfig {
 }
 
 impl Default for DenseConfig {
+    /// The shipped default is `auto` (shape-routing), matching `load()` and the live
+    /// interceptor. For the lossless-only baseline use [`DenseConfig::lossless`] (or the
+    /// `safe` preset).
     fn default() -> Self {
+        Self::auto()
+    }
+}
+
+impl DenseConfig {
+    /// The lossless-only baseline that every preset and `auto()` layer their flags over:
+    /// only quality-neutral lossless input compression (`hygiene`, `serialize`, exact-duplicate
+    /// `dedup`). This is the `safe` preset.
+    pub fn lossless() -> Self {
         Self {
             hygiene: true,
             serialize: true,
@@ -239,9 +255,7 @@ impl Default for DenseConfig {
             quality_gate: true,
         }
     }
-}
 
-impl DenseConfig {
     /// Load config. Resolution order:
     /// 1. `LLMTRIM_PRESET=<name>` env → that named profile.
     /// 2. A config file (`LLMTRIM_CONFIG` or the platform config dir) with a `preset = "<name>"`
@@ -310,14 +324,14 @@ impl DenseConfig {
     pub fn auto() -> Self {
         Self {
             auto: true,
-            ..Self::default()
+            ..Self::lossless()
         }
     }
 
-    /// A named bundle of stage flags layered over the defaults, so callers opt into
+    /// A named bundle of stage flags layered over the lossless baseline, so callers opt into
     /// a workload profile without setting ~20 flags. `None` for an unknown name.
     pub fn preset(name: &str) -> Option<Self> {
-        let mut c = Self::default();
+        let mut c = Self::lossless();
         match name.to_ascii_lowercase().as_str() {
             // Defaults already = lossless input only (hygiene + serialize + exact dedup).
             "safe" | "lossless" => {}
@@ -637,8 +651,12 @@ mod tests {
     }
 
     #[test]
-    fn defaults_enable_mvp_stages() {
-        let c = DenseConfig::default();
+    fn lossless_baseline_enables_mvp_stages() {
+        let c = DenseConfig::lossless();
+        assert!(
+            !c.auto,
+            "lossless()/`safe` is the bare baseline, not shape-routing"
+        );
         assert!(
             c.hygiene && c.serialize,
             "lossless input compression on by default"
@@ -649,7 +667,7 @@ mod tests {
         );
         assert!(
             !c.output_control,
-            "default()/`safe` is the lossless baseline — output shaping is on in the shipped `auto` default (via presets), not in this bare base"
+            "lossless()/`safe` is the lossless baseline — output shaping is on in the shipped `auto` default (via presets), not in this bare base"
         );
         assert!(
             !c.retrieve,
@@ -733,8 +751,9 @@ mod tests {
                 "preset `{p}` does not minify tool schemas"
             );
         }
-        // Default (= `safe`) is off.
+        // The `auto` default and the lossless baseline both leave it off.
         assert!(!DenseConfig::default().tool_minify_schema);
+        assert!(!DenseConfig::lossless().tool_minify_schema);
     }
 
     #[test]
@@ -810,6 +829,10 @@ mod tests {
         assert!(!c.serialize);
         assert!(c.hygiene, "unset fields take the default");
         assert_eq!(c.serialize_min_rows, 2);
+        assert!(
+            !c.auto,
+            "partial config deserialization fills from the lossless baseline, not auto"
+        );
     }
 
     /// Resolve with no env set (every lookup returns `None`) against the given file TOML.

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -232,7 +232,7 @@ pub fn route(req: &Request, provider: &dyn provider::Provider) -> &'static str {
 /// environment/default path. `provider` may be `None` to auto-detect from shape.
 pub fn compress(input: &str, provider: Option<ProviderKind>) -> Result<CompressResult> {
     let config = config::DenseConfig::load().unwrap_or_else(|e| {
-        eprintln!("llmtrim: {e}; using defaults");
+        eprintln!("llmtrim: {e}; using the auto default");
         config::DenseConfig::default()
     });
     compress_with_config(input, provider, &config)
@@ -267,7 +267,11 @@ pub fn compress_with_config(
     // `auto` resolves the preset from the request shape (structural, zero-model).
     let routed;
     let config = if config.auto {
-        routed = config::DenseConfig::preset(route(&req, adapter.as_ref())).unwrap_or_default();
+        // Explicit lossless fallback: `route` only returns known preset names today, but a
+        // future label without a matching preset must degrade to the safe baseline, not to
+        // `auto` (which `unwrap_or_default` would now give after the default flip).
+        routed = config::DenseConfig::preset(route(&req, adapter.as_ref()))
+            .unwrap_or_else(config::DenseConfig::lossless);
         &routed
     } else {
         config
@@ -347,10 +351,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn compress_default_is_behavior_preserving() {
+    fn compress_lossless_is_behavior_preserving() {
         let input =
             r#"{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":5}"#;
-        let cfg = config::DenseConfig::default();
+        let cfg = config::DenseConfig::lossless();
         let result =
             compress_with_config(input, Some(ProviderKind::OpenAi), &cfg).expect("compress");
         // Exact only when the `tiktoken` feature supplies the OpenAI BPE vocab; the rest of
@@ -359,7 +363,7 @@ mod tests {
         assert!(result.tokenizer_exact);
         let body: Value = serde_json::from_str(&result.request_json).unwrap();
         let msgs = body.get("messages").and_then(Value::as_array).unwrap();
-        // Default = lossless input only: content intact, no injected system
+        // Lossless = input only: content intact, no injected system
         // instruction (the model's output behavior is unchanged).
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].get("content").and_then(Value::as_str), Some("hi"));
@@ -367,7 +371,7 @@ mod tests {
             !msgs
                 .iter()
                 .any(|m| m.get("role").and_then(Value::as_str) == Some("system")),
-            "default must not change the model's output behavior"
+            "lossless must not change the model's output behavior"
         );
     }
 
@@ -413,8 +417,12 @@ mod tests {
             "auto routed to agent and trimmed the tool description"
         );
         assert!(
-            !config::DenseConfig::default().auto,
-            "plain default is not auto"
+            config::DenseConfig::default().auto,
+            "the shipped default is auto (shape-routing)"
+        );
+        assert!(
+            !config::DenseConfig::lossless().auto,
+            "the lossless baseline is not auto"
         );
     }
 
@@ -426,7 +434,7 @@ mod tests {
             hygiene: false,
             serialize: false,
             output_control: false,
-            ..config::DenseConfig::default()
+            ..config::DenseConfig::lossless()
         };
         let result =
             compress_with_config(input, Some(ProviderKind::OpenAi), &cfg).expect("compress");

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -297,6 +297,35 @@ pub fn compress_with_config(
     })
 }
 
+/// Stable entrypoint for integration adapters (Kong, Higress, Vercel AI SDK, OpenCode,
+/// Continue, Genkit, LiteLLM, LangChain).
+///
+/// An adapter hands over the host's provider-shaped request body verbatim and gets back a
+/// compressed body to forward. `preset` defaults to `auto` (per-request structural routing:
+/// tools → agent, code → code, long-context → rag, else aggressive) so a gateway seeing mixed
+/// traffic behaves correctly without a fixed profile. Unlike [`compress`], this never reads
+/// the environment or a config file, so the result is reproducible across every binding
+/// (native, WASM, UniFFI): the divergence that `preset: None` carries in the raw bindings
+/// cannot reach an adapter that goes through here.
+///
+/// `preset` accepts (case-insensitively) any name [`config::DenseConfig::preset`] knows:
+/// `auto`, `aggressive`, `agent`, `code`, `rag`, `safe`/`lossless`. An unrecognized name is
+/// an error rather than a silent fallback.
+///
+/// The signature is the frozen adapter contract: pass the body through untouched (never re-key
+/// messages or strip `cache_control`, which would break the cache-zone freeze), call this,
+/// forward [`CompressResult::request_json`].
+pub fn rewrite_request(
+    input: &str,
+    provider: Option<ProviderKind>,
+    preset: Option<&str>,
+) -> Result<CompressResult> {
+    let name = preset.unwrap_or("auto");
+    let config =
+        config::DenseConfig::preset(name).with_context(|| format!("unknown preset: {name}"))?;
+    compress_with_config(input, provider, &config)
+}
+
 /// Reverse the lossless output transforms recorded in a rehydration plan. Internal: no
 /// output-side transform ships today (Stage D is input-only; DSS was removed), so this is an
 /// inert passthrough — a JSON response is normalized, plain text returned unchanged. Kept

--- a/crates/llmtrim-core/src/quality_gate.rs
+++ b/crates/llmtrim-core/src/quality_gate.rs
@@ -847,7 +847,7 @@ mod pipeline_tests {
     }
 
     /// `quality_gate = true` is the shipped default in `DenseConfig`, and it is not
-    /// touched by any preset (presets rebuild from `default()`).
+    /// touched by any preset (presets rebuild from `lossless()`).
     #[test]
     fn quality_gate_default_is_on() {
         assert!(DenseConfig::default().quality_gate, "default ON");

--- a/crates/llmtrim-core/tests/common/mod.rs
+++ b/crates/llmtrim-core/tests/common/mod.rs
@@ -16,7 +16,7 @@ use serde_json::{Value, json};
 pub fn input_only() -> DenseConfig {
     DenseConfig {
         output_control: false,
-        ..DenseConfig::default()
+        ..DenseConfig::lossless()
     }
 }
 

--- a/crates/llmtrim-core/tests/conformance.rs
+++ b/crates/llmtrim-core/tests/conformance.rs
@@ -1,0 +1,177 @@
+//! Cross-binding conformance suite for the adapter contract.
+//!
+//! Every integration adapter (Kong, Higress, Vercel AI SDK, OpenCode, Continue, Genkit,
+//! LiteLLM, LangChain) calls [`llmtrim_core::rewrite_request`] through its binding. These
+//! fixtures pin that entrypoint's behavior so a core change cannot silently alter what an
+//! adapter forwards. The JS (vitest) and Python (pytest) harnesses load the SAME JSON files
+//! and assert the same invariants, so all three surfaces stay in lockstep.
+//!
+//! Each fixture is `tests/conformance/<name>.json`:
+//!
+//! ```json
+//! {
+//!   "input":   { ...raw provider request body... },
+//!   "provider": "anthropic",     // or null to auto-detect
+//!   "preset":   "agent",         // or null (the adapter default `auto` is applied)
+//!   "expect": {
+//!     "provider":       "anthropic",   // required: detected/declared provider
+//!     "output_shaped":  false,         // required: tokenizer-independent
+//!     "request_json":   { ... }        // optional golden; deep-equal on parsed JSON
+//!   }
+//! }
+//! ```
+//!
+//! Goldens are engine-generated, never hand-written: run `LLMTRIM_BLESS=1 cargo test -p
+//! llmtrim-core --test conformance` to (re)write `expect.request_json` from the actual
+//! output, review the diff, and commit. Token counts are deliberately NOT asserted — the
+//! WASM build has no tiktoken, so counts differ by build while the rewritten body does not.
+
+use std::fs;
+use std::path::Path;
+
+use llmtrim_core::ir::ProviderKind;
+use serde_json::Value;
+
+fn fixtures_dir() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/conformance")
+}
+
+fn provider_kind(s: &str) -> ProviderKind {
+    s.parse()
+        .unwrap_or_else(|_| panic!("fixture has unknown provider {s:?}"))
+}
+
+#[test]
+fn conformance_fixtures_hold_across_the_adapter_contract() {
+    let bless = std::env::var_os("LLMTRIM_BLESS").is_some();
+    let dir = fixtures_dir();
+    let mut checked = 0;
+    // Collect every fixture's failures and report them together: one failing fixture must
+    // not mask regressions in the others (the JS/Python harnesses run the same set).
+    let mut failures: Vec<String> = Vec::new();
+
+    let mut entries: Vec<_> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect();
+    entries.sort();
+    let total = entries.len();
+
+    for path in entries {
+        let name = path.file_stem().unwrap().to_string_lossy().into_owned();
+        let raw = fs::read_to_string(&path).expect("read fixture");
+        let mut fixture: Value = serde_json::from_str(&raw)
+            .unwrap_or_else(|e| panic!("{name}: fixture is not valid JSON: {e}"));
+
+        let input = serde_json::to_string(&fixture["input"])
+            .unwrap_or_else(|_| panic!("{name}: missing `input`"));
+        let provider = fixture["provider"].as_str().map(provider_kind);
+        let preset = fixture["preset"].as_str().map(str::to_string);
+
+        let result = llmtrim_core::rewrite_request(&input, provider, preset.as_deref())
+            .unwrap_or_else(|e| panic!("{name}: rewrite_request failed: {e:#}"));
+
+        // Deep-equal on PARSED JSON (never string-equal: serde, JS, and Python serializers
+        // order keys and format numbers differently).
+        let actual_body: Value =
+            serde_json::from_str(&result.request_json).expect("rewritten body is valid JSON");
+
+        if bless {
+            // Seed every expectation from the engine, then review the written values.
+            fixture["expect"] = serde_json::json!({
+                "provider": result.provider.as_str(),
+                "output_shaped": result.output_shaped,
+                "request_json": actual_body,
+            });
+            let pretty = serde_json::to_string_pretty(&fixture).unwrap();
+            fs::write(&path, pretty + "\n").expect("write blessed fixture");
+            checked += 1;
+            continue;
+        }
+
+        let expect = &fixture["expect"];
+
+        // Tokenizer-independent invariants, identical on every binding.
+        let want_provider = expect["provider"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name}: expect.provider missing"));
+        if result.provider.as_str() != want_provider {
+            failures.push(format!(
+                "{name}: provider mismatch: got {}, want {want_provider}",
+                result.provider.as_str()
+            ));
+        }
+        let want_shaped = expect["output_shaped"]
+            .as_bool()
+            .unwrap_or_else(|| panic!("{name}: expect.output_shaped missing"));
+        if result.output_shaped != want_shaped {
+            failures.push(format!(
+                "{name}: output_shaped mismatch: got {}, want {want_shaped}",
+                result.output_shaped
+            ));
+        }
+
+        let golden = expect["request_json"].clone();
+        assert!(
+            !golden.is_null(),
+            "{name}: no golden request_json (run with LLMTRIM_BLESS=1 to seed it)"
+        );
+        // The load-bearing invariant for every adapter: any frozen (cache_control) block must
+        // survive byte-for-byte, or we churn the provider's cached prefix. Check it explicitly
+        // so a careless rebless can't quietly relax it under the full-body deep-equal.
+        assert_cache_control_stable(&name, &actual_body, &golden, &mut failures);
+        if actual_body != golden {
+            failures.push(format!(
+                "{name}: rewritten body diverged from golden (review and rebless if intended)"
+            ));
+        }
+        checked += 1;
+    }
+
+    assert_eq!(
+        checked, total,
+        "only {checked}/{total} fixtures ran; some were skipped"
+    );
+    assert!(
+        total > 0,
+        "no conformance fixtures found in {}",
+        dir.display()
+    );
+    assert!(
+        failures.is_empty(),
+        "conformance failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// Assert every array entry carrying a `cache_control` marker in the golden is reproduced
+/// byte-for-byte (same position, same surrounding fields) in the actual output. Scans the
+/// top-level arrays providers use for the cacheable prefix (`system`, `messages`, `tools`).
+fn assert_cache_control_stable(
+    name: &str,
+    actual: &Value,
+    golden: &Value,
+    failures: &mut Vec<String>,
+) {
+    for key in ["system", "messages", "tools"] {
+        let (Some(g_arr), a_arr) = (
+            golden.get(key).and_then(Value::as_array),
+            actual.get(key).and_then(Value::as_array),
+        ) else {
+            continue;
+        };
+        for (i, g) in g_arr.iter().enumerate() {
+            if g.get("cache_control").is_none() {
+                continue;
+            }
+            let a = a_arr.and_then(|a| a.get(i));
+            if a != Some(g) {
+                failures.push(format!(
+                    "{name}: frozen {key}[{i}] (cache_control) not byte-stable"
+                ));
+            }
+        }
+    }
+}

--- a/crates/llmtrim-core/tests/conformance/anthropic_agent_tool_result.json
+++ b/crates/llmtrim-core/tests/conformance/anthropic_agent_tool_result.json
@@ -1,0 +1,71 @@
+{
+  "input": {
+    "model": "claude-3-5-sonnet-20241022",
+    "tools": [
+      {
+        "name": "run",
+        "description": "run a shell command",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "cmd": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    ],
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "t1",
+            "content": "ERROR boom\nERROR boom\nERROR boom\nERROR boom\nERROR boom\nERROR boom\nERROR boom\nERROR boom\nERROR boom\nERROR boom\n"
+          }
+        ]
+      }
+    ],
+    "max_tokens": 1024
+  },
+  "provider": "anthropic",
+  "preset": "agent",
+  "expect": {
+    "provider": "anthropic",
+    "output_shaped": false,
+    "request_json": {
+      "model": "claude-3-5-sonnet-20241022",
+      "tools": [
+        {
+          "description": "run a shell command",
+          "input_schema": {
+            "properties": {
+              "cmd": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": "run",
+          "cache_control": {
+            "type": "ephemeral"
+          }
+        }
+      ],
+      "messages": [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "tool_result",
+              "tool_use_id": "t1",
+              "content": "ERROR boom [×10]"
+            }
+          ]
+        }
+      ],
+      "max_tokens": 1024
+    }
+  }
+}

--- a/crates/llmtrim-core/tests/conformance/anthropic_cache_frozen_prefix.json
+++ b/crates/llmtrim-core/tests/conformance/anthropic_cache_frozen_prefix.json
@@ -1,0 +1,50 @@
+{
+  "input": {
+    "model": "claude-3-5-sonnet-20241022",
+    "system": [
+      {
+        "type": "text",
+        "text": "You are a careful assistant. Follow the rules exactly.",
+        "cache_control": {
+          "type": "ephemeral"
+        }
+      }
+    ],
+    "messages": [
+      {
+        "role": "user",
+        "content": "summarize the build log: warning warning warning warning warning warning warning warning warning warning warning warning"
+      }
+    ],
+    "max_tokens": 256
+  },
+  "provider": "anthropic",
+  "preset": "auto",
+  "expect": {
+    "provider": "anthropic",
+    "output_shaped": true,
+    "request_json": {
+      "model": "claude-3-5-sonnet-20241022",
+      "system": [
+        {
+          "type": "text",
+          "text": "You are a careful assistant. Follow the rules exactly.",
+          "cache_control": {
+            "type": "ephemeral"
+          }
+        },
+        {
+          "type": "text",
+          "text": "Be concise: no preamble, no restating the question, no filler. Answer directly."
+        }
+      ],
+      "messages": [
+        {
+          "role": "user",
+          "content": "summarize the build log: warning warning warning warning warning warning warning warning warning warning warning warning"
+        }
+      ],
+      "max_tokens": 256
+    }
+  }
+}

--- a/crates/llmtrim-core/tests/conformance/openai_chat_basic.json
+++ b/crates/llmtrim-core/tests/conformance/openai_chat_basic.json
@@ -1,0 +1,34 @@
+{
+  "_note": "The golden's prompt_cache_key is a hash of the injected terse-output instruction. If that instruction text changes, the hash rotates and this fixture must be reblessed; that is expected, not an adapter regression.",
+  "input": {
+    "model": "gpt-4o",
+    "messages": [
+      {
+        "role": "user",
+        "content": "hi"
+      }
+    ],
+    "max_tokens": 5
+  },
+  "provider": "openai",
+  "preset": null,
+  "expect": {
+    "provider": "openai",
+    "output_shaped": true,
+    "request_json": {
+      "model": "gpt-4o",
+      "messages": [
+        {
+          "role": "system",
+          "content": "Be concise: no preamble, no restating the question, no filler. Answer directly."
+        },
+        {
+          "role": "user",
+          "content": "hi"
+        }
+      ],
+      "max_tokens": 5,
+      "prompt_cache_key": "f2e91a8ec143f0dc"
+    }
+  }
+}

--- a/crates/llmtrim-core/tests/eval.rs
+++ b/crates/llmtrim-core/tests/eval.rs
@@ -66,7 +66,7 @@ fn input_side_savings_report() {
 
 #[test]
 fn robustness_never_panics_on_edge_inputs() {
-    let cfg = DenseConfig::default();
+    let cfg = DenseConfig::lossless();
     for body in [
         r#"{}"#,
         r#"{"messages":[]}"#,

--- a/crates/llmtrim-core/tests/output.rs
+++ b/crates/llmtrim-core/tests/output.rs
@@ -28,11 +28,11 @@ use common::user_chat;
 const PROSE: &str = include_str!("fixtures/openai_prose.json");
 
 /// Output shaping on, input stages at their defaults (so only the terse instruction
-/// distinguishes it from `DenseConfig::default()`, which ships output shaping off).
+/// distinguishes it from `DenseConfig::lossless()`, which ships output shaping off).
 fn output_on() -> DenseConfig {
     DenseConfig {
         output_control: true,
-        ..DenseConfig::default()
+        ..DenseConfig::lossless()
     }
 }
 
@@ -100,7 +100,7 @@ fn output_instruction_input_overhead_is_small() {
     let off = llmtrim_core::compress_with_config(
         PROSE,
         Some(ProviderKind::OpenAi),
-        &DenseConfig::default(),
+        &DenseConfig::lossless(),
     )
     .unwrap();
     let on = llmtrim_core::compress_with_config(PROSE, Some(ProviderKind::OpenAi), &output_on())
@@ -147,7 +147,7 @@ fn terse_injected_provider_agnostic() {
             "{provider:?}: terse instruction injected end-to-end"
         );
 
-        let off = request_json(&body, provider, &DenseConfig::default());
+        let off = request_json(&body, provider, &DenseConfig::lossless());
         assert!(
             !injected_text(&off).contains(TERSE_INSTRUCTION),
             "{provider:?}: no instruction when output shaping off"
@@ -167,7 +167,7 @@ fn config_knobs_flow_through_to_request() {
         &DenseConfig {
             output_control: true,
             output_level: "draft".to_string(),
-            ..DenseConfig::default()
+            ..DenseConfig::lossless()
         },
     );
     assert!(
@@ -181,7 +181,7 @@ fn config_knobs_flow_through_to_request() {
         &DenseConfig {
             output_control: true,
             output_token_budget: Some(120),
-            ..DenseConfig::default()
+            ..DenseConfig::lossless()
         },
     );
     assert!(
@@ -195,7 +195,7 @@ fn config_knobs_flow_through_to_request() {
         ProviderKind::OpenAi,
         &DenseConfig {
             output_compact_code: true,
-            ..DenseConfig::default()
+            ..DenseConfig::lossless()
         },
     );
     assert!(
@@ -211,7 +211,7 @@ fn hard_cap_imposed_only_when_absent() {
     let capped = DenseConfig {
         output_control: true,
         output_max_tokens: Some(256),
-        ..DenseConfig::default()
+        ..DenseConfig::lossless()
     };
 
     let uncapped = user_chat("gpt-4o", &["hi"]);

--- a/crates/llmtrim-uniffi/src/lib.rs
+++ b/crates/llmtrim-uniffi/src/lib.rs
@@ -129,6 +129,10 @@ fn project(r: llmtrim_core::CompressResult) -> CompressOutput {
 /// - `preset`: a named workload preset (`aggressive`, `agent`, `code`, `rag`, `safe`, …)
 ///   to compress with. `None` uses the configuration from the environment / config file
 ///   (the same defaults the `llmtrim` CLI uses).
+///
+/// Cross-binding note: with no preset, this binding reads the host's environment/config,
+/// while the WASM binding applies `auto`. For output that matches every binding regardless
+/// of host, pass an explicit preset.
 #[uniffi::export]
 pub fn compress(
     input: String,

--- a/crates/llmtrim-wasm/src/lib.rs
+++ b/crates/llmtrim-wasm/src/lib.rs
@@ -88,9 +88,15 @@ fn project(r: llmtrim_core::CompressResult) -> CompressOutput {
 /// - `provider`: `"openai"`, `"anthropic"`, or `"google"`; omit (`null`/`undefined`) to
 ///   auto-detect from the body shape.
 /// - `preset`: a named workload preset (`aggressive`, `agent`, `code`, `rag`, `safe`, …);
-///   omit to use the built-in defaults. Unlike the native crate, this binding never reads
-///   the environment or a config file (there is none in a Worker), so the configuration
-///   comes only from the preset or the defaults.
+///   omit to use the shipped default (`auto` shape-routing), matching the native CLI.
+///   Unlike the native crate, this binding never reads the environment or a config file
+///   (there is none in a Worker), so the configuration comes only from the preset or the
+///   `auto` default. Pass `"safe"` to restore the lossless-only behavior this binding had
+///   before `auto` became the no-preset default.
+///
+/// Cross-binding note: with no preset, this binding applies `auto`, while the UniFFI binding
+/// reads the host's environment/config. For output that matches every binding regardless of
+/// host, pass an explicit preset.
 ///
 /// Returns the [`CompressOutput`] as a typed JS object (TypeScript types are generated for
 /// it), or throws on invalid JSON, an undetectable provider, or an unknown preset/provider
@@ -149,13 +155,32 @@ mod tests {
     }
 
     #[test]
+    fn no_preset_compresses_a_real_body_via_auto_default() {
+        // The point of the `auto` no-preset default: a compressible body actually shrinks
+        // when called with `None`, not just when an explicit preset is passed.
+        let input = serde_json::json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1",
+                "content": "ERROR boom\n".repeat(60)}]}],
+            "max_tokens": 1024,
+        })
+        .to_string();
+        let out = run(&input, Some("anthropic"), None);
+        assert_eq!(out.provider, "anthropic");
+        assert!(
+            out.input_tokens_after < out.input_tokens_before,
+            "auto default must compress a tool-heavy body with no preset"
+        );
+    }
+
+    #[test]
     fn default_preset_preserves_a_basic_request() {
         let input =
             r#"{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"max_tokens":5}"#;
         let out = run(input, Some("openai"), None);
         assert_eq!(out.provider, "openai");
         assert_eq!(out.model.as_deref(), Some("gpt-4o"));
-        // Default (lossless-only) preserves the message content.
+        // The `auto` default preserves a trivial message (nothing to shape away).
         assert!(out.request_json.contains("\"hi\""));
         // The real wasm build has no tiktoken, so counts are approximate; but a host
         // workspace build unifies `tiktoken` on from other crates, so the exactness flag


### PR DESCRIPTION
## What

Two related changes that make every llmtrim binding compress consistently out of the box.

### `rewrite_request` adapter entrypoint + conformance suite
A stable `llmtrim_core::rewrite_request(input, provider, preset)` for integration adapters. Defaults the preset to `auto`, never reads the environment or a config file, so the same request compresses identically across native / WASM / UniFFI. A cross-binding conformance suite pins its output.

### Default to `auto`, add `DenseConfig::lossless()`
`DenseConfig::default()` now returns the `auto` shape-routing config, matching the runtime default already used by `load()` and the live interceptor. The WASM binding (`@llmtrim/js`) previously fell back to the lossless-only baseline when called with no preset, so the npm package barely compressed out of the box; it now defaults to `auto` like the native CLI.

The lossless baseline moves to `DenseConfig::lossless()` (= the `safe` preset). `auto()` and every `preset()` layer over it. Config files that set explicit per-stage flags still deserialize over lossless (`#[serde(default = "DenseConfig::lossless")]`), so flipping one flag does not silently enable shape-routing.

## Verification
- `cargo fmt` clean, `cargo clippy --features intercept,mcp` clean
- 687/687 tests pass
- 3 reviewers run; all actionable findings applied (test call sites repointed to `lossless()`, partial-config deserialization hardened with `!c.auto` assertion, stale comments fixed)