### PR TITLE
chore: complete the crates.io publish in 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **The `llmtrim` and `llmtrim-ledger` crates on crates.io catch up to the current
+  version.** The 0.6.2 crates.io publish stopped after `llmtrim-core` because
+  `llmtrim-ledger` was missing its Trusted Publisher, leaving `llmtrim` and
+  `llmtrim-ledger` stuck at 0.6.1 on crates.io (the binaries, installers, npm, Homebrew,
+  Scoop, and Docker image all shipped 0.6.2 normally). This release completes the
+  crates.io publish so `cargo install llmtrim` serves the current version again.
+
 ## [0.6.2] - 2026-07-04
 
 ### Added


### PR DESCRIPTION
The v0.6.2 crates.io publish stopped after `llmtrim-core` because `llmtrim-ledger` was missing its Trusted Publisher, so `llmtrim` and `llmtrim-ledger` stayed at 0.6.1 on crates.io. The Trusted Publisher is now configured. This adds the changelog entry so cutting v0.6.3 completes the crates.io publish. No code change.

crates.io state before this: core=0.6.2, ledger=0.6.1, llmtrim=0.6.1. Everything else (binaries, NSIS installer, npm, Homebrew, Scoop, Docker) shipped 0.6.2 normally.