### PR TITLE
fix: surface, type, and retry subscription reroute upstream failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Subscription reroute now surfaces the real upstream error.** When the ChatGPT/Codex or
+  Kimi backend rejected a rerouted turn (e.g. the plan hit its usage limit, HTTP 429),
+  llmtrim wrapped the failure in a `200 OK` SSE `error` frame, which Claude Code showed as
+  the opaque "API returned an empty or malformed response (HTTP 200)". The failure now comes
+  back with the upstream status code and the provider's message, including when a
+  rate-limited plan resets, so `--resume` and normal turns report what actually went wrong.
+
 ## [0.9.0] - 2026-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ All notable changes to this project are documented here. The format follows
 ### Fixed
 
 - **Subscription reroute now surfaces the real upstream error.** When the ChatGPT/Codex or
-  Kimi backend rejected a rerouted turn (e.g. the plan hit its usage limit, HTTP 429),
-  llmtrim wrapped the failure in a `200 OK` SSE `error` frame, which Claude Code showed as
-  the opaque "API returned an empty or malformed response (HTTP 200)". The failure now comes
-  back with the upstream status code and the provider's message, including when a
-  rate-limited plan resets, so `--resume` and normal turns report what actually went wrong.
+  Kimi backend rejected a rerouted turn, llmtrim wrapped the failure in a `200 OK` SSE `error`
+  frame, which Claude Code showed as the opaque "API returned an empty or malformed response
+  (HTTP 200)". This covered both a non-2xx response (e.g. the plan hit its usage limit, HTTP
+  429) and a turn that failed mid-stream on an HTTP 200 response (e.g.
+  `context_length_exceeded` when a resumed transcript is larger than the target model's
+  context window). The failure now comes back with a real status code and the provider's
+  message, including when a rate-limited plan resets, so `--resume` and normal turns report
+  what actually went wrong.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ All notable changes to this project are documented here. The format follows
   back with the upstream status code and the provider's message, including when a
   rate-limited plan resets, so `--resume` and normal turns report what actually went wrong.
 
+### Added
+
+- **Subscription reroute retries transient failures.** A rerouted turn that hits a transient
+  upstream failure (HTTP 500/502/503/504/529) or a short rate limit is now re-issued with
+  exponential backoff (up to 3 attempts), honoring the provider's reset hint. A usage-limit
+  reset that is hours away is surfaced at once rather than burning pointless retries. The
+  surfaced error is also typed by status (`rate_limit_error` / `authentication_error` /
+  `overloaded_error`) and, for rate limits, carries a capped `Retry-After` header so the
+  client backs off instead of tight-retrying a large resumed request.
+
 ## [0.9.0] - 2026-07-09
 
 ### Added

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -432,6 +432,48 @@ mod imp {
         json_response(status, &body)
     }
 
+    /// Build the client-facing message for a non-2xx subscription-backend response. Pulls the
+    /// upstream `error.message` out of the JSON body when present (falling back to a raw snippet),
+    /// and adds a hint for the common rate-limit case so the user sees "usage limit reached" and
+    /// when it resets instead of an opaque HTTP code.
+    fn reroute_upstream_error_message(
+        provider: crate::reroute::SubProvider,
+        status: u16,
+        raw: &[u8],
+    ) -> String {
+        let json: Option<serde_json::Value> = serde_json::from_slice(raw).ok();
+        let err = json.as_ref().and_then(|v| v.get("error"));
+        let detail = err
+            .and_then(|e| e.get("message"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                String::from_utf8_lossy(raw)
+                    .trim()
+                    .chars()
+                    .take(200)
+                    .collect()
+            });
+
+        let mut msg = format!(
+            "llmtrim: {} subscription backend returned HTTP {status}: {detail}",
+            provider.as_str(),
+        );
+        if let Some(secs) = err
+            .and_then(|e| e.get("resets_in_seconds"))
+            .and_then(serde_json::Value::as_i64)
+            .filter(|s| *s > 0)
+        {
+            let mins = secs / 60;
+            if mins >= 60 {
+                msg.push_str(&format!(" (resets in ~{}h{:02}m)", mins / 60, mins % 60));
+            } else {
+                msg.push_str(&format!(" (resets in ~{mins}m)"));
+            }
+        }
+        msg
+    }
+
     /// Override the Codex reasoning effort on a to-be-translated Anthropic body by writing
     /// `output_config.effort`, the field the Codex translator reads. By default the reroute honors
     /// the client's own `output_config.effort` (Claude Code sets it per turn); this overwrites it
