### PR TITLE
fix(release): don't let a Dependabot check-run block the pre-release gate

### DIFF
--- a/tools/check_ci_green.sh
+++ b/tools/check_ci_green.sh
@@ -12,14 +12,23 @@ if [ "$HEAD" != "$REMOTE" ]; then
 fi
 
 # All check runs for HEAD must exist and be completed+successful (neutral/skipped ok).
+# The "Dependabot" check-run is excluded: it reports the result of Dependabot's scheduled
+# dependency-update job, not a CI check on the release commit's code. It goes red on a
+# `security_update_not_possible` (an advisory whose fixed version isn't resolvable in our
+# tree yet), which is a standing dependency-tree fact, not a reason to block a release.
+# The exclusion is by name, so it drops that check-run for any conclusion, not just the
+# advisory case — intentional: the scheduled dependency-update job is never a CI check on
+# the release commit's code, so it should not gate a release whatever its result.
+NOT_DEPENDABOT='.name != "Dependabot"'
 PENDING=$(gh api "repos/{owner}/{repo}/commits/$HEAD/check-runs" \
-    --jq '[.check_runs[] | select(.status != "completed")] | length')
+    --jq "[.check_runs[] | select($NOT_DEPENDABOT and .status != \"completed\")] | length")
 RED=$(gh api "repos/{owner}/{repo}/commits/$HEAD/check-runs" \
-    --jq '[.check_runs[] | select(.status == "completed" and (.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped"))] | .[].name')
-TOTAL=$(gh api "repos/{owner}/{repo}/commits/$HEAD/check-runs" --jq '.check_runs | length')
+    --jq "[.check_runs[] | select($NOT_DEPENDABOT and .status == \"completed\" and (.conclusion != \"success\" and .conclusion != \"neutral\" and .conclusion != \"skipped\"))] | .[].name")
+TOTAL=$(gh api "repos/{owner}/{repo}/commits/$HEAD/check-runs" \
+    --jq "[.check_runs[] | select($NOT_DEPENDABOT)] | length")
 
 if [ "$TOTAL" = "0" ]; then
-    echo "release blocked: no CI checks found for $HEAD (still queued? docs-only push skips CI — make sure the release commit's parent ran)" >&2
+    echo "release blocked: no CI checks found for $HEAD (still queued? docs-only push skips CI — make sure the release commit's parent ran; the Dependabot check-run is excluded from this count)" >&2
     exit 1
 fi
 if [ "$PENDING" != "0" ]; then


### PR DESCRIPTION
The pre-release hook (`tools/check_ci_green.sh`) treats every red check-run on the release commit as a blocker.

Dependabot posts a check-run named `Dependabot` reporting its scheduled dependency-update job. It goes red on a `security_update_not_possible` advisory (the fixed version is not resolvable in our tree yet, e.g. `glib` non-vulnerable `0.20.0` vs latest-resolvable `0.18.5`). That is a standing property of the dependency tree, not a CI failure on the release commit code, and it currently blocks `cargo release`.

This excludes the `Dependabot` check-run from the pending / red / total counts. All real CI checks (CI, CodeQL, coverage, etc.) still gate the release exactly as before.

Verified against the current `main` HEAD: `PENDING=0`, `RED=[]`, `TOTAL=27` (Dependabot excluded).