### PR TITLE
fix(wasm): enable getrandom 0.4 wasm_js backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,11 +1429,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2170,6 +2172,7 @@ dependencies = [
  "gaoya",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "image",
  "once_cell",
  "regex",

--- a/crates/llmtrim-core/Cargo.toml
+++ b/crates/llmtrim-core/Cargo.toml
@@ -77,10 +77,12 @@ unicode-segmentation = "1.13.3"
 whatlang = "0.18.0"
 
 # wasm32 needs the JS-backed getrandom: 0.2 (via gaoya→rand) takes the `js` feature; 0.3
-# (via ahash) takes `wasm_js` plus `--cfg getrandom_backend="wasm_js"` in RUSTFLAGS.
+# (via ahash) and 0.4 (via newer gaoya→rand) take `wasm_js` plus
+# `--cfg getrandom_backend="wasm_js"` in RUSTFLAGS.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 
 [features]
 default = ["skeleton", "tiktoken", "multimodal"]


### PR DESCRIPTION
Enable the JS-backed getrandom 0.4 backend for the wasm32 build.

## Why
Dependabot's cargo-minor-patch group (#121, was #116) bumps gaoya 0.2.0 to 0.2.2, which
bumps its `rand` dependency and drags `getrandom` 0.4 into the wasm32-unknown-unknown build.
The existing target-specific pins in `llmtrim-core/Cargo.toml` only cover getrandom 0.2 (`js`)
and 0.3 (`wasm_js`), so 0.4's JS backend never gets enabled and the build hits getrandom's
`compile_error!` ("the wasm32-unknown-unknown targets are not supported by default; you may
need to enable the wasm_js crate feature"). That is the "WASM binding (smoke)" failure on #116.

## What
Add a `getrandom` 0.4 pin with the `wasm_js` feature under the same
`cfg(target_arch = "wasm32")` block, matching the existing 0.2/0.3 pattern.

## Sequencing
On this branch alone the pin is inert: the lockfile still resolves gaoya 0.2.0, so nothing
pulls getrandom 0.4 yet. Land this first, then rebase #121 on top; #121 carries gaoya 0.2.2
and its "WASM binding (smoke)" job then exercises the pin and passes.

## Verification
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build -p llmtrim-wasm --release
  --target wasm32-unknown-unknown` succeeds.
- Reproduced the failure and the fix: forcing `cargo update -p gaoya` (0.2.0 to 0.2.2) pulls
  getrandom 0.4.2 into the wasm tree, and the build succeeds with this pin, fails without it.
