### PR TITLE
ci(release): make crate publishing idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,11 +284,38 @@ jobs:
               echo "waiting for $crate $V on the index (attempt $i)"; sleep 30
             done
           }
-          cargo publish -p llmtrim-core
-          wait_for_index llmtrim-core ll/mt/llmtrim-core
-          cargo publish -p llmtrim-ledger
-          wait_for_index llmtrim-ledger ll/mt/llmtrim-ledger
-          cargo publish -p llmtrim
+          # True only when version $V is live (published AND not yanked) on the sparse index.
+          # Matches the exact `vers` and requires `yanked == false` via jq, so a yanked entry
+          # counts as absent (a yanked version can't be re-published, so a real publish attempt
+          # would then fail loudly rather than silently ship against a gone dependency). Retries
+          # to ride out the index CDN cache (cache-control max-age=600) instead of concluding
+          # "absent" on a single transient read.
+          is_live_on_index() {
+            local path="$1"
+            for i in 1 2 3; do
+              if curl -fsSL "https://index.crates.io/$path" 2>/dev/null \
+                   | jq -e --arg v "$V" 'select(.vers == $v and (.yanked | not))' >/dev/null; then
+                return 0
+              fi
+              sleep 5
+            done
+            return 1
+          }
+          # Idempotent publish: skip a crate whose version is already live on the index. A re-run
+          # after a partial failure, or a locally bootstrapped first publish of a new crate
+          # (crates.io has no pending trusted publishers, so a brand-new crate's first publish
+          # is a manual token publish), is then a no-op instead of an "already exists" error.
+          publish_if_absent() {
+            local crate="$1" path="$2"
+            if is_live_on_index "$path"; then
+              echo "$crate $V already live on the index; skipping publish"; return 0
+            fi
+            cargo publish -p "$crate"
+            wait_for_index "$crate" "$path"
+          }
+          publish_if_absent llmtrim-core ll/mt/llmtrim-core
+          publish_if_absent llmtrim-ledger ll/mt/llmtrim-ledger
+          publish_if_absent llmtrim ll/mt/llmtrim
 
   # Multi-arch proxy image on GHCR from the released (attested) binaries — not rebuilt.
   # amd64 ← x86_64-musl (fully static), arm64 ← aarch64-gnu (distroless cc has glibc).


### PR DESCRIPTION
## What
Wrap each `cargo publish` in the release workflow with a `publish_if_absent` helper that skips a crate whose version is already served on the sparse index.

## Why
- A re-run after a partial publish failure used to hit `error: crate version already exists` and fail the job. It now skips the already-published crates and carries on.
- The workspace gained a new crate, `llmtrim-ledger`. crates.io has no pending trusted publishers, so a brand-new crate cannot publish over OIDC until it exists and a trusted publisher is attached to it. Its first publish has to be a manual token publish; with this guard the tagged release then skips that already-published version instead of erroring, and later releases go through OIDC like the other crates.

## Risk
Publish step only. Nothing changes about what gets built or which versions ship. The index check runs inside an `if`, so a 404 for a not-yet-published crate falls through to a normal publish (same pattern the existing `wait_for_index` uses).
