### PR TITLE
fix(status): make breakdown opt-in and bound its retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **Ledger retention is now configurable.** Two new settings cap how much history llmtrim keeps: `max_rows` (env `LLMTRIM_MAX_ROWS`) for the compression event ledger and `max_breakdown_turns` (env `LLMTRIM_MAX_BREAKDOWN_TURNS`) for the per-source cost breakdown. Both take a positive integer and fall back to the built-in defaults when unset. Raise `max_breakdown_turns` to keep a deeper breakdown history at the cost of a larger database file.
+
 ### Changed
 - **`llmtrim status` opens the live dashboard directly on a TTY.** The `--watch` flag is now a hidden no-op, kept so existing scripts keep working.
 
 ### Fixed
+- **`status --json` no longer scans the whole ledger by default.** The per-source/per-session `breakdown` object aggregated the entire history on every call (a full `breakdown_blocks` scan that pinned a CPU core and used over a gigabyte of RAM on a large database). It is now opt-in via `status --json --breakdown`; the default export carries the same health and savings fields it always did.
+- **The per-source breakdown table is now bounded.** It was capped at 100,000 *turns*, but each turn fans out into hundreds of source rows, so the table reached millions of rows and its write-ahead log grew past 700 MB without a checkpoint. Breakdown retention now defaults to 50,000 turns (tunable via `max_breakdown_turns`) and is enforced both as the daemon records turns and when the ledger is next opened, with a WAL checkpoint after pruning so the file shrinks once the daemon is stopped. Note: on first run after upgrading, breakdown history beyond the cap is deleted permanently.
 - **Restart-to-update hints now point at `llmtrim start --force` everywhere.** The stale-version banner in `status`/`doctor` and the Homebrew/Cargo note in INSTALL.md previously suggested `llmtrim stop && llmtrim start` or `llmtrim setup`; the latter does not restart a healthy daemon already on the right port, so it could leave the old binary running after an update. All three now match what `llmtrim update` actually runs.
 
 ## [0.4.0] - 2026-06-28

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -222,6 +222,12 @@ enum Commands {
         /// Emit JSON instead of the dashboard (snapshot + time-series).
         #[arg(long)]
         json: bool,
+        /// Include the heavy per-source/per-session `breakdown` object in `--json`.
+        /// Off by default: it aggregates the entire ledger history (a full
+        /// `breakdown_blocks` scan that is expensive on a large DB), and the common
+        /// consumers — the health badge and savings percentages — never read it.
+        #[arg(long, requires = "json")]
+        breakdown: bool,
         /// Emit CSV time-series instead of the dashboard.
         #[arg(long)]
         csv: bool,
@@ -710,9 +716,12 @@ fn run() -> Result<()> {
             weekly,
             monthly,
             json,
+            breakdown,
             csv,
             quiet,
-        } => run_monitor(interval, daily, weekly, monthly, json, csv, quiet)?,
+        } => run_monitor(
+            interval, daily, weekly, monthly, json, breakdown, csv, quiet,
+        )?,
         Commands::Doctor => {
             let report = llmtrim::doctor::gather();
             print!("{}", llmtrim::doctor::render(ui::color_stdout(), &report));
@@ -1825,9 +1834,13 @@ fn overview_data(tracker: &Tracker) -> llmtrim::breakdown::app::OverviewData {
 }
 
 /// Merge the per-source breakdown (every session + corpus-wide per-source cost) into a
-/// `status --json` string. No-op when the breakdown feature is off or no data exists yet,
-/// so the JSON shape is a superset of the prior one (additive `breakdown` key).
-fn merge_breakdown_json(s: String) -> String {
+/// `status --json` string. No-op unless `--breakdown` is given (the section aggregates
+/// the full ledger history, which is expensive on a large DB) and the breakdown feature
+/// is built in with data present; the `breakdown` key is purely additive when emitted.
+fn merge_breakdown_json(s: String, include: bool) -> String {
+    if !include {
+        return s;
+    }
     #[cfg(feature = "breakdown")]
     if let Some(bd) = llmtrim::breakdown::export::breakdown_json() {
         // A parse failure here means a regression upstream in the status JSON — surface it
@@ -1876,6 +1889,7 @@ fn run_monitor(
     weekly: bool,
     monthly: bool,
     json: bool,
+    breakdown: bool,
     csv: bool,
     quiet: bool,
 ) -> Result<()> {
@@ -1912,7 +1926,7 @@ fn run_monitor(
                 &rows,
                 Some(&daemon),
             );
-            println!("{}", merge_breakdown_json(out));
+            println!("{}", merge_breakdown_json(out, breakdown));
         } else {
             print!(
                 "{}",
@@ -1933,7 +1947,7 @@ fn run_monitor(
             let daemon = daemon_view(&tracker.summary()?);
             println!(
                 "{}",
-                merge_breakdown_json(monitor::stats_json(&tracker, Some(&daemon))?)
+                merge_breakdown_json(monitor::stats_json(&tracker, Some(&daemon))?, breakdown)
             );
         }
         return Ok(());
@@ -2021,6 +2035,26 @@ mod tests {
             Commands::Monitor { watch, .. } => assert!(watch),
             _ => panic!("expected status to parse as the Monitor command"),
         }
+    }
+
+    // The heavy per-source `breakdown` object is opt-in: without `--breakdown`, `status --json`
+    // must not run the full-history aggregation, so the merge is a no-op that returns the input
+    // untouched (the common consumers — health badge, savings % — never read that section).
+    #[test]
+    fn breakdown_section_is_omitted_unless_requested() {
+        let base = r#"{"daemon":{"running":true}}"#.to_string();
+        assert_eq!(merge_breakdown_json(base.clone(), false), base);
+    }
+
+    // The flag only makes sense with `--json`; clap must reject it on its own.
+    #[test]
+    fn breakdown_flag_requires_json() {
+        assert!(
+            Cli::try_parse_from(["llmtrim", "status", "--breakdown"]).is_err(),
+            "--breakdown without --json must be rejected"
+        );
+        Cli::try_parse_from(["llmtrim", "status", "--json", "--breakdown"])
+            .expect("status --json --breakdown must parse");
     }
 
     fn scratch_dir(tag: &str) -> PathBuf {

--- a/crates/llmtrim-cli/src/mcp.rs
+++ b/crates/llmtrim-cli/src/mcp.rs
@@ -157,7 +157,7 @@ mod imp {
         }
 
         #[tool(
-            description = "Report recent savings from the local ledger: tokens trimmed, dollars saved, and a per-model breakdown. The same data the `llmtrim status --json` dashboard shows."
+            description = "Report recent savings from the local ledger: tokens trimmed and dollars saved. The same headline figures the `llmtrim status --json` dashboard shows."
         )]
         fn llmtrim_stats(
             &self,

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1607,7 +1607,8 @@ mod imp {
                     since_prune += 1;
                     if since_prune >= PRUNE_EVERY {
                         since_prune = 0;
-                        let _ = tracker.prune_breakdown(crate::tracking::DEFAULT_MAX_ROWS);
+                        let _ = tracker
+                            .prune_breakdown(crate::tracking::Tracker::breakdown_turns_cap());
                     }
                 }
             }

--- a/crates/llmtrim-cli/src/tracking.rs
+++ b/crates/llmtrim-cli/src/tracking.rs
@@ -239,6 +239,18 @@ impl Summary {
 /// metadata only (~100 bytes), so this bounds the file to roughly 10-15 MB.
 pub const DEFAULT_MAX_ROWS: i64 = 100_000;
 
+/// Retention cap for the per-source breakdown, in *turns*. A turn fans out into one
+/// `breakdown_blocks` row per source (hundreds in agent traffic), so the block table grows
+/// far faster than `compressions` and needs its own cap — reusing `DEFAULT_MAX_ROWS` here let
+/// the blocks table reach millions of rows and made `status --json` aggregate a
+/// multi-hundred-MB join on every call.
+///
+/// The expensive aggregate is now opt-in (`status --json --breakdown`), so the cap no longer
+/// governs the hot path — it only bounds disk. We keep it generous to preserve a long history
+/// for the breakdown TUI; the file scales with usage (heavy agent traffic at this cap can reach
+/// a few hundred MB to ~1 GB).
+pub const DEFAULT_MAX_BREAKDOWN_TURNS: i64 = 50_000;
+
 pub struct Tracker {
     conn: Connection,
 }
@@ -263,6 +275,10 @@ impl Tracker {
         // Bound the ledger on open: row cap + (if configured) age retention. The daemon
         // opens once and re-prunes periodically (see serve.rs); CLI paths prune per call.
         let _ = tracker.prune_default();
+        // Also bound the per-source breakdown here, not just in the daemon's write loop, so a
+        // restart immediately reclaims a table that grew unbounded under an older build (it
+        // checkpoints the WAL when it deletes). A no-op COUNT once the table is within cap.
+        let _ = tracker.prune_breakdown(Self::breakdown_turns_cap());
         Ok(tracker)
     }
 
@@ -458,11 +474,21 @@ impl Tracker {
         Ok(deleted)
     }
 
-    /// Prune with the default policy: the built-in row cap ([`DEFAULT_MAX_ROWS`]) plus the
-    /// configured age retention (`LLMTRIM_RETENTION_DAYS` env or `retention_days` in the
-    /// config file; `None` = age retention disabled, row cap only).
+    /// Prune with the default policy: the configured row cap (`LLMTRIM_MAX_ROWS` env or `max_rows`
+    /// in the config file, default [`DEFAULT_MAX_ROWS`]) plus the configured age retention
+    /// (`LLMTRIM_RETENTION_DAYS` env or `retention_days` in the config file; `None` = age
+    /// retention disabled, row cap only).
     pub fn prune_default(&self) -> Result<u64> {
-        self.prune(DEFAULT_MAX_ROWS, llmtrim_core::config::retention_days())
+        self.prune(
+            llmtrim_core::config::max_rows().unwrap_or(DEFAULT_MAX_ROWS),
+            llmtrim_core::config::retention_days(),
+        )
+    }
+
+    /// The effective breakdown retention cap: the configured value (`LLMTRIM_MAX_BREAKDOWN_TURNS`
+    /// env or `max_breakdown_turns` in the config file) or [`DEFAULT_MAX_BREAKDOWN_TURNS`].
+    pub fn breakdown_turns_cap() -> i64 {
+        llmtrim_core::config::max_breakdown_turns().unwrap_or(DEFAULT_MAX_BREAKDOWN_TURNS)
     }
 
     pub fn record(&self, r: &Record) -> Result<()> {
@@ -565,8 +591,11 @@ impl Tracker {
         Ok(turn_id)
     }
 
-    /// Cap the breakdown tables to the most recent `max_turns` turns, deleting the blocks of any
-    /// dropped turn. Mirrors the `compressions` row cap so the always-on daemon stays bounded.
+    /// Cap the breakdown tables to the most recent `max_turns` *turns* (not rows — each turn owns
+    /// many `breakdown_blocks`), deleting the blocks of any dropped turn. Runs from both the daemon
+    /// write loop and `Tracker::open()`, so any CLI invocation can trigger it; turns beyond the cap
+    /// are deleted permanently. Mirrors the `compressions` row cap so the always-on daemon stays
+    /// bounded.
     pub fn prune_breakdown(&self, max_turns: i64) -> Result<u64> {
         let n: i64 = self
             .conn
@@ -589,6 +618,16 @@ impl Tracker {
                 params![max_turns],
             )
             .context("failed to cap-prune breakdown turns")? as u64;
+        // Deleting the bulk of `breakdown_blocks` writes a large volume to the WAL; without a
+        // checkpoint the WAL file grows unbounded (it reached ~700 MB in the wild) even as the
+        // logical row count shrinks. TRUNCATE checkpoints and resets the WAL to zero. Best-effort
+        // and only when we actually pruned, so the steady state stays cheap. Note TRUNCATE no-ops
+        // (returns SQLITE_BUSY, swallowed here) while another connection holds the WAL open — so a
+        // CLI prune only compacts the file when the daemon is stopped; otherwise the daemon's own
+        // prune loop does it.
+        if deleted > 0 {
+            let _ = self.conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);");
+        }
         Ok(deleted)
     }
 
@@ -1204,6 +1243,40 @@ mod tests {
             .query_row("PRAGMA busy_timeout", [], |r| r.get(0))
             .unwrap();
         assert!(timeout >= 2000, "busy_timeout set (got {timeout})");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn open_at_prunes_breakdown_without_dropping_in_cap_history() {
+        // open_at() runs the breakdown prune on every open (so a restart self-heals a table that
+        // grew under an older build). Exercise that path against a real on-disk DB: seed turns
+        // under the cap, reopen, and confirm the open-time prune is a safe no-op that keeps the
+        // full history. The over-cap deletion arm is covered by
+        // `prune_breakdown_caps_turns_and_orphan_blocks`; we can't drive the cap below the seed
+        // here because the cap comes from the process-wide RuntimeConfig cache.
+        let dir = std::env::temp_dir().join(format!("llmtrim_bd_open_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("t.db");
+        {
+            let t = Tracker::open_at(&path).expect("open file ledger");
+            for i in 0..5 {
+                t.record_breakdown(
+                    &breakdown_turn(&format!("s{i}")),
+                    &[breakdown_block("System prompt", 10)],
+                )
+                .unwrap();
+            }
+        }
+        // Reopen: this is the path that runs prune_breakdown(breakdown_turns_cap()).
+        let t = Tracker::open_at(&path).expect("reopen file ledger");
+        let turns: i64 = t
+            .conn
+            .query_row("SELECT COUNT(*) FROM breakdown_turns", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            turns, 5,
+            "history within the cap survives the open-time prune"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -486,6 +486,8 @@ pub(crate) const RUNTIME_ONLY_KEYS: &[&str] = &[
     "capture_max_mb",
     "breakdown_window",
     "retention_days",
+    "max_rows",
+    "max_breakdown_turns",
     "theme",
 ];
 
@@ -782,6 +784,49 @@ pub fn retention_days() -> Option<i64> {
     RuntimeConfig::get().retention_days
 }
 
+/// Resolve a positive integer setting from the environment (first) then the config file,
+/// rejecting non-positive values (`<= 0` → `None`). Kept off [`RuntimeConfig`] and read on
+/// demand so the published struct's field set (and so its public API) stays stable; these caps
+/// are only consulted at prune time, not in any hot path.
+fn resolve_positive_int(
+    env: impl Fn(&str) -> Option<String>,
+    file: Option<&toml::Value>,
+    env_key: &str,
+    file_key: &str,
+) -> Option<i64> {
+    env(env_key)
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.trim().parse::<i64>().ok())
+        .or_else(|| {
+            file.and_then(|v| v.get(file_key))
+                .and_then(toml::Value::as_integer)
+        })
+        .filter(|n| *n > 0)
+}
+
+/// Configured ledger row cap (env `LLMTRIM_MAX_ROWS` / file `max_rows`), or `None` to fall back
+/// to the caller's built-in default. Positive only.
+pub fn max_rows() -> Option<i64> {
+    resolve_positive_int(
+        |k| std::env::var(k).ok(),
+        cached_config_file(),
+        "LLMTRIM_MAX_ROWS",
+        "max_rows",
+    )
+}
+
+/// Configured breakdown retention cap in turns (env `LLMTRIM_MAX_BREAKDOWN_TURNS` / file
+/// `max_breakdown_turns`), or `None` to fall back to the built-in default. Positive only; a turn
+/// fans out into many block rows, so this is the knob that governs breakdown-history depth.
+pub fn max_breakdown_turns() -> Option<i64> {
+    resolve_positive_int(
+        |k| std::env::var(k).ok(),
+        cached_config_file(),
+        "LLMTRIM_MAX_BREAKDOWN_TURNS",
+        "max_breakdown_turns",
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1034,6 +1079,39 @@ mod tests {
         assert_eq!(c.bind.as_deref(), Some("0.0.0.0"));
         assert_eq!(c.capture_max_mb, Some(99));
         assert_eq!(c.retention_days, Some(14));
+    }
+
+    /// `resolve_positive_int` (backing `max_rows` / `max_breakdown_turns`) takes env over file,
+    /// parses both sources, and rejects non-positive values.
+    #[test]
+    fn positive_int_resolves_env_over_file_and_rejects_nonpositive() {
+        let file: toml::Value = toml::from_str("max_rows = 1000\n").unwrap();
+        let f = Some(&file);
+
+        // env wins over file
+        assert_eq!(
+            resolve_positive_int(
+                |k| (k == "LLMTRIM_MAX_ROWS").then(|| "2000".to_string()),
+                f,
+                "LLMTRIM_MAX_ROWS",
+                "max_rows",
+            ),
+            Some(2000)
+        );
+        // file used when env absent
+        assert_eq!(
+            resolve_positive_int(|_| None, f, "LLMTRIM_MAX_ROWS", "max_rows"),
+            Some(1000)
+        );
+        // non-positive (and missing) collapse to None
+        for src in ["max_rows = 0", "max_rows = -1", "hygiene = true"] {
+            let v: toml::Value = toml::from_str(src).unwrap();
+            assert_eq!(
+                resolve_positive_int(|_| None, Some(&v), "LLMTRIM_MAX_ROWS", "max_rows"),
+                None,
+                "{src}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`status --json` aggregated the entire per-source/per-session `breakdown` object on every call: a full `breakdown_blocks` scan that pinned a CPU core and used over a gigabyte of RAM on a large ledger. The herdr savings poller calls `status --json` every 20s, so this ran continuously and bloated the database (the WAL alone reached ~700 MB without a checkpoint).

## Changes

- **Gate the breakdown behind `status --json --breakdown`.** The default export keeps the health and savings fields its only consumers (the herdr badge and `mcp.rs`) read.
- **Bound the breakdown table.** It was capped at 100,000 turns, but each turn fans out into hundreds of block rows, so the table reached millions of rows. Retention now defaults to 50,000 turns, prunes on open as well as during writes, and checkpoints the WAL (TRUNCATE) after pruning.
- **Make both retention caps configurable** (env-first then file, following the existing `retention_days` pattern): `max_rows` (`LLMTRIM_MAX_ROWS`) for the event ledger and `max_breakdown_turns` (`LLMTRIM_MAX_BREAKDOWN_TURNS`) for the breakdown.

## Notes

- Backward compatible: the only `status --json` consumers read `cost.round_trip_pct` / `input.saved_pct`, neither of which lived in the `breakdown` object.
- On first run after upgrade, breakdown history beyond the cap is pruned permanently (documented in the CHANGELOG).
- The companion herdr poller-leak fix is in fkiene/llmtrim-herdr#1.

## Testing

`cargo fmt`, `cargo clippy --features intercept`, `cargo nextest run --features intercept` (753 passed). New tests cover the config knobs and open-time pruning. Reviewed across two rounds of 3 parallel reviewers.