### PR TITLE
ci: add codecov.yml so the project-coverage gate can block PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+# Coverage gating policy.
+#
+# `project` is the blocking gate: overall coverage must not regress (a small
+# threshold absorbs rounding noise). `patch` is informational only, never a
+# blocker, because real-IO entrypoints (installer and daemon spawns, stdio run
+# loops, real-ledger open arms) are legitimately uncovered, and a hard per-diff
+# gate would block PRs that add them.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Why

The repo has no `codecov.yml`, so Codecov only posts `codecov/patch` (per-diff) and never `codecov/project`. `codecov/patch` fails on any PR that adds real-IO entrypoints (installer/daemon spawns, stdio run loops) — lines that are legitimately uncovered — so it's the wrong status to block on.

## What

Configure the two statuses to match the project's policy:
- **`project`**: blocking gate, `target: auto` with a `1%` threshold (overall coverage must not regress; the threshold absorbs rounding noise).
- **`patch`**: `informational: true` — reports but never blocks.

Validated against `https://codecov.io/validate` (Valid!).

## Follow-up (manual, after merge)

Once this lands and Codecov starts posting `codecov/project` on PRs, add that context to the `main` branch-protection required checks:

```
gh api -X POST repos/fkiene/llmtrim/branches/main/protection/required_status_checks/contexts -f 'contexts[]=codecov/project'
```

(The `Coverage` workspace job is already a required check; this adds the Codecov project-delta gate alongside it. `codecov/patch` is intentionally left non-required.)