### PR TITLE
perf(core): reduce per-request allocation and tokenization overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to this project are documented here. The format follows
   artifact at `ghcr.io/fkiene/llmtrim-gateway-plugin` (for Higress) and a `.wasm` Release asset
   (for Kong). See `crates/adapters/llmtrim-gateway-plugin/README.md`.
 
+### Performance
+- **Lower per-request compression cost on tool-heavy (agent) prompts.** The pipeline now
+  re-serializes and re-tokenizes the tools array only when a stage actually changed it, instead
+  of after every content-rewriting stage. Per-language stopword sets are built once and reused
+  (behind a read-mostly lock) rather than rebuilt per segment. Output is unchanged.
+
 ### Changed
 - **`@llmtrim/js`: calling `compress()` with no preset now compresses with `auto`
   (shape-routing) instead of the lossless-only baseline.** The npm package barely compressed

--- a/crates/llmtrim-cli/src/bench/mod.rs
+++ b/crates/llmtrim-cli/src/bench/mod.rs
@@ -25,6 +25,7 @@ use regex::Regex;
 use serde_json::{Value, json};
 use statrs::distribution::{ContinuousCDF, StudentsT};
 use statrs::statistics::Statistics;
+use std::collections::HashMap;
 use std::time::Duration;
 use wait_timeout::ChildExt;
 
@@ -166,18 +167,21 @@ fn token_f1(answer: &str, gold: &str) -> f64 {
             0.0
         };
     }
