### PR TITLE
feat(config): exclude providers or hosts from compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **Exclude providers or hosts from compression.** Two new config keys let a request pass
+  through verbatim while still being proxied: `exclude_providers` (env
+  `LLMTRIM_EXCLUDE_PROVIDERS`) by wire shape — `openai`, `anthropic`, `google`; coarse, covers
+  every host of that shape — and `exclude_hosts` (env `LLMTRIM_EXCLUDE_HOSTS`) by exact hostname,
+  precise. Each env var is comma-separated and replaces the file array. Set
+  `exclude_providers = ["anthropic"]` (or `LLMTRIM_EXCLUDE_PROVIDERS=anthropic`) to leave Claude
+  Code traffic untouched while still compressing everything else.
+
 ### Fixed
 - **Replies now stay in the user's language.** The output-shaping instructions are written in
   English and land last in the request, which biased the model to answer in English even when

--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ These knobs are orthogonal to compression. Each resolves env-first, then from th
 | env var | config key | meaning |
 | --- | --- | --- |
 | `LLMTRIM_EXTRA_HOSTS` | `extra_hosts` | extra exact LLM-API hosts to intercept (comma-separated env / array in file), e.g. a self-hosted OpenAI-compatible endpoint |
+| `LLMTRIM_EXCLUDE_PROVIDERS` | `exclude_providers` | wire shapes to skip compressing — `openai` / `anthropic` / `google` (e.g. `anthropic` to leave Claude Code untouched); coarse, covers every host of that shape |
+| `LLMTRIM_EXCLUDE_HOSTS` | `exclude_hosts` | exact hostnames to skip compressing (e.g. `openrouter.ai`); precise, leaves other hosts of the same shape compressed |
 | `LLMTRIM_UPSTREAM_PROXY` | `upstream_proxy` | route egress through another proxy (see below) |
 | `LLMTRIM_DB_PATH` | `db_path` | ledger location |
 | `LLMTRIM_CAPTURE_DIR` | `capture_dir` | before/after QA capture directory |

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -139,6 +139,21 @@ mod imp {
             || user_hosts.iter().any(|s| host == s)
     }
 
+    /// True if a request to `host` resolving to wire shape `provider` should bypass compression
+    /// (user opt-out via `exclude_hosts` / `exclude_providers`). Excluded traffic is still
+    /// intercepted; it is just forwarded verbatim. Host match is exact (mirrors a user
+    /// `extra_hosts` entry); provider match is by canonical wire-shape name. `host` is expected
+    /// lowercased (the entries are normalized at config load).
+    fn exclusion_match(
+        host: &str,
+        provider: ProviderKind,
+        exclude_hosts: &[String],
+        exclude_providers: &[String],
+    ) -> bool {
+        exclude_hosts.iter().any(|h| host == h)
+            || exclude_providers.iter().any(|p| p == provider.as_str())
+    }
+
     /// Every name-constraint domain the CA should permit: the registry parent domains plus the
     /// curated extra hosts, sorted + deduped. The single source of truth for what we intend to
     /// intercept; compared byte-for-byte against the CA's sidecar to decide whether to regenerate.
