### PR TITLE
feat: Proxy-Wasm gateway plugin for Kong and Higress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,36 @@ jobs:
       - name: Node smoke test
         run: node crates/llmtrim-wasm/smoke.mjs
 
+  # Gateway adapters: the `test` job builds only default-members, which excludes the adapter
+  # crates (they target wasm). So test the shared logic here (this resolves llmtrim-core with
+  # default features OFF, the set the plugin actually ships) and build the Proxy-Wasm plugin
+  # for wasm32-wasip1 so a wasm break or a features-off regression fails CI, not deployment.
+  #
+  # Target is wasm32-wasip1, not wasm32-unknown-unknown: the engine needs an entropy source
+  # (hash seeding), which on unknown-unknown only resolves to a browser JS backend a gateway
+  # cannot run. wasip1 uses the WASI random_get import, which the Envoy (Higress) and Kong wasm
+  # runtimes provide.
+  gateway-plugin:
+    name: Gateway plugin (wasm)
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: wasm32-wasip1
+      - uses: Swatinem/rust-cache@v2
+      - name: Clippy + test the shared logic (core features off)
+        run: |
+          cargo clippy -p llmtrim-gateway --all-targets -- -D warnings
+          cargo test -p llmtrim-gateway
+      - name: Build the Proxy-Wasm plugin for wasm32-wasip1
+        run: |
+          cargo clippy -p llmtrim-gateway-plugin --target wasm32-wasip1 -- -D warnings
+          cargo build -p llmtrim-gateway-plugin --release --target wasm32-wasip1
+
   # Swift: compile the generated bindings + a smoke against the cdylib on macOS and run it.
   # This is the compile-and-load verification for the Swift target (the prerequisite to a
   # SwiftPM package); full xcframework/SwiftPM packaging is a later step.
@@ -320,4 +350,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
+      # `--all-targets` covers default-members; add the adapter logic crate explicitly since it
+      # is excluded from default-members. (The wasm plugin crate is leaf host glue checked on
+      # its wasm target in the gateway-plugin job, not here.)
       - run: cargo check --all-targets
+      - run: cargo check -p llmtrim-gateway --all-targets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,6 +424,87 @@ jobs:
           npm view "@llmtrim/js@$VER" version
           npm view "@llmtrim/wasm@$VER" version
 
