### PR TITLE
stop unwires the proxy so tools keep working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+
+- `llmtrim stop` no longer breaks tools in new terminals. On POSIX the shell-profile block now exports `HTTPS_PROXY` only while the interceptor is running, so a terminal opened after `stop` talks to LLM hosts directly instead of failing at a dead proxy, and new terminals re-wire on their own once you `start` again. On Windows, `stop` clears the interceptor values from `HKCU\Environment` and `start` re-sets them, so newly-launched terminals and apps stay in sync. The shell you run `stop` in keeps the vars it already inherited (a process can't rewrite its parent shell), so `stop` prints the one-line `unset` for it. Existing installs pick up the new behavior the next time the daemon starts, with no `setup` re-run.
+
 ### Fixed
 
 - The Python package build was broken on Linux (`No UniFFI metadata found`), so `pip install llmtrim` had no Linux wheel.

--- a/crates/llmtrim-cli/src/doctor.rs
+++ b/crates/llmtrim-cli/src/doctor.rs
@@ -160,10 +160,27 @@ pub fn build(s: &State) -> Report {
                 s.port
             ),
         )),
+        // POSIX self-gates (the shell block only wires while the daemon is up), so a stopped
+        // daemon means new shells route directly — informational, not a failure. Windows env
+        // lives in the registry and is only cleared by an explicit `stop`; if the daemon died
+        // without one, new terminals still hit the dead proxy and fail — a real problem.
+        #[cfg(not(windows))]
+        (Some(p), false) => rows.push((
+            ui::NOTE,
+            "env".into(),
+            format!(
+                "persisted (:{p}) but the daemon is stopped — new shells route directly \
+                 (uncompressed, untracked); run: llmtrim start to resume interception"
+            ),
+        )),
+        #[cfg(windows)]
         (Some(p), false) => rows.push((
             ui::WARN,
             "env".into(),
-            format!("wired to :{p} but the daemon is stopped — LLM calls fail; run: llmtrim start"),
+            format!(
+                "wired to :{p} but the daemon is stopped — new terminals fail until you run \
+                 llmtrim start (or llmtrim stop to clear the env)"
+            ),
         )),
         (None, _) => rows.push((
             ui::WARN,
@@ -172,9 +189,16 @@ pub fn build(s: &State) -> Report {
         )),
     }
 
