### PR TITLE
feat: shape the first agent turn and preserve reply language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. The format follows
 ### Changed
 
 - The anti-overthinking directive now reaches Claude Code and other agent harnesses. It fires for any model the models.dev registry marks as a reasoning model, detected from the model id so it works even when the client sends no `thinking`/`reasoning` field on the wire. It also rides tool-call-shaped agent turns now, not just prose, since a thinking model runs a chain of thought before its tool calls too. On the agent path it injects first-turn-only, so it shares the loop's cached prefix without churning it.
+- Terse output shaping now applies to the first turn of an agent loop (Claude Code and other tool-using harnesses), where the model still emits real prose to shape. Later tool-call turns stay unshaped, so the cached prefix is untouched. The reply-language clause that keeps answers in the user's language now rides any injected directive, not only terse, so a non-English conversation is preserved even when only the frugality or anti-overthink directive fires.
 
 ## [0.8.0] - 2026-07-06
 

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -401,9 +401,13 @@ impl DenseConfig {
                 c.serialize_flatten = true; // dot-flatten nested tool-result JSON
                 c.serialize_buckets = true; // bucket heterogeneous record arrays
                 c.json_crush = true; // sample huge record arrays to representatives
-                // No terse output here: short tool-call replies leave nothing to trim, so it
-                // gave ~no cost benefit (glaive cost 5%) at neutral quality (n=39 +0.0pp,
-                // CI ±5.2 — the n=12 -8pp was noise; see bench/README).
+                // Terse output, FIRST TURN ONLY (gated in `stages::output`): later tool-call
+                // replies leave nothing to trim, so terse across the whole loop gave ~no cost
+                // benefit (glaive cost 5%) at neutral quality (n=39 +0.0pp, CI ±5.2 — the n=12
+                // -8pp was noise; see bench/README). The opening turn is the one that emits real
+                // prose (planning, explanation), so shape only that. Pending a first-turn-scoped
+                // bench to confirm it beats the whole-loop 0.0%.
+                c.output_control = true;
                 c.multimodal = true; // downscale images to the provider cap (see `rag` note)
                 c.strip_base64 = true; // elide base64 blobs (measured +0.0pp, see `rag` note)
                 // Agent-loop frugality directive: fires only on the FIRST tool-call turn of a
@@ -892,17 +896,14 @@ mod tests {
         // The metric is cost-at-no-quality-loss, not losslessness: every shape `auto`
         // routes to (agent / code / rag / aggressive) enables output control by default.
         // Lossless-only lives in `safe`, the opt-in mode.
-        for p in ["code", "rag", "aggressive", "reasoning"] {
+        for p in ["code", "rag", "aggressive", "reasoning", "agent"] {
             assert!(
                 DenseConfig::preset(p).unwrap().output_control,
                 "preset `{p}` enables output control by default"
             );
         }
-        // `agent` (tool-calling): terse gives ~no cost benefit + a noisy quality dip, so off.
-        assert!(
-            !DenseConfig::preset("agent").unwrap().output_control,
-            "agent leaves output unshaped — terse doesn't help tool-calls"
-        );
+        // `agent` enables it, but the terse injection is first-turn-only there (see
+        // `stages::output`): later tool-call turns leave nothing to shape.
         assert!(
             !DenseConfig::preset("safe").unwrap().output_control,
             "`safe` is the lossless mode — no output shaping"

--- a/crates/llmtrim-core/src/stages/output.rs
+++ b/crates/llmtrim-core/src/stages/output.rs
@@ -167,31 +167,27 @@ impl Transform for OutputControlStage {
         provider: &dyn Provider,
         _plan: &mut Vec<PlanEntry>,
     ) -> Result<()> {
-        // Tool-call-shaped request: the expected answer is a function-call payload, not
-        // prose. Prose-shaping instructions can't shrink call arguments — the live A/B's
-        // agent corpus saves 0.0% output tokens with them — so on the most-resent request
-        // shape (agent loops) they are pure input cost. Skip them; the hard `max_tokens`
-        // cap below stays (it costs nothing). `tool_choice: "none"` means the model is
-        // told NOT to call, so the answer is prose again and shaping applies.
+        // Track whether this stage injected any (English) directive, so the reply-language clause
+        // below rides exactly once when the conversation is non-English — every directive we add
+        // (terse, token budget, compact_code, frugality, anti-overthink) could otherwise nudge the
+        // reply into English.
+        let mut injected_any = false;
+
+        // Terse/draft prose shaping. Fires on prose requests, and on the FIRST turn of a tool-call
+        // (agent) loop: the opening turn is where the model emits real prose (planning, an
+        // explanation) that terse can shrink, while later tool-call turns leave nothing to trim and
+        // shaping them is pure input cost (see the `agent` preset note). First-turn-only keeps it
+        // in lockstep with the other agent-path directives so the cached prefix stays stable.
+        // Gated on `output_control`, which the sibling levers (`compact_code`, `frugal_tools`)
+        // leave off, so preset `frugal` still isolates the agent-loop directive.
+        if self.output_control && (!tool_call_shaped(req) || is_first_turn(req)) {
+            provider.add_system_instruction(req, self.level.instruction());
+            injected_any = true;
+        }
+        // `tool_choice: "none"` means the model is told NOT to call, so the answer is prose again
+        // and shaping applies. The soft budget / compact_code below stay prose-only: unlike terse
+        // they can't shape a tool-call turn at all.
         if !tool_call_shaped(req) {
-            // Only inject the prose-shaping instruction when output control is actually on. The
-            // stage also runs for the sibling levers (`compact_code`, `frugal_tools`), and those
-            // must NOT drag terse/draft prose in with them — preset `frugal` isolates the
-            // agent-loop directive, so forcing terse on non-tool requests would confound it.
-            if self.output_control {
-                // The clause only earns its tokens when the user wrote in a non-English language;
-                // an English (or too-short-to-detect) prompt already answers in English, so skip
-                // it there and add nothing. `detect_lang` returns `Some` only on a reliable
-                // detection, so ambiguous/short prose keeps the clause (cheap, safe).
-                let non_english =
-                    detect_lang(&user_prose(req, provider)) != Some(whatlang::Lang::Eng);
-                let instruction = if non_english {
-                    format!("{}{}", self.level.instruction(), REPLY_LANGUAGE_CLAUSE)
-                } else {
-                    self.level.instruction().to_string()
-                };
-                provider.add_system_instruction(req, &instruction);
-            }
             // Soft numeric token budgets ("answer within N tokens") FAIL on reasoning
             // models: the batch-prompting overthinking study (arXiv:2511.04108, 2025)
             // found explicit thinking-budget instructions are ignored on DeepSeek-R1 /
@@ -209,9 +205,11 @@ impl Transform for OutputControlStage {
                     req,
                     &TOKEN_BUDGET_TMPL.replace("{budget}", &budget.to_string()),
                 );
+                injected_any = true;
             }
             if self.compact_code {
                 provider.add_system_instruction(req, COMPACT_CODE_INSTRUCTION);
+                injected_any = true;
             }
         }
         // Independent of the prose branch above (its own gate on `tool_call_shaped`), so it and the
@@ -239,6 +237,7 @@ impl Transform for OutputControlStage {
             // models ignore it and just pay the directive's input cost, so they are skipped. See
             // `crate::capability`. Opt-out: an unknown model id still injects.
             provider.add_system_instruction(req, TOOLS_FRUGAL_INSTRUCTION);
+            injected_any = true;
         }
         // Anti-overthinking directive (arXiv:2606.00206): a reasoning pass restarting mid-CoT
         // ("Wait", "Actually…") after it already had the answer. Runs on BOTH request shapes,
@@ -268,6 +267,15 @@ impl Transform for OutputControlStage {
             && !anti_overthink_present(req, provider)
         {
             provider.add_system_instruction(req, ANTI_OVERTHINK_INSTRUCTION);
+            injected_any = true;
+        }
+        // Reply-language clause, injected exactly once when we added any (English) directive above
+        // and the user wrote in a non-English language — otherwise our directives could nudge the
+        // reply into English. Skipped when nothing was injected (no clause to hang off) and for
+        // English / too-short-to-detect prose (already answers in English). `detect_lang` returns
+        // `Some` only on a reliable detection, so ambiguous/short prose keeps the clause.
+        if injected_any && detect_lang(&user_prose(req, provider)) != Some(whatlang::Lang::Eng) {
+            provider.add_system_instruction(req, REPLY_LANGUAGE_CLAUSE.trim());
         }
         if let Some(cap) = self.max_tokens
             && provider.max_tokens(req).is_none()
@@ -434,10 +442,10 @@ mod tests {
     }
 
     #[test]
-    fn tool_call_request_skips_prose_shaping_but_keeps_cap() {
-        // tools present + tool_choice auto ⇒ the answer is a function call: no terse/budget
-        // instruction (pure input cost, 0% output saving on the agent corpus), but the free
-        // hard cap still applies.
+    fn first_turn_tool_call_gets_terse_but_not_budget_or_compact() {
+        // First turn of an agent loop: the model still emits real prose (planning), so terse
+        // rides. The soft token budget and compact_code stay prose-only (they can't shape a
+        // tool-call turn), and the free hard cap still applies.
         let req = run_one(
             json!({"messages":[{"role":"user","content":"book a flight"}],
                    "tools":[{"type":"function","function":{"name":"book","parameters":{}}}],
@@ -461,8 +469,12 @@ mod tests {
             .filter_map(|m| m.get("content").and_then(Value::as_str))
             .collect();
         assert!(
-            !joined.contains("concise") && !joined.contains("120 tokens"),
-            "no prose-shaping instructions on a tool-call request: {joined}"
+            joined.contains("concise"),
+            "first-turn terse injected: {joined}"
+        );
+        assert!(
+            !joined.contains("120 tokens"),
+            "soft budget stays prose-only: {joined}"
         );
         assert_eq!(
             req.raw()
@@ -470,6 +482,42 @@ mod tests {
                 .and_then(Value::as_u64),
             Some(900),
             "hard cap still set (free)"
+        );
+    }
+
+    #[test]
+    fn later_tool_call_turn_skips_terse() {
+        // A tool already invoked ⇒ not the first turn: terse must NOT ride (later tool-call
+        // replies leave nothing to shape, and re-injecting churns the agent-loop cache prefix).
+        let req = run_one(
+            json!({"messages":[
+                       {"role":"user","content":"book a flight"},
+                       {"role":"assistant","tool_calls":[
+                           {"id":"c1","type":"function","function":{"name":"book","arguments":"{}"}}]},
+                       {"role":"tool","tool_call_id":"c1","content":"no seats"}],
+                   "tools":[{"type":"function","function":{"name":"book","parameters":{}}}],
+                   "tool_choice":"auto"}),
+            OutputControlStage {
+                output_control: true,
+                level: OutputLevel::Terse,
+                max_tokens: None,
+                token_budget: None,
+                compact_code: false,
+                frugal_tools: false,
+                anti_overthink: false,
+            },
+        );
+        let joined: String = req
+            .raw()
+            .pointer("/messages")
+            .and_then(Value::as_array)
+            .unwrap()
+            .iter()
+            .filter_map(|m| m.get("content").and_then(Value::as_str))
+            .collect();
+        assert!(
+            !joined.contains("concise"),
+            "no terse on a later tool-call turn: {joined}"
         );
     }
 
@@ -496,8 +544,9 @@ mod tests {
 
     #[test]
     fn frugal_tools_injects_on_tool_call_request_only() {
-        // On a tool-call-shaped request, prose shaping is skipped but the frugality directive
-        // fires — it targets the agent trajectory, not response prose.
+        // On the FIRST turn of a tool-call-shaped request, the frugality directive fires and terse
+        // rides too (the opening turn still emits prose); the directive targets the agent
+        // trajectory, terse the opening prose.
         let req = run_one(
             json!({"messages":[{"role":"user","content":"find the bug"}],
                    "tools":[{"type":"function","function":{"name":"grep","parameters":{}}}],
@@ -514,8 +563,8 @@ mod tests {
         );
         let joined = joined_content(&req);
         assert!(
-            joined.contains("fewest tool-use turns") && !joined.contains("concise"),
-            "frugal directive fires on tool-call shape, prose shaping stays skipped: {joined}"
+            joined.contains("fewest tool-use turns") && joined.contains("concise"),
+            "frugal directive and first-turn terse both fire on tool-call shape: {joined}"
         );
 
         // On a plain prose request, frugal_tools stays silent (prose shaping owns that shape).

--- a/crates/llmtrim-core/tests/conformance/anthropic_agent_tool_result.json
+++ b/crates/llmtrim-core/tests/conformance/anthropic_agent_tool_result.json
@@ -33,7 +33,7 @@
   "preset": "agent",
   "expect": {
     "provider": "anthropic",
-    "output_shaped": false,
+    "output_shaped": true,
     "request_json": {
       "model": "claude-sonnet-4-6",
       "tools": [
@@ -69,7 +69,7 @@
       "system": [
         {
           "type": "text",
-          "text": "Use the fewest tool-use turns: run independent tool calls together in one turn, take all you need from each result, and never repeat a call you've already made.\n\n\nOnce your reasoning reaches an answer, commit to it immediately. Do not restart or re-derive your reasoning once you are confident (avoid phrases like \"Wait\", \"But\", \"Actually\" when reconsidering). Output the final answer as soon as you reach it.\n",
+          "text": "Be concise: no preamble, no restating the question, no filler. Answer directly.\n\nUse the fewest tool-use turns: run independent tool calls together in one turn, take all you need from each result, and never repeat a call you've already made.\n\n\nOnce your reasoning reaches an answer, commit to it immediately. Do not restart or re-derive your reasoning once you are confident (avoid phrases like \"Wait\", \"But\", \"Actually\" when reconsidering). Output the final answer as soon as you reach it.\n\n\nReply in the user's language.",
           "cache_control": {
             "type": "ephemeral"
           }

--- a/crates/llmtrim-core/tests/conformance/anthropic_cache_frozen_prefix.json
+++ b/crates/llmtrim-core/tests/conformance/anthropic_cache_frozen_prefix.json
@@ -35,7 +35,11 @@
         },
         {
           "type": "text",
-          "text": "Be concise: no preamble, no restating the question, no filler. Answer directly. Reply in the user's language."
+          "text": "Be concise: no preamble, no restating the question, no filler. Answer directly."
+        },
+        {
+          "type": "text",
+          "text": "Reply in the user's language."
         }
       ],
       "messages": [

--- a/crates/llmtrim-core/tests/conformance/openai_chat_basic.json
+++ b/crates/llmtrim-core/tests/conformance/openai_chat_basic.json
@@ -20,7 +20,7 @@
       "messages": [
         {
           "role": "system",
-          "content": "Be concise: no preamble, no restating the question, no filler. Answer directly. Reply in the user's language."
+          "content": "Be concise: no preamble, no restating the question, no filler. Answer directly.\nReply in the user's language."
         },
         {
           "role": "user",
@@ -28,7 +28,7 @@
         }
       ],
       "max_tokens": 5,
-      "prompt_cache_key": "77920950cbfe6fc7"
+      "prompt_cache_key": "9934e87abf95a7a5"
     }
   }
 }


### PR DESCRIPTION
## What

Two related output-control fixes, both aimed at Claude Code (which always ships its tool set, so every turn is tool-shaped).

- **Terse on the first agent turn.** Terse output shaping was gated off for all tool-call-shaped requests, so CC never got it. But the opening turn of an agent loop still emits real prose (planning, an explanation) that terse can shrink. Inject terse on the first tool-call turn only, so later turns leave the cached prefix untouched. `output_control` is enabled on the `agent` preset so the auto route carries it.
- **Reply-language clause generalized.** It used to ride only the terse instruction, so a non-English conversation that got the frugality or anti-overthink directive (both English) had nothing keeping the answer in the user's language. Now it fires once at the end whenever any directive was injected and the user's prose is non-English.

## Verified

- Live `claude -p --model sonnet` through a local build: the first CC turn now carries terse ("Be concise...") alongside frugal and anti-overthink. English prompt correctly gets no language clause.
- `cargo fmt` + clippy clean, 830 tests pass (new first-turn-terse, later-turn-skip, and clause-generalization tests).
- Three conformance goldens reblessed; diffs are exactly the added terse block / clause split, cache_control stability held.
- Coverage on changed files: output 94%, config 90%, capability 96.5%.

## Caveat

The whole-loop terse measurement on the agent corpus was a wash (n=39, +0.0pp quality, ~no cost benefit), but that averaged over later tool-only turns. The opening prose turn this targets is untested, so it wants a first-turn-scoped bench before it is trusted as a default.