### PR TITLE
chore(glama): add glama.json maintainer manifest

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["fkiene"]
+}


### PR DESCRIPTION
Adds a `glama.json` so [Glama](https://glama.ai/mcp) can verify maintainership of llmtrim's MCP server when it indexes the repo.

- Metadata only; `maintainers: ["fkiene"]` per the Glama schema (validated).
- A `Dockerfile` already exists, which Glama uses for its server checks.

Note: full listing still needs the Glama GitHub App installed on the repo (a one-time owner action); this manifest is the in-repo half. Landing it also supports re-submitting the closed punkpeye/awesome-mcp-servers entry, whose bot requires a Glama listing.