### PR TITLE
refactor(status): deprecate --watch, status opens the live TUI directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+- **`llmtrim status` opens the live dashboard directly on a TTY.** The `--watch` flag is now a hidden no-op, kept so existing scripts keep working.
+
 ## [0.4.0] - 2026-06-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,17 +834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
-dependencies = [
- "dispatch2",
- "nix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,8 +1006,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags",
- "block2",
- "libc",
  "objc2",
 ]
 
@@ -2077,7 +2064,6 @@ dependencies = [
  "clap",
  "comfy-table",
  "crossterm 0.28.1",
- "ctrlc",
  "dotenvy",
  "http-body-util",
  "hudsucker",
@@ -2096,7 +2082,6 @@ dependencies = [
  "serde",
  "serde_json",
  "statrs",
- "terminal_size",
  "time",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -4032,16 +4017,6 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
-dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,7 +109,7 @@ The `curl | sh` installer runs this for you. If you built from source or skipped
 
 ```bash
 llmtrim setup     # CA + HTTPS_PROXY/NODE_EXTRA_CA_CERTS in your shell profile + autostart + start
-llmtrim status    # savings dashboard (add --watch for a live view)
+llmtrim status    # live savings dashboard
 ```
 
 llmtrim is purely a MITM proxy; it configures your **environment** (no IDE settings).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: light)" srcset="assets/status-watch-light.svg">
-    <img src="assets/status-watch-dark.svg" alt="llmtrim status --watch: a live dashboard showing tokens trimmed, dollars saved off your real bill, input/output savings bars, and a per-model breakdown" width="760">
+    <img src="assets/status-watch-dark.svg" alt="llmtrim status: a live dashboard showing tokens trimmed, dollars saved off your real bill, input/output savings bars, and a per-model breakdown" width="760">
   </picture>
 </p>
 
@@ -160,7 +160,7 @@ npm install -g @llmtrim/cli@latest && llmtrim setup
 # 2. Open a new shell. Your AI tools now route through llmtrim automatically.
 
 # 3. Watch the savings add up as you work
-llmtrim status --watch
+llmtrim status
 ```
 
 **No Node?** Use an installer instead:

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -42,7 +42,6 @@ anyhow.workspace = true
 chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive"] }
 comfy-table = { version = "7.2.2", default-features = false, features = ["custom_styling"] }
-ctrlc = "3.5.2"
 dotenvy = "0.15.7"
 once_cell.workspace = true
 owo-colors = "4.3.0"
@@ -51,9 +50,6 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 serde.workspace = true
 serde_json.workspace = true
 statrs = "0.18.0"
-# Terminal width for the watch-mode repaint (truncates lines to one screen row so the
-# in-place repaint never drifts on narrow terminals). Wraps the already-present rustix.
-terminal_size = "0.4"
 toml.workspace = true
 unicode-width = "0.2"
 ureq = "3.3.0"

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -198,14 +198,16 @@ enum Commands {
     ///
     /// Savings from the ledger, plus the health chain (daemon → port → env → CA →
     /// traffic). Default: a snapshot, exiting 0 healthy / 1 stopped / 2 degraded;
-    /// `-q` for the health word only; `--watch` for a live view;
+    /// `-q` for the health word only; on a TTY opens the live cost-breakdown TUI;
     /// `--daily/--weekly/--monthly` for time-series; `--json/--csv` to export.
     #[command(name = "status", visible_aliases = ["monitor", "gain"])]
     Monitor {
-        /// Live refreshing dashboard (Ctrl-C to exit).
-        #[arg(long)]
+        /// Deprecated no-op kept for backward compatibility: `status` opens the live
+        /// dashboard on a TTY by default, so `--watch` is no longer needed. Hidden from
+        /// help; still accepted so existing scripts and aliases don't break.
+        #[arg(long, hide = true)]
         watch: bool,
-        /// Refresh interval for `--watch`, in seconds.
+        /// Refresh interval for the live dashboard, in seconds.
         #[arg(long, default_value_t = 2)]
         interval: u64,
         /// Daily time-series report.
@@ -224,7 +226,7 @@ enum Commands {
         #[arg(long)]
         csv: bool,
         /// Health only: print healthy|degraded|stopped and exit 0/2/1 (script-friendly).
-        #[arg(long, short, conflicts_with_all = ["watch", "daily", "weekly", "monthly", "json", "csv"])]
+        #[arg(long, short, conflicts_with_all = ["daily", "weekly", "monthly", "json", "csv"])]
         quiet: bool,
     },
     /// Run an MCP server over stdio (or `mcp install` to register it with a client)
@@ -701,7 +703,8 @@ fn run() -> Result<()> {
             Some(McpAction::Install { print, force }) => llmtrim::mcp::install(print, force)?,
         },
         Commands::Monitor {
-            watch,
+            // Deprecated no-op (see the field docs): accepted, then ignored.
+            watch: _,
             interval,
             daily,
             weekly,
@@ -709,7 +712,7 @@ fn run() -> Result<()> {
             json,
             csv,
             quiet,
-        } => run_monitor(watch, interval, daily, weekly, monthly, json, csv, quiet)?,
+        } => run_monitor(interval, daily, weekly, monthly, json, csv, quiet)?,
         Commands::Doctor => {
             let report = llmtrim::doctor::gather();
             print!("{}", llmtrim::doctor::render(ui::color_stdout(), &report));
@@ -1821,129 +1824,6 @@ fn overview_data(tracker: &Tracker) -> llmtrim::breakdown::app::OverviewData {
     })
 }
 
-/// Restores the normal screen buffer when the watch loop unwinds (error/broken pipe).
-/// The Ctrl-C path can't rely on Drop (`process::exit` skips destructors), so the
-/// signal handler in [`run_watch`] writes the same escape itself.
-struct AltScreenGuard;
-
-impl Drop for AltScreenGuard {
-    fn drop(&mut self) {
-        let mut out = std::io::stdout();
-        let _ = out.write_all(b"\x1b[?1049l");
-        let _ = out.flush();
-    }
-}
-
-/// Live dashboard. On a TTY it runs in the alternate screen buffer (the user's
-/// scrollback survives, like htop/less), repaints in place — home + per-line
-/// clear-to-EOL instead of a full-screen wipe, wrapped in synchronized-output marks
-/// (DEC 2026) so capable terminals commit each frame atomically: no flicker, no
-/// infinite scroll. Piped/redirected output keeps plain appended frames. Exits on
-/// Ctrl-C, restoring the normal screen.
-fn run_watch(tracker: &Tracker, interval: u64) -> Result<()> {
-    let color = ui::color_stdout();
-    // Screen-control escapes are for interactive terminals only — piped/redirected
-    // watch output gets appended frames instead of raw escapes.
-    let tty = ui::stdout_is_tty();
-    let _alt = if tty {
-        let mut out = std::io::stdout();
-        let _ = out.write_all(b"\x1b[?1049h\x1b[H");
-        let _ = out.flush();
-        // Default SIGINT would kill the process inside the alternate screen, leaving
-        // the terminal stuck in it — restore first, then exit.
-        let _ = ctrlc::set_handler(|| {
-            let mut out = std::io::stdout();
-            let _ = out.write_all(b"\x1b[?1049l");
-            let _ = out.flush();
-            std::process::exit(0);
-        });
-        Some(AltScreenGuard)
-    } else {
-        None
-    };
-    let mut prev: Option<i64> = None;
-    let mut frame_n: usize = 0;
-    loop {
-        let summary = tracker.summary()?;
-        let mut body = render_snapshot(tracker, color, false, false)?.0;
-        // Live throughput this interval, folded into the status bar below — only when traffic
-        // actually flowed (a perpetual "+0/s" on an idle proxy reads like fake data), and
-        // humanised to match the rest of the dashboard.
-        let rate_seg = match prev {
-            Some(p) if (summary.saved() - p) as f64 / interval as f64 >= 0.5 => {
-                let rate = (summary.saved() - p) as f64 / interval as f64;
-                format!(" · +{} tok/s saved", ui::human(rate as i64))
-            }
-            _ => String::new(),
-        };
-        prev = Some(summary.saved());
-
-        // Live status-bar footer. On a TTY: a spinner that advances every refresh (proves the
-        // view is live even when the numbers don't move), a ticking clock, the live rate when
-        // traffic flowed, and a right-aligned quit keycap. Piped output keeps a plain one-liner.
-        let cols = if tty {
-            terminal_size::terminal_size()
-                .map(|(w, _)| w.0 as usize)
-                .unwrap_or(80)
-        } else {
-            0
-        };
-        if tty {
-            const SPIN: [&str; 8] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
-            // Workload liveness — "is traffic flowing?" — is more useful here than a wall
-            // clock (the spinner already proves the UI is live). Idle shows how long ago the
-            // last request was, so a stalled workload is obvious.
-            let traffic = summary
-                .last_ts
-                .as_deref()
-                .and_then(llmtrim::daemon::human_age)
-                .map(|age| format!("last request {age}"))
-                .unwrap_or_else(|| "no requests yet".to_string());
-            let left = format!(
-                "{}  {}",
-                ui::paint(color, Tone::Accent, SPIN[frame_n % SPIN.len()]),
-                ui::paint(color, Tone::Dim, &format!("{traffic}{rate_seg}")),
-            );
-            let right = format!(
-                "{} {}",
-                ui::paint(color, Tone::Bold, "Ctrl-C"),
-                ui::paint(color, Tone::Dim, "exit"),
-            );
-            let used = 1 + ui::visible_width(&left) + ui::visible_width(&right);
-            let pad = " ".repeat(cols.saturating_sub(used).max(1));
-            body.push_str(&format!(" {left}{pad}{right}\n"));
-        } else {
-            body.push_str(&format!(
-                "  refreshing every {interval}s{rate_seg} · Ctrl-C to exit\n"
-            ));
-        }
-        frame_n += 1;
-
-        let frame = if tty {
-            // Each logical line must occupy exactly one screen row, or the home + per-line
-            // `\x1b[K` repaint drifts when a line soft-wraps. Truncate to the terminal width
-            // (ANSI-aware), then sync-begin + home, clear each line's tail (`\x1b[K`), clear
-            // below the frame (`\x1b[0J`), sync-end. The full untruncated text stays in the
-            // one-shot `status` (no repaint there, so wrapping is harmless).
-            let painted: String = body
-                .lines()
-                .map(|l| format!("{}\x1b[K\n", ui::truncate_visible(l, cols)))
-                .collect();
-            format!("\x1b[?2026h\x1b[H{painted}\x1b[0J\x1b[?2026l")
-        } else {
-            body
-        };
-        // Write, don't print!: a piped reader that exits (e.g. `| head`) closes the
-        // pipe, and print! would panic on the broken pipe — exit cleanly instead.
-        let mut stdout = std::io::stdout();
-        if stdout.write_all(frame.as_bytes()).is_err() {
-            return Ok(());
-        }
-        stdout.flush().ok();
-        std::thread::sleep(std::time::Duration::from_secs(interval));
-    }
-}
-
 /// Merge the per-source breakdown (every session + corpus-wide per-source cost) into a
 /// `status --json` string. No-op when the breakdown feature is off or no data exists yet,
 /// so the JSON shape is a superset of the prior one (additive `breakdown` key).
@@ -1991,7 +1871,6 @@ fn print_top_sources() {
 
 #[allow(clippy::too_many_arguments)]
 fn run_monitor(
-    watch: bool,
     interval: u64,
     daily: bool,
     weekly: bool,
@@ -2000,6 +1879,10 @@ fn run_monitor(
     csv: bool,
     quiet: bool,
 ) -> Result<()> {
+    // `interval` only drives the breakdown TUI's refresh; without that feature there is no
+    // live view to refresh, so it is unused.
+    #[cfg(not(feature = "breakdown"))]
+    let _ = interval;
     let tracker = Tracker::open().context("failed to open savings ledger")?;
 
     // Health-only mode: one word + the health exit code, for scripts and prompts
@@ -2056,7 +1939,7 @@ fn run_monitor(
         return Ok(());
     }
 
-    // On a TTY, the interactive view (watch or default) opens the cost-breakdown TUI:
+    // On a TTY, the interactive view opens the cost-breakdown TUI:
     // a tabbed Overview / Sessions / Detail explorer. Piped output and the export modes
     // above keep the plain snapshot, so scripts and `| less` are unaffected.
     #[cfg(feature = "breakdown")]
@@ -2106,20 +1989,16 @@ fn run_monitor(
         }
     }
 
-    if watch {
-        run_watch(&tracker, interval.max(1))
-    } else {
-        let (out, health) = render_snapshot(&tracker, ui::color_stdout(), false, false)?;
-        print!("{out}");
-        // Propagate health as the exit code (0 healthy / 1 stopped / 2 degraded) so
-        // `llmtrim status && …` means "llmtrim is actually working".
-        if health != monitor::Health::Healthy {
-            use std::io::Write as _;
-            let _ = std::io::stdout().flush();
-            std::process::exit(health.exit_code());
-        }
-        Ok(())
+    let (out, health) = render_snapshot(&tracker, ui::color_stdout(), false, false)?;
+    print!("{out}");
+    // Propagate health as the exit code (0 healthy / 1 stopped / 2 degraded) so
+    // `llmtrim status && …` means "llmtrim is actually working".
+    if health != monitor::Health::Healthy {
+        use std::io::Write as _;
+        let _ = std::io::stdout().flush();
+        std::process::exit(health.exit_code());
     }
+    Ok(())
 }
 
 /// Per-provider `(cache_read, cache_write)` price multipliers vs the list input rate:
@@ -2131,6 +2010,18 @@ fn run_monitor(
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    // `--watch` is a deprecated no-op, but it must still parse: removing it outright would
+    // break existing `llmtrim status --watch` scripts and aliases.
+    #[test]
+    fn status_still_accepts_deprecated_watch_flag() {
+        let cli = Cli::try_parse_from(["llmtrim", "status", "--watch"])
+            .expect("status --watch must still parse for backward compatibility");
+        match cli.command {
+            Commands::Monitor { watch, .. } => assert!(watch),
+            _ => panic!("expected status to parse as the Monitor command"),
+        }
+    }
 
     fn scratch_dir(tag: &str) -> PathBuf {
         let nanos = SystemTime::now()

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -440,8 +440,8 @@ fn render_header(color: bool, d: &DaemonView) -> String {
 }
 
 /// The savings dashboard: daemon header + health chain, a hero panel (cost / round-trip /
-/// requests), per-axis bars, and a per-model table. Returned as a string so the watch
-/// loop can repaint it atomically. `today_saved_usd` is the priced saving for today (UTC),
+/// requests), per-axis bars, and a per-model table. Returned as a string for the plain-text
+/// snapshot path (piped output, `--json/--csv`, non-TTY). `today_saved_usd` is the priced saving for today (UTC),
 /// shown next to the all-time hero when it is non-trivial.
 #[allow(clippy::too_many_arguments)]
 pub fn snapshot(

--- a/crates/llmtrim-cli/src/tracking.rs
+++ b/crates/llmtrim-cli/src/tracking.rs
@@ -316,7 +316,7 @@ impl Tracker {
 
     fn migrate(&self) -> Result<()> {
         // The ledger is written by the daemon thread AND by every CLI compress/send while
-        // `monitor --watch` reads it every 2s. With rusqlite's defaults (rollback journal,
+        // the `status` TUI reads it every ~2s. With rusqlite's defaults (rollback journal,
         // busy_timeout 0) a concurrent writer/reader hits SQLITE_BUSY immediately, dropping
         // rows or failing reads. WAL lets a reader and a writer proceed together; a 2s busy
         // timeout absorbs the brief writer-vs-writer overlap. Best-effort: an in-memory DB
@@ -1189,7 +1189,7 @@ mod tests {
     #[test]
     fn file_ledger_enables_wal_and_busy_timeout() {
         // WAL + a non-zero busy timeout protect the always-on daemon writer against the
-        // `monitor --watch` reader. (In-memory DBs can't run WAL, so test a file path.)
+        // `status` TUI reader. (In-memory DBs can't run WAL, so test a file path.)
         let dir = std::env::temp_dir().join(format!("llmtrim_wal_{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("t.db");

--- a/tools/npm/README.md
+++ b/tools/npm/README.md
@@ -12,7 +12,7 @@ save, so it can never increase your bill or break a request.
 ```bash
 npm install -g @llmtrim/cli@latest && llmtrim setup
 # open a new shell, then watch the bill shrink:
-llmtrim status --watch
+llmtrim status
 ```
 
 `setup` is transparent and fully reversible (`llmtrim uninstall`): a local CA, a proxy


### PR DESCRIPTION
## What

On a TTY, `llmtrim status` already opens the ratatui cost-breakdown dashboard (the `breakdown` feature ships by default), so the separate `--watch` flag and its legacy text-mode repaint loop are obsolete.

- Delete the dead `run_watch` loop and `AltScreenGuard`.
- Keep `--watch` **accepted but hidden and ignored** (a no-op), so existing `llmtrim status --watch` scripts and aliases keep working. This is a non-breaking deprecation, not a removal.
- Keep `--interval` as the live dashboard refresh interval; reword its docs.
- Drop `--watch` from the README / INSTALL / npm quick-start examples.
- Reword stale `monitor --watch` source comments.
- Add a regression test that `status --watch` still parses.

## Verification

- `cargo clippy --features intercept`: clean
- `cargo nextest run --features intercept`: 731 passed