### PR TITLE
docs(ci): correct xcframework fast-mode comments to macOS-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,10 +345,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: swift-package
-      # XCFRAMEWORK_FAST builds only the Apple-silicon macOS + iOS-sim arm64 slices — the
-      # ones a host `swift test` actually links against — skipping the x86_64 and iOS-device
-      # cross-compiles. The SwiftPM build+test validation below is unchanged: it links and
-      # runs the real test target against a valid (if reduced) xcframework. The full
+      # XCFRAMEWORK_FAST builds only the Apple-silicon macOS slice — the one a host
+      # `swift test` on the arm64 runner actually links against — skipping the x86_64 and
+      # iOS cross-compiles. The SwiftPM build+test validation below is unchanged: it links
+      # and runs the real test target against a valid (if reduced) xcframework. The full
       # universal/device xcframework is built unconditionally by release-bindings.yml on tags.
       - name: Build the XCFramework
         env:

--- a/crates/llmtrim-uniffi/scripts/build-xcframework.sh
+++ b/crates/llmtrim-uniffi/scripts/build-xcframework.sh
@@ -38,8 +38,8 @@ echo "==> building static libs per Apple target"
 # Note: x86_64 iOS is only ever the simulator, so its target is `x86_64-apple-ios` (no
 # `-sim` suffix — that exists only for aarch64, to split arm64 device vs arm64 sim).
 #
-# XCFRAMEWORK_FAST=1 builds only the slices a host `swift test` actually links against
-# (Apple-silicon macOS + iOS-sim arm64), skipping the x86_64 and iOS-device cross-compiles.
+# XCFRAMEWORK_FAST=1 builds only the slice a host `swift test` actually links against
+# (Apple-silicon macOS), skipping the x86_64 and iOS cross-compiles.
 # CI PR runs set it to cut wall-clock; the release build leaves it unset for the full
 # universal/device xcframework.
 if [ "${XCFRAMEWORK_FAST:-0}" = "1" ]; then


### PR DESCRIPTION
Two comments still described the earlier two-slice ("macOS + iOS-sim") fast-mode
xcframework build, but the script was reduced to a single Apple-silicon macOS slice.
This updates the comment in `ci.yml` and the script header to match.

Comments only, no behavior change. Follow-up to #90.