### PR TITLE
fix: point restart-to-update hints at `llmtrim start --force`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project are documented here. The format follows
 ### Changed
 - **`llmtrim status` opens the live dashboard directly on a TTY.** The `--watch` flag is now a hidden no-op, kept so existing scripts keep working.
 
+### Fixed
+- **Restart-to-update hints now point at `llmtrim start --force` everywhere.** The stale-version banner in `status`/`doctor` and the Homebrew/Cargo note in INSTALL.md previously suggested `llmtrim stop && llmtrim start` or `llmtrim setup`; the latter does not restart a healthy daemon already on the right port, so it could leave the old binary running after an update. All three now match what `llmtrim update` actually runs.
+
 ## [0.4.0] - 2026-06-28
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,7 +126,7 @@ llmtrim update
 
 - **Binary** (`curl | sh`): re-runs the installer to fetch the latest release, then restarts.
 - **Cargo / Homebrew**: prints the right command (`cargo install --locked llmtrim --force` /
-  `brew upgrade fkiene/tap/llmtrim`), then run `llmtrim setup` to restart the daemon on it.
+  `brew upgrade fkiene/tap/llmtrim`), then run `llmtrim start --force` to restart the daemon on it.
 
 `status` shows a one-line notice when a newer release exists (checked at most once a day,
 cached; set `LLMTRIM_NO_UPDATE_CHECK=1` to disable, and it's skipped offline). Pin a version

--- a/crates/llmtrim-cli/src/doctor.rs
+++ b/crates/llmtrim-cli/src/doctor.rs
@@ -242,7 +242,7 @@ pub fn build(s: &State) -> Report {
             ui::WARN,
             "version".into(),
             format!(
-                "daemon is v{v}, binary is v{} — restart to update: llmtrim stop && llmtrim start",
+                "daemon is v{v}, binary is v{} — restart to update: llmtrim start --force",
                 s.binary_version
             ),
         ));

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -378,7 +378,7 @@ fn render_header(color: bool, d: &DaemonView) -> String {
                 color,
                 Tone::Warn,
                 &format!(
-                    "  {} daemon is v{v}, binary is v{} — restart to update: llmtrim stop && llmtrim start\n",
+                    "  {} daemon is v{v}, binary is v{} — restart to update: llmtrim start --force\n",
                     ui::WARN, d.binary_version
                 ),
             ));
@@ -1876,7 +1876,7 @@ mod tests {
             },
         );
         assert!(out.contains("daemon is v0.0.9, binary is v0.1.0"));
-        assert!(out.contains("llmtrim stop && llmtrim start"));
+        assert!(out.contains("llmtrim start --force"));
 
         let out = render_header(
             false,


### PR DESCRIPTION
## What

The restart-to-update hints disagreed across the codebase and one was wrong:

| Location | Was | Now |
|---|---|---|
| `INSTALL.md` (Homebrew/Cargo note) | `llmtrim setup` | `llmtrim start --force` |
| `monitor.rs` stale-version banner | `llmtrim stop && llmtrim start` | `llmtrim start --force` |
| `doctor.rs` stale-version banner | `llmtrim stop && llmtrim start` | `llmtrim start --force` |

## Why

`llmtrim setup` leaves a healthy daemon already serving the resolved port **untouched** (`setup.rs:452-462`), so it does not restart onto the freshly installed binary after an update — the exact stale-daemon trap the Update docs warn about. `llmtrim start --force` is what the `update` command already runs (`update.rs` `RESTART_HINT` / `restart_daemon`), so this makes all guidance match what the tool actually does.

## Test

`cargo fmt` + `cargo clippy --features intercept` clean; `cargo nextest run --features intercept` → 749 passed. Updated the matching assertion in `monitor.rs`.