### PR TITLE
fix(release): build the tray binary with an explicit --package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,12 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: ${{ matrix.tray && 'llmtrim,llmtrim-tray' || 'llmtrim' }}
+          # llmtrim-tray is deliberately excluded from `default-members` (bare `cargo
+          # build` on Linux CI must skip Tauri), so `--bin llmtrim-tray` alone can't
+          # resolve it. Naming the packages makes the action pass `--package llmtrim
+          # --package llmtrim-tray`, which selects both crates so both bins build into
+          # the one archive.
+          package: ${{ matrix.tray && 'llmtrim,llmtrim-tray' || 'llmtrim' }}
           target: ${{ matrix.target }}
           archive: llmtrim-$target
           checksum: sha256
@@ -194,6 +200,9 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: llmtrim-tray
+          # llmtrim-tray is not in `default-members`, so `--bin llmtrim-tray` needs an
+          # explicit `--package llmtrim-tray` to resolve (see the main build job).
+          package: llmtrim-tray
           target: x86_64-unknown-linux-gnu
           archive: llmtrim-tray-$target
           checksum: sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **Prebuilt binaries and the desktop tray downloads ship again.** The 0.6.0 release
+  built each archive with `--bin llmtrim-tray` but no matching `--package`, and the tray
+  crate sits outside the workspace `default-members`, so every tray target failed. No
+  prebuilt binaries, npm / Homebrew / Scoop packages, Docker image, or tray downloads
+  were published for 0.6.0 (installing from crates.io with `cargo install llmtrim` still
+  worked). This restores the full binary and tray distribution.
+
 ## [0.6.0] - 2026-07-04
 
 ### Added


### PR DESCRIPTION
The 0.6.0 release run failed: all four macOS/Windows binary targets and the Linux tray job errored with `error: no bin target named ` + "`llmtrim-tray`" + ` in default-run packages`, and the skipped downstream jobs meant **no prebuilt binaries, npm / Homebrew / Scoop packages, Docker image, or tray downloads shipped for 0.6.0** (crates.io publish succeeded and is immutable, so `cargo install llmtrim` works; the tag is not re-cut).

## Cause
The binary jobs build the tray with `--bin llmtrim-tray`, but `llmtrim-tray` is intentionally outside the workspace `default-members` (so bare `cargo build` / `cargo test` on Linux CI skips Tauri, which needs WebKitGTK). Cargo then cannot resolve `--bin llmtrim-tray` and aborts.

## Fix
`taiki-e/upload-rust-binary-action` has a `package` input that emits one `--package` per name. Setting `package:` to mirror `bin:` makes the build `cargo build --bin llmtrim --bin llmtrim-tray --package llmtrim --package llmtrim-tray`, which selects both crates so both binaries build into the single archive. The standalone Linux tray job gets `package: llmtrim-tray`.

Verified locally that `cargo build --release --bin llmtrim --bin llmtrim-tray --package llmtrim --package llmtrim-tray` resolves both bins (compiles past resolution; only fails later on this Linux box's missing system glib, which the macOS/Windows runners do not need). `default-members` is left unchanged so Linux CI still skips the tray.

Ships in 0.6.1.