@@ -1158,21 +1200,12 @@ mod imp {
                     .await
                     .map(|c| c.to_bytes().to_vec())
                     .unwrap_or_default();
-                let snippet: String = String::from_utf8_lossy(&raw).chars().take(400).collect();
-                let mut enc = AnthropicSseEncoder::new(&info.model);
-                let mut out = String::new();
-                enc.encode(
-                    &ReduceEvent::Error {
-                        message: format!(
-                            "llmtrim: {} upstream HTTP {}: {}",
-                            info.provider.as_str(),
-                            status.as_u16(),
-                            snippet
-                        ),
-                    },
-                    &mut out,
-                );
-                let acc = Arc::new(Mutex::new(out.clone().into_bytes()));
+                // Surface the upstream failure as a real non-2xx Anthropic error (like the reroute
+                // pre-flight failures), not a 200 SSE `error` frame: Claude Code renders a bare
+                // in-stream error event that never had a `message_start` as "empty or malformed
+                // response (HTTP 200)", hiding the actual cause (e.g. a rate-limited subscription).
+                let message = reroute_upstream_error_message(info.provider, status.as_u16(), &raw);
+                let acc = Arc::new(Mutex::new(message.clone().into_bytes()));
                 // Record the row (output 0) as this Finalize drops.
                 let _finalize = Finalize {
                     acc,
@@ -1180,7 +1213,7 @@ mod imp {
                     ledger: self.ledger.clone(),
                     breakdown_ledger: self.breakdown_ledger.clone(),
                 };
-                return sse_response(out);
+                return anthropic_error(status.as_u16(), &message);
             }
 
             let acc = Arc::new(Mutex::new(Vec::<u8>::new()));
@@ -2713,6 +2746,42 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::*;
+
+        #[test]
+        fn reroute_error_message_surfaces_rate_limit_and_reset() {
+            // The ChatGPT/Codex backend returns this exact shape when the plan is exhausted.
+            let raw = br#"{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"plus","resets_in_seconds":6922}}"#;
+            let msg = reroute_upstream_error_message(crate::reroute::SubProvider::Codex, 429, raw);
+            assert!(msg.contains("HTTP 429"), "names the status: {msg}");
+            assert!(
+                msg.contains("The usage limit has been reached"),
+                "carries the upstream detail: {msg}"
+            );
+            assert!(msg.contains("resets in ~1h55m"), "shows reset time: {msg}");
+        }
+
+        #[test]
+        fn reroute_error_message_formats_sub_hour_reset() {
+            let raw = br#"{"error":{"message":"slow down","resets_in_seconds":300}}"#;
+            let msg = reroute_upstream_error_message(crate::reroute::SubProvider::Kimi, 429, raw);
+            assert!(msg.contains("resets in ~5m"), "shows minute reset: {msg}");
+            assert!(msg.contains("kimi"), "names the provider: {msg}");
+        }
+
+        #[test]
+        fn reroute_error_message_falls_back_to_body_snippet() {
+            // Non-JSON / unexpected body: still surface something, never an empty message.
+            let msg = reroute_upstream_error_message(
+                crate::reroute::SubProvider::Codex,
+                502,
+                b"Bad Gateway",
+            );
+            assert!(msg.contains("HTTP 502"), "names the status: {msg}");
+            assert!(
+                msg.contains("Bad Gateway"),
+                "carries the raw snippet: {msg}"
+            );
+        }
 
         #[test]
         fn port_in_use_message_points_to_force_when_llmtrim_owns_it() {

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -338,6 +338,19 @@ mod imp {
     struct RerouteInfo {
         provider: crate::reroute::SubProvider,
         model: String,
+        /// The rewritten upstream request, retained so `reroute_response` can re-issue it on a
+        /// retryable failure (429/5xx). `None` on paths that never retry (the on-error fallback).
+        replay: Option<RerouteReplay>,
+    }
+
+    /// Enough of the rewritten upstream request to re-issue it on a retryable failure. The body is
+    /// shared (`Arc`) so retaining it for retries costs one copy of the compressed body, not one
+    /// per attempt.
+    #[derive(Clone)]
+    struct RerouteReplay {
+        url: String,
+        headers: Vec<(String, String)>,
+        body: Arc<Vec<u8>>,
     }
 
     /// On-error fallback marker attached to a [`Pending`] (see its `fallback` field). Holds what
@@ -424,12 +437,106 @@ mod imp {
     /// An Anthropic-shaped error the client (Claude Code) renders, for reroute pre-flight failures
     /// (no auth, unparseable body, translation error). `status` is the HTTP status.
     fn anthropic_error(status: u16, message: &str) -> Response<Body> {
+        anthropic_error_typed(status, "api_error", message, None)
+    }
+
+    /// Like [`anthropic_error`] but with an explicit error `kind` (so a rate limit renders as
+    /// `rate_limit_error`, not a generic `api_error`) and an optional `Retry-After` header
+    /// (seconds) so the client backs off sensibly instead of tight-retrying.
+    fn anthropic_error_typed(
+        status: u16,
+        kind: &str,
+        message: &str,
+        retry_after_secs: Option<u64>,
+    ) -> Response<Body> {
         let body = serde_json::json!({
             "type": "error",
-            "error": { "type": "api_error", "message": message },
+            "error": { "type": kind, "message": message },
         })
         .to_string();
-        json_response(status, &body)
+        let mut builder = Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "application/json");
+        if let Some(secs) = retry_after_secs {
+            builder = builder.header(header::RETRY_AFTER, secs.to_string());
+        }
+        builder
+            .body(Body::from(Full::new(Bytes::from(body))))
+            .unwrap_or_else(|_| Response::new(Body::empty()))
+    }
+
+    /// Anthropic error `type` for an upstream status, so Claude Code renders rate limits and
+    /// auth failures as their own error classes instead of a generic `api_error`.
+    fn reroute_error_kind(status: u16) -> &'static str {
+        match status {
+            401 | 403 => "authentication_error",
+            429 => "rate_limit_error",
+            529 => "overloaded_error",
+            _ => "api_error",
+        }
+    }
+
+    /// Statuses worth re-issuing against the subscription backend: transient server/overload
+    /// errors and rate limits. A rate limit is only actually retried when its backoff fits the
+    /// budget (see [`reroute_backoff_ms`]); a multi-hour usage-limit reset is surfaced at once.
+    fn reroute_should_retry(status: u16) -> bool {
+        matches!(status, 429 | 500 | 502 | 503 | 504 | 529)
+    }
+
+    const REROUTE_RETRY_MAX: u32 = 3;
+    const REROUTE_RETRY_BASE_MS: u64 = 1_000;
+    const REROUTE_RETRY_CAP_MS: u64 = 20_000;
+
+    /// Backoff before retry `attempt` (0-based). Honors an upstream reset hint (`retry_after_secs`)
+    /// when present, otherwise jittered-free exponential backoff. Returns `None` when the wait
+    /// would exceed the cap — e.g. a usage-limit reset hours away — so the caller stops retrying
+    /// and surfaces the error immediately instead of stalling.
+    fn reroute_backoff_ms(attempt: u32, retry_after_secs: Option<u64>) -> Option<u64> {
+        if let Some(secs) = retry_after_secs {
+            let ms = secs.saturating_mul(1_000);
+            return (ms <= REROUTE_RETRY_CAP_MS).then_some(ms);
+        }
+        let ms = REROUTE_RETRY_BASE_MS
+            .saturating_mul(1u64 << attempt.min(5))
+            .min(REROUTE_RETRY_CAP_MS);
+        Some(ms)
+    }
+
+    /// Extract a rate-limit reset hint (seconds) from an upstream response: the standard
+    /// `Retry-After`, a Codex `x-codex-primary-reset-after-seconds` header, or the JSON body's
+    /// `error.resets_in_seconds`. `None` when the response carries no usable hint.
+    fn reroute_retry_after_secs(
+        retry_after_header: Option<&str>,
+        codex_reset_header: Option<&str>,
+        body: &[u8],
+    ) -> Option<u64> {
+        let parse = |s: &str| s.trim().parse::<f64>().ok().filter(|v| *v >= 0.0);
+        if let Some(v) = retry_after_header.and_then(parse) {
+            return Some(v.ceil() as u64);
+        }
+        if let Some(v) = codex_reset_header.and_then(parse) {
+            return Some(v.ceil() as u64);
+        }
+        serde_json::from_slice::<serde_json::Value>(body)
+            .ok()
+            .and_then(|j| {
+                j.get("error")
+                    .and_then(|e| e.get("resets_in_seconds"))
+                    .and_then(serde_json::Value::as_i64)
+            })
+            .filter(|s| *s > 0)
+            .map(|s| s as u64)
+    }
+
+    /// [`reroute_retry_after_secs`] over a response header map (the first, hudsucker-fetched
+    /// attempt, which still carries the provider's headers).
+    fn reroute_retry_after_from_headers(headers: &header::HeaderMap, body: &[u8]) -> Option<u64> {
+        let get = |n: &str| headers.get(n).and_then(|v| v.to_str().ok());
+        reroute_retry_after_secs(
+            get("retry-after"),
+            get("x-codex-primary-reset-after-seconds"),
+            body,
+        )
     }
 
     /// Build the client-facing message for a non-2xx subscription-backend response. Pulls the
@@ -1143,6 +1250,11 @@ mod imp {
                 reroute: Some(RerouteInfo {
                     provider: sub,
                     model: rewrite.model.clone(),
+                    replay: Some(RerouteReplay {
+                        url: format!("https://{}{}", rewrite.host, rewrite.path),
+                        headers: rewrite.headers.clone(),
+                        body: Arc::new(rewrite.body.clone()),
+                    }),
                 }),
                 fallback: None,
             });
@@ -1192,19 +1304,46 @@ mod imp {
         ) -> Response<Body> {
             use crate::reroute::sse::{AnthropicSseEncoder, ReduceEvent};
             let status = res.status();
-            let (_parts, body) = res.into_parts();
+            let (parts, body) = res.into_parts();
 
             if !status.is_success() {
-                let raw = body
+                let mut cur_status = status.as_u16();
+                let mut cur_body = body
                     .collect()
                     .await
                     .map(|c| c.to_bytes().to_vec())
                     .unwrap_or_default();
+                let mut retry_after = reroute_retry_after_from_headers(&parts.headers, &cur_body);
+
+                // Server-side retry for transient / rate-limit failures (mirrors what a native
+                // Anthropic client does): re-issue the same upstream request with backoff, honoring
+                // the reset hint. A multi-hour usage-limit reset exceeds the budget and is surfaced
+                // at once rather than burning pointless retries.
+                if let Some(replay) = info.replay.as_ref() {
+                    let mut attempt = 0;
+                    while attempt < REROUTE_RETRY_MAX && reroute_should_retry(cur_status) {
+                        let Some(wait_ms) = reroute_backoff_ms(attempt, retry_after) else {
+                            break;
+                        };
+                        tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+                        attempt += 1;
+                        let Some((s, raw, ra)) = self.reissue_reroute(replay).await else {
+                            break;
+                        };
+                        if (200..300).contains(&s) {
+                            return self.finish_buffered_reroute(pending, &info, raw);
+                        }
+                        cur_status = s;
+                        cur_body = raw;
+                        retry_after = ra;
+                    }
+                }
+
                 // Surface the upstream failure as a real non-2xx Anthropic error (like the reroute
                 // pre-flight failures), not a 200 SSE `error` frame: Claude Code renders a bare
                 // in-stream error event that never had a `message_start` as "empty or malformed
                 // response (HTTP 200)", hiding the actual cause (e.g. a rate-limited subscription).
-                let message = reroute_upstream_error_message(info.provider, status.as_u16(), &raw);
+                let message = reroute_upstream_error_message(info.provider, cur_status, &cur_body);
                 let acc = Arc::new(Mutex::new(message.clone().into_bytes()));
                 // Record the row (output 0) as this Finalize drops.
                 let _finalize = Finalize {
@@ -1213,7 +1352,19 @@ mod imp {
                     ledger: self.ledger.clone(),
                     breakdown_ledger: self.breakdown_ledger.clone(),
                 };
-                return anthropic_error(status.as_u16(), &message);
+                // Emit `Retry-After` for a rate limit, capped so the client backs off without
+                // stalling for the full (possibly multi-hour) reset — the true reset is in the
+                // message. Type the error by status so it renders as a rate limit / auth failure.
+                let retry_after_header = (cur_status == 429)
+                    .then_some(retry_after)
+                    .flatten()
+                    .map(|s| s.min(60));
+                return anthropic_error_typed(
+                    cur_status,
+                    reroute_error_kind(cur_status),
+                    &message,
+                    retry_after_header,
+                );
             }
 
             let acc = Arc::new(Mutex::new(Vec::<u8>::new()));
@@ -1324,6 +1475,65 @@ mod imp {
                 .unwrap_or_else(|_| Response::new(Body::empty()))
         }
 
+        /// Re-issue a rerouted upstream request (blocking, buffered `forward_post` like the replay
+        /// net) for a retry attempt. Returns `(status, body, reset-hint-seconds)`, or `None` if the
+        /// round-trip or its task failed (the caller stops retrying and surfaces the last error).
+        async fn reissue_reroute(
+            &self,
+            replay: &RerouteReplay,
+        ) -> Option<(u16, Vec<u8>, Option<u64>)> {
+            let url = replay.url.clone();
+            let headers = replay.headers.clone();
+            let body = replay.body.clone();
+            let proxy = self.upstream_proxy.clone();
+            // `forward_post` exposes no response headers, so a retried attempt's reset hint comes
+            // from the body (`resets_in_seconds`) — enough for the Codex/Kimi usage-limit shape.
+            let (status, raw) = tokio::task::spawn_blocking(move || {
+                use std::io::Read;
+                let body_str = String::from_utf8_lossy(&body);
+                let mut up =
+                    crate::transport::forward_post(&url, &headers, &body_str, proxy.as_deref())
+                        .map_err(|e| e.to_string())?;
+                let mut buf = Vec::new();
+                up.reader.read_to_end(&mut buf).map_err(|e| e.to_string())?;
+                Ok::<(u16, Vec<u8>), String>((up.status, buf))
+            })
+            .await
+            .ok()?
+            .ok()?;
+            let retry_after = reroute_retry_after_secs(None, None, &raw);
+            Some((status, raw, retry_after))
+        }
+
+        /// Translate a buffered, successful retry response into Anthropic SSE in one shot (the rare
+        /// retry path, not the streaming hot path) and record the row on `Finalize` drop.
+        fn finish_buffered_reroute(
+            &self,
+            pending: Pending,
+            info: &RerouteInfo,
+            raw: Vec<u8>,
+        ) -> Response<Body> {
+            use crate::reroute::sse::AnthropicSseEncoder;
+            let mut enc = AnthropicSseEncoder::new(&info.model);
+            let mut out = String::new();
+            let mut reducer = crate::reroute::StreamReducer::new(info.provider, &info.model);
+            for ev in reducer.push(&raw) {
+                enc.encode(&ev, &mut out);
+            }
+            for ev in reducer.finish() {
+                enc.encode(&ev, &mut out);
+            }
+            enc.finish_if_open(&mut out);
+            let acc = Arc::new(Mutex::new(out.clone().into_bytes()));
+            let _finalize = Finalize {
+                acc,
+                pending: Some(pending),
+                ledger: self.ledger.clone(),
+                breakdown_ledger: self.breakdown_ledger.clone(),
+            };
+            sse_response(out)
+        }
+
         /// On-error reroute: Anthropic returned a quota/overload status, so replay the (stashed
         /// original) turn to the subscription provider and hand the client the provider's answer as
         /// Anthropic SSE. Uses a blocking provider round-trip (`transport::forward_post`, like the
@@ -1394,6 +1604,7 @@ mod imp {
             pending.reroute = Some(RerouteInfo {
                 provider,
                 model: model.clone(),
+                replay: None,
             });
 
             let url = format!("https://{}{}", rewrite.host, rewrite.path);
@@ -2758,6 +2969,55 @@ mod imp {
                 "carries the upstream detail: {msg}"
             );
             assert!(msg.contains("resets in ~1h55m"), "shows reset time: {msg}");
+        }
+
+        #[test]
+        fn reroute_error_kind_maps_status_to_anthropic_type() {
+            assert_eq!(reroute_error_kind(429), "rate_limit_error");
+            assert_eq!(reroute_error_kind(401), "authentication_error");
+            assert_eq!(reroute_error_kind(403), "authentication_error");
+            assert_eq!(reroute_error_kind(529), "overloaded_error");
+            assert_eq!(reroute_error_kind(500), "api_error");
+        }
+
+        #[test]
+        fn reroute_should_retry_covers_transient_and_rate_limit() {
+            for s in [429, 500, 502, 503, 504, 529] {
+                assert!(reroute_should_retry(s), "{s} should retry");
+            }
+            for s in [200, 400, 401, 403, 404, 422] {
+                assert!(!reroute_should_retry(s), "{s} should not retry");
+            }
+        }
+
+        #[test]
+        fn reroute_backoff_grows_and_respects_budget() {
+            // No hint: exponential from the base, capped.
+            assert_eq!(reroute_backoff_ms(0, None), Some(REROUTE_RETRY_BASE_MS));
+            assert_eq!(reroute_backoff_ms(1, None), Some(REROUTE_RETRY_BASE_MS * 2));
+            assert_eq!(reroute_backoff_ms(9, None), Some(REROUTE_RETRY_CAP_MS));
+            // A short reset hint is honored; a multi-hour one exceeds the budget -> stop retrying.
+            assert_eq!(reroute_backoff_ms(0, Some(3)), Some(3_000));
+            assert_eq!(reroute_backoff_ms(0, Some(6_922)), None);
+        }
+
+        #[test]
+        fn reroute_retry_after_prefers_header_then_body() {
+            // Retry-After header wins.
+            assert_eq!(
+                reroute_retry_after_secs(Some("12"), Some("999"), b"{}"),
+                Some(12)
+            );
+            // Codex reset header when no Retry-After.
+            assert_eq!(
+                reroute_retry_after_secs(None, Some("300"), b"{}"),
+                Some(300)
+            );
+            // Body fallback.
+            let body = br#"{"error":{"resets_in_seconds":6922}}"#;
+            assert_eq!(reroute_retry_after_secs(None, None, body), Some(6922));
+            // Nothing usable.
+            assert_eq!(reroute_retry_after_secs(None, None, b"nope"), None);
         }
 
         #[test]

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -469,10 +469,26 @@ mod imp {
     /// auth failures as their own error classes instead of a generic `api_error`.
     fn reroute_error_kind(status: u16) -> &'static str {
         match status {
+            400 | 422 => "invalid_request_error",
             401 | 403 => "authentication_error",
             429 => "rate_limit_error",
             529 => "overloaded_error",
             _ => "api_error",
+        }
+    }
+
+    /// Best-effort HTTP status for an error surfaced *inside* an HTTP 200 upstream stream (the
+    /// reducer keeps only the message text, not the upstream code). Context-window overflow is a
+    /// client input error (400); an explicit rate/usage limit is 429; anything else is treated as a
+    /// bad gateway (502).
+    fn reroute_stream_error_status(message: &str) -> u16 {
+        let m = message.to_lowercase();
+        if m.contains("context") && (m.contains("window") || m.contains("length")) {
+            400
+        } else if m.contains("rate limit") || m.contains("usage limit") {
+            429
+        } else {
+            502
         }
     }
 
@@ -1367,6 +1383,57 @@ mod imp {
                 );
             }
 
+            // Peek the head of the 2xx stream: drive the reducer until its first content event or a
+            // terminal. An upstream that fails the whole turn on an HTTP 200 stream (e.g.
+            // `context_length_exceeded` as an `error`/`response.failed`) is surfaced as a real typed
+            // error instead of a 200 stream Claude Code rejects as empty/malformed.
+            use hudsucker::futures::StreamExt;
+            let mut inner = BodyStream::new(body);
+            let mut reducer = crate::reroute::StreamReducer::new(info.provider, &info.model);
+            let mut encoder = AnthropicSseEncoder::new(&info.model);
+            let mut prelude = String::new();
+            let mut committed = false;
+            let mut fatal: Option<String> = None;
+            while !committed && fatal.is_none() {
+                match inner.next().await {
+                    Some(Ok(frame)) => {
+                        let Ok(chunk) = frame.into_data() else {
+                            continue;
+                        };
+                        for ev in reducer.push(&chunk) {
+                            match &ev {
+                                ReduceEvent::Error { message } => {
+                                    fatal.get_or_insert_with(|| message.clone());
+                                }
+                                ReduceEvent::Finish { .. } => {}
+                                _ => committed = true,
+                            }
+                            encoder.encode(&ev, &mut prelude);
+                        }
+                    }
+                    Some(Err(_)) => {
+                        fatal.get_or_insert_with(|| "llmtrim: upstream stream error".to_string());
+                    }
+                    None => break,
+                }
+            }
+
+            if let Some(detail) = fatal {
+                let status = reroute_stream_error_status(&detail);
+                let message = format!(
+                    "llmtrim: {} subscription backend: {detail}",
+                    info.provider.as_str()
+                );
+                let acc = Arc::new(Mutex::new(message.clone().into_bytes()));
+                let _finalize = Finalize {
+                    acc,
+                    pending: Some(pending),
+                    ledger: self.ledger.clone(),
+                    breakdown_ledger: self.breakdown_ledger.clone(),
+                };
+                return anthropic_error_typed(status, reroute_error_kind(status), &message, None);
+            }
+
             let acc = Arc::new(Mutex::new(Vec::<u8>::new()));
             let finalize = Finalize {
                 acc: acc.clone(),
@@ -1376,6 +1443,7 @@ mod imp {
             };
 
             enum Phase {
+                Prelude,
                 Body,
                 Flush,
                 Done,
@@ -1387,21 +1455,37 @@ mod imp {
                 acc: Arc<Mutex<Vec<u8>>>,
                 finalize: Finalize,
                 phase: Phase,
+                prelude: String,
             }
             let st = St {
-                inner: BodyStream::new(body),
-                reducer: crate::reroute::StreamReducer::new(info.provider, &info.model),
-                encoder: AnthropicSseEncoder::new(&info.model),
+                inner,
+                reducer,
+                encoder,
                 acc: acc.clone(),
                 finalize,
-                phase: Phase::Body,
+                phase: Phase::Prelude,
+                prelude,
             };
 
-            use hudsucker::futures::StreamExt;
             let stream = hudsucker::futures::stream::unfold(st, |mut st| async move {
                 loop {
                     match st.phase {
                         Phase::Done => return None,
+                        Phase::Prelude => {
+                            // Emit the bytes buffered while peeking, then stream the rest.
+                            st.phase = Phase::Body;
+                            if st.prelude.is_empty() {
+                                continue;
+                            }
+                            let out = std::mem::take(&mut st.prelude);
+                            if let Ok(mut buf) = st.acc.lock() {
+                                buf.extend_from_slice(out.as_bytes());
+                            }
+                            return Some((
+                                Ok::<Bytes, std::io::Error>(Bytes::from(out.into_bytes())),
+                                st,
+                            ));
+                        }
                         Phase::Flush => {
                             let mut out = String::new();
                             for ev in st.reducer.finish() {
@@ -2972,7 +3056,24 @@ mod imp {
         }
 
         #[test]
+        fn reroute_stream_error_status_infers_from_message() {
+            assert_eq!(
+                reroute_stream_error_status("Your input exceeds the context window of this model."),
+                400
+            );
+            assert_eq!(reroute_stream_error_status("context_length_exceeded"), 400);
+            assert_eq!(reroute_stream_error_status("rate limit reached"), 429);
+            assert_eq!(
+                reroute_stream_error_status("The usage limit has been reached"),
+                429
+            );
+            assert_eq!(reroute_stream_error_status("something else broke"), 502);
+        }
+
+        #[test]
         fn reroute_error_kind_maps_status_to_anthropic_type() {
+            assert_eq!(reroute_error_kind(400), "invalid_request_error");
+            assert_eq!(reroute_error_kind(422), "invalid_request_error");
             assert_eq!(reroute_error_kind(429), "rate_limit_error");
             assert_eq!(reroute_error_kind(401), "authentication_error");
             assert_eq!(reroute_error_kind(403), "authentication_error");


### PR DESCRIPTION
Fixes the misleading `HTTP 200 empty/malformed response` a rerouted turn showed when the
subscription backend (Codex/Kimi) rejected it, and hardens the reroute error path along the
lines of how [`claude-code-proxy`](../claude-code-proxy) handles the same case.

## The bug

`claude --resume` against a Codex plan that had hit its usage limit failed with:

```
API Error: API returned an empty or malformed response (HTTP 200)
```

The backend actually returned `HTTP 429 usage_limit_reached`, but `reroute_response`
encoded that as a single Anthropic SSE `error` frame returned with **HTTP 200**. That frame
has no preceding `message_start`, so Claude Code treats the stream as empty/malformed and
hides the real cause.

## Changes

**1. Surface the real upstream error** (`fix:` commit)
Return upstream failures as a real non-2xx Anthropic error (the path the reroute pre-flight
failures already use), carrying the upstream status and the provider's message, plus when a
rate-limited plan resets. Example now seen by the client (HTTP 429):

```json
{"type":"error","error":{"type":"rate_limit_error",
 "message":"llmtrim: codex subscription backend returned HTTP 429: The usage limit has been reached (resets in ~1h48m)"}}
```

**2. Type the error by status** (`feat:` commit)
`429 → rate_limit_error`, `401/403 → authentication_error`, `529 → overloaded_error`, else
`api_error`, so Claude Code's SDK renders the right class instead of a generic api_error.

**3. Retry transient failures** (`feat:` commit)
Retryable statuses (`429/500/502/503/504/529`) are re-issued with exponential backoff (up to
3 attempts), honoring the provider reset hint (`Retry-After`, `x-codex-*-reset-after-seconds`,
or the body's `resets_in_seconds`). A reset that exceeds the backoff budget (a multi-hour
usage limit) is surfaced immediately rather than burning pointless retries. Rate-limit errors
also carry a capped `Retry-After` so the client backs off instead of tight-retrying a large
resumed request (which is what caused the original re-upload stall).

## Design notes

The proxy hands the rewritten request to hudsucker to forward, so the response side has to
replay it to retry. The rewritten upstream request is retained on the reroute `Pending` with
a shared `Arc` body (one copy of the compressed body, not per attempt); retries reuse the
buffered `forward_post` round-trip, the same machinery as the on-error fallback.

Not a context-window change: the failure was a rate limit, not overflow. Genuine overflow now
surfaces cleanly through the same path; if it ever needs active handling the right lever is
the Responses API's server-side `truncation`, not a client-side byte budget.

## Verification

- Reproduced the original failure end to end through an isolated proxy against the live Codex
  backend, then confirmed the happy path still streams correctly after the change.
- New unit tests cover error typing, the retry decision, backoff/budget, reset-hint
  extraction, and the rate-limit message. `fmt` + `clippy --features intercept` clean; full
  suite green (950 tests).
