### PR TITLE
refactor(config)!: make RuntimeConfig non_exhaustive so new settings aren't breaking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim"
-version = "0.4.1-dev"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-core"
-version = "0.4.1-dev"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "base64",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-uniffi"
-version = "0.4.1-dev"
+version = "0.5.0-dev"
 dependencies = [
  "llmtrim-core",
  "serde_json",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-wasm"
-version = "0.4.1-dev"
+version = "0.5.0-dev"
 dependencies = [
  "llmtrim-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 # Shared package metadata — inherited by each member via `field.workspace = true`.
 [workspace.package]
-version = "0.4.1-dev"
+version = "0.5.0-dev"
 edition = "2024"
 rust-version = "1.88"
 repository = "https://github.com/fkiene/llmtrim"

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -37,7 +37,7 @@ path = "src/main.rs"
 [dependencies]
 # `version` is required for `cargo publish` (path alone isn't publishable) and is kept in
 # lockstep with llmtrim-core by cargo-release's shared-version on every bump.
-llmtrim-core = { path = "../llmtrim-core", version = "0.4.1-dev" }
+llmtrim-core = { path = "../llmtrim-core", version = "0.5.0-dev" }
 anyhow.workspace = true
 chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive"] }

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -502,6 +502,10 @@ pub(crate) const RUNTIME_ONLY_KEYS: &[&str] = &[
 /// `LLMTRIM_HOME` (base dir resolved before config loads), `LLMTRIM_PROFILE` (dev timing
 /// toggle), `LLMTRIM_VERSION` (internal updater handoff). None are persistable user settings.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+// Constructed only inside this crate (`resolve`/`load`); every other crate just reads fields
+// off `RuntimeConfig::get()`. Marking it non-exhaustive keeps adding a new setting a
+// non-breaking change instead of tripping cargo-semver-checks' `constructible_struct_adds_field`.
+#[non_exhaustive]
 pub struct RuntimeConfig {
     /// Extra exact LLM-API hosts to intercept beyond the built-in registry. Env
     /// `LLMTRIM_EXTRA_HOSTS` (comma-separated) replaces the file `extra_hosts` array.


### PR DESCRIPTION
## Why

`RuntimeConfig` (in `llmtrim-core`) is a `pub` struct with all-`pub` fields and no `#[non_exhaustive]`, so cargo-semver-checks treats it as externally constructible and flags *any* added field as breaking (`constructible_struct_adds_field`). That forces a minor bump for every new config knob, and it is why #111 had to resolve its two retention caps on demand instead of storing them as fields.

Nothing outside `llmtrim-core` ever constructs the struct: every other crate only reads fields off `RuntimeConfig::get()`.

## Change

- Mark `RuntimeConfig` `#[non_exhaustive]`. Field reads and in-crate construction are unchanged; only downstream struct-literal construction or exhaustive matching would now need `..` (no such caller exists). Adding a setting is a non-breaking change from here on.
- The marker is itself a one-time breaking change, so the workspace is bumped to `0.5.0-dev` (shared-version: core, cli, uniffi, wasm, and llmtrim's internal dep requirement). **This pre-commits the next release to 0.5.0.**

No changelog entry: the marker is invisible to CLI users.

## Testing

`cargo fmt`, `cargo clippy --features intercept`, `cargo nextest run --features intercept` (753 passed). `cargo semver-checks check-release -p llmtrim-core` now reports no update required.