### PR TITLE
ci: add Rust quality gates, speed up CI, drop unused deps

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,18 @@
+# nextest configuration. The `default` profile governs local runs; `ci` is selected in
+# GitHub Actions with `--profile ci` for retries on flaky tests and JUnit reporting.
+
+[profile.default]
+# Surface slow tests early without failing the run.
+slow-timeout = { period = "30s", terminate-after = 4 }
+
+[profile.ci]
+# Retry a failing test up to twice before reporting it red — absorbs transient flakes
+# (network, filesystem races) without hiding a genuinely broken test.
+retries = 2
+# Print final status for every test so CI logs show the full picture.
+status-level = "all"
+final-status-level = "slow"
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,20 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-# Least privilege: every job only reads the repo; none of them write anything back.
+# Least privilege default: read-only. The one exception is the `test` job, which grants
+# itself `checks: write` to post JUnit annotations (overridden at that job's level).
 permissions:
   contents: read
 
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  # Incremental compilation is pure overhead in CI (every job is a clean-ish build) and its
+  # per-crate artifacts bloat the rust-cache without ever being reused. Disable it everywhere.
+  CARGO_INCREMENTAL: "0"
+  # The stable channel is pinned repo-wide by rust-toolchain.toml. MSRV lives here so the
+  # `msrv` job (which must override that file via RUSTUP_TOOLCHAIN) bumps in one place.
+  RUST_MSRV: "1.88"
 
 jobs:
   # Detect whether anything other than docs/assets changed. On a docs-only change the
@@ -45,6 +52,8 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -74,6 +83,10 @@ jobs:
     # keeps it running even if the `changes` job failed (fail-safe — never skip real tests).
     if: ${{ !cancelled() }}
     runs-on: ${{ matrix.os }}
+    # checks: write lets the junit reporter annotate failing tests inline on the PR.
+    permissions:
+      contents: read
+      checks: write
     strategy:
       fail-fast: false
       matrix:
