### PR TITLE
fix(update): unbreak Test (windows-latest) clippy on main

### DIFF
--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -306,6 +306,9 @@ pub fn restart_daemon(color: bool) -> Result<()> {
 /// installer subprocess runs. For a pinned tag the version goes on the `sh` stage of the pipe
 /// (`… | LLMTRIM_VERSION=<tag> sh`), where `install.sh` reads it — same env the subprocess sets
 /// via `.env()`. The `main` channel runs unpinned.
+// Called only from the `#[cfg(not(windows))]` installer path above; on Windows it is used
+// solely by unit tests, so allow it to be unused in the non-test build there.
+#[cfg_attr(windows, allow(dead_code))]
 fn manual_install_cmd(url: &str, tag: &str) -> String {
     if tag == "main" {
         format!("curl -fsSL {url} | sh")


### PR DESCRIPTION
Fixes a pre-existing Windows CI failure on `main` (from #93). `manual_install_cmd` is only called from the `#[cfg(not(windows))]` installer path, so on Windows it is unused in the non-test build and `clippy` (warnings=deny) fails `Test (windows-latest)`, blocking all PRs from merging.

Minimal fix: annotate the function `#[cfg_attr(windows, allow(dead_code))]`, matching the idiom already used in this file (`#[cfg_attr(windows, allow(unused_imports))]`). It remains compiled and unit-tested on every platform. No behavior change; no user-facing change (so no CHANGELOG entry).