### PR TITLE
Fix the Windows tray: black window, console flash, and installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,58 @@ jobs:
         with:
           subject-path: ${{ steps.traybin.outputs.path }}
 
+  # The Windows desktop tray, as a proper NSIS installer. The other jobs ship the bare
+  # llmtrim-tray.exe, which renders a black window on any Windows without the Edge WebView2
+  # runtime already installed (preinstalled on Win11 / recent Win10, absent otherwise). This
+  # job runs `tauri build` to produce an installer whose `webviewInstallMode` bootstraps
+  # WebView2 on setup, so the tray always has an engine to render into. Independent of the
+  # CLI release — a tray build failure never blocks it.
+  build-tray-windows:
+    needs: [create-release, license-notice]
+    runs-on: windows-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v7
+      # aws-lc-rs (pulled in transitively) assembles its x86 asm with NASM on Windows x64.
+      - name: Install NASM
+        uses: ilammy/setup-nasm@v1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install the tray frontend deps
+        working-directory: crates/llmtrim-tray
+        run: npm ci
+      - uses: dtolnay/rust-toolchain@stable
+      # `tauri build` runs the frontend build (beforeBuildCommand) then bundles the NSIS
+      # installer with the WebView2 download bootstrapper. Output lands in the workspace
+      # target dir (target/release/bundle/nsis/), not the crate dir.
+      - name: Build the NSIS installer
+        working-directory: crates/llmtrim-tray
+        run: npx --yes @tauri-apps/cli@^2 build --bundles nsis
+      - name: Locate and checksum the installer
+        id: installer
+        shell: bash
+        run: |
+          path=$(ls target/release/bundle/nsis/*-setup.exe)
+          sha256sum "$path" > "$path.sha256"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+          echo "found $path"
+      - name: Upload the installer to the release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "${{ steps.installer.outputs.path }}" \
+            "${{ steps.installer.outputs.path }}.sha256" --clobber
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ steps.installer.outputs.path }}
+
   # The release verifies itself: run the real installers against the assets just uploaded,
   # on the same three OSes users have. LLMTRIM_VERSION pins to this tag so the test can't
   # race `releases/latest`. Catches what unit tests can't: asset naming, checksum sidecars,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **The Windows tray no longer shows a black window.** Vite stamped a `crossorigin`
+  attribute on the tray's bundled `<script>` and `<link>` tags. On Windows the webview
+  serves the app from `http://tauri.localhost` with no `Access-Control-Allow-Origin`, so
+  the CORS check blocked the JS and CSS and nothing rendered (macOS/Linux use the
+  `tauri://` scheme, which is unaffected). The build now strips the attribute.
+
 ## [0.6.1] - 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **The Windows tray now ships as an installer.** The release attaches a `-setup.exe`
+  NSIS installer for the desktop tray that bootstraps the Edge WebView2 runtime on
+  install (preinstalled on Windows 11 and recent Windows 10, absent on older setups).
+
 ### Fixed
 - **The Windows tray no longer shows a black window.** Vite stamped a `crossorigin`
   attribute on the tray's bundled `<script>` and `<link>` tags. On Windows the webview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project are documented here. The format follows
   serves the app from `http://tauri.localhost` with no `Access-Control-Allow-Origin`, so
   the CORS check blocked the JS and CSS and nothing rendered (macOS/Linux use the
   `tauri://` scheme, which is unaffected). The build now strips the attribute.
+- **The Windows tray no longer flashes a console window every few seconds.** The tray
+  polls the `llmtrim` CLI (`status --json`) on each refresh; on Windows those subprocess
+  spawns opened a console window each tick. The tray now spawns the CLI with
+  `CREATE_NO_WINDOW`, so no terminal appears.
 
 ## [0.6.1] - 2026-07-04
 

--- a/crates/llmtrim-tray/dist/index.html
+++ b/crates/llmtrim-tray/dist/index.html
@@ -9,8 +9,8 @@
       Vite emits the bundle as an external `<script type="module" src>` below — no inline
       script, no remote origin. Fonts use the system stack, so nothing is fetched.
     -->
-    <script type="module" crossorigin src="./assets/index.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index.css">
+    <script type="module" src="./assets/index.js"></script>
+    <link rel="stylesheet" href="./assets/index.css">
   </head>
   <body>
     <div id="app"></div>

--- a/crates/llmtrim-tray/src/main.rs
+++ b/crates/llmtrim-tray/src/main.rs
@@ -200,17 +200,31 @@ fn llmtrim_binary() -> std::path::PathBuf {
     std::path::PathBuf::from(name)
 }
 
+/// Build a `Command` for the `llmtrim` CLI with `args`.
+///
+/// On Windows the tray is a GUI (`windows_subsystem = "windows"`) process, so
+/// spawning a console subprocess flashes a console window each call. Since the
+/// poll loop shells out to `status --json` every interval, that window would pop
+/// up repeatedly. `CREATE_NO_WINDOW` (0x0800_0000) suppresses it. No-op elsewhere.
+fn llmtrim_command(args: &[&str]) -> std::process::Command {
+    let mut cmd = std::process::Command::new(llmtrim_binary());
+    cmd.args(args);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}
+
 /// Run `llmtrim <args>` to completion, mapping any failure to a sanitised string
 /// (full detail logged to stderr, never surfaced to JS).
 fn run_llmtrim(args: &[&str]) -> Result<(), String> {
-    let bin = llmtrim_binary();
-    let output = std::process::Command::new(&bin)
-        .args(args)
-        .output()
-        .map_err(|e| {
-            eprintln!("llmtrim-tray: failed to run llmtrim {args:?}: {e}");
-            "could not run the llmtrim CLI — is it installed?".to_string()
-        })?;
+    let output = llmtrim_command(args).output().map_err(|e| {
+        eprintln!("llmtrim-tray: failed to run llmtrim {args:?}: {e}");
+        "could not run the llmtrim CLI — is it installed?".to_string()
+    })?;
     if output.status.success() {
         Ok(())
     } else {
@@ -244,11 +258,7 @@ fn stop_proxy() -> Result<(), String> {
 /// `degraded` for a stopped-but-still-wired proxy, so it can't tell running from stopped.)
 /// Any failure reads as "not running" so the menu offers Start, the safe default.
 fn proxy_running() -> bool {
-    let bin = llmtrim_binary();
-    let Ok(output) = std::process::Command::new(&bin)
-        .args(["status", "--json"])
-        .output()
-    else {
+    let Ok(output) = llmtrim_command(&["status", "--json"]).output() else {
         return false;
     };
     serde_json::from_slice::<serde_json::Value>(&output.stdout)
@@ -278,9 +288,7 @@ fn refresh_proxy_menu(app: &AppHandle) {
 /// any failure reads as "off" so the toggle defaults to a safe state.
 #[tauri::command]
 fn get_tray_autostart() -> bool {
-    let bin = llmtrim_binary();
-    std::process::Command::new(&bin)
-        .args(["autostart", "--tray", "--status"])
+    llmtrim_command(&["autostart", "--tray", "--status"])
         .output()
         .ok()
         .filter(|o| o.status.success())
@@ -302,9 +310,7 @@ fn set_tray_autostart(enable: bool) -> Result<(), String> {
 /// (`autostart` vs `autostart --tray`); any failure reads as "off".
 #[tauri::command]
 fn get_proxy_autostart() -> bool {
-    let bin = llmtrim_binary();
-    std::process::Command::new(&bin)
-        .args(["autostart", "--status"])
+    llmtrim_command(&["autostart", "--status"])
         .output()
         .ok()
         .filter(|o| o.status.success())

--- a/crates/llmtrim-tray/tauri.conf.json
+++ b/crates/llmtrim-tray/tauri.conf.json
@@ -40,6 +40,11 @@
     "resources": [],
     "copyright": "",
     "category": "Utility",
+    "windows": {
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper"
+      }
+    },
     "macOS": {
       "entitlements": null,
       "exceptionDomain": "",

--- a/crates/llmtrim-tray/vite.config.ts
+++ b/crates/llmtrim-tray/vite.config.ts
@@ -1,4 +1,20 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
+
+// Strip the `crossorigin` attribute Vite stamps onto the emitted <script> and
+// <link rel=stylesheet> tags. On Windows the webview serves the app from
+// `http://tauri.localhost`, and the asset-protocol response carries no
+// `Access-Control-Allow-Origin`, so a `crossorigin` tag fails the CORS check and
+// the JS/CSS never load — a black window. macOS/Linux use the `tauri://`
+// opaque-origin scheme, which skips the check, so the attribute only breaks
+// Windows. The assets are same-origin and local, so dropping it is safe.
+function stripCrossorigin(): Plugin {
+  return {
+    name: "strip-crossorigin",
+    transformIndexHtml(html) {
+      return html.replace(/ crossorigin/g, "");
+    },
+  };
+}
 
 // Frontend for the llmtrim tray popover.
 //
@@ -12,6 +28,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   root: __dirname,
   base: "./",
+  plugins: [stripCrossorigin()],
   build: {
     outDir: "dist",
     emptyOutDir: true,


### PR DESCRIPTION
The tray shipped in v0.6.1 had two Windows-only regressions and a packaging gap.

## Fixed

- **Black window.** Vite stamped a `crossorigin` attribute on the bundled `<script>`/`<link>` tags. On Windows the webview is served from `http://tauri.localhost` with no `Access-Control-Allow-Origin`, so the CORS check blocked the JS and CSS and nothing rendered. macOS/Linux use the `tauri://` opaque-origin scheme, so it only broke Windows. A `transformIndexHtml` plugin now strips the attribute; assets are same-origin and local, so it is safe.
- **Console window flashing every few seconds.** The poll loop spawns the `llmtrim` CLI (`status --json`) each tick; as a GUI process that flashed a console window. All four CLI spawns now go through a helper that sets `CREATE_NO_WINDOW` on Windows.

## Added

- **Windows NSIS installer.** The release only shipped the bare `llmtrim-tray.exe`, which needs WebView2 already installed. A new `build-tray-windows` job runs `tauri build --bundles nsis` to attach a `-setup.exe` that bootstraps WebView2 on install. Independent job, so a tray build failure never blocks the CLI release.

## Testing notes

- Frontend rebuilt: the committed `dist/index.html` no longer carries `crossorigin`.
- The Rust `CREATE_NO_WINDOW` change is behind `#[cfg(windows)]`; it and the installer job can only be exercised on Windows/CI (the tray crate does not build on the Linux dev box — missing `libdbus-1-dev`).