-    // env (this shell) — the env can be persisted yet absent from this terminal.
+    // env (this shell) — the env can be persisted yet absent from this terminal, either because
+    // the terminal predates setup or because the daemon is stopped (the managed block only wires
+    // HTTPS_PROXY while the daemon is up, so a stopped daemon correctly leaves new shells clear).
     match (s.shell_proxy_port, s.env_port) {
         (Some(p), _) => rows.push((ui::OK, "this shell".into(), format!("HTTPS_PROXY=:{p}"))),
+        (None, Some(_)) if !s.running => rows.push((
+            ui::NOTE,
+            "this shell".into(),
+            "HTTPS_PROXY not set here — the daemon is stopped, so shells route directly".into(),
+        )),
         (None, Some(_)) => rows.push((
             ui::NOTE,
             "this shell".into(),
@@ -322,17 +346,26 @@ mod tests {
     }
 
     #[test]
-    fn stopped_but_wired_is_a_problem() {
+    fn stopped_but_wired_flags_the_daemon_and_explains_direct_routing() {
         let r = build(&State {
             running: false,
             port_accepting: false,
             ..healthy()
         });
-        assert!(r.problems >= 2, "daemon down + env wired are both problems");
+        // The stopped daemon is always the actionable problem. The persisted-env row differs by
+        // platform: POSIX self-gates (new shells route directly — a note, not a second problem),
+        // while Windows env lives in the registry and stays wired at a dead proxy until an
+        // explicit `stop`, so it's a real warning.
+        assert!(r.problems >= 1, "daemon down is a problem");
         let out = render(false, &r);
         assert!(out.contains("not running — start: llmtrim start"));
-        assert!(out.contains("LLM calls fail"));
-        assert!(out.contains("problems found"));
+        #[cfg(not(windows))]
+        {
+            assert!(out.contains("route directly"));
+            assert!(out.contains("resume interception"));
+        }
+        #[cfg(windows)]
+        assert!(out.contains("new terminals fail"));
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -190,6 +190,12 @@ enum Commands {
     },
     /// Stop the background interceptor daemon
     Stop,
+    /// Fast liveness probe for the shell-profile block (hidden): exit 0 if the daemon is up,
+    /// 1 if not. Reads the pidfile + `kill -0` only (no network), so it's cheap enough to run
+    /// on every new shell — the managed env block calls it to wire HTTPS_PROXY only while the
+    /// interceptor is actually running.
+    #[command(name = "_alive", hide = true)]
+    Alive,
     /// Update llmtrim to the latest release
     ///
     /// Channel-aware: a binary install self-updates via the installer; cargo and
@@ -624,6 +630,13 @@ fn run() -> Result<()> {
                 // a foreground `llmtrim serve` must not rewrite the user's shell profiles.
                 // Best-effort: never let it stop the proxy coming up.
                 let _ = llmtrim::setup::heal_managed_env();
+                // Windows: the daemon is up, so wire the interceptor env into the registry now.
+                // POSIX self-gates via the shell block's `_alive` probe, but Windows env is read
+                // at process launch with no per-shell hook, so we set it here (the one process
+                // both `start` and login autostart bring the daemon up through) and clear it in
+                // `stop`. Best-effort: never block the proxy coming up.
+                #[cfg(windows)]
+                let _ = llmtrim::setup::wire_env_windows(port);
                 llmtrim::serve::run_supervised(port, force)?;
             } else {
                 llmtrim::serve::run(port, force)?;
@@ -703,6 +716,14 @@ fn run() -> Result<()> {
             }
         }
         Commands::Wrap { args } => llmtrim::wrap::run(args)?,
+        Commands::Alive => {
+            // The shell-profile block runs this on every new shell to decide whether to wire
+            // HTTPS_PROXY. Keep it silent and pidfile-only (no TCP probe) so shell startup
+            // stays cheap. Exit 0 = daemon up, 1 = down.
+            if llmtrim::daemon::running().is_none() {
+                std::process::exit(1);
+            }
+        }
         Commands::Stop => match llmtrim::daemon::stop()? {
             Some(pid) => {
                 println!(
@@ -712,16 +733,48 @@ fn run() -> Result<()> {
                         &format!("Stopped interceptor (pid {pid}).")
                     )
                 );
-                if llmtrim::setup::profile_has_block() {
+                // New shells self-heal: the managed block only wires HTTPS_PROXY while the
+                // daemon is up, so a fresh terminal now talks to LLM hosts directly. But this
+                // shell already exported the vars at launch and a child can't unset them in its
+                // parent — so hand the user the one-liner. Only when HTTPS_PROXY actually points at
+                // the local interceptor, so we never tell someone to strip an unrelated corporate
+                // proxy they happen to have set.
+                #[cfg(not(windows))]
+                if llmtrim::wrap::https_proxy_is_local() {
                     eprintln!(
                         "{}",
                         ui::warn(
                             ui::color_stderr(),
-                            "HTTPS_PROXY still points at llmtrim in your environment — \
-                             new HTTPS to LLM hosts will fail until you start it again \
-                             (llmtrim start) or run llmtrim uninstall."
+                            &format!(
+                                "This shell still points at the stopped interceptor. New \
+                                 terminals are already clear; to fix this one, run:\n    {}",
+                                llmtrim::setup::UNSET_HINT
+                            )
                         )
                     );
+                }
+                // Windows has no per-shell gate (env lives in HKCU\Environment, read at process
+                // launch), so clear the registry values now: newly-launched terminals and apps
+                // come up clear. `start` re-wires them when the daemon is back up.
+                #[cfg(windows)]
+                match llmtrim::setup::unwire_env_windows() {
+                    Ok(true) => eprintln!(
+                        "{}",
+                        ui::note(
+                            ui::color_stderr(),
+                            "Cleared HTTPS_PROXY from your user environment — new terminals and \
+                             apps are clear. Apps already running keep the old proxy until you \
+                             restart them."
+                        )
+                    ),
+                    Ok(false) => {}
+                    Err(e) => eprintln!(
+                        "{}",
+                        ui::warn(
+                            ui::color_stderr(),
+                            &format!("could not clear the interceptor env: {e}")
+                        )
+                    ),
                 }
             }
             None => println!(
@@ -2103,6 +2156,25 @@ mod tests {
     fn breakdown_section_is_omitted_unless_requested() {
         let base = r#"{"daemon":{"running":true}}"#.to_string();
         assert_eq!(merge_breakdown_json(base.clone(), false), base);
+    }
+
+    // `_alive` is baked verbatim into every user's shell profile (setup.rs `env_block`), so its
+    // name is a forever-contract: a rename silently breaks proxy wiring for every new shell. Pin
+    // it here so CI catches an accidental rename, and confirm it stays hidden from help.
+    #[test]
+    fn alive_subcommand_name_is_stable_and_hidden() {
+        let cli = Cli::try_parse_from(["llmtrim", "_alive"]).expect("`_alive` must parse");
+        assert!(matches!(cli.command, Commands::Alive));
+        let help = {
+            use clap::CommandFactory;
+            let mut out = Vec::new();
+            Cli::command().write_long_help(&mut out).unwrap();
+            String::from_utf8(out).unwrap()
+        };
+        assert!(
+            !help.contains("_alive"),
+            "`_alive` must stay hidden from help"
+        );
     }
 
     // The flag only makes sense with `--json`; clap must reject it on its own.

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -1,9 +1,11 @@
 //! `llmtrim setup` — the one-command bootstrap. llmtrim is *only* a MITM proxy, so
 //! integration is purely at the environment level: it ensures the local CA, then sets
 //! `HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS` for the user (POSIX: a managed shell-profile
-//! block; Windows: `HKCU\Environment`) so every newly-launched tool routes through the
-//! interceptor and trusts the CA — **no IDE settings touched, no sudo** — enables
-//! run-at-login, and starts the daemon.
+//! block; Windows: `HKCU\Environment`) so newly-launched tools route through the
+//! interceptor and trust the CA — **no IDE settings touched, no sudo** — enables
+//! run-at-login, and starts the daemon. On POSIX the block wires the vars only while the
+//! daemon is up (gated on `llmtrim _alive`), so a shell opened after `stop` routes directly
+//! instead of at a dead proxy; Windows syncs the registry on daemon start/stop instead.
 //!
 //! Best-effort and idempotent: a step that fails warns and the rest proceeds.
 
@@ -16,6 +18,12 @@ use crate::ui::{self, Tone};
 
 const BEGIN: &str = "# >>> llmtrim >>>";
 const END: &str = "# <<< llmtrim <<<";
+
+/// The shell command that clears the interceptor env vars from the *current* shell. A running
+/// process can't rewrite its parent shell's environment, so `stop`/`uninstall` print this for
+/// the user to run (or they open a new shell, which self-heals via the daemon-gated block).
+/// Single source of truth for the five managed vars, in both `NO_PROXY` casings.
+pub const UNSET_HINT: &str = "unset HTTPS_PROXY HTTP_PROXY NO_PROXY no_proxy NODE_EXTRA_CA_CERTS SSL_CERT_FILE CURL_CA_BUNDLE";
 
 /// Hosts/ranges that must bypass the interceptor: loopback, link-local, and the private LAN
 /// ranges (RFC-1918 + IPv6 ULA). llmtrim only MITMs a fixed set of public LLM API hosts (the
@@ -248,16 +256,20 @@ pub fn heal_managed_env() -> Result<Vec<PathBuf>> {
 }
 
 /// Inner seam for [`heal_managed_env`] (POSIX), against `base` as the home dir so tests stay
-/// hermetic. Rewrites the managed block only in profiles that already contain it AND lack the
-/// `NO_PROXY` bypass; returns the paths actually rewritten.
-/// Does `s` contain a *well-formed* managed block (`BEGIN`…`END`) that lacks the `NO_PROXY`
-/// bypass? Only such a block is healable: a malformed BEGIN-without-END is skipped (rewriting it
-/// would stack a duplicate), an already-current block is skipped, and a `NO_PROXY` the user set
-/// *outside* the markers does not count (it must be inside the block we manage). Pure/testable.
+/// hermetic. Rewrites the managed block only in profiles that already contain a healable one (see
+/// [`managed_block_needs_heal`]); returns the paths actually rewritten.
+/// Does `s` contain a *well-formed* managed block (`BEGIN`…`END`) that predates the current block
+/// shape and should be rewritten? A block is healable when it lacks either the `NO_PROXY` bypass
+/// or the daemon-liveness gate (`llmtrim _alive`) — both are silent rewrites into the current
+/// form, and the second is what migrates every pre-gate install so `stop` unwires new shells
+/// without the user re-running `setup`. Only a well-formed block qualifies: a malformed
+/// BEGIN-without-END is skipped (rewriting it would stack a duplicate), an already-current block
+/// (both markers present inside it) is skipped, and a `NO_PROXY`/guard the user placed *outside*
+/// the markers does not count — it must be inside the block we manage. Pure/testable.
 #[cfg(not(windows))]
 fn managed_block_needs_heal(s: &str) -> bool {
-    let (mut in_block, mut saw_begin, mut saw_end, mut bypass_in_block) =
-        (false, false, false, false);
+    let (mut in_block, mut saw_begin, mut saw_end, mut bypass_in_block, mut gate_in_block) =
+        (false, false, false, false, false);
     for line in s.lines() {
         match line.trim() {
             BEGIN => {
@@ -270,11 +282,12 @@ fn managed_block_needs_heal(s: &str) -> bool {
                 }
                 in_block = false;
             }
+            l if in_block && l.contains("llmtrim _alive") => gate_in_block = true,
             l if in_block && l.contains("NO_PROXY") => bypass_in_block = true,
             _ => {}
         }
     }
-    saw_begin && saw_end && !bypass_in_block
+    saw_begin && saw_end && (!bypass_in_block || !gate_in_block)
 }
 
 #[cfg(not(windows))]
@@ -970,9 +983,10 @@ pub fn uninstall(purge: bool, keep_binary: bool) -> Result<()> {
         ui::paint(
             color,
             Tone::Bold,
-            "Done. Your current shell still has HTTPS_PROXY, HTTP_PROXY, NO_PROXY, and \
-             NODE_EXTRA_CA_CERTS exported. Open a new shell to clear them, or run: \
-             unset HTTPS_PROXY HTTP_PROXY NO_PROXY no_proxy NODE_EXTRA_CA_CERTS"
+            &format!(
+                "Done. Your current shell still has HTTPS_PROXY, HTTP_PROXY, NO_PROXY, and \
+                 NODE_EXTRA_CA_CERTS exported. Open a new shell to clear them, or run: {UNSET_HINT}"
+            )
         )
     );
     // The env is gone from disk, but processes that were already running inherited it at
@@ -1082,10 +1096,11 @@ fn remove_profile_block() -> Result<Vec<PathBuf>> {
     }
 }
 
-/// Is the interceptor env still wired up? Used to warn that stopping the daemon while
-/// `HTTPS_PROXY` still points at it will break the client's HTTPS. Windows reads the
-/// `HKCU\Environment` value; POSIX checks **all three candidate shell profiles** —
-/// a stale block in any of them means the env may still be wired for that shell.
+/// Has `setup` wired the interceptor env for this user? Windows reads the `HKCU\Environment`
+/// value; POSIX reports whether the managed block exists in any candidate shell profile. Note
+/// that on POSIX block *presence* no longer implies the env is actively exported: the block is
+/// gated on `llmtrim _alive`, so it can be present yet inert while the daemon is down. Callers
+/// (`start`, `wrap`) use this only as a "has setup run" signal, not a liveness check.
 pub fn profile_has_block() -> bool {
     #[cfg(windows)]
     {
@@ -1155,6 +1170,34 @@ fn clear_user_env() -> Result<bool> {
 #[cfg(windows)]
 fn user_env_has_proxy() -> bool {
     user_env_key().is_ok_and(|env| has_proxy_in(&env))
+}
+
+/// Windows: wire the interceptor env into `HKCU\Environment` (and broadcast the change) when the
+/// daemon comes up. The registry is read at process launch, so unlike POSIX there is no per-shell
+/// liveness gate — the env is set on daemon start and cleared on `stop`, keeping newly-launched
+/// processes in sync with whether the interceptor is actually running. Called from the supervised
+/// `serve` path, which is the single process `start` and login autostart both bring the daemon up
+/// through. Best-effort; ensures the CA exists so `NODE_EXTRA_CA_CERTS` points at a real file.
+#[cfg(windows)]
+pub fn wire_env_windows(port: u16) -> Result<()> {
+    crate::serve::ensure_ca()?;
+    let ca = crate::serve::ca_cert_path()?.to_string_lossy().to_string();
+    let proxy = format!("http://127.0.0.1:{port}");
+    set_user_env(&proxy, &ca)?;
+    broadcast_env_change();
+    Ok(())
+}
+
+/// Windows: clear the interceptor env from `HKCU\Environment` (and broadcast) when the daemon
+/// stops, so a terminal or app launched afterwards doesn't route at the now-dead proxy. Returns
+/// true if anything was set. Idempotent: clearing an already-clear env is not an error.
+#[cfg(windows)]
+pub fn unwire_env_windows() -> Result<bool> {
+    let cleared = clear_user_env()?;
+    if cleared {
+        broadcast_env_change();
+    }
+    Ok(cleared)
 }
 
 /// Broadcast `WM_SETTINGCHANGE("Environment")` so Explorer (and through it, newly-launched
@@ -1498,25 +1541,34 @@ fn env_block(proxy: &str, ca: &str, bundle: Option<&str>, syntax: Syntax) -> Str
     match syntax {
         // NO_PROXY is set in both cases (lowercase too on POSIX: curl/libcurl, Go, and others
         // only honor `no_proxy`). Windows env vars are case-insensitive, so one suffices there.
+        // Wire the env only while the daemon is actually up. A new shell opened after
+        // `llmtrim stop` must not route at a now-dead proxy — so the block gates every export
+        // behind `llmtrim _alive`, a fast pidfile check (no network, no TCP connect). Daemon
+        // down → the vars stay unset → tools talk to the LLM host directly and just work.
+        // The current shell can't be fixed this way (a child can't rewrite its parent's env);
+        // that's what `stop`'s printed `unset` line and `uninstall` handle.
         Syntax::Posix => {
             // Node trusts the CA via NODE_EXTRA_CA_CERTS; native OpenSSL/rustls clients don't
             // read it, so point their bundle vars at the full combined bundle when we have one.
+            // Indented to sit inside the liveness guard alongside the other exports.
             let native = bundle
                 .map(|b| {
                     format!(
-                        "export SSL_CERT_FILE=\"{b}\"\n\
-                         export CURL_CA_BUNDLE=\"{b}\"\n"
+                        "\x20   export SSL_CERT_FILE=\"{b}\"\n\
+                         \x20   export CURL_CA_BUNDLE=\"{b}\"\n"
                     )
                 })
                 .unwrap_or_default();
             format!(
                 "{BEGIN}\n\
-                 export HTTPS_PROXY=\"{proxy}\"\n\
-                 export HTTP_PROXY=\"{proxy}\"\n\
-                 export NO_PROXY=\"{NO_PROXY}\"\n\
-                 export no_proxy=\"{NO_PROXY}\"\n\
-                 export NODE_EXTRA_CA_CERTS=\"{ca}\"\n\
-                 {native}{END}\n"
+                 if command -v llmtrim >/dev/null 2>&1 && llmtrim _alive 2>/dev/null; then\n\
+                 \x20   export HTTPS_PROXY=\"{proxy}\"\n\
+                 \x20   export HTTP_PROXY=\"{proxy}\"\n\
+                 \x20   export NO_PROXY=\"{NO_PROXY}\"\n\
+                 \x20   export no_proxy=\"{NO_PROXY}\"\n\
+                 \x20   export NODE_EXTRA_CA_CERTS=\"{ca}\"\n\
+                 {native}fi\n\
+                 {END}\n"
             )
         }
         Syntax::PowerShell => format!(
@@ -1718,7 +1770,22 @@ mod tests {
         let old = format!("{BEGIN}\nexport HTTPS_PROXY=\"x\"\n{END}\n");
         assert!(managed_block_needs_heal(&old), "old block needs heal");
 
-        let current = format!("{BEGIN}\nexport NO_PROXY=\"y\"\n{END}\n");
+        // Pre-gate block: has the NO_PROXY bypass but not the `llmtrim _alive` liveness gate. It
+        // must still heal so existing installs migrate to the daemon-gated form (the fix that lets
+        // `stop` unwire new shells) without the user re-running `setup`.
+        let pre_gate = format!("{BEGIN}\nexport NO_PROXY=\"y\"\n{END}\n");
+        assert!(
+            managed_block_needs_heal(&pre_gate),
+            "block missing the _alive gate needs heal"
+        );
+
+        // The actually-current block carries both the bypass and the gate, so it is skipped.
+        let current = env_block(
+            "http://127.0.0.1:8787",
+            "/home/u/ca.pem",
+            None,
+            Syntax::Posix,
+        );
         assert!(!managed_block_needs_heal(&current), "current block skipped");
 
         let malformed = format!("{BEGIN}\nexport HTTPS_PROXY=\"x\"\n"); // no END
@@ -1971,6 +2038,83 @@ mod tests {
         assert!(contents.contains("LLMTRIMFAKE"));
 
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // The block is sourced into every user's .bashrc/.zshrc, so a shell-syntax error breaks their
+    // terminal startup — worse than a wrong var. `sh -n`/`bash -n` parse without executing, so
+    // this catches an unbalanced if/fi or a bad quote that string-offset checks can't.
+    #[cfg(unix)]
+    #[test]
+    fn env_block_posix_is_syntactically_valid_shell() {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+        let block = env_block(
+            "http://127.0.0.1:8787",
+            "/home/u/ca.pem",
+            None,
+            Syntax::Posix,
+        );
+        for shell in ["sh", "bash"] {
+            let mut child = match Command::new(shell)
+                .arg("-n")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+            {
+                Ok(c) => c,
+                Err(_) => continue, // shell not on this runner — skip
+            };
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(block.as_bytes())
+                .unwrap();
+            let status = child.wait().unwrap();
+            assert!(status.success(), "{shell} -n rejected the block:\n{block}");
+        }
+    }
+
+    #[test]
+    fn env_block_posix_gates_exports_on_daemon_liveness() {
+        // The exports must be guarded by the `_alive` probe so a new shell opened after
+        // `stop` doesn't wire itself at a dead proxy. Both the guard and a `fi` must be present,
+        // and every export must sit inside the conditional (i.e. after the `if` line).
+        let b = env_block(
+            "http://127.0.0.1:8787",
+            "/home/u/ca.pem",
+            None,
+            Syntax::Posix,
+        );
+        assert!(
+            b.contains("llmtrim _alive"),
+            "block must probe daemon liveness"
+        );
+        let if_at = b.find("if command -v llmtrim").expect("guard present");
+        let fi_at = b.find("\nfi\n").expect("guard closed with fi");
+        let export_at = b.find("export HTTPS_PROXY").expect("export present");
+        assert!(
+            if_at < export_at && export_at < fi_at,
+            "exports must live inside the liveness guard"
+        );
+
+        // The native-TLS bundle exports (added for curl/git/rustls clients) must be gated too,
+        // so a new shell after `stop` doesn't keep trusting the interceptor CA at a dead proxy.
+        let with_bundle = env_block(
+            "http://127.0.0.1:8787",
+            "/home/u/ca.pem",
+            Some("/home/u/.llmtrim/ca-bundle.pem"),
+            Syntax::Posix,
+        );
+        let fi_at = with_bundle.find("\nfi\n").expect("guard closed with fi");
+        let ssl_at = with_bundle
+            .find("export SSL_CERT_FILE")
+            .expect("bundle exports present");
+        assert!(
+            ssl_at < fi_at,
+            "native-TLS exports must sit inside the guard"
+        );
     }
 
     #[test]
@@ -2411,7 +2555,9 @@ mod tests {
 
     // ── env_block syntax verification ───────────────────────────────────────────────
 
-    /// POSIX block: every line between the markers is a valid `export KEY="value"` line.
+    /// POSIX block: the env lines are valid `export KEY="value"` lines, wrapped in the daemon
+    /// liveness guard (`if … ; then` / `fi`). Every non-marker line is either the guard, the
+    /// closing `fi`, or an export.
     #[test]
     fn env_block_posix_all_lines_are_valid_exports() {
         let proxy = "http://127.0.0.1:8787";
@@ -2422,9 +2568,12 @@ mod tests {
         let inner: Vec<&str> = block.lines().filter(|l| *l != BEGIN && *l != END).collect();
         assert!(!inner.is_empty(), "no inner lines in POSIX block");
         for line in &inner {
+            let trimmed = line.trim_start();
+            let is_guard = trimmed.starts_with("if ") || trimmed == "fi";
+            let is_export = trimmed.starts_with("export ") && trimmed.contains("=\"");
             assert!(
-                line.starts_with("export ") && line.contains("=\""),
-                "line is not a valid POSIX export: {line:?}"
+                is_guard || is_export,
+                "line is neither the liveness guard nor a valid export: {line:?}"
             );
         }
     }

--- a/crates/llmtrim-cli/src/wrap.rs
+++ b/crates/llmtrim-cli/src/wrap.rs
@@ -78,7 +78,7 @@ fn readiness(daemon_running: bool, env_wired: bool) -> Readiness {
 /// This is what matters: the child inherits our live environment, not the shell profile on
 /// disk. Checking `profile_has_block()` would pass when `setup` has run but the current
 /// shell predates it, launching the agent with no proxy and silently skipping compression.
-fn https_proxy_is_local() -> bool {
+pub fn https_proxy_is_local() -> bool {
     std::env::var("HTTPS_PROXY")
         .or_else(|_| std::env::var("https_proxy"))
         .map(|v| v.contains("127.0.0.1") || v.contains("localhost"))


### PR DESCRIPTION
## Problem

After `llmtrim stop`, a new terminal broke: the shell profile still exported `HTTPS_PROXY` at the now-dead local proxy, so Claude Code, codex, and curl hard-failed. `stop` was effectively unusable without manually undoing the env.

## Fix

Keep `start`/`stop` as daemon toggles and make the env follow daemon liveness, per platform.

**POSIX.** The managed shell block now wraps its exports in a liveness guard, `if command -v llmtrim && llmtrim _alive; then ... fi`. `_alive` is a new hidden subcommand: a network-free pidfile probe (`daemon::running()`, pidfile + `kill -0`, which self-heals stale pidfiles), cheap enough to run on every new shell. Daemon down means the vars stay unset and tools route directly; `start` respawns the daemon and new shells re-wire on their own. The shell that ran `stop` keeps the vars it inherited (a child can't rewrite its parent's env), so `stop` prints a one-line `unset`, but only when `HTTPS_PROXY` actually points at the local interceptor, so it never suggests stripping an unrelated corporate proxy.

**Windows.** Env lives in `HKCU\Environment`, read at process launch with no per-shell hook, so the registry is synced to daemon liveness instead: the supervised `serve` child (spawned by both `start` and login autostart) sets the values; `stop` clears them and broadcasts the change, so new terminals and apps come up clear.

**Migration.** Existing installs pick up the new gated block on the next daemon start: `heal_managed_env` now rewrites any block missing the `_alive` gate, not just one missing `NO_PROXY`. No `setup` re-run needed.

**doctor** reports the new states: on POSIX a persisted block with a stopped daemon is direct-routing (a note, not a failure); on Windows the same state is a real problem (registry still wired at a dead proxy).

## Review

Design and implementation were challenged by multiple reviewer passes before and after coding. Rejected earlier designs (a `stop --unset` flag, then a wrapper shell function plus a state-marker file) because they either shadowed the `llmtrim` binary in ways that broke `sudo`/CI/non-interactive calls, or introduced a second source of truth that drifts against the pidfile. The probe-gated block derives liveness live from the self-healing pidfile, so there is no new state to drift. Post-implementation review caught the migration gap, the `stop`-hint scoping, and the Windows doctor message, all fixed here.

## Verification

- `cargo fmt`, `cargo clippy --features intercept`, and `cargo nextest run --features intercept`: 841 tests pass.
- New tests: the `_alive` subcommand name is pinned and kept hidden (it is baked into every user's profile), the generated block is checked against `sh -n`/`bash -n`, native-TLS bundle exports are gated, and pre-gate blocks heal.
- The `cfg(windows)` paths could not be cross-compiled locally (no mingw toolchain in the dev sandbox), so they are review-verified and rely on CI's Windows build to compile-verify.
