### PR TITLE
feat: fingerprint 18 coding agents in the cost breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project are documented here. The format follows
   precise. Each env var is comma-separated and replaces the file array. Set
   `exclude_providers = ["anthropic"]` (or `LLMTRIM_EXCLUDE_PROVIDERS=anthropic`) to leave Claude
   Code traffic untouched while still compressing everything else.
+- **Cost breakdown now labels 18 coding agents, up from 3.** The per-source view recognized
+  only Claude Code, Codex, and Cursor; every other tool's traffic landed under `unknown`. It
+  now fingerprints cline, roo, kilo, goose, opencode, crush, gemini, qwen, grok, kimi,
+  mistral-vibe, mux, pi, forge, and openclaw from their system prompts as well, so their token
+  and cost stats show up under the right name.
 
 ### Fixed
 - **Replies now stay in the user's language.** The output-shaping instructions are written in

--- a/README.md
+++ b/README.md
@@ -288,18 +288,22 @@ The printed block is the standard MCP config; for a client you edit by hand it l
 
 ## Works with
 
-Any tool that honors `HTTPS_PROXY` and an env-provided CA, which is essentially every CLI agent and most Node apps:
+Any tool that honors `HTTPS_PROXY` and an env-provided CA. That covers all 18 agents below plus any HTTPS_PROXY-aware CLI or SDK you build yourself:
 
 | Tool | Works | Notes |
 |---|:---:|---|
 | Claude Code | ✅ | Prompt-cache discount stays intact |
 | Codex CLI | ✅ | |
 | Gemini CLI | ✅ | |