@@ -85,44 +98,88 @@ jobs:
     steps:
       - if: ${{ env.RUN != 'false' }}
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - if: ${{ env.RUN != 'false' }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: clippy
       - if: ${{ env.RUN != 'false' }}
         uses: Swatinem/rust-cache@v2
+        with:
+          # Per-OS cache; the 3-OS matrix would otherwise collide on one key.
+          shared-key: test-${{ matrix.os }}
+      - if: ${{ env.RUN != 'false' }}
+        uses: taiki-e/install-action@nextest
       # aws-lc-rs (pulled in by the interceptor's rustls stack) assembles with NASM on Windows.
       - name: Install NASM (Windows)
         if: ${{ env.RUN != 'false' && runner.os == 'Windows' }}
         uses: ilammy/setup-nasm@v1
-      - name: Format
-        if: ${{ env.RUN != 'false' }}
-        run: cargo fmt --all -- --check
+      # Clippy stays per-OS: setup.rs/daemon.rs carry heavy `#[cfg(windows)]`/`#[cfg(unix)]`/
+      # `#[cfg(target_os = ...)]` gated code (40+ blocks in setup.rs alone), so an
+      # ubuntu-only clippy would miss lints in the Windows/macOS arms. fmt and the
+      # release/feature-variant builds (platform-independent) move to the `lint` job.
       - name: Clippy
         if: ${{ env.RUN != 'false' }}
         run: cargo clippy --all-targets -- -D warnings
       - name: Test
         if: ${{ env.RUN != 'false' }}
-        run: cargo test
-      - name: Build (release)
+        run: cargo nextest run --profile ci
+      # Surface failing tests as inline PR annotations instead of buried log lines.
+      # !cancelled() so it still reports when the test step above failed (but not on cancel).
+      - name: Annotate test results
+        if: ${{ !cancelled() && env.RUN != 'false' }}
+        uses: mikepenz/action-junit-report@v5
+        with:
+          # Glob (not a literal path) so it also matches Windows' backslash output.
+          report_paths: "**/nextest/ci/junit.xml"
+          check_name: Test report (${{ matrix.os }})
+          fail_on_failure: false
+      # nextest does not run doctests; keep the 16 doc examples under test.
+      - name: Doctests
         if: ${{ env.RUN != 'false' }}
+        run: cargo test --doc
+      # The optional features (skeleton/tiktoken/multimodal) must each drop cleanly: the
+      # no-default build is the one the wasm binding ships, so guard it (and run its tests).
+      # Kept per-OS — it's a real test run, cheap, and surfaces platform-specific breaks.
+      - name: Compile + test core with all optional features off
+        if: ${{ env.RUN != 'false' }}
+        run: cargo nextest run --profile ci -p llmtrim-core --no-default-features
+
+  # Platform-independent build/lint work, run once on ubuntu instead of on all 3 OS in the
+  # `test` matrix. `cargo build --release` was the single biggest matrix step (~205s on
+  # Windows, ~105s on Linux) yet adds little over the per-OS test compile — the release
+  # *profile* almost never surfaces an error the dev/test compile misses, and release.yml
+  # builds the real shipping binaries on tags. fmt and the feature-variant compile checks are
+  # likewise OS-independent. Clippy stays in the matrix (per-OS) because of the heavy
+  # platform-gated code (see that job).
+  lint:
+    name: Lint and build
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: lint
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Build (release)
         run: cargo build --release
       - name: Compile live feature
-        if: ${{ env.RUN != 'false' }}
         run: cargo build -p llmtrim --features live
       # Guard the embeddable engine: llmtrim-core must build standalone, and the CLI lib
       # must still compile with the interceptor (+ tokio) dropped. `--features`/`--lib` are
       # package-scoped — they can't run at the virtual workspace root.
       - name: Compile embedder core (llmtrim-core)
-        if: ${{ env.RUN != 'false' }}
         run: cargo check -p llmtrim-core
-      # The optional features (skeleton/tiktoken/multimodal) must each drop cleanly: the
-      # no-default build is the one the wasm binding ships, so guard it (and run its tests).
-      - name: Compile + test core with all optional features off
-        if: ${{ env.RUN != 'false' }}
-        run: cargo test -p llmtrim-core --no-default-features
       - name: Compile CLI lib without the interceptor
-        if: ${{ env.RUN != 'false' }}
         run: cargo check -p llmtrim --no-default-features --lib
 
   # Exercise the UniFFI bindings end-to-end, not just the Rust-side tests in the `test`
@@ -136,8 +193,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: bindings
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
@@ -170,10 +231,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+        with:
+          # wasm32 target artifacts + a custom RUSTFLAGS (getrandom wasm_js) — own key.
+          shared-key: wasm
       # wasm-bindgen-cli must match the wasm-bindgen crate version in Cargo.lock exactly
       # (the binary checks a schema version), so derive it instead of pinning a literal.
       - name: Resolve wasm-bindgen version
@@ -205,8 +271,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: swift-smoke
       - name: Build cdylib + generate Swift
         run: |
           cargo build -p llmtrim-uniffi
@@ -230,8 +300,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: kotlin-smoke
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -265,9 +339,20 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: swift-package
+      # XCFRAMEWORK_FAST builds only the Apple-silicon macOS + iOS-sim arm64 slices — the
+      # ones a host `swift test` actually links against — skipping the x86_64 and iOS-device
+      # cross-compiles. The SwiftPM build+test validation below is unchanged: it links and
+      # runs the real test target against a valid (if reduced) xcframework. The full
+      # universal/device xcframework is built unconditionally by release-bindings.yml on tags.
       - name: Build the XCFramework
+        env:
+          XCFRAMEWORK_FAST: "1"
         run: crates/llmtrim-uniffi/scripts/build-xcframework.sh
       - name: Build + test the SwiftPM package against it
         run: swift test --package-path crates/llmtrim-uniffi/packaging/swift
@@ -281,6 +366,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check licenses sources
@@ -307,6 +394,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - run: for f in Formula/*.rb; do ruby -c "$f"; done
 
   # Guard the advertised MSRV (`rust-version` in Cargo.toml). Stable-only CI can silently
@@ -318,6 +407,121 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.88
+        with:
+          fetch-depth: 1
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_MSRV }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv
+      # rust-toolchain.toml pins stable repo-wide; RUSTUP_TOOLCHAIN overrides it so this job
+      # actually compiles against the advertised MSRV instead of silently using stable.
       - run: cargo check --all-targets
+        env:
+          RUSTUP_TOOLCHAIN: ${{ env.RUST_MSRV }}
+
+  # Coverage gate. The local "Coverage gate" loop (CLAUDE.md) is opt-in and bypassable;
+  # this job runs it for every PR so a new module can't merge untested. Same feature set
+  # (`intercept,mcp`) as the fast-check loop so the build reuses that cache.
+  coverage:
+    name: Coverage
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Coverage compiles with llvm instrumentation (-C instrument-coverage) — distinct
+          # artifacts from every other job. Keep it on its own key so it never evicts or gets
+          # evicted by the normal builds.
+          shared-key: coverage
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
+      # nextest under llvm-cov so coverage matches the runner we actually test with.
+      - name: Collect coverage
+        run: cargo llvm-cov nextest --features intercept,mcp --lcov --output-path lcov.info
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Doc build with warnings denied: catches broken intra-doc links and malformed `///`
+  # examples before they reach docs.rs (both llmtrim-core and llmtrim are published).
+  docs:
+    name: Doc build
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: docs
+      - run: cargo doc --no-deps --all-features --workspace
+
+  # API-compatibility gate for the two published crates. They share one version and ship
+  # together, so an accidental breaking change in a patch/minor would break downstreams.
+  # The action infers the required bump from the git tags and fails if the diff exceeds it.
+  semver:
+    name: SemVer (public API)
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      # No fetch-depth limit: the action infers the required bump from the git tags, which a
+      # shallow clone would omit.
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: semver
+      # Baseline is the last version published on crates.io. Between releases the workspace
+      # carries an `X.Y.Z-dev` version; the action compares the public API against that
+      # published baseline and fails when the diff exceeds the implied bump. A deliberate
+      # pre-1.0 breaking change therefore needs its version bumped before this passes.
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: llmtrim-core, llmtrim
+
+  # Unused-dependency check. Dead deps inflate the binary and slow the build/startup that
+  # this CLI optimizes for. cargo-machete is fast (manifest scan, no compile).
+  machete:
+    name: Unused deps (machete)
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: taiki-e/install-action@cargo-machete
+      - run: cargo machete
+
+  # TOML formatting gate (Cargo.toml, deny.toml, filter configs). Options + excludes live in
+  # taplo.toml; keeps hand-edited manifests in one consistent shape.
+  toml:
+    name: TOML format
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: taiki-e/install-action@taplo
+      - run: taplo fmt --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,19 +55,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi-to-tui"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67555e1f1ece39d737e28c8a017721287753af3f93225e4a445b29ccb0f5912c"
-dependencies = [
- "nom",
- "ratatui",
- "simdutf8",
- "smallvec",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "ansitok"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,7 +189,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -259,7 +246,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -305,7 +292,7 @@ dependencies = [
  "dirs",
  "os_info",
  "smappservice-rs",
- "thiserror 2.0.18",
+ "thiserror",
  "windows-registry",
  "windows-result",
 ]
@@ -458,7 +445,7 @@ dependencies = [
  "cached_proc_macro_types",
  "hashbrown 0.15.5",
  "once_cell",
- "thiserror 2.0.18",
+ "thiserror",
  "web-time",
 ]
 
@@ -509,7 +496,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1597,7 +1584,7 @@ dependencies = [
  "moka",
  "rand 0.10.1",
  "rcgen",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tokio",
  "tokio-graceful",
@@ -1940,7 +1927,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -2082,24 +2069,19 @@ dependencies = [
 name = "llmtrim"
 version = "0.3.2-dev"
 dependencies = [
- "ansi-to-tui",
  "anyhow",
  "async-openai",
- "async-trait",
  "auto-launch",
- "base64",
  "bytes",
  "chrono",
  "clap",
  "comfy-table",
  "crossterm 0.28.1",
- "csv",
  "ctrlc",
  "dotenvy",
  "http-body-util",
  "hudsucker",
  "hyper-http-proxy",
- "hyper-rustls",
  "hyper-util",
  "llm_providers",
  "llmtrim-core",
@@ -2115,7 +2097,6 @@ dependencies = [
  "serde_json",
  "statrs",
  "terminal_size",
- "tiktoken-rs",
  "time",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -2882,7 +2863,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2904,7 +2885,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3174,7 +3155,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3297,7 +3278,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3324,7 +3305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3892,7 +3873,7 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "objc2-service-management",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4076,31 +4057,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4356,7 +4317,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4685,7 +4646,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror",
  "utf-8",
 ]
 
@@ -5607,7 +5568,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 resolver = "3"
 members = [
-    "crates/llmtrim-core",
-    "crates/llmtrim-cli",
-    "crates/llmtrim-uniffi",
-    "crates/llmtrim-wasm",
+  "crates/llmtrim-core",
+  "crates/llmtrim-cli",
+  "crates/llmtrim-uniffi",
+  "crates/llmtrim-wasm",
 ]
 
 # Shared package metadata — inherited by each member via `field.workspace = true`.

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -39,11 +39,9 @@ path = "src/main.rs"
 # lockstep with llmtrim-core by cargo-release's shared-version on every bump.
 llmtrim-core = { path = "../llmtrim-core", version = "0.3.2-dev" }
 anyhow.workspace = true
-base64.workspace = true
 chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive"] }
 comfy-table = { version = "7.2.2", default-features = false, features = ["custom_styling"] }
-csv.workspace = true
 ctrlc = "3.5.2"
 dotenvy = "0.15.7"
 once_cell.workspace = true
@@ -56,7 +54,6 @@ statrs = "0.18.0"
 # Terminal width for the watch-mode repaint (truncates lines to one screen row so the
 # in-place repaint never drifts on narrow terminals). Wraps the already-present rustix.
 terminal_size = "0.4"
-tiktoken-rs.workspace = true
 toml.workspace = true
 unicode-width = "0.2"
 ureq = "3.3.0"
@@ -64,9 +61,21 @@ wait-timeout = "0.2.1"
 # Live A/B benchmarking (the `bench` command's network path).
 async-openai = { version = "0.41.0", features = ["chat-completion", "byot"], optional = true }
 reqwest = { version = "0.13", default-features = false, optional = true }
-tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "signal", "time"], optional = true }
+tokio = { version = "1.52", features = [
+  "rt",
+  "rt-multi-thread",
+  "macros",
+  "net",
+  "io-util",
+  "signal",
+  "time",
+], optional = true }
 # The MITM interceptor (`serve`).
-hudsucker = { version = "0.24", default-features = false, features = ["rcgen-ca", "rustls-client", "http2"], optional = true }
+hudsucker = { version = "0.24", default-features = false, features = [
+  "rcgen-ca",
+  "rustls-client",
+  "http2",
+], optional = true }
 # Upstream-proxy connector for the MITM path — tunnels HTTPS origin connections via CONNECT.
 # `rustls-tls-native-roots` enables the `__rustls` internal feature, which causes ProxyConnector
 # to build a tokio-rustls TlsConnector for the ORIGIN leg of tunnelled connections (the part
@@ -74,11 +83,13 @@ hudsucker = { version = "0.24", default-features = false, features = ["rcgen-ca"
 # so it needs no TLS. The tokio-rustls ClientConfig inherits whatever CryptoProvider is
 # installed at runtime; we call aws_lc_rs::default_provider() at startup, so origin TLS uses
 # aws-lc-rs throughout — no ring is pulled in as an active provider.
-hyper-http-proxy = { version = "1.1", default-features = false, features = ["rustls-tls-native-roots"], optional = true }
-# Direct dep so serve.rs can call HttpsConnectorBuilder if needed for non-proxy paths.
-hyper-rustls = { version = "0.27", default-features = false, features = ["native-tokio", "http1", "http2"], optional = true }
-hyper-util = { version = "0.1", default-features = false, features = ["client-legacy", "http2"], optional = true }
-async-trait = { version = "0.1", optional = true }
+hyper-http-proxy = { version = "1.1", default-features = false, features = [
+  "rustls-tls-native-roots",
+], optional = true }
+hyper-util = { version = "0.1", default-features = false, features = [
+  "client-legacy",
+  "http2",
+], optional = true }
 http-body-util = { version = "0.1", optional = true }
 bytes = { version = "1", optional = true }
 llm_providers = { version = "0.14", optional = true }
@@ -88,7 +99,11 @@ llm_providers = { version = "0.14", optional = true }
 time = { version = ">=0.3.36, <0.3.48", default-features = false, optional = true }
 # MCP server over stdio (`mcp`). rmcp is the official Model Context Protocol Rust SDK;
 # `transport-io` is the stdio transport, `macros` derives each tool's JSON Schema.
-rmcp = { version = "1.7", default-features = false, features = ["server", "macros", "transport-io"], optional = true }
+rmcp = { version = "1.7", default-features = false, features = [
+  "server",
+  "macros",
+  "transport-io",
+], optional = true }
 schemars = { version = "1", optional = true }
 # Interactive cost-breakdown TUI (`status`/`monitor` on a TTY). crossterm is the terminal
 # backend; ratatui draws the tabbed tree-tables.
@@ -96,7 +111,6 @@ ratatui = { version = "0.29", default-features = false, features = ["crossterm"]
 crossterm = { version = "0.28", optional = true }
 # Parse the existing ANSI-colored dashboard string into styled ratatui spans for the
 # Overview tab (so the hero box / gauges / sparkline keep their colors).
-ansi-to-tui = { version = "7", optional = true }
 
 # The protocol-level MCP test (`tests/mcp_protocol.rs`, gated on the `mcp` feature) drives
 # the server through an in-memory client, which needs rmcp's `client` side. Dev-only —
@@ -118,8 +132,17 @@ winreg = "0.56"
 default = ["intercept", "mcp", "breakdown"]
 live = ["dep:async-openai", "dep:reqwest", "dep:tokio"]
 # Interactive cost-breakdown TUI. In default so the shipped binary's `status` opens it on a TTY.
-breakdown = ["dep:ratatui", "dep:crossterm", "dep:ansi-to-tui"]
-intercept = ["dep:hudsucker", "dep:tokio", "dep:async-trait", "dep:http-body-util", "dep:bytes", "dep:llm_providers", "dep:time", "dep:hyper-http-proxy", "dep:hyper-util", "dep:hyper-rustls"]
+breakdown = ["dep:ratatui", "dep:crossterm"]
+intercept = [
+  "dep:hudsucker",
+  "dep:tokio",
+  "dep:http-body-util",
+  "dep:bytes",
+  "dep:llm_providers",
+  "dep:time",
+  "dep:hyper-http-proxy",
+  "dep:hyper-util",
+]
 mcp = ["dep:rmcp", "dep:schemars", "dep:tokio"]
 
 [lints]

--- a/crates/llmtrim-cli/src/bench/mod.rs
+++ b/crates/llmtrim-cli/src/bench/mod.rs
@@ -51,7 +51,7 @@ pub enum Scorer {
     /// chosen answer, not a letter mentioned in passing.
     ChoiceExact,
     /// Run the model's code against provided unit tests (HumanEval/MBPP). Gold is
-    /// JSON `{"test":…, "entry_point":…}`; scored in [`exec`] (needs a subprocess).
+    /// JSON `{"test":…, "entry_point":…}`; scored by `pass_at_one` (needs a subprocess).
     PassAtOne,
     /// Compare the emitted tool call (name + args) against gold JSON (agent corpora).
     ToolCallMatch,

--- a/crates/llmtrim-cli/src/breakdown/db.rs
+++ b/crates/llmtrim-cli/src/breakdown/db.rs
@@ -79,7 +79,7 @@ pub struct BreakdownDb {
 }
 
 impl BreakdownDb {
-    /// Open the ledger for reading. Goes through [`Tracker`], which creates the file if
+    /// Open the ledger for reading. Goes through `Tracker`, which creates the file if
     /// absent (fresh install, before any proxy run — the TUI then just shows no sessions),
     /// runs the schema migration, and sets WAL + a busy timeout. WAL lets this reader run
     /// alongside the daemon's writer without blocking it; opening read-write (we only ever

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -957,7 +957,7 @@ fn cache_multipliers(provider: &str) -> (f64, f64) {
     }
 }
 
-/// USD cost figures priced per model via [`llm_prices`], `None` when no recorded model
+/// USD cost figures priced per model via `llm_prices`, `None` when no recorded model
 /// is priced.
 ///
 /// - `saved`/`spend` value tokens at **list input rates** (tokens cut × input price; the

--- a/crates/llmtrim-cli/src/tracking.rs
+++ b/crates/llmtrim-cli/src/tracking.rs
@@ -277,7 +277,7 @@ impl Tracker {
         Self::open_reader_at(&path)
     }
 
-    /// [`open_reader`] at an explicit path.
+    /// `open_reader` at an explicit path.
     #[cfg(any(test, feature = "breakdown"))]
     pub fn open_reader_at(path: &Path) -> Result<Self> {
         if let Some(parent) = path.parent() {
@@ -740,7 +740,7 @@ impl Tracker {
         self.by_model_where("")
     }
 
-    /// [`by_model`] restricted to rows recorded today (UTC) — prices the dashboard's
+    /// [`Self::by_model`] restricted to rows recorded today (UTC) — prices the dashboard's
     /// "today" figure. Same day bucketing as `by_period(Day)`: `ts` is rfc3339 UTC, so its
     /// first 10 chars are the UTC date.
     pub fn by_model_today(&self) -> Result<Vec<ModelRow>> {
@@ -751,7 +751,7 @@ impl Tracker {
         self.by_model_where("WHERE ts >= date('now') || 'T00:00:00+00:00'")
     }
 
-    /// Shared query for [`by_model`]/[`by_model_today`]. `where_clause` is a static SQL
+    /// Shared query for [`Self::by_model`]/[`by_model_today`]. `where_clause` is a static SQL
     /// fragment chosen by the callers above, never user input.
     fn by_model_where(&self, where_clause: &str) -> Result<Vec<ModelRow>> {
         let mut stmt = self

--- a/crates/llmtrim-core/Cargo.toml
+++ b/crates/llmtrim-core/Cargo.toml
@@ -36,7 +36,10 @@ csv.workspace = true
 gaoya = "0.2.0"
 # Optional: image decoders (png/jpeg) for Stage H downscaling. Behind the default-on
 # `multimodal` feature so text-only / size-constrained builds (wasm) can drop them.
-image = { version = "0.25.10", default-features = false, features = ["png", "jpeg"], optional = true }
+image = { version = "0.25.10", default-features = false, features = [
+  "png",
+  "jpeg",
+], optional = true }
 once_cell.workspace = true
 regex.workspace = true
 serde.workspace = true
@@ -89,21 +92,21 @@ multimodal = ["dep:image"]
 tiktoken = ["dep:tiktoken-rs"]
 # Stage C tree-sitter code skeletonization. Drop it for targets with no C toolchain.
 skeleton = [
-    "dep:tree-sitter",
-    "dep:tree-sitter-javascript",
-    "dep:tree-sitter-rust",
-    "dep:tree-sitter-typescript",
-    "dep:tree-sitter-python",
-    "dep:tree-sitter-go",
-    "dep:tree-sitter-java",
-    "dep:tree-sitter-c",
-    "dep:tree-sitter-cpp",
-    "dep:tree-sitter-c-sharp",
-    "dep:tree-sitter-kotlin-ng",
-    "dep:tree-sitter-swift",
-    "dep:tree-sitter-zig",
-    "dep:tree-sitter-ruby",
-    "dep:tree-sitter-php",
+  "dep:tree-sitter",
+  "dep:tree-sitter-javascript",
+  "dep:tree-sitter-rust",
+  "dep:tree-sitter-typescript",
+  "dep:tree-sitter-python",
+  "dep:tree-sitter-go",
+  "dep:tree-sitter-java",
+  "dep:tree-sitter-c",
+  "dep:tree-sitter-cpp",
+  "dep:tree-sitter-c-sharp",
+  "dep:tree-sitter-kotlin-ng",
+  "dep:tree-sitter-swift",
+  "dep:tree-sitter-zig",
+  "dep:tree-sitter-ruby",
+  "dep:tree-sitter-php",
 ]
 
 [lints]

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -537,7 +537,7 @@ impl RuntimeConfig {
     /// Process-wide instance, loaded once from env + the config file on first use. Env vars
     /// don't change mid-process, so caching is safe and keeps per-request paths (the capture
     /// cap) off the filesystem. Because it is cached for the process lifetime, **tests must use
-    /// [`resolve`](Self::resolve), never `get`** — the first caller fixes the value for the
+    /// `resolve`, never `get`** — the first caller fixes the value for the
     /// whole test binary, so `get` can't observe a per-test environment.
     pub fn get() -> &'static RuntimeConfig {
         static CACHE: std::sync::OnceLock<RuntimeConfig> = std::sync::OnceLock::new();

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -239,7 +239,7 @@ pub fn compress(input: &str, provider: Option<ProviderKind>) -> Result<CompressR
     compress_with_config(input, provider, &config)
 }
 
-/// Compress with an explicit [`DenseConfig`] (no environment access — the
+/// Compress with an explicit [`config::DenseConfig`] (no environment access — the
 /// deterministic core used by tests and embedders).
 ///
 /// The request is parsed into the neutral [`Request`], measured with the real

--- a/crates/llmtrim-core/src/quality_gate.rs
+++ b/crates/llmtrim-core/src/quality_gate.rs
@@ -5,7 +5,7 @@
 //! This module supplies the missing axis — does query-relevant source content
 //! *survive* the cut — using pure n-gram arithmetic, no model, no embeddings,
 //! deterministic and language-universal (tokenization via the shared Unicode
-//! [`lex_words`]).
+//! `lex_words`).
 //!
 //! Two measures, after Grusky, Naaman & Artzi, "Newsroom" (NAACL 2018):
 //!
@@ -30,7 +30,7 @@
 //! answer-bearing content with probability ≥ `1 − alpha`
 //! (arXiv:2509.20461, "Document Summarization with Conformal Importance Guarantees").
 //! To re-run against a real corpus: load recall cases (e.g. LongBench / ZeroSCROLLS
-//! via [`crate::quality::load_corpus`]), compress each with the target preset,
+//! via `load_corpus`), compress each with the target preset,
 //! compute `coverage(source, compressed, query_terms)` per case alongside the known
 //! `recall(must_keep)`, then call `calibrate_threshold(&scored, 0.9, 0.1)` and paste
 //! the returned value here. The shipped value is calibrated on the synthetic fixture
@@ -93,7 +93,7 @@ pub fn context_text(req: &Request, provider: &dyn Provider) -> String {
 /// exists to do. The gate fires only when we actually know what the question is.
 ///
 /// Wire-shape agnostic (provider role/turn seam), language-universal (tokenized by
-/// [`lex_words`]).
+/// `lex_words`).
 pub fn query_terms(req: &Request, provider: &dyn Provider) -> Vec<String> {
     let q_turn = question_turn(req, provider);
     let mut text = String::new();
@@ -141,7 +141,7 @@ pub const COVERAGE_THRESHOLD: f64 = 0.5;
 /// query-agnostic proxy for "how much of the source structure survived".
 ///
 /// Deterministic and language-universal: tokenization is the shared Unicode
-/// [`lex_words`] (works on CJK / Cyrillic / Arabic …, not an ASCII split).
+/// `lex_words` (works on CJK / Cyrillic / Arabic …, not an ASCII split).
 ///
 /// Degenerate inputs: empty source ⇒ `1.0` (nothing to lose); non-empty source with
 /// empty compressed ⇒ `0.0` (everything lost).

--- a/crates/llmtrim-core/src/select.rs
+++ b/crates/llmtrim-core/src/select.rs
@@ -40,7 +40,7 @@
 //!
 //! Coverage is tracked as a `bigram → covered-weight` map (`O(n · avg_bigrams)` memory),
 //! never an `n×n` similarity matrix — the marginal of one item touches only *its own*
-//! bigrams. Tokenization is the crate's shared Unicode word splitter ([`lex_words`],
+//! bigrams. Tokenization is the crate's shared Unicode word splitter (`lex_words`,
 //! UAX#29), so it is script-universal, not English-only.
 
 use std::collections::HashMap;

--- a/crates/llmtrim-core/src/stages/ngram.rs
+++ b/crates/llmtrim-core/src/stages/ngram.rs
@@ -16,7 +16,7 @@
 //! no-ops on scripts without inter-word spaces (CJK, Thai) — a word-level glossary
 //! doesn't apply there, so that content is left verbatim rather than mis-abbreviated.
 //!
-//! Mining (see [`crate::stages::ngram_sa`]): the repeated phrases are the *maximal
+//! Mining (see `crate::stages::ngram_sa`): the repeated phrases are the *maximal
 //! repeats* of the word sequence, enumerated from a suffix array + LCP array in
 //! O(n log n) ("Efficient Repeat Finding via Suffix Arrays", arXiv:1304.0528), then
 //! chosen greedily by their real token gain with overlap accounting — the Re-Pair idea

--- a/crates/llmtrim-core/src/stages/toolout/mod.rs
+++ b/crates/llmtrim-core/src/stages/toolout/mod.rs
@@ -15,23 +15,23 @@
 //! The shape detectors contribute only structure *hints* (what a file field is, which
 //! tokens are failure levels, where hunks begin); none of them owns a drop policy. The
 //! drop policy is one shared recipe — fold losslessly first, ship that if it fits, else
-//! window under an adaptive budget ([`crate::stages::sizing`]) with dropped runs
+//! window under an adaptive budget (`crate::stages::sizing`) with dropped runs
 //! becoming positional elision markers (`[… N lines omitted …]`, like the `retrieve`
 //! stage) — plus three universal rails that apply to every windowed segment, current
 //! and future kinds alike:
 //!
-//! 1. **Attribution** ([`rebuild`]): windowed output opens with a self-identifying
+//! 1. **Attribution** (`rebuild`): windowed output opens with a self-identifying
 //!    header naming llmtrim and the recovery action, so an agent never misattributes
 //!    the elision to the tool (or to whatever wrapper ran it).
 //! 2. **Repeat → passthrough** ([`ToolOutputStage::apply`]): when a candidate's content
 //!    already appears earlier in the request — the agent re-ran the tool to get the
 //!    dropped detail back — the newest occurrence ships in full. Equality is on a
-//!    volatile-value-masked fingerprint ([`template::fingerprint`]), since re-runs are
+//!    volatile-value-masked fingerprint (`template::fingerprint`), since re-runs are
 //!    rarely byte-identical (timings, timestamps, PIDs). This is what makes the
 //!    header's "re-run the tool" promise true: compression is deterministic, so
 //!    without this rail a retry would be windowed identically and the agent would
 //!    conclude the tool itself is broken.
-//! 3. **Never inflate** ([`elide_into`]): an elision marker is emitted only when it is
+//! 3. **Never inflate** (`elide_into`): an elision marker is emitted only when it is
 //!    shorter than the lines it hides; a lone `--` separator survives as itself.
 //!
 //! Lossy, `InputTokens`-gated (reverts if it doesn't cut tokens), `Content`-scoped.
@@ -41,7 +41,7 @@
 //! *machine-emitted* by runtimes and build tools (`ERROR`, `FATAL`, `Traceback`,
 //! `panicked`), not human prose, so a fixed set is appropriate. Locale-specific terms
 //! from the user's request are handled by the query-overlap bonus, which is
-//! Unicode-segmented via [`lex_words`].
+//! Unicode-segmented via `lex_words`.
 
 mod detect;
 mod diff;
@@ -205,7 +205,7 @@ impl Transform for ToolOutputStage {
         // earlier content pointer is a re-invocation returning the same output — the
         // agent asking for the windowed detail back (the elision header tells it to).
         // Ship the newest occurrence in full. Equality is on the volatile-value-masked
-        // [`template::fingerprint`], not raw text: most re-runs are *not* byte-identical
+        // `template::fingerprint`, not raw text: most re-runs are *not* byte-identical
         // (test timings like TAP's `duration_ms`, log timestamps, ports, PIDs), and raw
         // equality would re-window exactly the retry the header promised would work.
         // Masking is provider-neutral and language-free; a masked false match merely

--- a/crates/llmtrim-core/src/tokenizer.rs
+++ b/crates/llmtrim-core/src/tokenizer.rs
@@ -121,7 +121,7 @@ fn estimate_tokens(text: &str) -> usize {
 }
 
 /// Token counter for providers without a public tokenizer (Anthropic, Google): the cheap
-/// [`estimate_tokens`] heuristic, flagged approximate.
+/// `estimate_tokens` heuristic, flagged approximate.
 pub struct ApproxCounter {
     label: &'static str,
 }

--- a/crates/llmtrim-uniffi/pyproject.toml
+++ b/crates/llmtrim-uniffi/pyproject.toml
@@ -10,10 +10,10 @@ requires-python = ">=3.9"
 license = { text = "MPL-2.0" }
 keywords = ["llm", "tokens", "compression", "openai", "anthropic"]
 classifiers = [
-    "Programming Language :: Rust",
-    "Programming Language :: Python :: 3",
-    "Topic :: Text Processing",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: 3",
+  "Topic :: Text Processing",
+  "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
 ]
 dynamic = ["version"]
 

--- a/crates/llmtrim-uniffi/scripts/build-xcframework.sh
+++ b/crates/llmtrim-uniffi/scripts/build-xcframework.sh
@@ -37,23 +37,41 @@ cp "$gen/llmtrim_ffi.swift" "$pkg_dir/Sources/Llmtrim/llmtrim_ffi.swift"
 echo "==> building static libs per Apple target"
 # Note: x86_64 iOS is only ever the simulator, so its target is `x86_64-apple-ios` (no
 # `-sim` suffix — that exists only for aarch64, to split arm64 device vs arm64 sim).
-targets="aarch64-apple-darwin x86_64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios"
+#
+# XCFRAMEWORK_FAST=1 builds only the slices a host `swift test` actually links against
+# (Apple-silicon macOS + iOS-sim arm64), skipping the x86_64 and iOS-device cross-compiles.
+# CI PR runs set it to cut wall-clock; the release build leaves it unset for the full
+# universal/device xcframework.
+if [ "${XCFRAMEWORK_FAST:-0}" = "1" ]; then
+    # The host `swift test` runs on Apple-silicon macOS and links only the macOS arm64
+    # slice, so build just that one target — the iOS/sim slices are never exercised here.
+    echo "    (fast mode: Apple-silicon macOS only)"
+    targets="aarch64-apple-darwin"
+else
+    targets="aarch64-apple-darwin x86_64-apple-darwin aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios"
+fi
 for t in $targets; do
     rustup target add "$t" >/dev/null 2>&1 || true
     cargo build --release -p llmtrim-uniffi --target "$t"
 done
 
 lib() { echo "target/$1/release/libllmtrim_ffi.a"; }
-mkdir -p "$work/macos" "$work/ios" "$work/iossim"
-lipo -create "$(lib aarch64-apple-darwin)" "$(lib x86_64-apple-darwin)" -output "$work/macos/libllmtrim_ffi.a"
-cp "$(lib aarch64-apple-ios)" "$work/ios/libllmtrim_ffi.a"
-lipo -create "$(lib aarch64-apple-ios-sim)" "$(lib x86_64-apple-ios)" -output "$work/iossim/libllmtrim_ffi.a"
+mkdir -p "$work/macos"
+xcargs=()
+if [ "${XCFRAMEWORK_FAST:-0}" = "1" ]; then
+    cp "$(lib aarch64-apple-darwin)" "$work/macos/libllmtrim_ffi.a"
+    xcargs+=(-library "$work/macos/libllmtrim_ffi.a" -headers "$hdrs")
+else
+    mkdir -p "$work/ios" "$work/iossim"
+    lipo -create "$(lib aarch64-apple-darwin)" "$(lib x86_64-apple-darwin)" -output "$work/macos/libllmtrim_ffi.a"
+    cp "$(lib aarch64-apple-ios)" "$work/ios/libllmtrim_ffi.a"
+    lipo -create "$(lib aarch64-apple-ios-sim)" "$(lib x86_64-apple-ios)" -output "$work/iossim/libllmtrim_ffi.a"
+    xcargs+=(-library "$work/macos/libllmtrim_ffi.a" -headers "$hdrs")
+    xcargs+=(-library "$work/ios/libllmtrim_ffi.a" -headers "$hdrs")
+    xcargs+=(-library "$work/iossim/libllmtrim_ffi.a" -headers "$hdrs")
+fi
 
 echo "==> assembling llmtrimFFI.xcframework"
 rm -rf "$pkg_dir/llmtrimFFI.xcframework"
-xcodebuild -create-xcframework \
-    -library "$work/macos/libllmtrim_ffi.a"  -headers "$hdrs" \
-    -library "$work/ios/libllmtrim_ffi.a"     -headers "$hdrs" \
-    -library "$work/iossim/libllmtrim_ffi.a"  -headers "$hdrs" \
-    -output "$pkg_dir/llmtrimFFI.xcframework"
+xcodebuild -create-xcframework "${xcargs[@]}" -output "$pkg_dir/llmtrimFFI.xcframework"
 echo "==> done: $pkg_dir/llmtrimFFI.xcframework"

--- a/deny.toml
+++ b/deny.toml
@@ -16,22 +16,22 @@ all-features = true
 # confidence-threshold: how sure the SPDX scanner must be (0.8 = standard).
 confidence-threshold = 0.8
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
-    "Zlib",
-    "BSL-1.0",          # Boost — permissive
-    "0BSD",
-    "CC0-1.0",          # public-domain dedication
-    "MIT-0",
-    "Unicode-3.0",      # unicode-ident data
-    "Unlicense",
-    "CDLA-Permissive-2.0", # webpki-roots cert data
-    "MPL-2.0",          # weak copyleft (file-level) — our own crates + transitive deps
-    "OpenSSL",          # ring/aws-lc transitive, permissive
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Zlib",
+  "BSL-1.0", # Boost — permissive
+  "0BSD",
+  "CC0-1.0", # public-domain dedication
+  "MIT-0",
+  "Unicode-3.0", # unicode-ident data
+  "Unlicense",
+  "CDLA-Permissive-2.0", # webpki-roots cert data
+  "MPL-2.0", # weak copyleft (file-level) — our own crates + transitive deps
+  "OpenSSL", # ring/aws-lc transitive, permissive
 ]
 # fuchsia-cprng (transitive via gaoya→random_choice→rand, fuchsia-target only) has no
 # `license` field in its manifest — only a BSD-3-Clause LICENSE file. Clarify keeps the

--- a/release.toml
+++ b/release.toml
@@ -18,8 +18,8 @@ consolidate-commits = true
 # directory (crates/<name>/), so the path is workspace-root-relative; the script itself
 # is cwd-agnostic (git/gh resolve the repo from any subdir).
 pre-release-hook = ["sh", "../../tools/check_ci_green.sh"]
-publish = false      # crates.io publish happens in release.yml via Trusted Publishing
-verify = false       # CI is the verifier; keep the release command fast
+publish = false # crates.io publish happens in release.yml via Trusted Publishing
+verify = false # CI is the verifier; keep the release command fast
 push = true
 tag-name = "v{{version}}"
 pre-release-commit-message = "release: v{{version}}"

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,11 @@
+# taplo (TOML) formatter config. The CI `toml` job runs `taplo fmt --check` against this.
+# Conservative options: keep key/array order and avoid column alignment so the heavily
+# commented Cargo.toml lints/feature blocks aren't churned into a different shape.
+exclude = [".claude/**", "target/**", "**/worktrees/**", "**/node_modules/**"]
+
+[formatting]
+reorder_keys = false
+reorder_arrays = false
+align_entries = false
+align_comments = false
+column_width = 100


### PR DESCRIPTION
## What

Two related strands of work on this branch.

### Adapter contract (pre-existing commits)
- `rewrite_request` adapter entrypoint plus a cross-binding conformance suite (`tests/conformance/`) that pins fixture output so a core change cannot silently alter what an adapter forwards.
- Config defaults to `auto` (shape-routing) and adds a `lossless()` baseline.

### CI quality gates and tooling
- Tests run under cargo-nextest (`--profile ci`, retries + JUnit annotations) with a separate `cargo test --doc` step, since nextest skips doctests.
- Five new gates, all added to branch protection: coverage (cargo-llvm-cov to Codecov), docs (`cargo doc -D warnings`), semver (cargo-semver-checks on both published crates), machete (unused deps), and taplo TOML format.
- Perf: incremental compilation off in CI, shallow clones where history is not needed, and per-job rust-cache keys so the instrumented coverage build stops evicting the test cache.
- Fixed a latent bug where a committed `rust-toolchain.toml` made the MSRV job silently compile against stable instead of 1.88.
- Dropped five dependencies from `llmtrim-cli` that were unused there, fixed broken intra-doc links, and normalized the manifests with taplo.

## Verification
- 688 tests pass under nextest; builds green across the intercept/live/no-default feature sets.
- `cargo doc -D warnings`, `cargo machete`, and `taplo fmt --check` all clean locally.
- Three independent reviews ran over the CI/deps/docs changes; every actionable finding is fixed.

## Note for review
The `Coverage` job uploads to Codecov and wants a `CODECOV_TOKEN` secret (falls back to tokenless otherwise).