### PR TITLE
fix(output): keep replies in the user's language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **Replies now stay in the user's language.** The output-shaping instructions are written in
+  English and land last in the request, which biased the model to answer in English even when
+  the user wrote in another language. When the prompt is detected as non-English, the primary
+  shaping instruction now carries a short `Reply in the user's language.` clause; reliably
+  English prompts add nothing, so the fix costs no tokens on the common case (prompts too short
+  to detect get the clause as a cheap, safe fallback). Only applies when output shaping is
+  already active (never on tool-call requests).
+
 ## [0.3.2] - 2026-06-22
 
 ### Added

--- a/crates/llmtrim-core/src/stages/output.rs
+++ b/crates/llmtrim-core/src/stages/output.rs
@@ -14,7 +14,37 @@ use serde_json::Value;
 
 use crate::gate::{GateKind, PlanEntry, Transform};
 use crate::ir::Request;
-use crate::provider::Provider;
+use crate::provider::{Provider, Role};
+use crate::stages::tools::detect_lang;
+
+/// Cap on the user-prose sample handed to `detect_lang`: a reliable detection needs only a
+/// sentence or two, and agent requests can carry megabytes of pasted context. Enforced before
+/// each copy so one huge block can't blow the budget (char-boundary-safe, like `stopword_set`).
+const PROSE_SAMPLE_MAX_BYTES: usize = 4096;
+
+/// Concatenate the request's user-turn text — the language signal for the reply-language
+/// decision — up to [`PROSE_SAMPLE_MAX_BYTES`].
+fn user_prose(req: &Request, provider: &dyn Provider) -> String {
+    let mut prose = String::new();
+    for ptr in provider.content_text_pointers(req) {
+        if provider.role_at(req, &ptr) == Some(Role::User)
+            && let Some(text) = req.get_str(&ptr)
+        {
+            let mut take = PROSE_SAMPLE_MAX_BYTES
+                .saturating_sub(prose.len())
+                .min(text.len());
+            while take > 0 && !text.is_char_boundary(take) {
+                take -= 1;
+            }
+            prose.push_str(&text[..take]);
+            prose.push(' ');
+            if prose.len() >= PROSE_SAMPLE_MAX_BYTES {
+                break;
+            }
+        }
+    }
+    prose
+}
 
 /// `terse` tier: a small, fixed input cost for a real output-token reduction
 /// (output tokens cost ~3–5× input).
@@ -23,6 +53,12 @@ use crate::provider::Provider;
 // Output costs ~3–5× input, so the instruction's small input cost buys a much larger
 // output saving. Don't trade it away to flatter the input %.
 pub const TERSE_INSTRUCTION: &str = include_str!("../../prompts/output_terse.txt");
+
+/// Language-preservation clause appended to the primary shaping instruction. The injected
+/// instructions are in English and land last, biasing the model to answer in English even
+/// when the user wrote in another language; this one universal clause (no per-language
+/// detection) corrects that for a handful of input tokens. Only ships when shaping is on.
+pub const REPLY_LANGUAGE_CLAUSE: &str = " Reply in the user's language.";
 
 /// `draft` tier: Chain-of-Draft — collapse the reasoning scaffold, not the prose
 /// (arXiv:2502.18600). Targets reasoning-model output tokens, which concentrate in
