### PR TITLE
feat(tray): move dev server off 5173 to a far unassigned port (43217)

### DIFF
--- a/crates/llmtrim-tray/tauri.conf.json
+++ b/crates/llmtrim-tray/tauri.conf.json
@@ -3,7 +3,7 @@
   "identifier": "io.github.fkiene.llmtrim-tray",
   "build": {
     "beforeDevCommand": "npm run dev",
-    "devUrl": "http://localhost:5173",
+    "devUrl": "http://localhost:43217",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "./dist"
   },

--- a/crates/llmtrim-tray/vite.config.ts
+++ b/crates/llmtrim-tray/vite.config.ts
@@ -29,6 +29,15 @@ export default defineConfig({
   root: __dirname,
   base: "./",
   plugins: [stripCrossorigin()],
+  // Dev server only (production embeds `dist/` via the Tauri asset protocol, so no
+  // port is opened at runtime). Vite's default 5173 is a crowded, well-known port —
+  // pick one far up in the IANA-unassigned range, adjacent to llmtrim's own 43117
+  // (`DEFAULT_PORT` in the CLI) but distinct so the two never collide. `strictPort:
+  // true` fails fast if 43217 is taken instead of silently binding another port:
+  // Tauri's `devUrl` (in `tauri.conf.json`) is a static string, so a silent Vite
+  // fallback would leave `tauri dev` loading a dead URL. A loud "port in use" error
+  // is the actionable outcome. Keep `tauri.conf.json`'s `devUrl` on this same port.
+  server: { port: 43217, strictPort: true },
   build: {
     outDir: "dist",
     emptyOutDir: true,


### PR DESCRIPTION
## What

Moves the llmtrim-tray Vite dev server off Vite's crowded default `5173` to `43217`, up in the IANA-unassigned range next to llmtrim's own `43117` (`DEFAULT_PORT` in the CLI) but distinct so the two never collide. Tauri's `devUrl` tracks the new port.

Addresses TODO #4 ("pour le tray, prendre un port vraiment loin pas du tout utilisé").

## Scope

Affects `tauri dev` only. The production tray embeds `dist/` via the Tauri asset protocol and opens no port at runtime.

## strictPort choice

`strictPort: true` — Vite fails fast if `43217` is taken rather than silently binding another port. Tauri's `devUrl` is a static string, so a silent Vite fallback would leave `tauri dev` loading a dead URL (blank window, no obvious cause). A loud "port in use" error is the actionable outcome. Full CLI-style scan-and-sync would need a config-generation step, which is over-engineering for a dev-only convenience given a far port's low collision odds.

## Verification

- `vite build` green; committed `dist/` unchanged.
- No other `5173` references in the tray crate.
- Reviewed by the code-reviewer agent; the `strictPort` fix above is its recommendation.