### PR TITLE
fix: don't pin tool output as the live question in RetrieveStage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **`RetrieveStage` no longer mistakes a tool result for the live question.** On
+  Anthropic and Gemini requests, tool output (`tool_result` / `functionResponse`)
+  rides on a synthetic `role: "user"` message (neither provider has a distinct tool
+  role). When it landed on the newest turn — e.g. right after a large Skill
+  invocation or function call — retrieval treated it as the live question: folded
+  into the BM25 query (self-referential, near-zero pruning) and pinned verbatim
+  instead of pruned. It's now excluded from that classification on both providers, so
+  large tool results are pruned like any other bulk context.
+
 ## [0.7.0] - 2026-07-05
 
 ### Added

--- a/crates/llmtrim-core/src/provider/mod.rs
+++ b/crates/llmtrim-core/src/provider/mod.rs
@@ -144,6 +144,42 @@ pub trait Provider {
     fn downscale_images(&self, req: &mut Request);
 }
 
+/// Whether `pointer` addresses text inside a tool-output block — Anthropic
+/// `tool_result` (`/messages/{i}/content/{j}/...`) or Gemini `functionResponse`
+/// (`/contents/{i}/parts/{j}/...`). Both carry a synthetic `role: "user"` message on
+/// the wire (neither provider has a distinct tool role), so role-aware stages must not
+/// mistake the newest tool-output turn for the live human question — this is the seam
+/// that tells them apart, structurally rather than by content. OpenAI needs no such
+/// seam: its tool messages already get a real `Role::Tool` via `role_at`.
+pub(crate) fn is_tool_result_ptr(req: &Request, pointer: &str) -> bool {
+    if let Some(rest) = pointer.strip_prefix("/messages/") {
+        let mut parts = rest.split('/');
+        let Some(i) = parts.next() else { return false };
+        if parts.next() != Some("content") {
+            return false;
+        }
+        let Some(j) = parts.next() else { return false };
+        return req
+            .raw()
+            .pointer(&format!("/messages/{i}/content/{j}/type"))
+            .and_then(Value::as_str)
+            == Some("tool_result");
+    }
+    if let Some(rest) = pointer.strip_prefix("/contents/") {
+        let mut parts = rest.split('/');
+        let Some(i) = parts.next() else { return false };
+        if parts.next() != Some("parts") {
+            return false;
+        }
+        let Some(j) = parts.next() else { return false };
+        return req
+            .raw()
+            .pointer(&format!("/contents/{i}/parts/{j}/functionResponse"))
+            .is_some();
+    }
+    false
+}
+
 /// JSON pointer to a content block's text, when it is a `{"type":"text","text":"…"}`
 /// block (`prefix` is the block's own address, e.g. `/messages/0/content/2`). The
 /// single text-block predicate, shared by both providers' pointer scans.
