### PR TITLE
feat: anti-overthinking directive for quantized reasoning models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **Anti-overthinking directive (`output_anti_overthink`).** On prose requests that explicitly
+  declare both a quantized serving tier (OpenRouter `provider.quantizations`) and a reasoning
+  pass, `auto` now asks the model to commit to its answer instead of restarting mid-reasoning
+  ("Wait", "But", "Actually…") — the failure mode quantization amplifies in reasoning models
+  (arXiv:2606.00206). On in `aggressive`/`rag`/`code`/`agent`; `safe`/`lossless`/`frugal` stay
+  untouched. Bench (`llmtrim bench quality`, this lever isolated, `openai/gpt-oss-20b` via
+  OpenRouter, n=40 real GSM8K problems): −62.0% output tokens, quality retention +0.0pp
+  (unchanged).
+
 ### Fixed
 - **`RetrieveStage` no longer mistakes a tool result for the live question.** On
   Anthropic and Gemini requests, tool output (`tool_result` / `functionResponse`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim"
-version = "0.7.1-dev"
+version = "0.8.0-dev"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-core"
-version = "0.7.1-dev"
+version = "0.8.0-dev"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-ledger"
-version = "0.7.1-dev"
+version = "0.8.0-dev"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-tray"
-version = "0.7.1-dev"
+version = "0.8.0-dev"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-uniffi"
-version = "0.7.1-dev"
+version = "0.8.0-dev"
 dependencies = [
  "llmtrim-core",
  "serde_json",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-wasm"
-version = "0.7.1-dev"
+version = "0.8.0-dev"
 dependencies = [
  "llmtrim-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = [
 
 # Shared package metadata — inherited by each member via `field.workspace = true`.
 [workspace.package]
-version = "0.7.1-dev"
+version = "0.8.0-dev"
 edition = "2024"
 rust-version = "1.88"
 repository = "https://github.com/fkiene/llmtrim"

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -37,10 +37,10 @@ path = "src/main.rs"
 [dependencies]
 # `version` is required for `cargo publish` (path alone isn't publishable) and is kept in
 # lockstep with llmtrim-core by cargo-release's shared-version on every bump.
-llmtrim-core = { path = "../llmtrim-core", version = "0.7.1-dev" }
+llmtrim-core = { path = "../llmtrim-core", version = "0.8.0-dev" }
 # Published alongside core (see release.yml publish order). `version` is required
 # for `cargo publish` and is kept in lockstep by cargo-release's shared-version.
-llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.7.1-dev" }
+llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.8.0-dev" }
 anyhow.workspace = true
 chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive"] }

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -434,6 +434,12 @@ struct BenchArgs {
     /// (e.g. `groq`). Empty = let OpenRouter choose.
     #[arg(long, default_value = "groq")]
     route: String,
+    /// Request a reasoning pass at this effort (`low`/`medium`/`high`), sent as OpenRouter's
+    /// `reasoning.effort`. Empty = no reasoning field (default). Needed to exercise
+    /// reasoning-gated levers (e.g. the anti-overthink directive), which key off this field
+    /// being present on the wire, not the model id.
+    #[arg(long, default_value = "")]
+    reasoning_effort: String,
     /// Limit the number of cases run.
     #[arg(long)]
     n: Option<usize>,
@@ -941,9 +947,9 @@ fn dotenv_get(key: &str) -> Option<String> {
 }
 
 /// Pin the request to the chosen model and (optionally) a single OpenRouter upstream
-/// provider. Both fields are top-level passthrough, so compression preserves them and
-/// the original and compressed sends route identically.
-fn prepare_request(request_json: &str, model: &str, route: &str) -> String {
+/// provider and/or a reasoning pass. All three fields are top-level passthrough, so
+/// compression preserves them and the original and compressed sends route identically.
+fn prepare_request(request_json: &str, model: &str, route: &str, reasoning_effort: &str) -> String {
     match serde_json::from_str::<serde_json::Value>(request_json) {
         Ok(mut v) => {
             if let Some(obj) = v.as_object_mut() {
@@ -961,6 +967,12 @@ fn prepare_request(request_json: &str, model: &str, route: &str) -> String {
                         routing["quantizations"] = serde_json::json!([q]);
                     }
                     obj.insert("provider".to_string(), routing);
+                }
+                if !reasoning_effort.is_empty() {
+                    obj.insert(
+                        "reasoning".to_string(),
+                        serde_json::json!({"effort": reasoning_effort}),
+                    );
                 }
                 // Ask OpenRouter for the detailed usage breakdown (incl. cached_tokens).
                 obj.insert("usage".to_string(), serde_json::json!({"include": true}));
@@ -982,7 +994,7 @@ fn run_bench(args: BenchArgs) -> Result<()> {
     // Pin every case to the chosen model + upstream provider so the orig/compressed
     // sends are comparable and route identically.
     for c in &mut cases {
-        c.request = prepare_request(&c.request, &args.model, &args.route);
+        c.request = prepare_request(&c.request, &args.model, &args.route, &args.reasoning_effort);
     }
     // `--config FILE` overrides the preset with an explicit config (isolates a single flag
     // for measurement); otherwise resolve the named preset.
@@ -1072,6 +1084,7 @@ fn run_bench_suite(args: SuiteArgs) -> Result<()> {
             model: args.model.clone(),
             judge_model: args.judge_model.clone(),
             route: args.route.clone(),
+            reasoning_effort: String::new(),
             n,
             config: None,
             pricing: args.pricing.clone(),
@@ -1450,6 +1463,7 @@ fn quality_meta(args: &BenchArgs, config: &DenseConfig) -> serde_json::Value {
         "model": args.model,
         "judge_model": args.judge_model,
         "route": args.route,
+        "reasoning_effort": args.reasoning_effort,
         "corpus": args.corpus.display().to_string(),
     })
 }
@@ -2169,6 +2183,26 @@ mod tests {
         }
     }
 
+    #[test]
+    fn prepare_request_pins_model_route_and_reasoning() {
+        let base = r#"{"messages":[{"role":"user","content":"hi"}]}"#;
+        let out = prepare_request(base, "openai/gpt-oss-20b", "wandb/fp4", "medium");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["model"], "openai/gpt-oss-20b");
+        assert_eq!(v["provider"]["order"], serde_json::json!(["wandb"]));
+        assert_eq!(v["provider"]["quantizations"], serde_json::json!(["fp4"]));
+        assert_eq!(v["reasoning"]["effort"], "medium");
+    }
+
+    #[test]
+    fn prepare_request_omits_reasoning_when_effort_is_empty() {
+        let base = r#"{"messages":[{"role":"user","content":"hi"}]}"#;
+        let out = prepare_request(base, "openai/gpt-4o-mini", "", "");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(v.get("reasoning").is_none(), "no reasoning field: {v}");
+        assert!(v.get("provider").is_none(), "no provider field: {v}");
+    }
+
     const CORPUS_LINE: &str = r#"{"context":"The cat sat on the red mat.","question":"What color was the mat?","gold":"red","scorer":"token_f1"}"#;
 
     fn offline_args(corpus: PathBuf, json_out: Option<PathBuf>) -> BenchArgs {
@@ -2179,6 +2213,7 @@ mod tests {
             model: "openai/gpt-4o-mini".to_string(),
             judge_model: "openai/gpt-4o-mini".to_string(),
             route: String::new(),
+            reasoning_effort: String::new(),
             n: Some(1),
             config: None,
             pricing: PathBuf::new(), // unused: offline never reads pricing

--- a/crates/llmtrim-core/prompts/output_anti_overthink.txt
+++ b/crates/llmtrim-core/prompts/output_anti_overthink.txt
@@ -1,0 +1,1 @@
+Once your reasoning reaches an answer, commit to it immediately. Do not restart or re-derive your reasoning once you are confident (avoid phrases like "Wait", "But", "Actually" when reconsidering). Output the final answer as soon as you reach it.

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -53,6 +53,10 @@ pub struct DenseConfig {
     /// (steer trajectory toward info-per-call). Opt-in, model-gated; not in any preset until
     /// a full agent bench confirms it.
     pub output_frugal_tools: bool,
+    /// Stage F — inject the anti-overthinking directive (arXiv:2606.00206) on prose requests
+    /// that declare BOTH a quantized serving tier and a reasoning pass. Bench: gpt-oss-20b,
+    /// n=40, −62.0% output tokens, quality retention +0.0pp. See `stages::output`.
+    pub output_anti_overthink: bool,
     /// Stage D — also encode uniform arrays nested inside content JSON, not only
     /// when the whole content is an array.
     pub serialize_nested: bool,
@@ -217,6 +221,7 @@ impl DenseConfig {
             output_token_budget: None,
             output_compact_code: false,
             output_frugal_tools: false,
+            output_anti_overthink: false,
             serialize_nested: true,
             serialize_csv: false,
             serialize_flatten: false,
@@ -374,6 +379,11 @@ impl DenseConfig {
                 // marker) — measured quality-neutral (+0.0pp on bench/data/base64.jsonl):
                 // such blobs are noise the model can't use. Lossy, so `safe` keeps them.
                 c.strip_base64 = true;
+                // Anti-overthinking directive: fires only when the request explicitly declares
+                // BOTH a quantized serving tier and a reasoning pass (see `stages::output`), so
+                // it is a no-op on the vast majority of RAG traffic and only ever adds an
+                // instruction, never removes one.
+                c.output_anti_overthink = true;
             }
             "agent" => {
                 // Tool selection is first-turn-only (see `stages::tools::select_tools`): pruning
@@ -405,6 +415,10 @@ impl DenseConfig {
                 c.output_frugal_tools = true;
                 // ngram dropped: ~10–106 tok on agent traffic (bench) for an injected
                 // glossary that mutates the prompt — not worth it. Opt in explicitly.
+                // Anti-overthinking: only fires on the final non-tool-call turn of a loop
+                // (the branch `frugal_tools` doesn't touch), same quantized+reasoning gate
+                // as `rag`/`code`/`aggressive` below.
+                c.output_anti_overthink = true;
             }
             "code" => {
                 c.skeletonize = true;
@@ -420,6 +434,7 @@ impl DenseConfig {
                 // the bench confirmed it costs pass@1 (humaneval −21.6pp, CI ±14.5 at
                 // n=37). The −36% lever (arXiv:2508.13666) holds only via fine-tuning,
                 // not a raw instruction to a small model. Opt in explicitly if wanted.
+                c.output_anti_overthink = true; // quantized+reasoning gated, see `rag` note
             }
             "aggressive" => {
                 c.retrieve = true;
@@ -450,6 +465,7 @@ impl DenseConfig {
                 c.output_control = true;
                 c.multimodal = true; // downscale images to the provider cap (see `rag` note)
                 c.strip_base64 = true; // elide base64 blobs (measured +0.0pp, see `rag` note)
+                c.output_anti_overthink = true; // quantized+reasoning gated, see `rag` note
             }
             // Cache-first: lossless input only (no retrieve/reorder that *varies* the
             // prefix per request) + Stage A cache discipline, so a repeated long prefix

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -177,7 +177,11 @@ fn stages_for(_provider: ProviderKind, config: &config::DenseConfig) -> Vec<Box<
         }));
     }
     // Stage F (output-side): request-shaping output controls (terse / Chain-of-Draft / budget).
-    if config.output_control || config.output_compact_code || config.output_frugal_tools {
+    if config.output_control
+        || config.output_compact_code
+        || config.output_frugal_tools
+        || config.output_anti_overthink
+    {
         stages.push(Box::new(stages::OutputControlStage {
             output_control: config.output_control,
             level: stages::output::OutputLevel::parse(&config.output_level),
@@ -185,6 +189,7 @@ fn stages_for(_provider: ProviderKind, config: &config::DenseConfig) -> Vec<Box<
             token_budget: config.output_token_budget,
             compact_code: config.output_compact_code,
             frugal_tools: config.output_frugal_tools,
+            anti_overthink: config.output_anti_overthink,
         }));
     }
     // Stage A (lossless, latent payoff): mark the final prefix for provider caching.

--- a/crates/llmtrim-core/src/stages/output.rs
+++ b/crates/llmtrim-core/src/stages/output.rs
@@ -88,6 +88,22 @@ pub const TOOLS_FRUGAL_INSTRUCTION: &str = include_str!("../../prompts/tools_fru
 /// sitting in the system block, so a repeated inject is a no-op (idempotent guard).
 const TOOLS_FRUGAL_MARKER: &str = "fewest tool-use turns";
 
+/// Anti-overthinking directive for quantized reasoning models (arXiv:2606.00206): post-training
+/// quantization amplifies a tendency to reach a correct answer mid-reasoning and then restart
+/// ("Wait", "But", "Actually…") instead of committing to it — up to 52% of quantized-model
+/// failures are this "overthinking" pattern, not a capability loss. Live bench, this lever in
+/// isolation (`llmtrim bench quality --corpus bench/data/gsm8k.jsonl --config <anti_overthink-
+/// only.toml> --model openai/gpt-oss-20b --route wandb/fp4 --reasoning-effort medium`, n=40):
+/// output tokens cut 62.0%, quality retention +0.0pp (unchanged, paired 95% CI ±10.2).
+pub const ANTI_OVERTHINK_INSTRUCTION: &str =
+    include_str!("../../prompts/output_anti_overthink.txt");
+
+/// Stable substring of [`ANTI_OVERTHINK_INSTRUCTION`] for the idempotent guard. Deliberately NOT
+/// one of the restart words the instruction names ("Wait"/"But"/"Actually") — those are common
+/// enough to appear verbatim in an unrelated system prompt, which would falsely match and skip
+/// injection. "commit to it immediately" is specific to this directive.
+const ANTI_OVERTHINK_MARKER: &str = "commit to it immediately";
+
 /// Output-control intensity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputLevel {
@@ -130,6 +146,10 @@ pub struct OutputControlStage {
     /// request shape prose shaping skips. Opt-in, model-gated; ship only behind a full
     /// agent-bench that confirms total tokens fall AND task success holds.
     pub frugal_tools: bool,
+    /// Inject the anti-overthinking directive (see [`ANTI_OVERTHINK_INSTRUCTION`]) on prose
+    /// requests that explicitly declare BOTH a quantized serving tier and a reasoning pass.
+    /// Gated on wire fields, not a model-name list — same policy as `reasoning_model_request`.
+    pub anti_overthink: bool,
 }
 
 impl Transform for OutputControlStage {
@@ -193,6 +213,21 @@ impl Transform for OutputControlStage {
             if self.compact_code {
                 provider.add_system_instruction(req, COMPACT_CODE_INSTRUCTION);
             }
+            // Anti-overthinking directive: targets the specific failure mode this was benched
+            // on — a quantized reasoning pass restarting mid-CoT (arXiv:2606.00206) — so it
+            // requires BOTH signals, not quantization alone (a quantized non-reasoning model has
+            // no CoT to restart) and not reasoning alone (the effect is unproven on full-
+            // precision flagships). No capability floor is applied here (unlike `frugal_tools`):
+            // the benched model (gpt-oss-20b, Elo 1288) sits below that bar, so reusing it would
+            // exclude the only validated case. Known gap, accepted: an even weaker quantized
+            // reasoning tier gets the same "don't reconsider" instruction with no floor under it.
+            if self.anti_overthink
+                && quantized_model_request(req)
+                && reasoning_model_request(req)
+                && !anti_overthink_present(req, provider)
+            {
+                provider.add_system_instruction(req, ANTI_OVERTHINK_INSTRUCTION);
+            }
         } else if self.frugal_tools
             && is_first_turn(req)
             && crate::capability::model_honors_steering(req.model_id().unwrap_or(""))
@@ -250,6 +285,35 @@ fn frugal_directive_present(req: &Request, provider: &dyn Provider) -> bool {
             && req
                 .get_str(ptr)
                 .is_some_and(|t| t.contains(TOOLS_FRUGAL_MARKER))
+    })
+}
+
+/// True when the request explicitly pins a quantized serving tier (OpenRouter
+/// `provider.quantizations: [...]`). This is one half of the anti-overthink gate — the failure
+/// mode (arXiv:2606.00206) is caused by post-training quantization noise, not by "being a
+/// reasoning model" in general, so this is checked alongside [`reasoning_model_request`], never
+/// alone. Explicit request field, not a model-name table — same policy as that function.
+///
+/// Known gap, accepted: a quantized model called WITHOUT this field (a self-hosted quantized
+/// endpoint, or OpenRouter left to auto-pick a quantized upstream) is invisible to this gate and
+/// gets no directive. This only ever adds an instruction, never removes one, so the failure mode
+/// of a false negative is "no help," not "wrong behavior."
+fn quantized_model_request(req: &Request) -> bool {
+    req.raw()
+        .get("provider")
+        .and_then(|p| p.get("quantizations"))
+        .and_then(Value::as_array)
+        .is_some_and(|a| !a.is_empty())
+}
+
+/// True when the anti-overthink directive is already present in the request's system prose —
+/// mirrors [`frugal_directive_present`]'s idempotent guard and its both-shapes rationale.
+fn anti_overthink_present(req: &Request, provider: &dyn Provider) -> bool {
+    provider.content_text_pointers(req).iter().any(|ptr| {
+        matches!(provider.role_at(req, ptr), Some(Role::System) | None)
+            && req
+                .get_str(ptr)
+                .is_some_and(|t| t.contains(ANTI_OVERTHINK_MARKER))
     })
 }
 
@@ -314,6 +378,7 @@ mod tests {
             token_budget: None,
             compact_code: false,
             frugal_tools: true,
+            anti_overthink: false,
         }
     }
 
@@ -336,6 +401,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         let sys = req.get_str("/messages/0/content").unwrap();
@@ -353,6 +419,7 @@ mod tests {
                 token_budget: Some(120),
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         let joined: String = req
@@ -382,6 +449,7 @@ mod tests {
                 token_budget: Some(120),
                 compact_code: true,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         let joined: String = req
@@ -419,6 +487,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         let sys = req.get_str("/messages/0/content").unwrap();
@@ -440,6 +509,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: true,
+                anti_overthink: false,
             },
         );
         let joined = joined_content(&req);
@@ -458,6 +528,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: true,
+                anti_overthink: false,
             },
         );
         let pj = joined_content(&prose);
@@ -547,6 +618,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: true,
+                anti_overthink: false,
             },
         );
         assert!(
@@ -573,6 +645,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: true,
+                anti_overthink: false,
             },
         );
         let hits = joined_content(&req)
@@ -689,6 +762,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         let sys = req.get_str("/messages/0/content").unwrap();
@@ -717,6 +791,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         let sys = req.get_str("/messages/0/content").unwrap();
@@ -738,6 +813,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         let sys = req.get_str("/messages/0/content").unwrap();
@@ -776,6 +852,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         assert_eq!(OpenAiProvider.max_tokens(&req), Some(256));
@@ -789,6 +866,7 @@ mod tests {
                 token_budget: None,
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         assert_eq!(
@@ -824,6 +902,7 @@ mod tests {
                 token_budget: Some(120),
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         let joined = joined_content(&req);
@@ -851,6 +930,7 @@ mod tests {
                 token_budget: Some(120),
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         assert!(!joined_content(&req).contains("120 tokens"));
@@ -869,6 +949,7 @@ mod tests {
                 token_budget: Some(120),
                 compact_code: false,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         assert!(
@@ -930,6 +1011,7 @@ mod tests {
                 token_budget: None,
                 compact_code: true,
                 frugal_tools: false,
+                anti_overthink: false,
             },
         );
         let joined: String = req
@@ -944,5 +1026,127 @@ mod tests {
             joined.contains("minified"),
             "compact-code instruction injected"
         );
+    }
+
+    fn anti_overthink_stage() -> OutputControlStage {
+        OutputControlStage {
+            output_control: false,
+            level: OutputLevel::Terse,
+            max_tokens: None,
+            token_budget: None,
+            compact_code: false,
+            frugal_tools: false,
+            anti_overthink: true,
+        }
+    }
+
+    #[test]
+    fn anti_overthink_marker_is_substring_of_the_prompt() {
+        // Same invariant as `frugal_marker_is_substring_of_the_prompt`: if the prompt is
+        // reworded and the marker isn't, the idempotent guard silently no-ops and double-injects.
+        assert!(
+            ANTI_OVERTHINK_INSTRUCTION.contains(ANTI_OVERTHINK_MARKER),
+            "marker {ANTI_OVERTHINK_MARKER:?} must be a substring of the prompt {ANTI_OVERTHINK_INSTRUCTION:?}"
+        );
+    }
+
+    #[test]
+    fn detects_quantized_provider_request() {
+        assert!(quantized_model_request(&req_with(
+            json!({"provider":{"quantizations":["fp4"]}})
+        )));
+        assert!(!quantized_model_request(&req_with(
+            json!({"provider":{"quantizations":[]}})
+        )));
+        assert!(!quantized_model_request(&req_with(json!({"provider":{}}))));
+        assert!(!quantized_model_request(&req_with(json!({}))));
+    }
+
+    #[test]
+    fn anti_overthink_injects_only_when_quantized_and_reasoning() {
+        let quantized_reasoning = json!({"provider":{"quantizations":["fp4"]},
+               "reasoning":{"effort":"medium"},
+               "messages":[{"role":"user","content":"what is 2+2?"}]});
+        let req = run_one(quantized_reasoning, anti_overthink_stage());
+        assert!(
+            joined_content(&req).contains(ANTI_OVERTHINK_MARKER),
+            "quantized + reasoning prose request gets the directive: {}",
+            joined_content(&req)
+        );
+
+        // Quantized alone (no reasoning field): the model has no CoT to restart, so the
+        // directive must NOT fire.
+        let quantized_only = json!({"provider":{"quantizations":["fp4"]},
+               "messages":[{"role":"user","content":"what is 2+2?"}]});
+        let req = run_one(quantized_only, anti_overthink_stage());
+        assert!(
+            !joined_content(&req).contains(ANTI_OVERTHINK_MARKER),
+            "quantized-only request stays silent (no reasoning field): {}",
+            joined_content(&req)
+        );
+
+        // Reasoning alone (no quantization declared): unproven on full-precision models, so
+        // the directive must NOT fire.
+        let reasoning_only = json!({"reasoning":{"effort":"medium"},
+               "messages":[{"role":"user","content":"what is 2+2?"}]});
+        let req = run_one(reasoning_only, anti_overthink_stage());
+        assert!(
+            !joined_content(&req).contains(ANTI_OVERTHINK_MARKER),
+            "reasoning-only request stays silent (no quantization field): {}",
+            joined_content(&req)
+        );
+    }
+
+    #[test]
+    fn anti_overthink_skips_tool_call_shaped_requests() {
+        // The directive targets CoT-then-prose, not tool-call args; it must stay silent on the
+        // tool-call-shaped branch even when both gate signals are present.
+        let req = run_one(
+            json!({"provider":{"quantizations":["fp4"]},
+                   "reasoning":{"effort":"medium"},
+                   "messages":[{"role":"user","content":"find the bug"}],
+                   "tools":[{"type":"function","function":{"name":"grep","parameters":{}}}],
+                   "tool_choice":"auto"}),
+            anti_overthink_stage(),
+        );
+        assert!(
+            !joined_content(&req).contains(ANTI_OVERTHINK_MARKER),
+            "no anti-overthink directive on a tool-call-shaped request: {}",
+            joined_content(&req)
+        );
+    }
+
+    #[test]
+    fn anti_overthink_idempotent_when_already_present() {
+        let req = run_one(
+            json!({"provider":{"quantizations":["fp4"]},
+                   "reasoning":{"effort":"medium"},
+                   "messages":[
+                       {"role":"system","content":ANTI_OVERTHINK_INSTRUCTION},
+                       {"role":"user","content":"what is 2+2?"}]}),
+            anti_overthink_stage(),
+        );
+        let hits = joined_content(&req).matches(ANTI_OVERTHINK_MARKER).count();
+        assert_eq!(hits, 1, "directive present exactly once, not duplicated");
+    }
+
+    #[test]
+    fn agent_rag_code_aggressive_presets_enable_anti_overthink() {
+        for p in ["agent", "rag", "code", "aggressive"] {
+            assert!(
+                crate::config::DenseConfig::preset(p)
+                    .unwrap()
+                    .output_anti_overthink,
+                "{p} should enable the anti-overthink lever"
+            );
+        }
+        for p in ["safe", "lossless", "frugal"] {
+            assert!(
+                !crate::config::DenseConfig::preset(p)
+                    .unwrap()
+                    .output_anti_overthink,
+                "{p} must stay silent — no behavioral directive"
+            );
+        }
     }
 }

--- a/crates/llmtrim-ledger/Cargo.toml
+++ b/crates/llmtrim-ledger/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["llm", "sqlite", "tokens", "compression", "tracking"]
 categories = ["database", "development-tools"]
 
 [dependencies]
-llmtrim-core = { path = "../llmtrim-core", version = "0.7.1-dev" }
+llmtrim-core = { path = "../llmtrim-core", version = "0.8.0-dev" }
 anyhow.workspace = true
 chrono = "0.4.45"
 rusqlite = { version = "0.39", features = ["bundled"] }

--- a/crates/llmtrim-tray/Cargo.toml
+++ b/crates/llmtrim-tray/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.7.1-dev" }
+llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.8.0-dev" }
 # image-png: required for Image::from_bytes to decode the embedded PNG tray icon.
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }


### PR DESCRIPTION
## Summary

Quantized reasoning models sometimes reach a correct answer mid-chain-of-thought and then restart ("Wait", "But", "Actually…") instead of committing to it — arXiv:2606.00206 finds this "overthinking" pattern behind up to 52% of quantized-model failures, not a capability loss.

This adds a new output-shaping lever, `output_anti_overthink`: on prose requests that explicitly declare **both** a quantized serving tier (OpenRouter `provider.quantizations`) **and** a reasoning pass, it injects a short instruction asking the model to commit to its answer instead of restarting. Gated on explicit wire fields, not a model-name list, matching the existing `reasoning_model_request` policy.

On by default in `aggressive`/`rag`/`code`/`agent` (so `auto` picks it up on quantized reasoning traffic); `safe`/`lossless`/`frugal` stay untouched.

## Evidence

Measured with the repo's own `llmtrim bench quality` harness, this lever in isolation (a `--config` override with only `output_anti_overthink` set — no other compression), against real GSM8K:

```
llmtrim bench quality --corpus bench/data/gsm8k.jsonl \
  --config <anti-overthink-only.toml> \
  --model openai/gpt-oss-20b --route wandb/fp4 --reasoning-effort medium
```

n=40 real GSM8K problems: **output tokens −62.0%**, **quality retention +0.0pp** (unchanged).

The second commit adds `--reasoning-effort` to `bench quality` — needed to exercise this lever (and any future reasoning-gated lever) through the harness at all, since only `--route` previously stamped `provider.quantizations`.

## Design notes

- Gate requires **both** signals (quantized AND reasoning), not either alone: a quantized non-reasoning model has no CoT to restart, and the effect is unproven on full-precision reasoning models.
- No model-capability floor (unlike `frugal_tools`): the benched model (`gpt-oss-20b`, LMArena Elo 1288) sits below that gate's threshold, so reusing it would exclude the only validated case. Documented as an accepted gap in the doc comment.
- Idempotent (marker-based guard, mirrors `frugal_directive_present`) and only ever adds an instruction — never removes one — so a false-negative gate miss just means no help, not wrong behavior.

## Testing

- 6 new unit tests in `stages/output.rs` (gate combinatorics, tool-call-shape exclusion, idempotency, marker-substring self-check, preset assertions).
- 2 new unit tests in `llmtrim-cli` for the new bench flag.
- `cargo fmt`, `cargo clippy --features intercept` (clean), `cargo nextest run --features intercept` (827/827 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)