-    // Common tokens = sum of min(count_answer, count_gold) per distinct token.
-    let mut common = 0usize;
-    let mut seen: Vec<&str> = Vec::new();
-    for tok in &gt {
-        if seen.contains(tok) {
-            continue;
-        }
-        seen.push(tok);
-        let in_a = at.iter().filter(|t| *t == tok).count();
-        let in_g = gt.iter().filter(|t| *t == tok).count();
-        common += in_a.min(in_g);
+    // Common tokens = sum of min(count_answer, count_gold) per distinct token. Build a
+    // count map of the answer once, then fold the gold over it — O(|at| + |gt|) instead of
+    // the quadratic per-token rescans (P3).
+    let mut answer_counts: HashMap<&str, usize> = HashMap::with_capacity(at.len());
+    for tok in &at {
+        *answer_counts.entry(*tok).or_insert(0) += 1;
     }
+    let mut gold_counts: HashMap<&str, usize> = HashMap::with_capacity(gt.len());
+    for tok in &gt {
+        *gold_counts.entry(*tok).or_insert(0) += 1;
+    }
+    let common: usize = gold_counts
+        .iter()
+        .map(|(tok, &in_g)| in_g.min(answer_counts.get(tok).copied().unwrap_or(0)))
+        .sum();
     if common == 0 {
         return 0.0;
     }

--- a/crates/llmtrim-core/src/pipeline.rs
+++ b/crates/llmtrim-core/src/pipeline.rs
@@ -12,6 +12,14 @@ use crate::provider::Provider;
 use crate::quality_gate::{self, COVERAGE_THRESHOLD};
 use crate::tokenizer::{TokenCounter, Tokens};
 
+/// True if the stage left the `/tools` subtree byte-identical to `snapshot`, so the cached
+/// tools count is still valid and the array need not be re-serialized + re-tokenized (P1).
+/// Compares the actual subtree (not the stage's declared [`Scope`], which only promises
+/// "content text unchanged", not "only `/tools` mutated").
+fn tools_unchanged(req: &Request, snapshot: &Request) -> bool {
+    req.raw().get("tools") == snapshot.raw().get("tools")
+}
+
 /// Stage names that drop/window query-relevant *content* and are therefore subject to
 /// the quality gate as well as the token gate. The token gate can't tell these apart
 /// from a beneficial cut — both reduce tokens — so coverage decides if the cut hurt.
@@ -161,6 +169,7 @@ pub fn run_gated(
         .sum();
 
     for stage in stages {
+        let scope = stage.scope();
         let before = content + tools;
         let snapshot = req.clone();
         let plan_mark = plan.len();
@@ -182,17 +191,24 @@ pub fn run_gated(
                 let (new_content, new_tools) = if req.raw() == snapshot.raw() {
                     (content, tools)
                 } else {
-                    match stage.scope() {
-                        Scope::Content => (
-                            count_content_cached(req, provider, counter, &mut seg_cache),
-                            tools,
-                        ),
-                        Scope::Tools => (content, count_tools(req, counter)),
-                        Scope::Both => (
-                            count_content_cached(req, provider, counter, &mut seg_cache),
-                            count_tools(req, counter),
-                        ),
-                    }
+                    let new_content = match scope {
+                        Scope::Tools => content,
+                        Scope::Content | Scope::Both => {
+                            count_content_cached(req, provider, counter, &mut seg_cache)
+                        }
+                    };
+                    // Tools count is re-serialized + re-tokenized only when the `/tools`
+                    // subtree actually changed (P1): a stage that rewrites only content keeps
+                    // the cached tools count instead of paying a full tools BPE pass. Verified
+                    // against the actual subtree regardless of the stage's declared scope —
+                    // `Scope` only promises "content text unchanged", not "only /tools moved"
+                    // (CacheStage declares `Tools` yet writes into `/system` and `/messages`).
+                    let new_tools = if tools_unchanged(req, &snapshot) {
+                        tools
+                    } else {
+                        count_tools(req, counter)
+                    };
+                    (new_content, new_tools)
                 };
                 let after = new_content + new_tools;
                 if stage.gate_kind() == GateKind::InputTokens && after >= before {
@@ -203,7 +219,7 @@ pub fn run_gated(
                 } else if quality_gate
                     && !query.is_empty()
                     && stage.gate_kind() == GateKind::InputTokens
-                    && stage.scope() != Scope::Tools
+                    && scope != Scope::Tools
                     && (stage.quality_gated() || quality_gated_by_name(stage.name()))
                     && {
                         // Coverage of query-relevant source content surviving this cut. The
@@ -405,5 +421,73 @@ mod tests {
         assert!(!out.stages[0].applied);
         assert!(out.stages[0].note.as_deref().unwrap().contains("error"));
         assert_eq!(req.get_str("/messages/0/content"), Some(original.as_str()));
+    }
+
+    /// Test transform (`Scope::Tools`): replace the whole `/tools` array with a smaller one.
+    struct ShrinkTools;
+    impl Transform for ShrinkTools {
+        fn name(&self) -> &str {
+            "shrink-tools"
+        }
+        fn gate_kind(&self) -> GateKind {
+            GateKind::InputTokens
+        }
+        fn scope(&self) -> Scope {
+            Scope::Tools
+        }
+        fn apply(
+            &self,
+            req: &mut Request,
+            _provider: &dyn Provider,
+            _plan: &mut Vec<PlanEntry>,
+        ) -> anyhow::Result<()> {
+            req.set("/tools", serde_json::json!([{"name": "f"}]));
+            Ok(())
+        }
+    }
+
+    fn fresh_with_tools() -> (Request, Box<dyn TokenCounter>) {
+        let req = Request::parse(
+            ProviderKind::OpenAi,
+            r#"{"messages":[{"role":"user","content":"this is a fairly long original message about widgets and gadgets"}],"tools":[{"type":"function","function":{"name":"search_documents","description":"search a large corpus for relevant passages","parameters":{"q":"string"}}}]}"#,
+        )
+        .unwrap();
+        (
+            req,
+            counter_for(ProviderKind::OpenAi, Some("gpt-4o")).unwrap(),
+        )
+    }
+
+    /// P1: a content-only (Both-scope) stage keeps the cached tools count, and the reported
+    /// total must still equal a full independent recount that includes the tools tokens.
+    #[test]
+    fn content_stage_preserves_tools_token_count() {
+        let (mut req, counter) = fresh_with_tools();
+        let stages: Vec<Box<dyn Transform>> = vec![Box::new(SetContent {
+            name: "shrink".into(),
+            text: "hi".into(),
+        })];
+        let out = run(&mut req, &OpenAiProvider, counter.as_ref(), &stages);
+        assert!(out.stages[0].applied);
+        // The cached-tools path (P1) must produce the same number as a fresh full count.
+        let independent = content_tokens(&req, &OpenAiProvider, counter.as_ref());
+        assert_eq!(out.input_tokens_after.0, independent);
+        // And the tools tokens are genuinely part of that total (non-trivial tools block).
+        assert!(out.input_tokens_after.0 > count_content(&req, &OpenAiProvider, counter.as_ref()));
+    }
+
+    /// P1: a stage that actually mutates `/tools` triggers the recount, and the new total
+    /// reflects the smaller tools array.
+    #[test]
+    fn tools_stage_recounts_when_tools_change() {
+        let (mut req, counter) = fresh_with_tools();
+        let stages: Vec<Box<dyn Transform>> = vec![Box::new(ShrinkTools)];
+        let out = run(&mut req, &OpenAiProvider, counter.as_ref(), &stages);
+        assert!(out.stages[0].applied);
+        assert!(out.input_tokens_after < out.input_tokens_before);
+        assert_eq!(
+            out.input_tokens_after.0,
+            content_tokens(&req, &OpenAiProvider, counter.as_ref())
+        );
     }
 }

--- a/crates/llmtrim-core/src/quality_gate.rs
+++ b/crates/llmtrim-core/src/quality_gate.rs
@@ -190,7 +190,7 @@ pub fn coverage(source: &str, compressed: &str, query_terms: &[String]) -> f64 {
     let kept = rel_uni.iter().filter(|w| comp_uni.contains(*w)).count()
         + rel_bi
             .iter()
-            .filter(|(a, b)| comp_bi.contains(&((*a).to_string(), (*b).to_string())))
+            .filter(|(a, b)| comp_bi.contains(&(*a, *b)))
             .count();
     kept as f64 / total as f64
 }
@@ -210,15 +210,17 @@ fn bigram_coverage(src: &[String], comp: &[String]) -> f64 {
     }
     let comp_bi = bigram_set(comp);
     let src_bi = bigram_set(src);
-    let kept = src_bi.iter().filter(|b| comp_bi.contains(*b)).count();
+    let kept = src_bi.iter().filter(|b| comp_bi.contains(b)).count();
     kept as f64 / src_bi.len() as f64
 }
 
-/// Set of distinct adjacent token pairs (bigram types) of `words`.
-fn bigram_set(words: &[String]) -> std::collections::HashSet<(String, String)> {
+/// Set of distinct adjacent token pairs (bigram types) of `words`, borrowing the token
+/// slices instead of cloning each into an owned `String` (P5) — the `words` `Vec` owns the
+/// tokens for the duration of the coverage check.
+fn bigram_set(words: &[String]) -> std::collections::HashSet<(&str, &str)> {
     words
         .windows(2)
-        .map(|p| (p[0].clone(), p[1].clone()))
+        .map(|p| (p[0].as_str(), p[1].as_str()))
         .collect()
 }
 

--- a/crates/llmtrim-core/src/stages/retrieve.rs
+++ b/crates/llmtrim-core/src/stages/retrieve.rs
@@ -218,7 +218,7 @@ fn rebuild_sentence(text: &str, query: &[String], keep_ratio: f64) -> Option<Str
     }
     // Stopwords for the context's own language (whatlang-detected).
     let stops = stopword_set(text);
-    let kept = prune_sentences(&chunks, query, &stops, keep_ratio);
+    let kept = prune_sentences(&chunks, query, stops, keep_ratio);
     if kept.len() >= chunks.len() {
         return None; // nothing dropped
     }
@@ -1501,7 +1501,7 @@ mod tests {
         let query = vec!["vault".to_string(), "code".to_string()];
         let stops = stopword_set("the vault is here and the code is there for a test");
         // Loose cap: keep relevant + neighbours, drop only the zero-overlap filler (#2).
-        let kept = prune_sentences(&chunks, &query, &stops, 0.9);
+        let kept = prune_sentences(&chunks, &query, stops, 0.9);
         assert!(
             kept.contains(&0) && kept.contains(&4),
             "relevant sentences kept"
@@ -1512,7 +1512,7 @@ mod tests {
         assert_eq!(kept, sorted, "kept in original order");
 
         // Aggressive cap: drop the neighbours too, but never the answer (#0/#4).
-        let tight = prune_sentences(&chunks, &query, &stops, 0.4);
+        let tight = prune_sentences(&chunks, &query, stops, 0.4);
         assert!(
             tight.contains(&0) && tight.contains(&4),
             "answer + boundaries protected under aggressive cap"
@@ -1875,7 +1875,7 @@ mod tests {
         let chunks: Vec<String> = tap_log().lines().map(String::from).collect();
         let query = lex_words("run the tests");
         let stops = stopword_set(&tap_log());
-        let kept = prune_sentences(&chunks, &query, &stops, 0.1);
+        let kept = prune_sentences(&chunks, &query, stops, 0.1);
         let joined: String = kept.iter().map(|&i| chunks[i].as_str()).collect();
         assert!(
             joined.contains("not ok 19"),

--- a/crates/llmtrim-core/src/stages/tools.rs
+++ b/crates/llmtrim-core/src/stages/tools.rs
@@ -12,9 +12,11 @@
 //! from the `stop-words` crate, for the language `whatlang` detects in the request —
 //! not a hardcoded English list.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::RwLock;
 
 use anyhow::Result;
+use once_cell::sync::Lazy;
 use serde_json::Value;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -129,7 +131,7 @@ pub(crate) fn detect_lang(sample: &str) -> Option<whatlang::Lang> {
 /// `stop-words` crate), falling back to English when detection is unreliable or the
 /// language isn't in our supported map. The map is enum→enum glue; the word lists
 /// themselves come from the crate. Shared with Stage B sentence pruning.
-pub(crate) fn stopword_set(sample: &str) -> HashSet<&'static str> {
+pub(crate) fn stopword_set(sample: &str) -> &'static HashSet<&'static str> {
     use stop_words::LANGUAGE as L;
     use whatlang::Lang;
     // Detect on a leading slice of a large segment (see LANG_DETECT_MAX_BYTES): matches
@@ -172,7 +174,31 @@ pub(crate) fn stopword_set(sample: &str) -> HashSet<&'static str> {
         // Any other (or undetected) language falls back to English (graceful, never panics).
         _ => L::English,
     };
-    stop_words::get(language).iter().copied().collect()
+    intern_stopwords(stop_words::get(language))
+}
+
+/// Memoize the per-language `HashSet` so it is built once, not rebuilt on every segment
+/// and stage (P4). `whatlang` detection stays per call (input-dependent), but the set is
+/// keyed by the address of the crate's `&'static` word slice — stable per language — and
+/// the bounded set of results (one per supported language, ~25 max) is leaked for the
+/// process lifetime. After warmup every language is a cache hit, so the lock is a read in
+/// the common case: an `RwLock` keeps concurrent proxy requests from serializing on it.
+fn intern_stopwords(words: &'static [&'static str]) -> &'static HashSet<&'static str> {
+    static CACHE: Lazy<RwLock<HashMap<usize, &'static HashSet<&'static str>>>> =
+        Lazy::new(|| RwLock::new(HashMap::new()));
+    let key = words.as_ptr() as usize;
+    if let Some(&set) = CACHE
+        .read()
+        .expect("stopword cache lock poisoned")
+        .get(&key)
+    {
+        return set;
+    }
+    CACHE
+        .write()
+        .expect("stopword cache lock poisoned")
+        .entry(key)
+        .or_insert_with(|| Box::leak(Box::new(words.iter().copied().collect())))
 }
 
 /// Lowercased lexical tokens via the Unicode word segmenter (UAX#29) — works across
@@ -285,21 +311,21 @@ fn select_tools(req: &mut Request, provider: &dyn Provider) {
     }
     let sample_end = lower.len().min(LANG_SAMPLE_BYTES);
     let stop = stopword_set(lower.get(..sample_end).unwrap_or(&lower));
-    let query = content_words(&lower, &stop);
+    let query = content_words(&lower, stop);
     if query.is_empty() {
         return;
     }
 
     // Per-tool fielded documents (aligned to `descriptors` / the tools array order). Property
     // names come from the raw schema; provider-agnostic, like `tools_used_in_history`.
-    let param_fields = tool_param_words(req, &stop);
+    let param_fields = tool_param_words(req, stop);
     let docs: Vec<ToolDoc> = descriptors
         .iter()
         .enumerate()
         .map(|(i, (name, desc))| ToolDoc {
-            name: bag(&content_words(&name.to_lowercase(), &stop)),
+            name: bag(&content_words(&name.to_lowercase(), stop)),
             params: param_fields.get(i).cloned().unwrap_or_default(),
-            desc: bag(&content_words(&desc.to_lowercase(), &stop)),
+            desc: bag(&content_words(&desc.to_lowercase(), stop)),
         })
         .collect();
     let scores = bm25f_scores(&docs, &query);


### PR DESCRIPTION
## Summary

Reduces CPU and allocation overhead on the per-request compression path. Output is byte-identical; the full suite (690 tests) passes.

## Changes

- **Pipeline tools counting.** Re-serialize and re-tokenize the `tools` array only when a stage actually changes the `/tools` subtree, instead of after every content-rewriting stage. The check compares the subtree directly rather than trusting a stage's declared `Scope` — `Scope` only promises "content text unchanged", and `CacheStage` reports `Tools` while also writing into `/system` and `/messages`.
- **Stopword sets.** Build each language's stopword set once and cache it behind a read-mostly lock, instead of rebuilding it for every text segment.
- **Quality gate.** Borrow token slices when building bigram sets (`HashSet<(&str, &str)>`) instead of cloning a `String` pair per bigram and two more per membership test.
- **Benchmark scorer.** Compute token F1 with frequency maps (O(n+m)) instead of the previous quadratic per-token rescans.

## Tests

Adds two pipeline unit tests covering the tools-count caching (the cached path and the recount path). `cargo fmt` and clippy are clean.