### PR TITLE
debug(tray): auto-open DevTools in debug builds

### DIFF
--- a/crates/llmtrim-tray/src/main.rs
+++ b/crates/llmtrim-tray/src/main.rs
@@ -371,6 +371,15 @@ fn main() {
                 .get_webview_window("popover")
                 .expect("popover window not found — check tauri.conf.json");
 
+            // Debug builds: open DevTools and show the window on start so the
+            // webview console is visible for diagnosing render failures. Compiled
+            // out of release builds.
+            #[cfg(debug_assertions)]
+            {
+                popover.open_devtools();
+                let _ = popover.show();
+            }
+
             // Auto-hide on blur (works on both macOS and Windows). Record the
             // dismiss time so the tray click that caused this blur doesn't
             // immediately re-open the window (see `toggle_popover`).


### PR DESCRIPTION
Debug-only aid for diagnosing tray render failures. In debug builds the popover now opens DevTools and shows itself on start, so the webview console is visible without needing right-click Inspect.

Gated on `#[cfg(debug_assertions)]`, so it is compiled out of every release build (crates.io, installers, CI release binaries) — no effect for users, and it does not force-show the popover in release.

Came out of debugging the Windows black-window issue in #128.