### PR TITLE
fix(release): name the gateway plugin release asset correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,7 +454,10 @@ jobs:
       - name: Stage and validate the artifact
         run: |
           set -euo pipefail
+          # `plugin.wasm` is the name Higress expects inside the OCI tar.gz; the release asset
+          # gets the descriptive name the README points Kong users at. Same bytes, two names.
           cp target/wasm32-wasip1/release/llmtrim_gateway_plugin.wasm plugin.wasm
+          cp plugin.wasm llmtrim-gateway-plugin.wasm
           ls -lh plugin.wasm
           # A zero-byte or non-wasm file would otherwise publish silently. Check it is a real
           # wasm module (magic bytes "\0asm") before pushing it anywhere.
@@ -471,7 +474,7 @@ jobs:
           if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -qx 'llmtrim-gateway-plugin.wasm'; then
             echo "asset already published for $TAG; skipping"
           else
-            gh release upload "$TAG" plugin.wasm#llmtrim-gateway-plugin.wasm
+            gh release upload "$TAG" llmtrim-gateway-plugin.wasm
           fi
       - uses: oras-project/setup-oras@v1
       - name: Log in to GHCR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **The gateway plugin's GitHub Release asset is now named `llmtrim-gateway-plugin.wasm`.** In
+  v0.3.0 it published as `plugin.wasm` (the `file#label` upload syntax sets a display label, not
+  the filename), which did not match the name the README points Kong users at. The release
+  publish job now uploads it under the correct name and its post-publish verify passes.
+
 ## [0.3.0] - 2026-06-21
 
 ### Added


### PR DESCRIPTION
v0.3.0 published the Kong release asset as `plugin.wasm` instead of `llmtrim-gateway-plugin.wasm` (the `gh release upload file#label` syntax sets a display label, not the filename), so the README name did not exist and the publish job's verify step failed. The OCI/Higress publish was already correct (tar+gzip layer verified in-run).

Fix: upload a correctly-named copy for the release asset, keeping `plugin.wasm` for the Higress OCI tar. Takes effect on the next release (v0.3.1).