### PR TITLE
fix(update): restart the daemon after a binary-channel install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **`update` now restarts the daemon itself instead of leaving it stale.** On the binary
+  channel (the installer path), `llmtrim update` laid down the new binary but left the running
+  daemon on the old build, so `status` still showed a `u  Update` nudge and you had to restart
+  by hand. It now runs `llmtrim start --force` after a successful install, finishing the job in
+  one command.
+
 ## [0.3.1] - 2026-06-21
 
 ### Fixed

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -2092,16 +2092,12 @@ fn run_monitor(
                 }
                 PostAction::Update => llmtrim::update::run()?,
                 PostAction::Restart => {
-                    // Stale daemon: restart it onto the freshly-installed binary. `start --force`
-                    // is the documented "pick up a new binary after an update" path.
-                    let exe = std::env::current_exe().context("locate llmtrim binary")?;
-                    let status = std::process::Command::new(exe)
-                        .args(["start", "--force"])
-                        .status()
-                        .context("run llmtrim start --force")?;
+                    // Stale daemon: restart it onto the freshly-installed binary via the shared
+                    // helper (`start --force`, the documented "pick up a new binary" path).
                     // Surface a failed restart (port held, permission, ...) instead of exiting 0.
-                    if !status.success() {
-                        std::process::exit(status.code().unwrap_or(1));
+                    if let Err(e) = llmtrim::update::restart_daemon(ui::color_stdout()) {
+                        eprintln!("{e:#}");
+                        std::process::exit(1);
                     }
                 }
                 PostAction::None => {}

--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -182,7 +182,7 @@ pub fn run() -> Result<()> {
             "update via cargo",
             &[
                 "cargo install --locked llmtrim --force",
-                "llmtrim setup    # restart the daemon on the new binary",
+                "llmtrim start --force    # restart the daemon on the new binary",
             ],
         ),
         Channel::Homebrew => instructions(
@@ -190,14 +190,14 @@ pub fn run() -> Result<()> {
             &[
                 "brew tap fkiene/tap",
                 "brew upgrade fkiene/tap/llmtrim",
-                "llmtrim setup    # restart the daemon on the new binary",
+                "llmtrim start --force    # restart the daemon on the new binary",
             ],
         ),
         Channel::Npm => instructions(
             "update via npm",
             &[
                 "npm install -g @llmtrim/cli@latest",
-                "llmtrim setup    # restart the daemon on the new binary",
+                "llmtrim start --force    # restart the daemon on the new binary",
             ],
         ),
         Channel::Binary => {
@@ -213,7 +213,7 @@ pub fn run() -> Result<()> {
                         "iwr -useb https://raw.githubusercontent.com/{}/{tag}/install.ps1 | iex",
                         repo()
                     ),
-                    "llmtrim setup    # restart the daemon on the new binary",
+                    "llmtrim start --force    # restart the daemon on the new binary",
                 ],
             );
             #[cfg(not(windows))]
@@ -223,7 +223,7 @@ pub fn run() -> Result<()> {
                     repo()
                 );
                 println!(
-                    "Updating via the installer (downloads the latest release; `setup` restarts the daemon)…"
+                    "Updating via the installer (downloads the latest release, then restarts the daemon)…"
                 );
                 let mut cmd = std::process::Command::new("sh");
                 cmd.args(["-c", &format!("curl -fsSL {url} | sh")]);
@@ -241,8 +241,46 @@ pub fn run() -> Result<()> {
                 if let Some(v) = latest {
                     write_cache(&v); // clear the `monitor` banner
                 }
+                // The installer laid down the new binary, but the running daemon is still on
+                // the old one (Stale). Finish the job here so `update` leaves nothing behind —
+                // otherwise `status` would show a `u  Update` nudge for a restart the user must
+                // do by hand. Same path as the TUI's `u` (PostAction::Restart).
+                restart_daemon(color)?;
             }
         }
+    }
+    Ok(())
+}
+
+/// Restart the daemon onto the freshly-installed binary via `start --force` (the documented
+/// "pick up a new binary after an update" path). Shared by the binary channel here (which runs
+/// the installer) and the TUI's `PostAction::Restart` in `main.rs`, so the restart lives in one
+/// place. On failure it bails with an actionable message rather than leaving the user guessing.
+pub fn restart_daemon(color: bool) -> Result<()> {
+    // The installer replaces the binary on disk; on Linux `current_exe()` can then resolve to a
+    // `…/llmtrim (deleted)` ghost path. Fall back to `llmtrim` on PATH when the resolved path no
+    // longer exists, so the restart still lands on the freshly-installed binary.
+    let exe = std::env::current_exe()
+        .ok()
+        .filter(|p| p.exists())
+        .unwrap_or_else(|| std::path::PathBuf::from("llmtrim"));
+    println!(
+        "\n{}",
+        crate::ui::paint(
+            color,
+            crate::ui::Tone::Dim,
+            "Restarting the daemon on the new binary…"
+        )
+    );
+    let status = std::process::Command::new(exe)
+        .args(["start", "--force"])
+        .status()
+        .context("run llmtrim start --force")?;
+    if !status.success() {
+        anyhow::bail!(
+            "daemon restart failed (llmtrim start --force exited non-zero). \
+             Restart it yourself with: llmtrim start --force"
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
## Problem

`llmtrim update` on the binary/installer channel installed the new binary but never restarted the running daemon, leaving it `Stale`. After updating, `status` still showed the `u  Update` nudge and the user had to restart by hand (via `setup` or the TUI's `u`). The command was only doing half its job.

## Fix

`update` now restarts the daemon itself with `llmtrim start --force` after a successful install, so it leaves nothing behind. The restart logic moves into a shared `update::restart_daemon` helper that both this path and the TUI's `PostAction::Restart` call, replacing two copies that had already drifted (`bail!` vs `process::exit`).

Hardening in the shared helper:
- Falls back to `llmtrim` on PATH when `current_exe()` resolves to a `…(deleted)` ghost path (Linux, after a rename-replace install), so the restart lands on the freshly-installed binary.
- On a failed restart, bails with an actionable message (run `llmtrim start --force`), surfaced by the TUI caller too.

Package-manager channels (cargo/Homebrew/npm), which only print instructions since `update` can't install for them, now suggest `llmtrim start --force` uniformly rather than the heavier `setup`.

## Verification

- `cargo fmt` + `cargo clippy --features intercept`: clean
- `cargo nextest run --features intercept`: 729 passed, 1 skipped
- Reviewed by 3 agents (correctness, simplicity/DRY, conventions); all findings addressed.

`restart_daemon` is a real-IO entrypoint (spawns a subprocess), exempt from the coverage gate per CLAUDE.md.