### PR TITLE
ci(mcp): trigger registry publish on the release tag

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -2,13 +2,15 @@ name: Publish to MCP Registry
 
 # Registers/updates llmtrim in the official MCP Registry
 # (registry.modelcontextprotocol.io) under the io.github.fkiene namespace.
-# Runs after a GitHub Release is published, once release.yml has published
-# the matching @llmtrim/cli version to npm. Authenticates with GitHub OIDC,
-# so no stored token is needed.
+# Fires on the vX.Y.Z tag that release.yml pushes, waits for release.yml to
+# publish the matching @llmtrim/cli version to npm, then publishes. Uses a tag
+# trigger, not `release: published`, because a release created by the Actions
+# GITHUB_TOKEN does not trigger other workflows. Authenticates with GitHub
+# OIDC, so no stored token is needed.
 
 on:
-  release:
-    types: [published]
+  push:
+    tags: ["v*"]
   workflow_dispatch:
     inputs:
       version:
@@ -51,11 +53,13 @@ jobs:
         env:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          for i in $(seq 1 20); do
+          # release.yml builds 6 binaries then publishes @llmtrim/cli; a flaky
+          # binary leg + rerun can push that out, so wait generously (~60 min).
+          for i in $(seq 1 60); do
             if npm view "@llmtrim/cli@${VERSION}" version >/dev/null 2>&1; then
               echo "@llmtrim/cli@${VERSION} is on npm"; exit 0
             fi
-            echo "waiting for @llmtrim/cli@${VERSION} on npm ($i/20)"; sleep 30
+            echo "waiting for @llmtrim/cli@${VERSION} on npm ($i/60)"; sleep 60
           done
           echo "timed out waiting for @llmtrim/cli@${VERSION} on npm" >&2; exit 1
 


### PR DESCRIPTION
Future releases should publish to the MCP Registry automatically. They did not, because `publish-mcp-registry.yml` triggered on `release: published`, and a GitHub Release created by the Actions `GITHUB_TOKEN` (release.yml) does not trigger other workflows. v0.3.2 had to be dispatched by hand.

Changes:
- Trigger on `push: tags: ["v*"]` (release.yml pushes that tag with a real token, so it fires).
- Widen the npm wait window to ~60 min, since the 6 binary builds plus a possible flaky rerun can delay `@llmtrim/cli` publishing.
- `workflow_dispatch` is kept as a manual fallback.

The version is read from the tag (`github.ref_name`) on push and from the input on dispatch; both are semver-validated.