### PR TITLE
deps: bump rmcp 1.7 to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3396,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3418,9 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -95,7 +95,7 @@ llm_providers = { version = "0.14", optional = true }
 time = { version = ">=0.3.36, <0.3.48", default-features = false, optional = true }
 # MCP server over stdio (`mcp`). rmcp is the official Model Context Protocol Rust SDK;
 # `transport-io` is the stdio transport, `macros` derives each tool's JSON Schema.
-rmcp = { version = "1.7", default-features = false, features = [
+rmcp = { version = "2.0", default-features = false, features = [
   "server",
   "macros",
   "transport-io",
@@ -112,7 +112,7 @@ crossterm = { version = "0.28", optional = true }
 # the server through an in-memory client, which needs rmcp's `client` side. Dev-only —
 # the shipped binary keeps just the server features above.
 [dev-dependencies]
-rmcp = { version = "1.7", default-features = false, features = ["client", "transport-io"] }
+rmcp = { version = "2.0", default-features = false, features = ["client", "transport-io"] }
 
 [target.'cfg(not(windows))'.dependencies]
 auto-launch = "0.6.0"

--- a/crates/llmtrim-cli/src/mcp.rs
+++ b/crates/llmtrim-cli/src/mcp.rs
@@ -38,7 +38,7 @@ mod imp {
 
     use anyhow::{Context, Result};
     use rmcp::handler::server::wrapper::Parameters;
-    use rmcp::model::{CallToolResult, Content};
+    use rmcp::model::{CallToolResult, ContentBlock};
     use rmcp::{
         ErrorData as McpError, ServerHandler, ServiceExt, schemars, tool, tool_handler,
         tool_router, transport::stdio,
@@ -165,7 +165,7 @@ mod imp {
         ) -> Result<CallToolResult, McpError> {
             let tracker = self.tracker().map_err(internal)?;
             let stats = crate::monitor::stats_json(&tracker, None).map_err(internal)?;
-            Ok(CallToolResult::success(vec![Content::text(stats)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(stats)]))
         }
     }
 
@@ -335,7 +335,7 @@ mod imp {
     }
 
     fn ok_json(payload: &Value) -> Result<CallToolResult, McpError> {
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             payload.to_string(),
         )]))
     }


### PR DESCRIPTION
Bump rmcp 1.7 to 2.0 and adapt to its one breaking change.

Supersedes Dependabot #119, which bumped the manifest without the code migration 2.0 needs.
Close #119 in favor of this.

## Breaking change
rmcp 2.0 aligns its model types with the MCP 2025-11-25 spec and renames the tool-result
content type from `Content` to `ContentBlock`. `ContentBlock::text` replaces `Content::text`
with an identical signature and construction path, and `CallToolResult::success(Vec<ContentBlock>)`
is unchanged in body. The migration is the rename at three sites in `crates/llmtrim-cli/src/mcp.rs`.

No other rmcp symbol this crate uses changed (`ServerHandler`, `Parameters`, `ErrorCode`, the
`tool`/`tool_router`/`tool_handler` macros). rmcp is used only by `llmtrim-cli`, behind the
`mcp` feature.

## Behavior
No change to the MCP server: same tools, same output shape. rmcp 2.0's default served protocol
version is 2025-11-25 (latest); since MCP negotiates the version with the client, older clients
still interoperate, so this is not user-observable. No changelog entry.

## Verification
- All 18 mcp tests pass, including the `tests/mcp_protocol.rs` in-memory protocol test that
  drives initialize -> tools/list -> tools/call end to end.
- `cargo clippy -p llmtrim --features mcp --tests` and `cargo fmt --check` clean.
- MSRV unaffected (rmcp 2.0 needs edition 2024 / rustc 1.85; repo MSRV is 1.88).
- The one public item referencing an rmcp type, `test_server`, is `#[doc(hidden)]`, so the
  SemVer public-API gate is unaffected.