@@ -627,6 +642,11 @@ mod imp {
         /// (`forward_post`). The primary MITM interception path honours this setting via the
         /// `ProxyConnector` built at startup (see the `start` function in this module).
         upstream_proxy: Option<String>,
+        /// User opt-out lists (`exclude_hosts` / `exclude_providers`), snapshotted from
+        /// [`RuntimeConfig`] at construction like `domains` above: a request matching either is
+        /// forwarded verbatim (still intercepted, just not compressed).
+        exclude_hosts: Arc<Vec<String>>,
+        exclude_providers: Arc<Vec<String>>,
     }
 
     impl Drop for Interceptor {
@@ -676,7 +696,9 @@ mod imp {
         /// constructing a `hudsucker::HttpContext` (which is `#[non_exhaustive]` and
         /// cannot be instantiated outside the hudsucker crate).
         async fn handle_request_inner(&mut self, req: Request<Body>) -> RequestOrResponse {
-            let host = host_of(&req);
+            // Lowercase the host once: every host comparison below (Vertex suffix, provider
+            // lookup, exclusion match) is case-insensitive.
+            let host = host_of(&req).map(|h| h.to_ascii_lowercase());
             // Vertex AI serves all three wire shapes on one host, keyed by the path; every other
             // host is host-derived. Either way the kind here is only the fallback — the body
             // shape (`provider::detect`) refines it at compress time.
@@ -691,6 +713,13 @@ mod imp {
             let Some(provider) = provider.filter(|_| req.method() == Method::POST) else {
                 return req.into();
             };
+            // User opt-out: a host/provider on the exclude list is forwarded verbatim (still
+            // MITM'd, just not compressed) — e.g. exclude Anthropic so Claude Code is untouched.
+            if let Some(h) = host.as_deref()
+                && exclusion_match(h, provider, &self.exclude_hosts, &self.exclude_providers)
+            {
+                return req.into();
+            }
             // Compress text-generation endpoints only. Embeddings / moderations / token-count
             // bodies aren't prompts (or our edits would skew the result), so forward verbatim —
             // never silently mutate the input of a `/v1/embeddings` call.
@@ -1606,6 +1635,10 @@ mod imp {
             );
         }
 
+        // User opt-out lists, resolved once at startup (env + config file) like the other runtime
+        // settings, then snapshotted onto the handler.
+        let exclusions = llmtrim_core::config::exclusions();
+
         let handler = Interceptor {
             config: Arc::new(DenseConfig::load_for_interceptor()),
             ledger: tx,
@@ -1617,6 +1650,8 @@ mod imp {
             memo: Arc::new(Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY)),
             pending: None,
             upstream_proxy: upstream_proxy.clone(),
+            exclude_providers: Arc::new(exclusions.providers.clone()),
+            exclude_hosts: Arc::new(exclusions.hosts.clone()),
         };
         // Pre-flight bind: hudsucker's `Proxy::start` collapses a bind failure to a bare
         // "io error", hiding whether the port is in use or OS-reserved. Bind once ourselves
@@ -2403,6 +2438,46 @@ mod imp {
         }
 
         #[test]
+        fn exclusion_match_by_host_and_provider() {
+            // Provider exclusion is by canonical wire-shape name (coarse): excludes every host of
+            // that shape.
+            let excl_providers = vec!["anthropic".to_string()];
+            assert!(exclusion_match(
+                "api.anthropic.com",
+                ProviderKind::Anthropic,
+                &[],
+                &excl_providers,
+            ));
+            assert!(
+                !exclusion_match("api.openai.com", ProviderKind::OpenAi, &[], &excl_providers),
+                "a different wire shape is not excluded"
+            );
+            // Host exclusion is exact — one OpenAI-shaped host opts out without affecting siblings.
+            let excl_hosts = vec!["openrouter.ai".to_string()];
+            assert!(exclusion_match(
+                "openrouter.ai",
+                ProviderKind::OpenAi,
+                &excl_hosts,
+                &[],
+            ));
+            assert!(
+                !exclusion_match("api.groq.com", ProviderKind::OpenAi, &excl_hosts, &[]),
+                "another OpenAI-shaped host stays compressed"
+            );
+            assert!(
+                !exclusion_match("api.openrouter.ai", ProviderKind::OpenAi, &excl_hosts, &[]),
+                "host match is exact, not by subdomain"
+            );
+            // Empty lists exclude nothing.
+            assert!(!exclusion_match(
+                "api.anthropic.com",
+                ProviderKind::Anthropic,
+                &[],
+                &[],
+            ));
+        }
+
+        #[test]
         fn intercept_set_does_not_widen_to_shared_cloud_parents() {
             // Security: we key on exact endpoint hosts, never the registrable parent — else the
             // name-constrained MITM CA could forge certs for, and intercept, all of Google
@@ -2622,6 +2697,8 @@ mod imp {
                 memo: Arc::new(Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY)),
                 pending: None,
                 upstream_proxy: None,
+                exclude_hosts: Arc::new(Vec::new()),
+                exclude_providers: Arc::new(Vec::new()),
             };
             (handler, rx)
         }
@@ -2859,6 +2936,59 @@ mod imp {
             );
             let out_body = drain_body(out_req.into_body()).await;
             assert_eq!(out_body, body.as_bytes());
+        }
+
+        /// A compressible request whose host/provider is on the exclude list must pass through
+        /// verbatim (still routed, just not compressed): `pending` stays None and the body is
+        /// returned byte-identical. Covers the `exclusion_match` gate in `handle_request_inner`.
+        #[tokio::test]
+        async fn handle_request_inner_excludes_matching_host_and_provider() {
+            let body = r#"{"model":"gpt-4o","messages":[{"role":"user","content":"hello world"}]}"#;
+            let uri = "https://api.openai.com/v1/chat/completions";
+
+            // Exclude by exact host.
+            let (mut handler, _rx) = make_interceptor();
+            handler.exclude_hosts = Arc::new(vec!["api.openai.com".to_string()]);
+            let result = handler.handle_request_inner(post_request(uri, body)).await;
+            let RequestOrResponse::Request(out_req) = result else {
+                panic!("expected passthrough Request, got Response");
+            };
+            assert!(handler.pending.is_none(), "excluded host must not compress");
+            assert_eq!(drain_body(out_req.into_body()).await, body.as_bytes());
+
+            // Exclude by provider wire shape (api.openai.com → OpenAi).
+            let (mut handler, _rx) = make_interceptor();
+            handler.exclude_providers = Arc::new(vec!["openai".to_string()]);
+            let result = handler.handle_request_inner(post_request(uri, body)).await;
+            let RequestOrResponse::Request(out_req) = result else {
+                panic!("expected passthrough Request, got Response");
+            };
+            assert!(
+                handler.pending.is_none(),
+                "excluded provider must not compress"
+            );
+            assert_eq!(drain_body(out_req.into_body()).await, body.as_bytes());
+        }
+
+        /// A mixed-case `Host` header still matches a (lowercased) exclude entry — the gate
+        /// lowercases the host before comparing, like `provider_for_host` does.
+        #[tokio::test]
+        async fn handle_request_inner_exclude_host_is_case_insensitive() {
+            let (mut handler, _rx) = make_interceptor();
+            handler.exclude_hosts = Arc::new(vec!["api.openai.com".to_string()]);
+            let body = r#"{"model":"gpt-4o","messages":[{"role":"user","content":"hello world"}]}"#;
+            let req = post_request("https://API.OpenAI.COM/v1/chat/completions", body);
+
+            let result = handler.handle_request_inner(req).await;
+
+            let RequestOrResponse::Request(out_req) = result else {
+                panic!("expected passthrough Request, got Response");
+            };
+            assert!(
+                handler.pending.is_none(),
+                "mixed-case host must still be excluded"
+            );
+            assert_eq!(drain_body(out_req.into_body()).await, body.as_bytes());
         }
 
         // Test 3: replay on 400 ───────────────────────────────────────────────

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -5,6 +5,7 @@
 //! the default is `auto` (shape-routing). See [`DenseConfig::load`].
 
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -475,6 +476,8 @@ fn config_path() -> Option<PathBuf> {
 /// and keeps the `auto` default, instead of silently downgrading shape-routing.
 pub(crate) const RUNTIME_ONLY_KEYS: &[&str] = &[
     "extra_hosts",
+    "exclude_providers",
+    "exclude_hosts",
     "upstream_proxy",
     "capture_dir",
     "db_path",
@@ -546,11 +549,7 @@ impl RuntimeConfig {
 
     /// Load from the real environment and config file (the one parse of the TOML).
     fn load() -> RuntimeConfig {
-        let file = config_path()
-            .filter(|p| p.exists())
-            .and_then(|p| std::fs::read_to_string(p).ok())
-            .and_then(|t| toml::from_str::<toml::Value>(&t).ok());
-        Self::resolve(|k| std::env::var(k).ok(), file.as_ref())
+        Self::resolve(|k| std::env::var(k).ok(), cached_config_file())
     }
 
     /// Pure resolver: `env` looks up an environment variable, `file` is the parsed config TOML
@@ -570,23 +569,12 @@ impl RuntimeConfig {
         let fbool = |key: &str| file.and_then(|v| v.get(key)).and_then(toml::Value::as_bool);
         let positive = |v: Option<i64>| v.filter(|n| *n > 0);
 
-        // extra_hosts: env (comma-split) replaces the file array; both normalized + validated.
-        let raw_hosts: Vec<String> = match env_set("LLMTRIM_EXTRA_HOSTS") {
-            Some(s) => s.split(',').map(str::to_string).collect(),
-            None => file
-                .and_then(|v| v.get("extra_hosts"))
-                .and_then(toml::Value::as_array)
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|e| e.as_str().map(str::to_string))
-                        .collect()
-                })
-                .unwrap_or_default(),
-        };
-        let mut extra_hosts: Vec<String> =
-            raw_hosts.iter().filter_map(|h| normalize_host(h)).collect();
-        extra_hosts.sort();
-        extra_hosts.dedup();
+        let extra_hosts = resolve_str_list(
+            env_set("LLMTRIM_EXTRA_HOSTS"),
+            file,
+            "extra_hosts",
+            normalize_host,
+        );
 
         RuntimeConfig {
             extra_hosts,
@@ -654,6 +642,107 @@ fn save_theme_at(path: &std::path::Path, name: &str) -> Result<()> {
     let mut text = out.join("\n");
     text.push('\n');
     std::fs::write(path, text).with_context(|| format!("failed to write {}", path.display()))
+}
+
+/// Canonicalize a user-supplied provider name to its wire-shape key (`openai` / `anthropic` /
+/// `google`), accepting the [`ProviderKind`](crate::ir::ProviderKind) aliases (`claude`,
+/// `gemini`, `gpt`, …). Returns `None` for an unknown name, which is silently dropped — same
+/// policy as a malformed host in [`normalize_host`].
+fn canon_provider(raw: &str) -> Option<String> {
+    crate::ir::ProviderKind::from_str(raw.trim())
+        .ok()
+        .map(|k| k.as_str().to_string())
+}
+
+/// One env-first-then-file string-list setting: the env var (comma-split) replaces the file
+/// array, each item passes through `norm` (validate/canonicalize, or drop), and survivors are
+/// sorted + deduped. Shared by `extra_hosts` and the exclusion lists.
+fn resolve_str_list(
+    env_value: Option<String>,
+    file: Option<&toml::Value>,
+    file_key: &str,
+    norm: fn(&str) -> Option<String>,
+) -> Vec<String> {
+    let raw: Vec<String> = match env_value {
+        Some(s) => s.split(',').map(str::to_string).collect(),
+        None => file
+            .and_then(|v| v.get(file_key))
+            .and_then(toml::Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|e| e.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    };
+    let mut out: Vec<String> = raw.iter().filter_map(|s| norm(s)).collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// The provider/host exclusion lists. Kept as its own type rather than fields on
+/// [`RuntimeConfig`] — surfaced via the additive [`exclusions`] accessor — so the feature stays
+/// backward-compatible with the published `llmtrim-core` API. A request whose host or resolved
+/// wire-shape provider matches is forwarded verbatim (still MITM'd, just not compressed).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Exclusions {
+    /// Wire-shape provider names to exclude (`openai`/`anthropic`/`google`; the
+    /// [`ProviderKind`](crate::ir::ProviderKind) aliases `claude`/`gemini`/`gpt` are accepted and
+    /// canonicalized, unknowns dropped). Coarse by design: the proxy classifies a host by wire
+    /// shape, so `openai` excludes *every* OpenAI-shaped host (OpenRouter, Groq, …), not just
+    /// `api.openai.com`. Use [`Exclusions::hosts`] to exclude one host precisely.
+    pub providers: Vec<String>,
+    /// Exact hosts to exclude, normalized like `extra_hosts` (lowercase plain hostnames;
+    /// malformed/overbroad entries dropped) and matched **exactly**, so excluding `api.openai.com`
+    /// leaves other OpenAI-shaped hosts compressed.
+    pub hosts: Vec<String>,
+}
+
+/// Pure resolver for the [`Exclusions`] lists. Env (`LLMTRIM_EXCLUDE_*`, comma-split) replaces the
+/// file array per list; each item is canonicalized/normalized (or dropped).
+fn resolve_exclusions(
+    env: impl Fn(&str) -> Option<String>,
+    file: Option<&toml::Value>,
+) -> Exclusions {
+    let env_set = |k: &str| env(k).filter(|s| !s.is_empty());
+    Exclusions {
+        providers: resolve_str_list(
+            env_set("LLMTRIM_EXCLUDE_PROVIDERS"),
+            file,
+            "exclude_providers",
+            canon_provider,
+        ),
+        hosts: resolve_str_list(
+            env_set("LLMTRIM_EXCLUDE_HOSTS"),
+            file,
+            "exclude_hosts",
+            normalize_host,
+        ),
+    }
+}
+
+/// Process-wide [`Exclusions`], loaded once from env + the config file like [`RuntimeConfig::get`].
+/// Cached for the process lifetime, so **tests must call `resolve_exclusions` directly** rather
+/// than this accessor.
+pub fn exclusions() -> &'static Exclusions {
+    static CACHE: std::sync::OnceLock<Exclusions> = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| resolve_exclusions(|k| std::env::var(k).ok(), cached_config_file()))
+}
+
+/// The config TOML parsed once for the whole process (if it exists and parses), shared by
+/// [`RuntimeConfig::load`] and [`exclusions`] so the file is read a single time.
+fn cached_config_file() -> Option<&'static toml::Value> {
+    static FILE: std::sync::OnceLock<Option<toml::Value>> = std::sync::OnceLock::new();
+    FILE.get_or_init(load_config_file).as_ref()
+}
+
+/// Read + parse the config TOML (if it exists and parses). Wrapped by [`cached_config_file`].
+fn load_config_file() -> Option<toml::Value> {
+    config_path()
+        .filter(|p| p.exists())
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|t| toml::from_str::<toml::Value>(&t).ok())
 }
 
 /// Normalize + validate a user-supplied intercept host: trim a trailing dot, lowercase, and