@@ -95,7 +131,17 @@ impl Transform for OutputControlStage {
         // cap below stays (it costs nothing). `tool_choice: "none"` means the model is
         // told NOT to call, so the answer is prose again and shaping applies.
         if !tool_call_shaped(req) {
-            provider.add_system_instruction(req, self.level.instruction());
+            // The clause only earns its tokens when the user wrote in a non-English language;
+            // an English (or too-short-to-detect) prompt already answers in English, so skip
+            // it there and add nothing. `detect_lang` returns `Some` only on a reliable
+            // detection, so ambiguous/short prose keeps the clause (cheap, safe).
+            let non_english = detect_lang(&user_prose(req, provider)) != Some(whatlang::Lang::Eng);
+            let instruction = if non_english {
+                format!("{}{}", self.level.instruction(), REPLY_LANGUAGE_CLAUSE)
+            } else {
+                self.level.instruction().to_string()
+            };
+            provider.add_system_instruction(req, &instruction);
             // Soft numeric token budgets ("answer within N tokens") FAIL on reasoning
             // models: the batch-prompting overthinking study (arXiv:2511.04108, 2025)
             // found explicit thinking-budget instructions are ignored on DeepSeek-R1 /
@@ -289,11 +335,71 @@ mod tests {
         );
         let sys = req.get_str("/messages/0/content").unwrap();
         assert!(sys.contains("concise"));
+        assert!(
+            sys.contains("Reply in the user's language."),
+            "language-preservation clause rides the shaping instruction: {sys}"
+        );
         assert_eq!(
             req.raw()
                 .pointer("/messages/0/role")
                 .and_then(Value::as_str),
             Some("system")
+        );
+    }
+
+    #[test]
+    fn non_english_prompt_gets_language_clause() {
+        let req = run_one(
+            json!({"messages":[{"role":"user",
+                "content":"Peux-tu m'expliquer comment fonctionne ce module de compression ?"}]}),
+            OutputControlStage {
+                level: OutputLevel::Terse,
+                max_tokens: None,
+                token_budget: None,
+                compact_code: false,
+            },
+        );
+        let sys = req.get_str("/messages/0/content").unwrap();
+        assert!(
+            sys.contains("Reply in the user's language."),
+            "non-English prompt keeps the language clause: {sys}"
+        );
+    }
+
+    #[test]
+    fn english_prompt_skips_language_clause() {
+        let req = run_one(
+            json!({"messages":[{"role":"user",
+                "content":"Can you explain how this compression module works under the hood?"}]}),
+            OutputControlStage {
+                level: OutputLevel::Terse,
+                max_tokens: None,
+                token_budget: None,
+                compact_code: false,
+            },
+        );
+        let sys = req.get_str("/messages/0/content").unwrap();
+        assert!(sys.contains("concise"), "shaping still applies: {sys}");
+        assert!(
+            !sys.contains("Reply in the user's language."),
+            "English prompt pays no clause tokens: {sys}"
+        );
+    }
+
+    #[test]
+    fn user_prose_caps_a_huge_block_without_panicking() {
+        // A single multi-megabyte user turn must not be copied whole, and slicing a
+        // multibyte-char block must stay on a char boundary.
+        let huge = "é".repeat(1_000_000); // 2 MB, 2-byte chars
+        let req = Request::from_value(
+            ProviderKind::OpenAi,
+            json!({"messages": [{"role": "user", "content": huge}]}),
+        );
+        let sample = user_prose(&req, &OpenAiProvider);
+        assert!(
+            sample.len() <= PROSE_SAMPLE_MAX_BYTES + 1,
+            "sample bounded: {}",
+            sample.len()
         );
     }
 

--- a/crates/llmtrim-core/tests/conformance/anthropic_cache_frozen_prefix.json
+++ b/crates/llmtrim-core/tests/conformance/anthropic_cache_frozen_prefix.json
@@ -35,7 +35,7 @@
         },
         {
           "type": "text",
-          "text": "Be concise: no preamble, no restating the question, no filler. Answer directly."
+          "text": "Be concise: no preamble, no restating the question, no filler. Answer directly. Reply in the user's language."
         }
       ],
       "messages": [

--- a/crates/llmtrim-core/tests/conformance/openai_chat_basic.json
+++ b/crates/llmtrim-core/tests/conformance/openai_chat_basic.json
@@ -20,7 +20,7 @@
       "messages": [
         {
           "role": "system",
-          "content": "Be concise: no preamble, no restating the question, no filler. Answer directly."
+          "content": "Be concise: no preamble, no restating the question, no filler. Answer directly. Reply in the user's language."
         },
         {
           "role": "user",
@@ -28,7 +28,7 @@
         }
       ],
       "max_tokens": 5,
-      "prompt_cache_key": "f2e91a8ec143f0dc"
+      "prompt_cache_key": "77920950cbfe6fc7"
     }
   }
 }


### PR DESCRIPTION
## Problem

When a user writes in a non-English language, the model often replies in English. The cause is on our side: the output-shaping instructions (`terse`/`draft`) are written in English and are injected **last** in the request, so they become the strongest, most recent instruction the model sees and pull the answer back to English.

## Fix

Detect the language of the user-turn prose with `whatlang` (via the crate's existing `detect_lang` seam) and append a short `Reply in the user's language.` clause to the primary shaping instruction **only when the prompt is not reliably English**.

- Reliably-English prompts add nothing, so the common case pays zero extra tokens.
- Prompts too short to detect keep the clause as a cheap, safe fallback (~6 tokens).
- The clause ships only when output shaping is already active, never on tool-call requests.
- The prose sample is capped at 4 KB before each copy (char-boundary-safe), so a multi-megabyte pasted context isn't copied whole just to sniff its language.

## Tests

- `non_english_prompt_gets_language_clause` — French prompt keeps the clause.
- `english_prompt_skips_language_clause` — English prompt keeps shaping but adds no clause.
- `user_prose_caps_a_huge_block_without_panicking` — 2 MB multibyte block is bounded and char-boundary-safe.
- Conformance goldens reblessed (the shaped instruction now carries the clause; `prompt_cache_key` is a derived hash).
- Full suite: 733 passed.

## Review

Three reviewers ran on the change. They surfaced two issues, both fixed here: a CHANGELOG wording inaccuracy about short prompts, and the 4 KB cap firing after the copy instead of before it.