### PR TITLE
fix: unstrip llmtrim-uniffi release cdylib so maturin can generate Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- The Python package build was broken on Linux (`No UniFFI metadata found`), so `pip install llmtrim` had no Linux wheel.
+
 ## [0.8.1] - 2026-07-07
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,10 @@ opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
+
+# maturin's uniffi bindings mode reads UniFFI metadata symbols from the just-built release
+# cdylib to generate the Python/Ruby/Kotlin glue. Workspace-wide `strip = true` removes
+# those symbols, which fails the build hard on Linux ("No UniFFI metadata found") — keep
+# this one crate unstripped so bindgen can read it.
+[profile.release.package.llmtrim-uniffi]
+strip = false


### PR DESCRIPTION
Both Linux Python wheel jobs failed on the v0.8.1 `release-bindings` run with `No UniFFI metadata found`.

Root cause: the workspace's `strip = true` release profile strips the UniFFI metadata symbols that maturin's `bindings = "uniffi"` mode reads from the release cdylib to generate the Python/Ruby/Kotlin glue. It only broke on Linux — macOS/Windows keep that section through their strip pass.

Fix: per-package profile override (`strip = false` for `llmtrim-uniffi` only); every other crate stays stripped.

Verified locally: built the wheel with `build-wheel.sh --release`, installed it, and called `llmtrim.compress(...)` through the FFI successfully end to end.