+  # Publish the Proxy-Wasm gateway plugin (one wasm) to BOTH gateway channels from a single
+  # build: a GitHub Release asset (a .wasm file Kong loads from disk after download) and an
+  # OCI artifact packaged in Higress's wasm-image format (Higress `WasmPlugin.url: oci://…`).
+  # Independent of the CLI release (nothing `needs` it), so a publish failure here never
+  # blocks a release (the same rule as publish-wasm). Builds for wasm32-wasip1; see the README
+  # for why not unknown-unknown. wasm-opt is deliberately skipped (it broke the v0.2.1 wasm
+  # publish on post-MVP features); rustc already optimizes under --release. Only a version tag
+  # is pushed, never `latest`: a Higress control plane consuming `oci://…:latest` would pick up
+  # a new build silently, so operators pin a version.
+  publish-gateway-plugin:
+    needs: create-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    env:
+      TAG: ${{ github.ref_name }}
+      IMAGE: ghcr.io/fkiene/llmtrim-gateway-plugin
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+      # Backstop against an in-repo .cargo poisoning the build (same guard the publish jobs use).
+      - run: rm -rf .cargo
+      - name: Build the plugin (wasm32-wasip1)
+        run: cargo build -p llmtrim-gateway-plugin --release --target wasm32-wasip1
+      - name: Stage and validate the artifact
+        run: |
+          set -euo pipefail
+          cp target/wasm32-wasip1/release/llmtrim_gateway_plugin.wasm plugin.wasm
+          ls -lh plugin.wasm
+          # A zero-byte or non-wasm file would otherwise publish silently. Check it is a real
+          # wasm module (magic bytes "\0asm") before pushing it anywhere.
+          [ -s plugin.wasm ] || { echo "::error::plugin.wasm is empty"; exit 1; }
+          head -c4 plugin.wasm | od -An -tx1 | tr -d ' \n' | grep -q '^0061736d$' \
+            || { echo "::error::plugin.wasm is not a wasm module"; exit 1; }
+      - name: Upload to the GitHub Release (for Kong)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Immutable: do not clobber an asset already published for this tag (a re-run must not
+          # change a published artifact's bytes). Re-running after a partial failure is a no-op.
+          if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -qx 'llmtrim-gateway-plugin.wasm'; then
+            echo "asset already published for $TAG; skipping"
+          else
+            gh release upload "$TAG" plugin.wasm#llmtrim-gateway-plugin.wasm
+          fi
+      - uses: oras-project/setup-oras@v1
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Package and push the OCI artifact (Higress wasm-image format)
+        run: |
+          set -euo pipefail
+          VER="${TAG#v}"
+          # Higress's wasm-image spec wants the wasm tar+gzipped as the final layer with the
+          # OCI tar+gzip media type, preceded by a spec.yaml metadata layer. A raw .wasm with
+          # the Solo.io/Istio media type does not load on Higress's native fetcher.
+          tar czf plugin.tar.gz plugin.wasm
+          cat > spec.yaml <<YAML
+          apiVersion: 1.0.0
+          info:
+            name: llmtrim-gateway-plugin
+            title: llmtrim gateway plugin
+            description: Compress LLM API request bodies with llmtrim.
+            version: ${VER}
+          YAML
+          oras push "$IMAGE:$VER" \
+            spec.yaml:application/vnd.module.wasm.spec.v1+yaml \
+            plugin.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip
+      - name: Verify both channels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VER="${TAG#v}"
+          # The OCI manifest carries the tar+gzip wasm layer, and the release asset exists.
+          oras manifest fetch "$IMAGE:$VER" | grep -q 'application/vnd.oci.image.layer.v1.tar+gzip'
+          gh release view "$TAG" --json assets --jq '.assets[].name' | grep -qx 'llmtrim-gateway-plugin.wasm'
+
   # Self-verify the cargo channel: install from the real crates.io index, exactly as a
   # user would. Retries because the index propagates with a small delay after publish.
   verify-crate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **Proxy-Wasm gateway plugin: compress LLM request bodies at Kong or Higress.** A single
+  wasm module buffers the request body, runs it through llmtrim, and forwards the smaller body
+  upstream. The same artifact runs on both gateways (both are Proxy-Wasm 0.2 ABI hosts); they
+  differ only in deployment config. It is fail-open: an oversized, non-JSON, or
+  undetectable-provider body is forwarded unchanged. Configurable per route with `provider`,
+  `preset`, and `max_body_bytes`. Each release publishes the module to both channels: an OCI
+  artifact at `ghcr.io/fkiene/llmtrim-gateway-plugin` (for Higress) and a `.wasm` Release asset
+  (for Kong). See `crates/adapters/llmtrim-gateway-plugin/README.md`.
+
 ### Changed
 - **`@llmtrim/js`: calling `compress()` with no preset now compresses with `auto`
   (shape-routing) instead of the lossless-only baseline.** The npm package barely compressed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2072,7 +2074,16 @@ name = "llmtrim-gateway"
 version = "0.2.2-dev"
 dependencies = [
  "llmtrim-core",
+ "serde",
  "serde_json",
+]
+
+[[package]]
+name = "llmtrim-gateway-plugin"
+version = "0.2.2-dev"
+dependencies = [
+ "llmtrim-gateway",
+ "proxy-wasm",
 ]
 
 [[package]]
@@ -2760,6 +2771,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proxy-wasm"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8f6564bd52c2f4ff79fa5d1bd3bc10d8f822162af8d527e121e46703496aa0"
+dependencies = [
+ "hashbrown 0.16.1",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "llmtrim-gateway"
+version = "0.2.2-dev"
+dependencies = [
+ "llmtrim-core",
+ "serde_json",
+]
+
+[[package]]
 name = "llmtrim-uniffi"
 version = "0.2.2-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/llmtrim-uniffi",
     "crates/llmtrim-wasm",
     "crates/adapters/llmtrim-gateway",
+    "crates/adapters/llmtrim-gateway-plugin",
 ]
 # The adapter crates (the shared gateway logic and the wasm plugins it backs) stay out of the
 # default dev loop: they target wasm and pull proxy-wasm deps that are noise for a host build.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,22 @@
 [workspace]
 resolver = "3"
-members = ["crates/llmtrim-core", "crates/llmtrim-cli", "crates/llmtrim-uniffi", "crates/llmtrim-wasm"]
+members = [
+    "crates/llmtrim-core",
+    "crates/llmtrim-cli",
+    "crates/llmtrim-uniffi",
+    "crates/llmtrim-wasm",
+    "crates/adapters/llmtrim-gateway",
+]
+# The adapter crates (the shared gateway logic and the wasm plugins it backs) stay out of the
+# default dev loop: they target wasm and pull proxy-wasm deps that are noise for a host build.
+# The fast check loop (`cargo … --features intercept`) keeps hitting only these four; test the
+# adapters explicitly with `-p llmtrim-gateway` (and the wasm plugins on their wasm target).
+default-members = [
+    "crates/llmtrim-core",
+    "crates/llmtrim-cli",
+    "crates/llmtrim-uniffi",
+    "crates/llmtrim-wasm",
+]
 
 # Shared package metadata — inherited by each member via `field.workspace = true`.
 [workspace.package]

--- a/crates/adapters/llmtrim-gateway-plugin/Cargo.toml
+++ b/crates/adapters/llmtrim-gateway-plugin/Cargo.toml
@@ -1,0 +1,25 @@
+# Proxy-Wasm plugin: one wasm module that compresses LLM request bodies via llmtrim. The same
+# artifact runs on Kong and Higress (both proxy-wasm 0.2 ABI hosts); they differ only in how
+# the deployment hands over plugin-config JSON, which `llmtrim_gateway::Config::from_json_bytes`
+# reads. All testable logic lives in llmtrim-gateway; this crate is the host glue and only
+# builds for wasm, so it is kept out of the default dev loop.
+[package]
+name = "llmtrim-gateway-plugin"
+description = "Proxy-Wasm plugin that compresses LLM API request bodies with llmtrim (Kong, Higress)."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+proxy-wasm = "0.2.5"
+llmtrim-gateway = { path = "../llmtrim-gateway" }
+
+[lints]
+workspace = true

--- a/crates/adapters/llmtrim-gateway-plugin/README.md
+++ b/crates/adapters/llmtrim-gateway-plugin/README.md
@@ -1,0 +1,92 @@
+# llmtrim gateway plugin (Proxy-Wasm)
+
+One Proxy-Wasm module that compresses LLM API request bodies with llmtrim as they pass through
+the gateway. It buffers the request body, runs it through the llmtrim engine, and forwards the
+smaller body upstream. The same `.wasm` runs on **Kong** and **Higress** (both are Proxy-Wasm
+0.2 ABI hosts); only the deployment config differs.
+
+It is fail-open: a non-JSON body, an undetectable provider, an oversized body, or any engine
+error forwards the original request unchanged. A gateway that fronts one provider should set
+`provider` so it does not depend on shape auto-detection.
+
+## Get the module
+
+Each release publishes the same `.wasm` to both channels:
+
+- **OCI artifact** (for Higress): `ghcr.io/fkiene/llmtrim-gateway-plugin:<version>` (version tags
+  only, no `:latest`, so a control plane never picks up a new build silently)
+- **Release asset** (for Kong): `llmtrim-gateway-plugin.wasm` on the matching GitHub Release;
+  download it to the host and point `wasm_filters_path` at it (Kong loads from disk, not a URL)
+
+Or build it yourself:
+
+```sh
+cargo build -p llmtrim-gateway-plugin --target wasm32-wasip1 --release
+# artifact: target/wasm32-wasip1/release/llmtrim_gateway_plugin.wasm
+```
+
+## Configuration
+
+The host passes a JSON config object. Every field is optional:
+
+| Field            | Type   | Default            | Meaning                                                        |
+| ---------------- | ------ | ------------------ | -------------------------------------------------------------- |
+| `provider`       | string | auto-detect        | `openai`, `anthropic`, or `google`. Set it when fronting one.  |
+| `preset`         | string | `auto`             | `auto`, `aggressive`, `agent`, `code`, `rag`, `safe`.          |
+| `max_body_bytes` | number | 4194304 (4 MiB)    | Bodies larger than this are forwarded uncompressed; `0` disables the guard. |
+
+A missing or malformed config falls back to these defaults rather than disabling the plugin.
+
+The module targets `wasm32-wasip1`, not `wasm32-unknown-unknown`: the engine needs an entropy
+source (for hash seeding), which on `wasm32-unknown-unknown` only resolves to a browser JS
+backend that a gateway has no runtime for. `wasm32-wasip1` uses the WASI `random_get` import,
+which the Envoy-based (Higress) and Kong wasm runtimes provide.
+
+## Deploy on Kong
+
+Kong loads Proxy-Wasm filters from `wasm_filters_path`. Point Kong at the `.wasm`, then attach
+the filter to a service or route with the config above:
+
+```yaml
+# kong.conf
+wasm = on
+wasm_filters_path = /etc/kong/wasm
+```
+
+```yaml
+# a route's filter chain
+filters:
+  - name: llmtrim_gateway_plugin
+    config: '{"provider":"openai","preset":"auto"}'
+```
+
+The filter-config field name and encoding have moved across Kong Gateway releases. Verify the
+exact `filters[].config` form against the Kong version you run (the plugin reads the bytes the
+host passes to `on_configure` as JSON); a wrong field silently leaves the plugin on defaults.
+
+## Deploy on Higress
+
+Higress (Envoy-based) loads it as a `WasmPlugin`:
+
+```yaml
+apiVersion: extensions.higress.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: llmtrim
+  namespace: higress-system
+spec:
+  url: oci://ghcr.io/fkiene/llmtrim-gateway-plugin:VERSION
+  defaultConfig:
+    provider: openai
+    preset: auto
+```
+
+Higress assigns plugin execution order itself; the Istio `WasmPlugin` `phase`/`priority`
+fields are not part of the Higress (`extensions.higress.io/v1alpha1`) schema. Use `matchRules`
+to scope the plugin to specific routes or domains if needed.
+
+## What lives where
+
+All logic (fail-open rules, the size guard, config parsing) is in the `llmtrim-gateway` crate,
+which is unit-tested on the host. This crate is only the Proxy-Wasm lifecycle glue and builds
+solely for wasm, so it carries no host tests.

--- a/crates/adapters/llmtrim-gateway-plugin/src/lib.rs
+++ b/crates/adapters/llmtrim-gateway-plugin/src/lib.rs
@@ -1,0 +1,77 @@
+//! Proxy-Wasm plugin: compress the LLM API request body with llmtrim on its way upstream.
+//!
+//! One wasm module serves both Kong and Higress (both proxy-wasm 0.2 ABI hosts). The host
+//! buffers the request body, hands it to [`llmtrim_gateway::compress_body`], and forwards what
+//! comes back. All decisions (fail-open, size guard, config parsing) live in `llmtrim-gateway`,
+//! which is unit-tested on the host; this crate is the thin lifecycle glue that only builds for
+//! wasm, so it carries no logic worth testing here.
+
+use llmtrim_gateway::{Config, compress_body};
+use proxy_wasm::traits::{Context, HttpContext, RootContext};
+use proxy_wasm::types::{Action, ContextType, LogLevel};
+
+proxy_wasm::main! {{
+    proxy_wasm::set_log_level(LogLevel::Warn);
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> {
+        Box::new(Root { config: Config::default() })
+    });
+}}
+
+/// Holds the parsed plugin config and stamps it onto each request's filter.
+struct Root {
+    config: Config,
+}
+
+impl Context for Root {}
+
+impl RootContext for Root {
+    fn on_configure(&mut self, _config_size: usize) -> bool {
+        // Fail-open: a missing or malformed config yields safe defaults (auto routing,
+        // default body-size guard), so the plugin still runs rather than rejecting traffic.
+        let bytes = self.get_plugin_configuration().unwrap_or_default();
+        self.config = Config::from_json_bytes(&bytes);
+        true
+    }
+
+    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
+        Some(Box::new(Filter {
+            config: self.config.clone(),
+        }))
+    }
+
+    fn get_type(&self) -> Option<ContextType> {
+        Some(ContextType::HttpContext)
+    }
+}
+
+/// Per-request filter: compress the buffered request body in place.
+struct Filter {
+    config: Config,
+}
+
+impl Context for Filter {}
+
+impl HttpContext for Filter {
+    fn on_http_request_body(&mut self, body_size: usize, end_of_stream: bool) -> Action {
+        if !end_of_stream {
+            // Wait until the host has buffered the whole body; then `body_size` is the total.
+            return Action::Pause;
+        }
+        if body_size == 0 {
+            return Action::Continue;
+        }
+        if let Some(body) = self.get_http_request_body(0, body_size) {
+            let outcome = compress_body(&body, &self.config);
+            if !outcome.is_passthrough() {
+                self.set_http_request_body(0, body_size, &outcome.body);
+            }
+            // Set Content-Length to the final body length so HTTP/1.1 upstreams (the OpenAI /
+            // Anthropic endpoints) get a well-framed request. The request is still buffered
+            // here (we paused the body), so its headers have not gone upstream yet and remain
+            // mutable. `outcome.body` is the original bytes on passthrough, the compressed
+            // bytes otherwise, so this length is correct either way.
+            self.set_http_request_header("content-length", Some(&outcome.body.len().to_string()));
+        }
+        Action::Continue
+    }
+}

