### PR TITLE
fix(status): reconcile SAVED TODAY + toggle the size gauge basis (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to this project are documented here. The format follows
   now fingerprints cline, roo, kilo, goose, opencode, crush, gemini, qwen, grok, kimi,
   mistral-vibe, mux, pi, forge, and openclaw from their system prompts as well, so their token
   and cost stats show up under the right name.
+- **`status` dashboard: press `c` to switch what the size gauge measures.** On the Overview tab,
+  the "SMALLER REQUESTS" gauge toggles between the reduction of new content (the default, what
+  llmtrim can actually trim) and the reduction across the whole prompt (diluted by the reused
+  cached prefix). The caption names the active basis. Dollar figures are unaffected.
 
 ### Fixed
 - **The SAVINGS TREND chart no longer prints the dollar amount on top of the bar.** ratatui's
@@ -32,6 +36,10 @@ All notable changes to this project are documented here. The format follows
   English prompts add nothing, so the fix costs no tokens on the common case (prompts too short
   to detect get the clause as a cheap, safe fallback). Only applies when output shaping is
   already active (never on tool-call requests).
+- **`status` dashboard: "SAVED TODAY" now reconciles with the totals.** It was priced at list
+  rates while the all-time and weekly figures used the real, cache-discounted bill, so on
+  cache-heavy traffic (e.g. Claude with prompt caching) today could read higher than the total
+  ever saved. Every dollar figure is now the same net-of-cache basis.
 
 ## [0.3.2] - 2026-06-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim"
-version = "0.3.3-dev"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-core"
-version = "0.3.3-dev"
+version = "0.4.0-dev"
 dependencies = [
  "anyhow",
  "base64",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-uniffi"
-version = "0.3.3-dev"
+version = "0.4.0-dev"
 dependencies = [
  "llmtrim-core",
  "serde_json",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-wasm"
-version = "0.3.3-dev"
+version = "0.4.0-dev"
 dependencies = [
  "llmtrim-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 # Shared package metadata — inherited by each member via `field.workspace = true`.
 [workspace.package]
-version = "0.3.3-dev"
+version = "0.4.0-dev"
 edition = "2024"
 rust-version = "1.88"
 repository = "https://github.com/fkiene/llmtrim"

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -37,7 +37,7 @@ path = "src/main.rs"
 [dependencies]
 # `version` is required for `cargo publish` (path alone isn't publishable) and is kept in
 # lockstep with llmtrim-core by cargo-release's shared-version on every bump.
-llmtrim-core = { path = "../llmtrim-core", version = "0.3.3-dev" }
+llmtrim-core = { path = "../llmtrim-core", version = "0.4.0-dev" }
 anyhow.workspace = true
 chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive"] }

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -66,8 +66,13 @@ pub struct OverviewData {
     pub would_have_usd: Option<f64>,
     pub saved_usd: Option<f64>,
     pub saved_today_usd: Option<f64>,
-    /// Input-savings fraction (0..1) → spoken as "about a third less".
+    /// Input-savings fraction (0..1) over the compressible surface → spoken as "about a third
+    /// less". This is the headline basis ("% of new content").
     pub pct_less: f64,
+    /// The same saving over the whole prompt (the cached prefix included) — the diluted basis
+    /// the `c` toggle reveals. Shares `pct_less`'s numerator with a wider denominator, so it is
+    /// always `<= pct_less` (see `overview_data`).
+    pub pct_less_whole: f64,
     pub added_ms: Option<f64>,
     pub requests: i64,
     /// Net $ saved per day, oldest→newest, last 7 days (for the sparkline).
@@ -88,6 +93,19 @@ pub struct OverviewData {
     /// A newer release version if the (cached, opt-out) update check found one — shown in the
     /// meta bar; `u` then runs the updater.
     pub update_available: Option<String>,
+}
+
+impl OverviewData {
+    /// Size-reduction fraction for the gauge: over the whole prompt (cached prefix included)
+    /// when `whole_prompt`, else over the compressible surface — the default headline. Dollars
+    /// are always the real net bill; only this percentage has two honest framings.
+    fn pct_smaller(&self, whole_prompt: bool) -> f64 {
+        if whole_prompt {
+            self.pct_less_whole
+        } else {
+            self.pct_less
+        }
+    }
 }
 
 /// Which tab is active.
@@ -333,6 +351,10 @@ struct App {
     /// background thread now, not on this timer.
     refresh: Duration,
     tab: Tab,
+    /// `c` flips the size gauge between "% of new content" (`false`, the default headline) and
+    /// "% of the whole prompt" (`true`, diluted by the cached prefix). Overview-only. Dollars
+    /// never change — they are always the real net-of-cache bill.
+    whole_prompt: bool,
     overview: Option<OverviewData>,
     /// Full-screen keymap overlay (`?`); dismissed by any key.
     show_help: bool,
@@ -353,6 +375,7 @@ impl App {
             db,
             refresh,
             tab: Tab::Overview,
+            whole_prompt: false,
             overview: None,
             show_help: false,
             sessions: TreeTable::new(
@@ -372,6 +395,7 @@ impl App {
     /// SQLite runs on the UI thread here — just cheap tree building.
     fn apply(&mut self, mut ov: OverviewData, rows: Vec<SessionRow>) {
         ov.sessions = rows.len() as i64;
+        self.overview = Some(ov);
         // Grand-total footer: total spend, overall savings %, and total messages.
         let bill: i64 = rows.iter().map(|r| r.bill_micros).sum();
         let turns: i64 = rows.iter().map(|r| r.turns).sum();
@@ -391,7 +415,6 @@ impl App {
             String::new(),
         ]);
         self.sessions.set_roots(build_session_tree(&rows));
-        self.overview = Some(ov);
     }
 
     /// Handle a key; returns true to quit.
@@ -430,6 +453,13 @@ impl App {
                     PostAction::Update
                 };
                 return true;
+            }
+            // `c` flips the Overview gauge between "% of new content" and "% of the whole prompt"
+            // — the one figure with two honest framings. It's a no-op on the other tabs, which
+            // have no size figure to reframe. Dollars are always the real net bill, so they
+            // never move.
+            KeyCode::Char('c') if self.tab == Tab::Overview => {
+                self.whole_prompt = !self.whole_prompt;
             }
             KeyCode::Char('1') => self.tab = Tab::Overview,
             KeyCode::Char('2') => self.tab = Tab::Sessions,
@@ -704,6 +734,7 @@ impl App {
         };
         // Borrow, don't clone: the sub-renderers take `&OverviewData`, so cloning the whole
         // struct (its Vecs + Strings) every frame was pure waste.
+        let whole_prompt = self.whole_prompt;
         let Some(ov) = self.overview.as_ref() else {
             return;
         };
@@ -712,9 +743,9 @@ impl App {
             StatusKind::Off | StatusKind::Degraded => render_overview_alert(f, inner, ov),
             // A stale daemon always shows the dashboard (and its `u  Update` nudge), even before
             // the first request — otherwise the empty-state card would hide the restart prompt.
-            StatusKind::Stale => render_overview_main(f, inner, ov),
+            StatusKind::Stale => render_overview_main(f, inner, ov, whole_prompt),
             _ if !ov.has_traffic => render_overview_empty(f, inner, ov),
-            _ => render_overview_main(f, inner, ov),
+            _ => render_overview_main(f, inner, ov, whole_prompt),
         }
     }
 
@@ -785,8 +816,10 @@ impl App {
                 .overview
                 .as_ref()
                 .is_some_and(|o| o.update_available.is_some());
+        // `c` flips the saved-% basis on the Overview gauge only — that's the one screen with a
+        // size figure to reframe — so the hint lives on that tab alone.
         let mut keys = match self.tab {
-            Tab::Overview => String::from(" Tab tabs"),
+            Tab::Overview => String::from(" Tab tabs · c %"),
             Tab::Sessions => String::from(" Tab tabs · ↑↓ move · →/← expand · ⏎ drill"),
             Tab::Detail => String::from(" Tab tabs · ⇧Tab pane · ↑↓ move · →/← expand"),
         };
@@ -844,6 +877,7 @@ fn render_help_overlay(f: &mut Frame) {
         Line::from("  Shift-Tab          switch pane (in Detail)"),
         Line::from("  Esc                back to Sessions"),
         Line::from("  t                  cycle theme (Mocha/Macchiato/Frappé/Latte)"),
+        Line::from("  c                  size %: new content / whole prompt (Overview)"),
         Line::from(""),
         Line::from("  \"would have cost\" = the price at your provider's"),
         Line::from("   normal rate; \"you paid\" is after llmtrim trimmed it."),
@@ -1323,11 +1357,11 @@ fn render_trend(f: &mut Frame, area: Rect, ov: &OverviewData) {
 
 /// Band D-mid — the "you send smaller requests" gauge: the percentage, a bar meter, and the
 /// 0–100 scale. (ratatui has no arc widget; a horizontal Gauge is the honest built-in.)
-fn render_gauge(f: &mut Frame, area: Rect, ov: &OverviewData) {
+fn render_gauge(f: &mut Frame, area: Rect, ov: &OverviewData, whole_prompt: bool) {
     let block = card("SMALLER REQUESTS", false);
     let inner = block.inner(area);
     f.render_widget(block, area);
-    let pct = ov.pct_less.clamp(0.0, 1.0);
+    let pct = ov.pct_smaller(whole_prompt).clamp(0.0, 1.0);
     let dim = Style::default().fg(palette::muted_gray());
     let rows = Layout::vertical([
         Constraint::Min(0),
@@ -1364,10 +1398,17 @@ fn render_gauge(f: &mut Frame, area: Rect, ov: &OverviewData) {
         Paragraph::new(Line::from(Span::styled("100%", dim))).alignment(Alignment::Right),
         ends[1],
     );
+    // Second caption line names the active basis, so the gauge is never ambiguous (the `c` key
+    // that flips it is documented in the footer and help overlay, not crammed in here).
+    let basis = if whole_prompt {
+        "of the whole prompt"
+    } else {
+        "of new content"
+    };
     f.render_widget(
         Paragraph::new(vec![
             Line::from(Span::styled("Average size reduction", dim)),
-            Line::from(Span::styled("across all requests", dim)),
+            Line::from(Span::styled(basis, dim)),
         ])
         .alignment(Alignment::Center),
         rows[4],
@@ -1491,7 +1532,7 @@ fn render_metrics(f: &mut Frame, area: Rect, ov: &OverviewData) {
 /// Healthy Overview — the edge-to-edge dashboard from the design mockup: status banner ·
 /// 5 KPI tiles · charts row (trend | gauge | top models) · 5 metric tiles · footer banner.
 /// Bands drop under height pressure; tiny terminals fall back to the spoken status line.
-fn render_overview_main(f: &mut Frame, inner: Rect, ov: &OverviewData) {
+fn render_overview_main(f: &mut Frame, inner: Rect, ov: &OverviewData, whole_prompt: bool) {
     // Tiny terminals: never hand widgets zero-height rects.
     if inner.height < 6 {
         f.render_widget(status_line(ov), inner);
@@ -1553,7 +1594,7 @@ fn render_overview_main(f: &mut Frame, inner: Rect, ov: &OverviewData) {
         .spacing(1)
         .split(charts);
         render_trend(f, c[0], ov);
-        render_gauge(f, c[1], ov);
+        render_gauge(f, c[1], ov, whole_prompt);
         render_savers(f, c[2], ov);
     } else if charts.width >= 60 {
         let c = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
@@ -2131,6 +2172,7 @@ mod tests {
             saved_usd: Some(142.58),
             saved_today_usd: Some(4.10),
             pct_less: 0.33,
+            pct_less_whole: 0.12,
             added_ms: Some(32.0),
             requests: 1204,
             trend_daily_usd: vec![7.0, 9.0, 11.0, 10.0, 13.0, 14.0, 16.0],
@@ -2157,7 +2199,7 @@ mod tests {
     #[test]
     fn overview_cards_show_kpis_charts_and_metrics() {
         let ov = sample_overview();
-        let s = render_to_string(140, 30, |f| render_overview_main(f, f.area(), &ov));
+        let s = render_to_string(140, 30, |f| render_overview_main(f, f.area(), &ov, false));
         // Band C — KPI tiles (values are plain text now, no block-glyph art).
         assert!(s.contains("TOTAL SAVED"), "{s}");
         assert!(s.contains("WOULD HAVE COST") && s.contains("226.82"));
@@ -2172,9 +2214,30 @@ mod tests {
     }
 
     #[test]
+    fn size_gauge_toggles_basis_but_dollars_never_change() {
+        let ov = sample_overview();
+        // Default (new content): the compressible-surface 33%, dollars are the net bill.
+        let new = render_to_string(140, 30, |f| render_overview_main(f, f.area(), &ov, false));
+        assert!(new.contains("33% smaller"), "{new}");
+        assert!(new.contains("of new content"), "{new}");
+        // Whole prompt: the diluted 12%. The dollar KPIs are byte-for-byte the same — only the
+        // percentage moved, so the toggle can never overstate the saving in money terms.
+        let whole = render_to_string(140, 30, |f| render_overview_main(f, f.area(), &ov, true));
+        assert!(whole.contains("12% smaller"), "{whole}");
+        assert!(whole.contains("of the whole prompt"), "{whole}");
+        for dollars in ["226.82", "84.24", "142.58"] {
+            assert_eq!(
+                new.contains(dollars),
+                whole.contains(dollars),
+                "dollar figure {dollars} must not depend on the size-basis toggle"
+            );
+        }
+    }
+
+    #[test]
     fn overview_keeps_jargon_off_the_default_screen() {
         let ov = sample_overview();
-        let s = render_to_string(140, 30, |f| render_overview_main(f, f.area(), &ov));
+        let s = render_to_string(140, 30, |f| render_overview_main(f, f.area(), &ov, false));
         assert!(s.contains("REQUESTS HANDLED"));
         // The old expert "more numbers" strip (and its jargon) is gone entirely.
         assert!(!s.contains("net of cache"));
@@ -2209,13 +2272,36 @@ mod tests {
         ov.update_available = None;
         // A stale daemon is not broken: it renders the normal dashboard with a `u Update` nudge,
         // never the Repair alert.
-        let s = render_to_string(140, 30, |f| render_overview_main(f, f.area(), &ov));
+        let s = render_to_string(140, 30, |f| render_overview_main(f, f.area(), &ov, false));
         assert!(s.contains("older version"), "{s}");
         assert!(s.contains("Update"), "u Update affordance shown: {s}");
         assert!(
             !s.contains("Repair"),
             "no Repair on a stale (not broken) daemon: {s}"
         );
+    }
+
+    #[test]
+    fn c_key_flips_the_size_basis_on_overview_only() {
+        let mut app = App::new(None, Duration::from_secs(2));
+        app.overview = Some(sample_overview());
+
+        // On Overview, `c` toggles the gauge basis.
+        assert!(!app.whole_prompt);
+        app.handle_key(KeyCode::Char('c'));
+        assert!(app.whole_prompt);
+        app.handle_key(KeyCode::Char('c'));
+        assert!(!app.whole_prompt);
+
+        // On the other tabs there is no size figure to reframe, so `c` is a no-op.
+        for tab in [Tab::Sessions, Tab::Detail] {
+            app.tab = tab;
+            app.handle_key(KeyCode::Char('c'));
+            assert!(
+                !app.whole_prompt,
+                "c must not toggle the basis off Overview"
+            );
+        }
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -1070,6 +1070,24 @@ pub fn overview_data(
         0.0
     };
 
+    // The same saving over the WHOLE prompt (the reused, cached prefix included) — the diluted
+    // basis the `c` toggle reveals. On cache-heavy agent traffic most of the input is the frozen
+    // prefix llmtrim can't touch, so this reads far smaller than the compressible-surface
+    // `pct_less` above. Both are honest; they answer "% of new content" vs "% of everything".
+    //
+    // It must share `pct_less`'s numerator and accounting so it can never EXCEED it (a bigger
+    // denominator only ever shrinks the figure): on the metered branch, keep the metered
+    // surface numerator and widen the denominator to the whole metered prompt; otherwise fall
+    // back to the same whole-ledger ratio `pct_less` uses. Mixing the metered numerator with the
+    // non-metered total here would let unmetered savings leak in and read larger than `pct_less`.
+    let pct_less_whole = if summary.frozen_input_tokens > 0 && new_before > 0 {
+        (new_before - new_after).max(0) as f64 / summary.metered_input_before as f64
+    } else if summary.input_before > 0 {
+        summary.saved() as f64 / summary.input_before as f64
+    } else {
+        0.0
+    };
+
     // Daily $ trend: scale the daily token-savings series by the blended $/token rate.
     let blend = match cost.as_ref() {
         Some(c) if summary.saved() > 0 => c.net_saved / summary.saved() as f64,
@@ -1111,6 +1129,7 @@ pub fn overview_data(
         saved_usd,
         saved_today_usd: today_saved_usd(tracker).filter(|t| *t >= 0.005),
         pct_less,
+        pct_less_whole,
         added_ms: summary.avg_compress_micros.map(|us| us / 1000.0),
         requests: summary.events,
         trend_daily_usd,
@@ -1591,6 +1610,86 @@ mod tests {
         assert_eq!(v["requests"], 2);
         assert_eq!(v["daemon"], serde_json::Value::Null);
         assert!(v["by_model"].as_array().is_some_and(|m| !m.is_empty()));
+    }
+
+    #[test]
+    fn overview_data_reports_both_savings_bases() {
+        use crate::tracking::Record;
+        let tracker = Tracker::open_in_memory().unwrap();
+        // 1000 input → 600 after (400 trimmed); 600 of the prompt is the frozen cached prefix.
+        tracker
+            .record(&Record {
+                provider: "openai".into(),
+                model: Some("gpt-4o".into()),
+                tokenizer: "tiktoken".into(),
+                exact: true,
+                input_before: 1000,
+                input_after: 600,
+                output_before: None,
+                output_after: None,
+                compress_micros: None,
+                cache_read_tokens: None,
+                fresh_input_tokens: None,
+                cache_write_tokens: None,
+                output_shaped: Some(false),
+                frozen_input_tokens: Some(600),
+            })
+            .unwrap();
+        let ov = overview_data(&tracker, |_, _| {
+            crate::breakdown::app::StatusLine::default()
+        });
+        // Whole prompt: 400/1000 = 0.40. New content excludes the frozen prefix, so it reads
+        // at least as large — the two honest framings the `c` toggle switches between.
+        assert!(
+            (ov.pct_less_whole - 0.40).abs() < 1e-6,
+            "{}",
+            ov.pct_less_whole
+        );
+        assert!(
+            ov.pct_less >= ov.pct_less_whole,
+            "{} {}",
+            ov.pct_less,
+            ov.pct_less_whole
+        );
+    }
+
+    // A mixed ledger (a metered row with the frozen meter, plus a pre-meter row that recorded
+    // no meter) is where the two bases can diverge wrongly: `pct_less` only sees the metered
+    // row's surface saving, so `pct_less_whole` must use the same metered numerator — not the
+    // whole-ledger `saved()`, which would fold in the pre-meter row's saving and read LARGER
+    // than `pct_less`, an impossible "whole prompt beats new content".
+    #[test]
+    fn whole_prompt_basis_never_exceeds_new_content_on_a_mixed_ledger() {
+        use crate::tracking::Record;
+        let rec = |before, after, frozen| Record {
+            provider: "openai".into(),
+            model: Some("gpt-4o".into()),
+            tokenizer: "tiktoken".into(),
+            exact: true,
+            input_before: before,
+            input_after: after,
+            output_before: None,
+            output_after: None,
+            compress_micros: None,
+            cache_read_tokens: None,
+            fresh_input_tokens: None,
+            cache_write_tokens: None,
+            output_shaped: Some(false),
+            frozen_input_tokens: frozen,
+        };
+        let tracker = Tracker::open_in_memory().unwrap();
+        // Metered row: 100 frozen, no saving on its 300-token surface.
+        tracker.record(&rec(400, 400, Some(100))).unwrap();
+        // Pre-meter row: a real 400-token saving, but no frozen meter recorded.
+        tracker.record(&rec(600, 200, None)).unwrap();
+        let ov = overview_data(&tracker, |_, _| {
+            crate::breakdown::app::StatusLine::default()
+        });
+        // The metered surface saved nothing, so both bases are 0 — the pre-meter row's saving
+        // must not leak into the whole-prompt figure.
+        assert!(ov.pct_less.abs() < 1e-6, "{}", ov.pct_less);
+        assert!(ov.pct_less_whole.abs() < 1e-6, "{}", ov.pct_less_whole);
+        assert!(ov.pct_less_whole <= ov.pct_less + 1e-9);
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -915,10 +915,12 @@ pub fn model_views_from(rows: &[ModelRow]) -> Vec<ModelView> {
 }
 
 /// Today's priced saving (UTC), for the hero's recency anchor. `None` when nothing
-/// priced ran today — the dashboard hides the figure rather than showing $0.00.
+/// priced ran today — the dashboard hides the figure rather than showing $0.00. Net-of-cache
+/// to match the text hero's all-time figure: a list-rate "today" next to a net all-time total
+/// is what made today exceed the total (issue #100).
 pub fn today_saved_usd(tracker: &Tracker) -> Option<f64> {
     let models = tracker.by_model_today().ok()?;
-    cost_estimate(&models).map(|c| c.saved)
+    cost_estimate(&models).map(|c| c.net_saved)
 }
 
 /// Per-1M-token rates for one turn, frozen into the breakdown ledger so a historical session


### PR DESCRIPTION
Fixes #100.

## Problem
The `status` dashboard mixed two cost bases. `TOTAL SAVED`, `YOU PAID` and `WEEK` used the net-of-cache (real, discounted) bill, while `SAVED TODAY` used list rates. On cache-heavy traffic (Claude Opus with prompt caching, the reporter's setup) the list figure is much larger, so `SAVED TODAY` could read higher than `TOTAL SAVED` and the receipt did not reconcile.

Separately, the "42% smaller / ~1% dollars" confusion came from there being only one size-reduction denominator on screen, with no way to see the diluted "% of my whole prompt" view.

## Change
Two commits:

1. **`fix(monitor)`** — price "saved today" net-of-cache, like every other dollar figure. Now today, week and all-time are one honest basis and reconcile.

2. **`feat(breakdown)`** — `c` toggles the **size gauge** between "% of new content" (default: the reduction of what llmtrim can actually trim) and "% of the whole prompt" (diluted by the reused cached prefix). The gauge caption and the footer name the active basis; the help overlay documents the key.

### Design note: dollars are always net, only the percentage toggles
An earlier revision of this PR also flipped the **dollar** figures to a "without cache" (list-rate) basis. That was wrong: the list-rate "saved" figure overstates the saving by crediting llmtrim with the discount that *prompt caching* gave you. There is only one honest dollar figure, the real net-of-cache bill, and for a model with no caching net and list are identical anyway. So the dollar side of the toggle was dropped. Only the size **percentage** has two honest framings, and neither is about money.

## Tests
- `size_gauge_toggles_basis_but_dollars_never_change` — the gauge shows the new-content % by default and the whole-prompt % after the toggle, and asserts every dollar KPI is byte-identical across both states (the toggle can't move money).
- `cargo clippy --features intercept,breakdown` clean; `731 passed, 1 skipped`.