@@ -1008,7 +1044,54 @@ pub(crate) fn append_stop(root: &mut Value, key: &str, stop: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::truncate_chars;
+    use super::{is_tool_result_ptr, truncate_chars};
+    use crate::ir::{ProviderKind, Request};
+    use serde_json::json;
+
+    #[test]
+    fn is_tool_result_ptr_rejects_malformed_pointers() {
+        let req = Request::from_value(
+            ProviderKind::Anthropic,
+            json!({"messages":[{"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"t1","content":"x"}]}]}),
+        );
+        assert!(is_tool_result_ptr(&req, "/messages/0/content/0/content"));
+        assert!(!is_tool_result_ptr(&req, "/system"), "no /messages/ prefix");
+        assert!(
+            !is_tool_result_ptr(&req, "/messages/0"),
+            "no content segment"
+        );
+        assert!(
+            !is_tool_result_ptr(&req, "/messages/0/role"),
+            "segment after index isn't \"content\""
+        );
+        assert!(
+            !is_tool_result_ptr(&req, "/messages/0/content"),
+            "no block index"
+        );
+    }
+
+    #[test]
+    fn is_tool_result_ptr_recognizes_gemini_function_response() {
+        let req = Request::from_value(
+            ProviderKind::Google,
+            json!({"contents":[{"role":"user","parts":[
+                {"text":"hi"},
+                {"functionResponse":{"name":"read","response":{"result":"x"}}}]}]}),
+        );
+        assert!(is_tool_result_ptr(
+            &req,
+            "/contents/0/parts/1/functionResponse/response/result"
+        ));
+        assert!(
+            !is_tool_result_ptr(&req, "/contents/0/parts/0/text"),
+            "plain text part isn't a function response"
+        );
+        assert!(
+            !is_tool_result_ptr(&req, "/contents/0/parts"),
+            "no part index"
+        );
+    }
 
     fn trunc(s: &str, max: usize) -> String {
         let mut s = s.to_string();

--- a/crates/llmtrim-core/src/stages/retrieve.rs
+++ b/crates/llmtrim-core/src/stages/retrieve.rs
@@ -77,18 +77,23 @@ impl Transform for RetrieveStage {
                 idx: crate::provider::turn_index(p),
                 role: provider.role_at(req, p),
                 len: req.get_str(p).map(|s| s.chars().count()).unwrap_or(0),
+                is_tool_result: crate::provider::is_tool_result_ptr(req, p),
                 ptr: p.clone(),
             })
             .collect();
         // Top-level text (`role_at` → None, e.g. Anthropic `system`) or an explicit
         // System role is instruction.
         let is_system = |s: &Seg| s.role.is_none() || s.role == Some(Role::System);
+        // The live question is the newest turn genuinely authored by the user — a
+        // tool_result never qualifies, even though it rides on a `role: "user"`
+        // message, or it would get folded into the BM25 query (self-referential,
+        // near-zero pruning) and pinned verbatim as if it were the human's ask.
         let last_user = segs
             .iter()
-            .filter(|s| s.role == Some(Role::User))
+            .filter(|s| s.role == Some(Role::User) && !s.is_tool_result)
             .filter_map(|s| s.idx)
             .max();
-        let is_last_user = |s: &Seg| s.idx.is_some() && s.idx == last_user;
+        let is_last_user = |s: &Seg| s.idx.is_some() && s.idx == last_user && !s.is_tool_result;
         // Only pin the final user turn when there is *other* long context to prune
         // instead — otherwise a single monolithic prompt would never compress (the
         // within-segment boundary pin in `select` still protects its edges).
@@ -365,6 +370,10 @@ struct Seg {
     idx: Option<usize>,
     role: Option<crate::provider::Role>,
     len: usize,
+    /// True when `ptr` addresses a `tool_result` block riding on a synthetic
+    /// `role: "user"` message (Anthropic has no distinct tool role). Never the live
+    /// human question, regardless of turn recency — see `is_last_user`.
+    is_tool_result: bool,
 }
 
 /// Split text into sentence chunks (terminal punctuation followed by space/newline),
@@ -1729,6 +1738,219 @@ mod tests {
                 .unwrap()
                 .contains("omitted"),
             "bulk context is pruned"
+        );
+    }
+
+    #[test]
+    fn tool_result_on_final_turn_is_not_mistaken_for_the_live_question() {
+        // Anthropic wire shape: the newest message is a `tool_result` (e.g. a Skill
+        // dump), not user prose. It must not be pinned verbatim or folded into the
+        // BM25 query as if it were the live question — the real question is the
+        // earlier user turn, and the tool_result is just more prunable bulk context.
+        use crate::provider::AnthropicProvider;
+        let earlier_question =
+            "what does the claude-api skill say about streaming responses?".to_string();
+        let skill_dump = (0..20)
+            .map(|i| {
+                format!(
+                    "Section {i}: unrelated reference material about topic {i} \
+                     with lots of filler prose that has nothing to do with streaming."
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let body = json!({"model":"claude-3-5-sonnet-20241022","messages":[
+            {"role":"user","content":earlier_question},
+            {"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Skill","input":{}}]},
+            {"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":skill_dump}]}]});
+        let mut req = Request::from_value(ProviderKind::Anthropic, body);
+        let counter = counter_for(ProviderKind::Anthropic, None).unwrap();
+        let stages: Vec<Box<dyn Transform>> = vec![Box::new(RetrieveStage {
+            keep_ratio: 0.3,
+            min_segment_chars: 120,
+            reorder: false,
+            mmr: false,
+            mmr_lambda: 0.5,
+            sentence: false,
+        })];
+        let out = pipeline::run(&mut req, &AnthropicProvider, counter.as_ref(), &stages);
+        assert!(
+            out.stages[0].applied,
+            "tool_result dump pruned -> tokens cut"
+        );
+        assert_eq!(
+            req.get_str("/messages/0/content").unwrap(),
+            earlier_question,
+            "earlier user turn untouched (too short to prune)"
+        );
+        assert!(
+            req.get_str("/messages/2/content/0/content")
+                .unwrap()
+                .contains("omitted"),
+            "tool_result on the newest turn is pruned like any other bulk context, not pinned"
+        );
+    }
+
+    #[test]
+    fn mixed_message_pins_only_the_text_block_not_the_tool_result_riding_with_it() {
+        // A single turn can carry both a tool_result and trailing prose in the same
+        // message (e.g. "here's the tool output; also, <question>"). Only the text
+        // block is the live question — the tool_result riding alongside it in the
+        // same message must still be treated as prunable bulk context.
+        use crate::provider::AnthropicProvider;
+        let follow_up_question = "Question: based on the tool output above, summarize the key \
+                                   financial figure for the logistics division and explain the \
+                                   quarterly trend in detail with full reasoning and context."
+            .to_string();
+        assert!(
+            follow_up_question.len() >= 120,
+            "question must exceed the prune threshold"
+        );
+        let skill_dump = (0..20)
+            .map(|i| {
+                format!(
+                    "Section {i}: unrelated reference material about topic {i} \
+                     with lots of filler prose that has nothing to do with the question."
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let body = json!({"model":"claude-3-5-sonnet-20241022","messages":[
+            {"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Skill","input":{}}]},
+            {"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"t1","content":skill_dump},
+                {"type":"text","text":follow_up_question}]}]});
+        let mut req = Request::from_value(ProviderKind::Anthropic, body);
+        let counter = counter_for(ProviderKind::Anthropic, None).unwrap();
+        let stages: Vec<Box<dyn Transform>> = vec![Box::new(RetrieveStage {
+            keep_ratio: 0.3,
+            min_segment_chars: 120,
+            reorder: false,
+            mmr: false,
+            mmr_lambda: 0.5,
+            sentence: false,
+        })];
+        let out = pipeline::run(&mut req, &AnthropicProvider, counter.as_ref(), &stages);
+        assert!(
+            out.stages[0].applied,
+            "tool_result riding with the question is pruned -> tokens cut"
+        );
+        assert_eq!(
+            req.get_str("/messages/1/content/1/text").unwrap(),
+            follow_up_question,
+            "trailing question text pinned verbatim even though it shares a turn with the tool_result"
+        );
+        assert!(
+            req.get_str("/messages/1/content/0/content")
+                .unwrap()
+                .contains("omitted"),
+            "tool_result sharing the final turn with the question is still pruned"
+        );
+    }
+
+    #[test]
+    fn tool_result_mid_conversation_is_unaffected_by_the_pin_fix() {
+        // Regression guard: a tool_result that is *not* on the newest turn was never
+        // misclassified by the old `is_last_user` logic either (its idx already didn't
+        // match `last_user`). Confirms adding `is_tool_result` didn't change that path —
+        // the mid-conversation dump is pruned as ordinary bulk context and the later,
+        // genuinely final user question is still pinned.
+        use crate::provider::AnthropicProvider;
+        let final_question = "Question: based on everything above, summarize the key financial \
+                               figure for the logistics division and explain the quarterly \
+                               trend in detail with full reasoning and supporting context."
+            .to_string();
+        assert!(
+            final_question.len() >= 120,
+            "question must exceed the prune threshold"
+        );
+        let skill_dump = (0..20)
+            .map(|i| {
+                format!(
+                    "Section {i}: unrelated reference material about topic {i} \
+                     with lots of filler prose that has nothing to do with the question."
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let body = json!({"model":"claude-3-5-sonnet-20241022","messages":[
+            {"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Skill","input":{}}]},
+            {"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":skill_dump}]},
+            {"role":"assistant","content":"Here's a summary of the skill docs."},
+            {"role":"user","content":final_question}]});
+        let mut req = Request::from_value(ProviderKind::Anthropic, body);
+        let counter = counter_for(ProviderKind::Anthropic, None).unwrap();
+        let stages: Vec<Box<dyn Transform>> = vec![Box::new(RetrieveStage {
+            keep_ratio: 0.3,
+            min_segment_chars: 120,
+            reorder: false,
+            mmr: false,
+            mmr_lambda: 0.5,
+            sentence: false,
+        })];
+        let out = pipeline::run(&mut req, &AnthropicProvider, counter.as_ref(), &stages);
+        assert!(
+            out.stages[0].applied,
+            "mid-conversation tool_result pruned -> tokens cut"
+        );
+        assert_eq!(
+            req.get_str("/messages/3/content").unwrap(),
+            final_question,
+            "the genuinely final user turn is still pinned verbatim"
+        );
+        assert!(
+            req.get_str("/messages/1/content/0/content")
+                .unwrap()
+                .contains("omitted"),
+            "mid-conversation tool_result is pruned like any other bulk context"
+        );
+    }
+
+    #[test]
+    fn gemini_function_response_on_final_turn_is_not_mistaken_for_the_live_question() {
+        // Same bug, Gemini shape: `functionResponse` rides on a synthetic `role: "user"`
+        // content item (Gemini has no distinct tool role either).
+        use crate::provider::GoogleProvider;
+        let earlier_question =
+            "what does the claude-api skill say about streaming responses?".to_string();
+        let skill_dump = (0..20)
+            .map(|i| {
+                format!(
+                    "Section {i}: unrelated reference material about topic {i} \
+                     with lots of filler prose that has nothing to do with streaming."
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let body = json!({"contents":[
+            {"role":"user","parts":[{"text":earlier_question}]},
+            {"role":"model","parts":[{"functionCall":{"name":"Skill","args":{}}}]},
+            {"role":"user","parts":[{"functionResponse":{"name":"Skill","response":{"result":skill_dump}}}]}]});
+        let mut req = Request::from_value(ProviderKind::Google, body);
+        let counter = counter_for(ProviderKind::Google, Some("gemini-1.5-pro")).unwrap();
+        let stages: Vec<Box<dyn Transform>> = vec![Box::new(RetrieveStage {
+            keep_ratio: 0.3,
+            min_segment_chars: 120,
+            reorder: false,
+            mmr: false,
+            mmr_lambda: 0.5,
+            sentence: false,
+        })];
+        let out = pipeline::run(&mut req, &GoogleProvider, counter.as_ref(), &stages);
+        assert!(
+            out.stages[0].applied,
+            "functionResponse dump pruned -> tokens cut"
+        );
+        assert_eq!(
+            req.get_str("/contents/0/parts/0/text").unwrap(),
+            earlier_question,
+            "earlier user turn untouched (too short to prune)"
+        );
+        assert!(
+            req.get_str("/contents/2/parts/0/functionResponse/response/result")
+                .unwrap()
+                .contains("omitted"),
+            "functionResponse on the newest turn is pruned like any other bulk context, not pinned"
         );
     }
 


### PR DESCRIPTION
## Problem

On Anthropic and Gemini requests, tool output (`tool_result` / `functionResponse`) rides on a synthetic `role: "user"` message — neither provider has a distinct tool role. `RetrieveStage` picks the newest `role: "user"` turn as "the live question" to pin it from pruning and to build the BM25 query.

When a tool_result/functionResponse landed on the newest turn — e.g. right after a large Skill invocation or function call — it was misclassified as the live human question: folded into the BM25 query (self-referential, near-zero pruning) and pinned verbatim instead of pruned like other bulk context. Traced this against a real captured Claude Code session where a Skill tool dumped ~190K tokens of reference docs in one turn, causing an instant context blowout and a forced auto-compaction.

## Fix

- `provider::is_tool_result_ptr(req, pointer)` — structural detection of tool output blocks, covering both Anthropic (`/messages/{i}/content/{j}`, `type: "tool_result"`) and Gemini (`/contents/{i}/parts/{j}/functionResponse`) wire shapes.
- `Seg::is_tool_result` in `retrieve.rs`, populated from the above, excluded from `last_user`/`is_last_user` regardless of turn recency.

OpenAI needs no change — its tool messages already get a real `Role::Tool` via `role_at`.

## Verification

- Replayed the real captured skill-dump payload (809,620 bytes) through `llmtrim compress` with the `rag` preset: 810,030 → 25,235 bytes (~97% reduction). Before the fix this content was pinned verbatim (0% reduction), matching what was actually observed in the traced session.
- Two independent sonnet-model adversarial reviews of the diff, both converging on the same real gap (Gemini's `functionResponse` had the identical bug) — now fixed and covered by tests.
- New tests: Anthropic tool_result on final turn, Gemini functionResponse on final turn, a mixed-message case (tool_result + real question sharing one turn), and a non-final-turn regression guard.
- 821 tests pass, clippy clean, `cargo fmt` applied.

## Changelog

Entry added under `## [Unreleased]` / `### Fixed`.