### PR TITLE
feat(mcp): register llmtrim in the official MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -15,6 +15,10 @@ on:
         description: "Version to publish (without leading v), e.g. 0.3.1"
         required: true
 
+env:
+  MCP_PUBLISHER_VERSION: v1.7.9
+  MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -23,39 +27,53 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
-      - name: Resolve version
+      - name: Resolve and validate version
         id: ver
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            v="${{ github.event.inputs.version }}"
+            v="$INPUT_VERSION"
           else
-            v="${GITHUB_REF_NAME#v}"
+            v="${REF_NAME#v}"
+          fi
+          # Reject anything that is not a plain semver, so the value is safe
+          # to use in later steps and as a registry version.
+          if ! printf '%s' "$v" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+            echo "invalid version: '$v'" >&2; exit 1
           fi
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
       - name: Wait for @llmtrim/cli on npm
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          v="${{ steps.ver.outputs.version }}"
           for i in $(seq 1 20); do
-            if npm view "@llmtrim/cli@$v" version >/dev/null 2>&1; then
-              echo "@llmtrim/cli@$v is on npm"; exit 0
+            if npm view "@llmtrim/cli@${VERSION}" version >/dev/null 2>&1; then
+              echo "@llmtrim/cli@${VERSION} is on npm"; exit 0
             fi
-            echo "waiting for @llmtrim/cli@$v on npm ($i/20)"; sleep 30
+            echo "waiting for @llmtrim/cli@${VERSION} on npm ($i/20)"; sleep 30
           done
-          echo "timed out waiting for @llmtrim/cli@$v on npm" >&2; exit 1
+          echo "timed out waiting for @llmtrim/cli@${VERSION} on npm" >&2; exit 1
 
       - name: Sync version into server.json
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          v="${{ steps.ver.outputs.version }}"
-          jq --arg v "$v" '.version = $v | .packages[0].version = $v' server.json > server.tmp
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp
           mv server.tmp server.json
           cat server.json
 
-      - name: Install mcp-publisher
+      - name: Install mcp-publisher (pinned + checksum-verified)
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          url="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSL "$url" -o mcp-publisher.tar.gz
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          rm mcp-publisher.tar.gz
 
       - name: Authenticate to MCP Registry (OIDC)
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,64 @@
+name: Publish to MCP Registry
+
+# Registers/updates llmtrim in the official MCP Registry
+# (registry.modelcontextprotocol.io) under the io.github.fkiene namespace.
+# Runs after a GitHub Release is published, once release.yml has published
+# the matching @llmtrim/cli version to npm. Authenticates with GitHub OIDC,
+# so no stored token is needed.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (without leading v), e.g. 0.3.1"
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC, proves the io.github.fkiene namespace
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            v="${{ github.event.inputs.version }}"
+          else
+            v="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for @llmtrim/cli on npm
+        run: |
+          v="${{ steps.ver.outputs.version }}"
+          for i in $(seq 1 20); do
+            if npm view "@llmtrim/cli@$v" version >/dev/null 2>&1; then
+              echo "@llmtrim/cli@$v is on npm"; exit 0
+            fi
+            echo "waiting for @llmtrim/cli@$v on npm ($i/20)"; sleep 30
+          done
+          echo "timed out waiting for @llmtrim/cli@$v on npm" >&2; exit 1
+
+      - name: Sync version into server.json
+        run: |
+          v="${{ steps.ver.outputs.version }}"
+          jq --arg v "$v" '.version = $v | .packages[0].version = $v' server.json > server.tmp
+          mv server.tmp server.json
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **llmtrim is registered in the official MCP Registry.** A `server.json` declares the
+  `io.github.fkiene/llmtrim` server, `@llmtrim/cli` carries the `mcpName` ownership marker, and a
+  release workflow publishes to `registry.modelcontextprotocol.io` over GitHub OIDC, so MCP
+  clients can discover the server (`llmtrim_compress`, `llmtrim_compress_text`, `llmtrim_stats`).
+
 ### Fixed
 - **`update` now restarts the daemon itself instead of leaving it stale.** On the binary
   channel (the installer path), `llmtrim update` laid down the new binary but left the running

--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.fkiene/llmtrim",
   "description": "MCP server and proxy that compresses LLM prompts, tool output, and replies to cut token cost.",
   "title": "llmtrim",
@@ -8,13 +8,13 @@
     "url": "https://github.com/fkiene/llmtrim",
     "source": "github"
   },
-  "version": "0.3.1",
+  "version": "0.0.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@llmtrim/cli",
-      "version": "0.3.1",
+      "version": "0.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.fkiene/llmtrim",
+  "description": "MCP server and proxy that compresses LLM prompts, tool output, and replies to cut token cost.",
+  "title": "llmtrim",
+  "websiteUrl": "https://github.com/fkiene/llmtrim",
+  "repository": {
+    "url": "https://github.com/fkiene/llmtrim",
+    "source": "github"
+  },
+  "version": "0.3.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@llmtrim/cli",
+      "version": "0.3.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/npm/build_npm_packages.sh
+++ b/tools/npm/build_npm_packages.sh
@@ -85,10 +85,11 @@ cat > "$META/package.json" <<EOF
   "name": "@llmtrim/cli",
   "version": "$VERSION",
   "description": "Cut your LLM bill: drop-in proxy that compresses input, output, and cache. Any provider, answers unchanged.",
+  "mcpName": "io.github.fkiene/llmtrim",
   "repository": "$REPO",
   "homepage": "$REPO#readme",
   "license": "MPL-2.0",
-  "keywords": ["llm", "tokens", "compression", "proxy", "openai", "anthropic", "claude"],
+  "keywords": ["llm", "tokens", "compression", "proxy", "mcp", "openai", "anthropic", "claude"],
   "bin": { "llmtrim": "bin/llmtrim.js" },
   "files": ["bin", "README.md"],
   "optionalDependencies": {


### PR DESCRIPTION
Registers llmtrim in the official MCP Registry (registry.modelcontextprotocol.io) under `io.github.fkiene/llmtrim`.

## What this adds
- **`server.json`** — declares the stdio MCP server, run via the `@llmtrim/cli` npm package with the `mcp` subcommand (`llmtrim_compress`, `llmtrim_compress_text`, `llmtrim_stats`).
- **`mcpName` marker** in the generated `@llmtrim/cli` package.json — the registry verifies package ownership; for npm this is the `mcpName` field, which must equal the server name. Also adds the `mcp` keyword.
- **`publish-mcp-registry.yml`** — on release, waits for the matching `@llmtrim/cli` version on npm, syncs the version into `server.json`, and publishes via GitHub OIDC (no stored token).

## Sequencing
The registry publish only succeeds once a release ships `@llmtrim/cli` carrying the `mcpName` marker. So: merge this, then the next release republishes the package with the marker and the workflow publishes to the registry automatically. `server.json` validates against the 2025-09-29 schema.