### PR TITLE
chore(crates): improve crates.io / lib.rs discoverability

### DIFF
--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 license.workspace = true
 readme = "README.md"
-keywords = ["llm", "tokens", "mcp", "compression", "openai"]
+keywords = ["llm", "mcp", "compression", "openai", "anthropic"]
 categories = ["command-line-utilities", "development-tools", "compression"]
 # Keep the published crate lean — benchmark corpora, CI config and editor rules aren't
 # needed to build or use llmtrim. bench/pricing.json is re-included: main.rs embeds it

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 license.workspace = true
 readme = "README.md"
-keywords = ["llm", "tokens", "compression", "openai", "anthropic"]
+keywords = ["llm", "tokens", "mcp", "compression", "openai"]
 categories = ["command-line-utilities", "development-tools", "compression"]
 # Keep the published crate lean — benchmark corpora, CI config and editor rules aren't
 # needed to build or use llmtrim. bench/pricing.json is re-included: main.rs embeds it

--- a/crates/llmtrim-core/Cargo.toml
+++ b/crates/llmtrim-core/Cargo.toml
@@ -8,8 +8,8 @@ repository.workspace = true
 homepage.workspace = true
 license.workspace = true
 readme = "README.md"
-keywords = ["llm", "tokens", "compression", "openai", "anthropic"]
-categories = ["compression", "text-processing", "api-bindings"]
+keywords = ["llm", "tokens", "mcp", "compression", "openai"]
+categories = ["compression", "text-processing", "api-bindings", "development-tools"]
 
 # Workspace CHANGELOG stamping (run once, on this crate). cargo-release resolves `file`
 # relative to this manifest, so `../../CHANGELOG.md` is the repo-root changelog shared by

--- a/crates/llmtrim-core/Cargo.toml
+++ b/crates/llmtrim-core/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 license.workspace = true
 readme = "README.md"
-keywords = ["llm", "tokens", "mcp", "compression", "openai"]
+keywords = ["llm", "mcp", "compression", "openai", "anthropic"]
 categories = ["compression", "text-processing", "api-bindings", "development-tools"]
 
 # Workspace CHANGELOG stamping (run once, on this crate). cargo-release resolves `file`


### PR DESCRIPTION
Improves how the crates surface on crates.io and lib.rs.

- Adds the `mcp` keyword to both `llmtrim-core` and `llmtrim` (the project now ships an MCP server).
- Adds the `development-tools` category to `llmtrim-core` (`llmtrim` already has it).

crates.io caps keywords at 5, so `anthropic` is swapped out for `mcp` (we keep `openai` as the broader provider term). No behavior change; metadata only, lands on the next `cargo publish`.