### PR TITLE
fix(intercept): cover chatgpt.com so Codex with ChatGPT sign-in is tracked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **Codex CLI with ChatGPT sign-in is now compressed and tracked.** It posts to `chatgpt.com`, which was missing from the intercept set, so its traffic passed through the proxy untouched and never showed up in `llmtrim status` (#101).
+
 ## [0.5.0] - 2026-06-29
 
 ### Added

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -106,6 +106,7 @@ mod imp {
         "inference.baseten.co",
         "api.studio.nebius.ai",
         "ai-gateway.vercel.sh",
+        "chatgpt.com", // Codex CLI with ChatGPT sign-in (OpenAI Responses shape)
     ];
 
     /// User-configured extra hosts (env `LLMTRIM_EXTRA_HOSTS` / file `extra_hosts`), already
@@ -2304,6 +2305,8 @@ mod imp {
                 provider_for_host("ai-gateway.vercel.sh"),
                 Some(ProviderKind::OpenAi)
             );
+            // Codex CLI with ChatGPT sign-in posts to chatgpt.com, not api.openai.com.
+            assert_eq!(provider_for_host("chatgpt.com"), Some(ProviderKind::OpenAi));
             // Non-LLM hosts are not intercepted.
             assert_eq!(provider_for_host("github.com"), None);
             assert_eq!(provider_for_host("example.com"), None);
@@ -2396,10 +2399,16 @@ mod imp {
             let d = intercept_domains();
             assert!(d.contains(&"api.openai.com".to_string())); // exact registry endpoint host
             assert!(d.contains(&"opencode.ai".to_string())); // from EXTRA_HOSTS
+            assert!(d.contains(&"chatgpt.com".to_string())); // Codex CLI, ChatGPT sign-in
             assert!(
                 d.windows(2).all(|w| w[0] <= w[1]),
                 "must be sorted for sidecar compare"
             );
+        }
+
+        #[test]
+        fn codex_responses_path_is_compressible() {
+            assert!(is_compressible_path("/backend-api/codex/responses"));
         }
 
         #[test]


### PR DESCRIPTION
Fixes #101.

Codex signed in with a ChatGPT subscription posts to `https://chatgpt.com/backend-api/codex/responses`, not `api.openai.com`. `chatgpt.com` was not in the intercept set (the `llm_providers` registry only has `api.openai.com`, and the host was not in `EXTRA_HOSTS`), so the proxy CONNECT-tunneled Codex traffic without touching it. That is why killing llmtrim killed the agent while `llmtrim status` showed nothing: the traffic went through the proxy but was never intercepted or recorded.

The fix adds `chatgpt.com` to the curated `EXTRA_HOSTS` list. No other change is needed: `provider_for_host` resolves it to the OpenAI wire shape via `is_extra_host`, and `is_compressible_path` already matches `/backend-api/codex/responses` (ends with `/responses`).

Tests added:
- `provider_for_host("chatgpt.com")` resolves to `ProviderKind::OpenAi`
- `is_compressible_path("/backend-api/codex/responses")` is true
- `intercept_domains()` contains `chatgpt.com`

One note for review: this widens the name-constrained MITM CA to `chatgpt.com` and its subdomains. Existing installs regenerate the CA on the next daemon start (sidecar comparison), no manual step. Users on current releases can get the same effect today with `LLMTRIM_EXTRA_HOSTS=chatgpt.com` and a daemon restart.

Verified with `cargo fmt`, `cargo clippy --features intercept` (clean), and `cargo nextest run --features intercept` (754 passed, 1 skipped).