--- a/crates/adapters/llmtrim-gateway/Cargo.toml
+++ b/crates/adapters/llmtrim-gateway/Cargo.toml
@@ -1,0 +1,26 @@
+# Shared, host-agnostic logic for the proxy-wasm gateway plugins (Kong, Higress). Pure Rust
+# over `llmtrim-core::rewrite_request` so it unit-tests on the host without a proxy-wasm host;
+# the per-gateway crates add only the lifecycle glue. Not published.
+[package]
+name = "llmtrim-gateway"
+description = "Shared request-compression logic for llmtrim's proxy-wasm gateway plugins (Kong, Higress)."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+# Default features off: gateway plugins target wasm and must drop the C toolchain
+# (tree-sitter) and the 8 MB tiktoken vocab. Token counts become estimates, which is fine
+# for a header/log value; the compressed body is identical.
+llmtrim-core = { path = "../../llmtrim-core", default-features = false }
+# Parse the host's plugin-config JSON into `Config` here (host-testable) so the wasm plugin
+# crate stays thin glue.
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/adapters/llmtrim-gateway/src/lib.rs
+++ b/crates/adapters/llmtrim-gateway/src/lib.rs
@@ -1,0 +1,368 @@
+//! Shared request-compression logic for llmtrim's proxy-wasm gateway plugins.
+//!
+//! Kong and Higress both buffer the LLM request body, hand it here, and replace the body
+//! with what comes back. The only host-specific part (how the body is buffered and swapped)
+//! lives in each gateway crate; the compression call and its rules live once, here.
+//!
+//! # Fail-open
+//!
+//! A gateway sits in the live request path, so a bug here must never break a user's request.
+//! [`compress_body`] therefore never errors: on an oversized body, non-UTF-8 input, non-JSON
+//! input, an undetectable provider, or any engine error, it returns the original bytes
+//! unchanged and records why in [`Outcome::passthrough`]. The caller forwards
+//! [`Outcome::body`] either way.
+
+use llmtrim_core::ir::ProviderKind;
+
+/// The default body-size ceiling: above this, the gateway forwards the request uncompressed
+/// rather than parsing it. Bounds wasm linear memory, since `serde_json` builds a heap tree a
+/// few times the raw size and an OOM in the wasm instance becomes a 500, not a passthrough.
+pub const DEFAULT_MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
+
+/// Per-route configuration a gateway reads from its own plugin config and passes in.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Target API shape (`openai` / `anthropic` / `google`), or `None` to auto-detect from
+    /// the body. A gateway that fronts one provider should set this to skip detection.
+    pub provider: Option<String>,
+    /// Workload preset, or `None` to use the `auto` shape-routing default (the recommended
+    /// setting for a gateway seeing mixed traffic).
+    pub preset: Option<String>,
+    /// Skip (pass through) bodies larger than this, to bound wasm memory. `None` disables the
+    /// guard. Defaults to [`DEFAULT_MAX_BODY_BYTES`].
+    pub max_body_bytes: Option<usize>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            provider: None,
+            preset: None,
+            max_body_bytes: Some(DEFAULT_MAX_BODY_BYTES),
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct RawConfig {
+    provider: Option<String>,
+    preset: Option<String>,
+    max_body_bytes: Option<usize>,
+}
+
+impl Config {
+    /// Build a [`Config`] from a gateway's JSON plugin-config bytes (`{"provider":…,
+    /// "preset":…, "max_body_bytes":…}`, all optional). Fail-open: empty or malformed config
+    /// yields the default (auto routing, default size limit) so a misconfigured plugin still
+    /// runs and compresses rather than refusing traffic. An absent `max_body_bytes` keeps the
+    /// default guard; a positive value sets it; `0` disables it (compress any size).
+    pub fn from_json_bytes(bytes: &[u8]) -> Self {
+        // Empty or whitespace-only config means "use defaults", not a parse error.
+        if bytes.iter().all(u8::is_ascii_whitespace) {
+            return Self::default();
+        }
+        match serde_json::from_slice::<RawConfig>(bytes) {
+            Ok(raw) => Self {
+                provider: raw.provider,
+                preset: raw.preset,
+                // Absent -> default guard; 0 -> disabled (None); positive -> that limit. This
+                // is the only way an operator can opt out of the guard from JSON config.
+                max_body_bytes: match raw.max_body_bytes {
+                    None => Some(DEFAULT_MAX_BODY_BYTES),
+                    Some(0) => None,
+                    Some(n) => Some(n),
+                },
+            },
+            Err(_) => Self::default(),
+        }
+    }
+}
+
+/// The result of a compression attempt. `body` is always present (original bytes on
+/// passthrough); `passthrough` names the reason the engine was skipped, if any.
+#[derive(Debug)]
+pub struct Outcome {
+    /// The body to forward: compressed on success, the untouched original on passthrough.
+    pub body: Vec<u8>,
+    /// `Some(reason)` when the engine was skipped and the original body is returned as-is.
+    pub passthrough: Option<Passthrough>,
+    /// Input token count before compression. Always `None` when [`Outcome::passthrough`] is
+    /// `Some` (the engine did not run); an estimate, not exact, in wasm builds (no tiktoken).
+    pub tokens_before: Option<u64>,
+    /// Input token count after compression. Always `None` on passthrough.
+    pub tokens_after: Option<u64>,
+}
+
+impl Outcome {
+    /// Whether the engine was skipped and the original body forwarded unchanged. When `true`,
+    /// the token counts are `None`; a metrics caller should record a zero-savings event.
+    pub fn is_passthrough(&self) -> bool {
+        self.passthrough.is_some()
+    }
+}
+
+/// Why a request was forwarded uncompressed.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Passthrough {
+    /// The body exceeded [`Config::max_body_bytes`]; it was forwarded without parsing.
+    TooLarge { len: usize, limit: usize },
+    /// The body was not valid UTF-8 (so not a JSON request body we can read).
+    NotUtf8,
+    /// The configured preset name is unknown, or the engine rejected the request (invalid
+    /// JSON, undetectable provider). The string is a structured engine message with no request
+    /// body content (only static text, the preset name, or a serde structural position), so a
+    /// host may log it verbatim. A test pins this; keep it true if engine errors change.
+    Engine(String),
+}
+
+/// Compress a buffered request body. Never errors; see the module-level fail-open note.
+///
+/// Calling this twice on the same body is safe: the engine is lossless and deterministic, so a
+/// second pass over an already-compressed body returns valid JSON without corrupting it (it may
+/// simply find little left to compress). A gateway with a retry path need not guard against it.
+pub fn compress_body(body: &[u8], config: &Config) -> Outcome {
+    if let Some(limit) = config.max_body_bytes
+        && body.len() > limit
+    {
+        return passthrough(
+            body,
+            Passthrough::TooLarge {
+                len: body.len(),
+                limit,
+            },
+        );
+    }
+
+    let Ok(input) = std::str::from_utf8(body) else {
+        return passthrough(body, Passthrough::NotUtf8);
+    };
+
+    // An unparseable provider hint falls back to auto-detect rather than failing the request.
+    let provider = config
+        .provider
+        .as_deref()
+        .and_then(|p| p.parse::<ProviderKind>().ok());
+
+    match llmtrim_core::rewrite_request(input, provider, config.preset.as_deref()) {
+        Ok(result) => Outcome {
+            body: result.request_json.into_bytes(),
+            passthrough: None,
+            tokens_before: Some(result.input_tokens_before.0 as u64),
+            tokens_after: Some(result.input_tokens_after.0 as u64),
+        },
+        Err(e) => passthrough(body, Passthrough::Engine(format!("{e:#}"))),
+    }
+}
+
+fn passthrough(body: &[u8], reason: Passthrough) -> Outcome {
+    Outcome {
+        body: body.to_vec(),
+        passthrough: Some(reason),
+        tokens_before: None,
+        tokens_after: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A top-level `system` field makes this unambiguously Anthropic-shaped, so auto-detect
+    // resolves it (a bare `{model, messages, max_tokens}` is ambiguous with OpenAI and
+    // correctly fails detection; see `non_distinguishable_body_passes_through`).
+    fn anthropic_agent_body() -> Vec<u8> {
+        serde_json::json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "system": "You are a coding agent.",
+            "messages": [{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1",
+                "content": "ERROR boom\n".repeat(60)}]}],
+            "max_tokens": 1024,
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[test]
+    fn compresses_a_tool_heavy_body_and_returns_valid_json() {
+        let out = compress_body(&anthropic_agent_body(), &Config::default());
+        assert!(
+            out.passthrough.is_none(),
+            "should not passthrough a valid body: {:?}",
+            out.passthrough
+        );
+        assert!(out.tokens_after.unwrap() < out.tokens_before.unwrap());
+        // The forwarded body must still parse as JSON for the upstream provider.
+        let v: serde_json::Value = serde_json::from_slice(&out.body).expect("valid JSON out");
+        assert_eq!(v["model"], "claude-3-5-sonnet-20241022");
+    }
+
+    #[test]
+    fn explicit_provider_hint_is_honored() {
+        let cfg = Config {
+            provider: Some("anthropic".into()),
+            ..Config::default()
+        };
+        let out = compress_body(&anthropic_agent_body(), &cfg);
+        assert!(out.passthrough.is_none());
+    }
+
+    #[test]
+    fn unparseable_provider_hint_falls_back_to_autodetect() {
+        // A bad hint must not fail the request; the body still auto-detects and compresses.
+        let cfg = Config {
+            provider: Some("not-a-provider".into()),
+            ..Config::default()
+        };
+        let out = compress_body(&anthropic_agent_body(), &cfg);
+        assert!(
+            out.passthrough.is_none(),
+            "bad provider hint must fall back, not fail"
+        );
+    }
+
+    #[test]
+    fn non_utf8_body_passes_through_unchanged() {
+        let body = vec![0xff, 0xfe, 0x00, 0x01];
+        let out = compress_body(&body, &Config::default());
+        assert_eq!(out.passthrough, Some(Passthrough::NotUtf8));
+        assert_eq!(out.body, body, "original bytes forwarded verbatim");
+    }
+
+    #[test]
+    fn non_json_body_passes_through_unchanged() {
+        let body = b"this is not json".to_vec();
+        let out = compress_body(&body, &Config::default());
+        assert!(matches!(out.passthrough, Some(Passthrough::Engine(_))));
+        assert_eq!(out.body, body);
+    }
+
+    #[test]
+    fn non_distinguishable_body_passes_through() {
+        // `{model, messages, max_tokens}` is shared by OpenAI and Anthropic, so with no
+        // provider configured the engine cannot detect a shape and the gateway forwards the
+        // body unchanged rather than guessing. A gateway fronting one provider sets `provider`.
+        let body = serde_json::json!({
+            "model": "x",
+            "messages": [{"role":"user","content":"hi"}],
+            "max_tokens": 16,
+        })
+        .to_string()
+        .into_bytes();
+        let out = compress_body(&body, &Config::default());
+        assert!(matches!(out.passthrough, Some(Passthrough::Engine(_))));
+        assert_eq!(out.body, body);
+    }
+
+    #[test]
+    fn empty_and_structural_json_bodies_pass_through() {
+        // Real gateway traffic: empty health-probe bodies, array-shaped batches, bare objects.
+        // None panic; all forward unchanged because there is no provider shape to detect.
+        for body in [&b""[..], b"[]", b"{}", b"   "] {
+            let out = compress_body(body, &Config::default());
+            assert!(
+                matches!(out.passthrough, Some(Passthrough::Engine(_))),
+                "body {body:?} should pass through via the engine arm"
+            );
+            assert_eq!(out.body, body);
+        }
+    }
+
+    #[test]
+    fn oversized_body_passes_through_without_parsing() {
+        let cfg = Config {
+            max_body_bytes: Some(64),
+            ..Config::default()
+        };
+        let big = vec![b'x'; 65];
+        let out = compress_body(&big, &cfg);
+        assert_eq!(
+            out.passthrough,
+            Some(Passthrough::TooLarge { len: 65, limit: 64 })
+        );
+        assert_eq!(out.body, big, "oversized body forwarded verbatim");
+        assert!(out.is_passthrough());
+    }
+
+    #[test]
+    fn double_compress_does_not_corrupt() {
+        let body = anthropic_agent_body();
+        let first = compress_body(&body, &Config::default());
+        let second = compress_body(&first.body, &Config::default());
+        let v: serde_json::Value = serde_json::from_slice(&second.body).expect("still valid JSON");
+        assert_eq!(v["model"], "claude-3-5-sonnet-20241022");
+    }
+
+    #[test]
+    fn engine_passthrough_message_carries_no_request_content() {
+        // The PII contract on Passthrough::Engine: a non-JSON body's reason must not echo the
+        // body bytes back (a host may log this string).
+        let body = b"SECRET_PROMPT_TEXT not json".to_vec();
+        let out = compress_body(&body, &Config::default());
+        let Some(Passthrough::Engine(msg)) = out.passthrough else {
+            panic!("expected engine passthrough");
+        };
+        assert!(
+            !msg.contains("SECRET_PROMPT_TEXT"),
+            "engine message must not leak request content: {msg}"
+        );
+    }
+
+    #[test]
+    fn config_from_json_parses_all_fields() {
+        let cfg = Config::from_json_bytes(
+            br#"{"provider":"anthropic","preset":"agent","max_body_bytes":1024}"#,
+        );
+        assert_eq!(cfg.provider.as_deref(), Some("anthropic"));
+        assert_eq!(cfg.preset.as_deref(), Some("agent"));
+        assert_eq!(cfg.max_body_bytes, Some(1024));
+    }
+
+    #[test]
+    fn config_from_json_fills_defaults_for_missing_fields() {
+        let cfg = Config::from_json_bytes(br#"{"provider":"openai"}"#);
+        assert_eq!(cfg.provider.as_deref(), Some("openai"));
+        assert_eq!(
+            cfg.preset, None,
+            "absent preset stays None (rewrite_request applies auto)"
+        );
+        assert_eq!(
+            cfg.max_body_bytes,
+            Some(DEFAULT_MAX_BODY_BYTES),
+            "absent size limit keeps the default guard"
+        );
+    }
+
+    #[test]
+    fn config_from_json_zero_max_body_disables_the_guard() {
+        let cfg = Config::from_json_bytes(br#"{"max_body_bytes":0}"#);
+        assert_eq!(cfg.max_body_bytes, None, "0 means unlimited");
+        // And a disabled guard actually lets a large body through to the engine.
+        let out = compress_body(&vec![b'x'; DEFAULT_MAX_BODY_BYTES + 1], &cfg);
+        assert!(
+            !matches!(out.passthrough, Some(Passthrough::TooLarge { .. })),
+            "guard disabled, so size is not the passthrough reason"
+        );
+    }
+
+    #[test]
+    fn config_from_json_is_fail_open_on_empty_or_malformed() {
+        // Empty, whitespace, and garbage all fall back to the safe default rather than
+        // disabling the plugin.
+        for raw in [&b""[..], b"   ", b"not json", b"{", br#"{"provider":42}"#] {
+            let cfg = Config::from_json_bytes(raw);
+            assert_eq!(cfg.provider, None, "raw {raw:?} should default");
+            assert_eq!(cfg.max_body_bytes, Some(DEFAULT_MAX_BODY_BYTES));
+        }
+    }
+
+    #[test]
+    fn unknown_preset_passes_through_rather_than_failing() {
+        let cfg = Config {
+            preset: Some("nonsense".into()),
+            ..Config::default()
+        };
+        let out = compress_body(&anthropic_agent_body(), &cfg);
+        assert!(matches!(out.passthrough, Some(Passthrough::Engine(_))));
+        assert_eq!(out.body, anthropic_agent_body());
+    }
+}


### PR DESCRIPTION
Adds the first Tier-1 integration adapter: a Proxy-Wasm gateway plugin that compresses LLM API request bodies with llmtrim as they pass through the gateway.

## What's here

- **`llmtrim-gateway`** (host-agnostic logic, 15 tests): `compress_body` and `Config::from_json_bytes`. Fail-open by contract: an oversized, non-UTF-8, non-JSON, unknown-preset, or undetectable-provider body forwards the original bytes unchanged. Pulls `llmtrim-core` with default features off (the wasm feature set). It is the only part with logic worth testing, so it carries the tests.
- **`llmtrim-gateway-plugin`** (Proxy-Wasm glue): buffers the request body, calls `compress_body`, swaps the body, and sets a correct Content-Length. Thin lifecycle code that only builds for wasm.

## One plugin, both gateways

Kong and Higress are both Proxy-Wasm 0.2 ABI hosts, so one `.wasm` runs on both; only the deployment config differs. Each release publishes the same module to both channels (a release job, `GITHUB_TOKEN` only, no new secret):

- Higress: an OCI artifact in Higress's wasm-image format at `ghcr.io/fkiene/llmtrim-gateway-plugin:<version>`
- Kong: a `.wasm` Release asset to download to disk

## CI / build

- `default-members` keeps the wasm crates out of the warm dev loop; a new `Gateway plugin (wasm)` CI job tests the gateway with core features off and builds the plugin for `wasm32-wasip1`.
- Built for `wasm32-wasip1`, not `unknown-unknown`: the engine needs an entropy source, which on `unknown-unknown` only resolves to a browser JS backend a gateway cannot run; `wasip1` uses the WASI `random_get` the gateway wasm hosts provide.

## Reviews

Both crates and the release job each went through a 3-reviewer pass; all findings are folded in.

## After first release (settings, not blockers)

- Set the GHCR package `llmtrim-gateway-plugin` to public so Higress can pull it anonymously.
- Add `Gateway plugin (wasm)` to the required status checks.