-| Cursor / VS Code extensions | ✅ | Node-based: picks up `NODE_EXTRA_CA_CERTS` |
-| Aider, OpenCode, any `HTTPS_PROXY`-aware CLI | ✅ | |
-| Hermes Agent | ✅ | route its upstream through llmtrim; add a `custom:` host via `extra_hosts` ([guide](HERMES.md)) |
-| Your own app / SDK | ✅ | or call the [CLI / library](#use-it-as-a-cli-mcp-or-library) directly |
-| GitHub Copilot | ❌ | certificate pinning blocks interception |
+| Cursor (IDE), Cline, Roo, Kilo Code | ✅ | VS Code extensions; set `NODE_EXTRA_CA_CERTS` for the Node host process |
+| Goose, OpenCode, Crush, Mux, Forge, OpenClaw, Pi/OMP | ✅ | CLI agents on standard provider hosts |
+| Qwen Code, Grok CLI, Kimi Code, Mistral Vibe | ✅ | Provider hosts ship in the `llm_providers` registry, intercepted out of the box |
+| Aider, any other `HTTPS_PROXY`-aware CLI | ✅ | |
+| Hermes, Droid (BYOK mode) | ✅ | Interceptable only when a direct provider key is configured; see [guide](HERMES.md) for Hermes |
+| Your own app / SDK | ✅ | Or call the [CLI / library](#use-it-as-a-cli-mcp-or-library) directly |
+| GitHub Copilot | ❌ | Certificate pinning blocks interception |
+| Warp, Devin | ❌ | Provider call is server-side; a local proxy never sees it |
+| Cursor Agent, Kiro | ❌ | Routes through a vendor gateway, not a standard provider host |
 
 Prefer no proxy? Any MCP client (Claude Code, Cursor, custom agents) can call llmtrim directly as tools instead: run `llmtrim mcp install`, or see [CLI, MCP, or library](#use-it-as-a-cli-mcp-or-library).
 

--- a/crates/llmtrim-core/src/attribution.rs
+++ b/crates/llmtrim-core/src/attribution.rs
@@ -652,20 +652,110 @@ fn stable_hash(s: &str) -> String {
     format!("{h:016x}")
 }
 
-/// Identify the agent from well-known system-prompt markers. These are registered product
-/// names that appear verbatim in the system prompt regardless of the user's locale, so the
-/// match is intentionally ASCII brand-name based, not localized; an unrecognized agent maps
-/// to `None` and is grouped under "unknown".
+/// A known coding agent and the verbatim product strings it embeds in its system prompt.
+///
+/// Identification is by system-prompt body, never by `User-Agent` or other headers: some
+/// agents deliberately spoof another's headers (Oh My Pi sends the Gemini CLI / Antigravity
+/// `User-Agent`; Forge sends Anthropic's `anthropic-beta: claude-code-20250219`), so a header
+/// match would mislabel them. The `markers` are registered ASCII brand strings that appear
+/// regardless of the user's locale, so the match is brand-name based, not localized.
+struct AgentFingerprint {
+    label: &'static str,
+    markers: &'static [&'static str],
+}
+
+/// The Tier A roster: agents that route through a host the live proxy intercepts and carry a
+/// verified system-prompt marker. Order matters only where a generic fallback marker could
+/// collide: Qwen Code is a Gemini CLI fork and can carry Gemini's legacy generic phrase, so
+/// `qwen` is listed before `gemini` and the brand-specific marker wins.
+static AGENTS: &[AgentFingerprint] = &[
+    AgentFingerprint {
+        label: "claude-code",
+        markers: &["Claude Code"],
+    },
+    AgentFingerprint {
+        label: "codex",
+        markers: &["running as a coding agent in the Codex CLI", "Codex CLI"],
+    },
+    AgentFingerprint {
+        label: "cursor",
+        markers: &["You operate exclusively in Cursor"],
+    },
+    AgentFingerprint {
+        label: "cline",
+        markers: &["You are Cline,"],
+    },
+    AgentFingerprint {
+        label: "roo",
+        markers: &["You are Roo,"],
+    },
+    AgentFingerprint {
+        label: "kilo",
+        markers: &["You are Kilo Code,"],
+    },
+    AgentFingerprint {
+        label: "goose",
+        markers: &["agent called goose"],
+    },
+    AgentFingerprint {
+        label: "opencode",
+        markers: &["You are OpenCode,", "You are opencode,"],
+    },
+    AgentFingerprint {
+        label: "crush",
+        markers: &["You are Crush,"],
+    },
+    AgentFingerprint {
+        label: "qwen",
+        markers: &["You are Qwen Code,"],
+    },
+    AgentFingerprint {
+        label: "grok",
+        markers: &["You are Grok CLI"],
+    },
+    AgentFingerprint {
+        label: "kimi",
+        markers: &["You are Kimi Code CLI,"],
+    },
+    AgentFingerprint {
+        label: "mistral-vibe",
+        markers: &["operating as and within Mistral Vibe"],
+    },
+    AgentFingerprint {
+        label: "mux",
+        markers: &["agent called Mux"],
+    },
+    AgentFingerprint {
+        label: "pi",
+        markers: &["Oh My Pi"],
+    },
+    AgentFingerprint {
+        label: "forge",
+        markers: &["You are Forge,"],
+    },
+    AgentFingerprint {
+        label: "openclaw",
+        markers: &["OpenClaw"],
+    },
+    // Listed after qwen: its primary marker is brand-specific, but the legacy fallback phrase
+    // is generic and also appears in Gemini CLI forks like Qwen Code.
+    AgentFingerprint {
+        label: "gemini",
+        markers: &[
+            "You are Gemini CLI,",
+            "interactive CLI agent specializing in software engineering tasks",
+        ],
+    },
+];
+
+/// Identify the agent from well-known system-prompt markers. Returns the first registered
+/// agent whose marker appears verbatim in the system prompt; an unrecognized agent maps to
+/// `None` and is grouped under "unknown".
 fn fingerprint_agent(system: &str) -> Option<&'static str> {
-    if system.contains("Claude Code") {
-        Some("claude-code")
-    } else if system.contains("Codex") || system.contains("codex") {
-        Some("codex")
-    } else if system.contains("Cursor") {
-        Some("cursor")
-    } else {
-        None
-    }
+    AGENTS
+        .iter()
+        .find(|a| a.markers.iter().any(|m| system.contains(m)))
+        .map(|a| a.label)
 }
 
 /// Pull a working-directory hint out of the system prompt. Claude Code and Codex embed a
@@ -853,6 +943,46 @@ mod tests {
             id.session_id,
             extract_identity(&body2, ProviderKind::Anthropic).session_id
         );
+    }
+
+    #[test]
+    fn every_registered_agent_fingerprints() {
+        // Drive the test from the registry itself, not a parallel table: every agent's first
+        // marker, fed through the real extraction path (which also guards `system_text`), must
+        // resolve back to that agent. A new `AGENTS` entry is covered the day it is added.
+        for agent in AGENTS {
+            let marker = agent.markers[0];
+            let body = json!({ "system": marker, "messages": [] });
+            let id = extract_identity(&body, ProviderKind::Anthropic);
+            assert_eq!(
+                id.agent.as_deref(),
+                Some(agent.label),
+                "marker {marker:?} did not fingerprint as {}",
+                agent.label
+            );
+        }
+    }
+
+    #[test]
+    fn qwen_legacy_phrase_does_not_steal_from_gemini_fork() {
+        // Qwen Code is a Gemini CLI fork: its prompt can carry both its own brand marker and
+        // Gemini's generic legacy phrase. The brand-specific qwen marker must win.
+        let body = json!({
+            "system": "You are Qwen Code, an interactive CLI agent specializing in software engineering tasks.",
+            "messages": []
+        });
+        assert_eq!(
+            extract_identity(&body, ProviderKind::Anthropic)
+                .agent
+                .as_deref(),
+            Some("qwen")
+        );
+    }
+
+    #[test]
+    fn unknown_agent_is_none() {
+        let body = json!({ "system": "You are a helpful assistant.", "messages": [] });
+        assert_eq!(extract_identity(&body, ProviderKind::Anthropic).agent, None);
     }
 
     #[test]