@@ -984,6 +1073,75 @@ mod tests {
     fn extra_hosts_from_file_when_env_absent() {
         let c = resolve_file("extra_hosts = [\"llm.acme.com\", \"gw.example.net\"]");
         assert_eq!(c.extra_hosts, vec!["gw.example.net", "llm.acme.com"]);
+    }
+
+    /// Resolve the exclusion lists with an explicit env map and file TOML.
+    fn exclusions_env(env: &[(&str, &str)], toml_src: &str) -> Exclusions {
+        let value: toml::Value = toml::from_str(toml_src).unwrap();
+        let env: std::collections::HashMap<String, String> = env
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        resolve_exclusions(|k| env.get(k).cloned(), Some(&value))
+    }
+
+    #[test]
+    fn exclude_providers_canonicalizes_and_drops_unknown() {
+        // Aliases map to canonical names; unknown entries are dropped; sorted + deduped.
+        let ex = exclusions_env(
+            &[(
+                "LLMTRIM_EXCLUDE_PROVIDERS",
+                "claude, anthropic, gemini, bogus",
+            )],
+            "exclude_providers = [\"ignored\"]",
+        );
+        assert_eq!(ex.providers, vec!["anthropic", "google"]);
+    }
+
+    #[test]
+    fn exclude_providers_from_file_when_env_absent() {
+        let value = toml::from_str("exclude_providers = [\"openai\", \"claude\"]").unwrap();
+        let ex = resolve_exclusions(|_| None, Some(&value));
+        assert_eq!(ex.providers, vec!["anthropic", "openai"]);
+    }
+
+    #[test]
+    fn exclude_hosts_normalizes_like_extra_hosts() {
+        // Env wins over file; lowercased, sorted, deduped; malformed dropped.
+        let ex = exclusions_env(
+            &[(
+                "LLMTRIM_EXCLUDE_HOSTS",
+                "API.OpenAI.com, *.bad, openrouter.ai",
+            )],
+            "exclude_hosts = [\"ignored.example\"]",
+        );
+        assert_eq!(ex.hosts, vec!["api.openai.com", "openrouter.ai"]);
+    }
+
+    #[test]
+    fn exclude_env_replaces_file_for_both_lists() {
+        // Env (comma-split) wins over the file array for each list independently.
+        let ex = exclusions_env(
+            &[
+                ("LLMTRIM_EXCLUDE_PROVIDERS", "openai"),
+                ("LLMTRIM_EXCLUDE_HOSTS", "api.openai.com"),
+            ],
+            "exclude_providers = [\"anthropic\"]\nexclude_hosts = [\"api.anthropic.com\"]\n",
+        );
+        assert_eq!(ex.providers, vec!["openai"]);
+        assert_eq!(ex.hosts, vec!["api.openai.com"]);
+    }
+
+    #[test]
+    fn exclude_keys_keep_auto_shape_routing() {
+        // A config that sets only the exclude keys must keep `auto` routing, not downgrade it.
+        for src in [
+            "exclude_providers = [\"anthropic\"]",
+            "exclude_hosts = [\"api.anthropic.com\"]",
+        ] {
+            let c = DenseConfig::from_toml_value(toml::from_str(src).unwrap()).unwrap();
+            assert!(c.auto, "exclude-only config `{src}` must keep auto routing");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #102.

## Problem

llmtrim compresses every intercepted provider, with no way to opt a provider out. When a tool misbehaves behind the proxy (e.g. Claude Code), the only recourse is to stop using llmtrim entirely instead of just sparing that one provider.

## Solution

Two new `RuntimeConfig` keys (env var or config file, following the existing `extra_hosts` pattern) that make a matching request pass through **verbatim** — still intercepted and proxied, just not compressed:

| key | env | meaning |
| --- | --- | --- |
| `exclude_providers` | `LLMTRIM_EXCLUDE_PROVIDERS` | by wire shape: `openai` / `anthropic` / `google` (aliases `claude`/`gemini`/`gpt` accepted). Coarse — covers every host of that shape. |
| `exclude_hosts` | `LLMTRIM_EXCLUDE_HOSTS` | exact hostnames. Precise — opts one host out without affecting siblings of the same shape. |

```toml
# leave Claude Code untouched, compress everything else
exclude_providers = ["anthropic"]
```

The gate sits in `handle_request_inner`, right after the per-request provider is resolved and before body collection — the same early-return shape as the existing non-provider passthrough. Both lists are env-first-then-file, normalized, sorted and deduped exactly like `extra_hosts`, and snapshotted onto the `Interceptor` at construction (like `domains`). Both keys are added to `RUNTIME_ONLY_KEYS` so an exclude-only config doesn't disable `auto` shape-routing.

## Design notes

- **Coarse by design for `exclude_providers`:** the proxy classifies a host by wire shape, so `openai` excludes every OpenAI-shaped host (OpenRouter, Groq, …). Use `exclude_hosts` for a single host.
- Excluded traffic is still MITM'd, so the CA name-constraints are unchanged — no re-trust needed.

## Tests

- `config.rs`: canonicalization + unknown-drop, env-replaces-file for both keys, the omnibus env-over-file test extended, and the `RUNTIME_ONLY_KEYS`/auto-routing guard.
- `serve.rs`: the pure `exclusion_match` (host-exact vs provider-coarse), plus async `handle_request_inner` tests covering host exclusion, provider exclusion, and mixed-case host matching.
- Full suite: 737 passed, clippy clean.

Reviewed by 4 agents (one initial + 3 focused on simplicity, correctness, conventions); all high-confidence findings were applied (DRY helper for the list loaders, Vertex host lowercasing, omnibus test coverage, case-insensitive host gate).