### PR DESCRIPTION
## What

The cost-breakdown view fingerprinted only 3 agents (Claude Code, Codex, Cursor); every other tool's traffic landed under `unknown`. This replaces `fingerprint_agent`'s hand-written if/else with an `AGENTS` registry keyed on verified system-prompt markers and adds the 15 remaining live-interceptable agents: cline, roo, kilo, goose, opencode, crush, gemini, qwen, grok, kimi, mistral-vibe, mux, pi, forge, openclaw.

Each agent is now one `AgentFingerprint` entry (label + markers), so adding the next one is a single slice entry with no if/else merge conflicts.

## Design notes

- **System-prompt only, never headers.** Oh My Pi spoofs the Gemini / Antigravity `User-Agent` and Forge sends Anthropic's `anthropic-beta: claude-code-20250219` header, so a header match would mislabel them. Identification keys on the prompt body.
- **qwen ordered before gemini.** Qwen Code is a Gemini CLI fork that can carry Gemini's generic legacy phrase; the brand-specific marker must win. Covered by `qwen_legacy_phrase_does_not_steal_from_gemini_fork`.
- **No host-routing or header plumbing needed.** All six provider hosts the plan flagged (x.ai, dashscope, moonshot, mistral, z.ai, openrouter) already ship in the `llm_providers` registry, and every agent here has a system-prompt marker, so no `serve.rs` changes were required.

## Scope

This is the live-interceptable (Tier A) roster from `docs/multi-agent-stats-plan.md`. The README "Works with" table is updated to group these agents and to add explicit not-supported rows for the server-side (Warp, Devin) and vendor-gateway (Cursor Agent, Kiro) agents, so it does not overclaim.

## Known residual

`forge`'s marker is `"You are Forge"`, the verified first prompt line, but it is less anchored than the other `"You are <Product>,"` markers. A custom persona literally named "Forge" could be mislabeled. Impact is label-only (never compression), and a tighter string could not be verified from a capture in this tree, so it is left as the source-verified value.

## Testing

- `every_registered_agent_fingerprints` drives every `AGENTS` entry through the real `extract_identity` path, so new entries are covered automatically.
- `qwen_legacy_phrase_does_not_steal_from_gemini_fork`, `unknown_agent_is_none`.
- Full suite: 733 passed. `attribution.rs` line coverage 85.8%.

## Review

Reviewed by 3 agents (correctness, simplicity, conventions). Applied: dropped qwen's over-generic `"developed by Alibaba Group"` marker; rewrote the agent test to derive from the registry instead of a parallel table.