### PR TITLE
feat: status line for Claude Code (llmtrim statusline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to this project are documented here. The format follows
 
 - **`llmtrim statusline`: a custom status line for Claude Code.** Reads Claude Code's JSON
   session blob on stdin and prints one width-adaptive line: `◆ model·effort→backend`, a
-  context-health gauge, compression saved, and (when present) 5-hour rate-limit usage and
-  this turn's prompt-cache reuse. The context gauge is anchored to a fixed 200k
+  context-health gauge, compression saved for the current session (`✂ –` until it has trimmed
+  anything), and (when present) 5-hour rate-limit usage (`◔ 5h·24%`) and this turn's prompt-cache
+  reuse. The context gauge is anchored to a fixed 200k
   health budget rather than the model's raw window, so 200k reads as heavy even on a
   1M-context model. The reroute arrow (`→codex`/`→kimi`) shows the subscription actually
   serving the turn, and a `⚠` replaces the savings segment when the interceptor is degraded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ All notable changes to this project are documented here. The format follows
 ### Added
 
 - **`llmtrim statusline`: a custom status line for Claude Code.** Reads Claude Code's JSON
-  session blob on stdin and prints one width-adaptive line: `◆ model·effort→backend`, a
-  context-health gauge, compression saved for the current session (`✂ –` until it has trimmed
-  anything), and (when present) 5-hour rate-limit usage (`◔ 5h·24%`) and this turn's prompt-cache
-  reuse. The context gauge is anchored to a fixed 200k
-  health budget rather than the model's raw window, so 200k reads as heavy even on a
-  1M-context model. The reroute arrow (`→codex`/`→kimi`) shows the subscription actually
-  serving the turn, and a `⚠` replaces the savings segment when the interceptor is degraded.
-  Extras shed right-to-left on narrow terminals. `llmtrim statusline install` wires it into
-  `~/.claude/settings.json` (`--print` emits the snippet instead); `uninstall` removes it.
+  session blob on stdin and prints one width-adaptive line: `◆ model·effort→backend`, a context
+  gauge, compression saved for the current session (`✂ –` until it has trimmed anything), and
+  (when present) 5-hour and 7-day rate-limit usage (`◔ 5h·24% · 7d·12%`) and this turn's
+  prompt-cache reuse. The context gauge fills and colours against the *real* window of the model
+  serving the turn — the rerouted backend's window from the model registry under a `sub` reroute,
+  not Claude's — green below 40%, orange 40–65%, red above. The cache segment turns into
+  `♻ cold · /compact` once the session has been idle past the cache TTL, since the next message
+  then pays a cold cache write. The reroute arrow (`→codex`/`→kimi`) shows the subscription
+  actually serving the turn, and a `⚠` replaces the savings segment when the interceptor is
+  degraded. Extras shed right-to-left on narrow terminals. `llmtrim statusline install` wires it
+  into `~/.claude/settings.json` (`--print` emits the snippet instead); `uninstall` removes it.
   `setup` points Claude Code users to it in its next-steps, but never writes the file itself
   (setup stays client-agnostic and touches no IDE config).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project are documented here. The format follows
   serving the turn, and a `⚠` replaces the savings segment when the interceptor is degraded.
   Extras shed right-to-left on narrow terminals. `llmtrim statusline install` wires it into
   `~/.claude/settings.json` (`--print` emits the snippet instead); `uninstall` removes it.
+  `setup` points Claude Code users to it in its next-steps, but never writes the file itself
+  (setup stays client-agnostic and touches no IDE config).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`llmtrim statusline`: a custom status line for Claude Code.** Reads Claude Code's JSON
+  session blob on stdin and prints one width-adaptive line: `◆ model·effort→backend`, a
+  context-health gauge, compression saved, and (when present) 5-hour rate-limit usage and
+  this turn's prompt-cache reuse. The context gauge is anchored to a fixed 200k
+  health budget rather than the model's raw window, so 200k reads as heavy even on a
+  1M-context model. The reroute arrow (`→codex`/`→kimi`) shows the subscription actually
+  serving the turn, and a `⚠` replaces the savings segment when the interceptor is degraded.
+  Extras shed right-to-left on narrow terminals. `llmtrim statusline install` wires it into
+  `~/.claude/settings.json` (`--print` emits the snippet instead); `uninstall` removes it.
+
 ### Changed
 
 - **`llmtrim sub` config changes apply immediately.** The interceptor reads its config once at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,18 @@ All notable changes to this project are documented here. The format follows
 ### Added
 
 - **`llmtrim statusline`: a custom status line for Claude Code.** Reads Claude Code's JSON
-  session blob on stdin and prints one width-adaptive line: `◆ model·effort→backend`, a context
-  gauge, compression saved for the current session (`✂ –` until it has trimmed anything), and
-  (when present) 5-hour and 7-day rate-limit usage (`◔ 5h·24% · 7d·12%`) and this turn's
-  prompt-cache reuse. The context gauge fills and colours against the *real* window of the model
-  serving the turn — the rerouted backend's window from the model registry under a `sub` reroute,
-  not Claude's — green below 40%, orange 40–65%, red above. The cache segment turns into
-  `♻ cold · /compact` once the session has been idle past the cache TTL, since the next message
-  then pays a cold cache write. The reroute arrow (`→codex`/`→kimi`) shows the subscription
-  actually serving the turn, and a `⚠` replaces the savings segment when the interceptor is
-  degraded. Extras shed right-to-left on narrow terminals. `llmtrim statusline install` wires it
-  into `~/.claude/settings.json` (`--print` emits the snippet instead); `uninstall` removes it.
+  session blob on stdin and prints one width-adaptive line: `◆ model→backend`, a context gauge,
+  compression saved for the current session (`✂ –` until it has trimmed anything), and (when
+  present) 5-hour and 7-day rate-limit usage (`◔ 5h·24% · 7d·12%`) and this turn's prompt-cache
+  reuse. The context gauge fills and colours against the *real* window of the model serving the
+  turn — the rerouted backend's window from the model registry under a `sub` reroute, not
+  Claude's — green below 40%, orange 40–65%, red above. Rate-limit percentages escalate green →
+  amber (70%) → orange (80%) → red (90%). The cache segment turns into `♻ cold · /compact` once
+  the session has been idle past the cache TTL, since the next message then pays a cold cache
+  write. The reroute arrow (`→codex`/`→kimi`) shows the subscription actually serving the turn,
+  and a `⚠` replaces the savings segment when the interceptor is degraded. Extras shed
+  right-to-left on narrow terminals. `llmtrim statusline install` wires it into
+  `~/.claude/settings.json` (`--print` emits the snippet instead); `uninstall` removes it.
   `setup` points Claude Code users to it in its next-steps, but never writes the file itself
   (setup stays client-agnostic and touches no IDE config).
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ llmtrim statusline install --print  # or print the settings snippet to paste you
 ```
 
 ```text
-◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
+◆ Opus→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
 ```
 
 The `✂` trim figure is scoped to the current Claude Code session; it reads `✂ –` until llmtrim

--- a/README.md
+++ b/README.md
@@ -207,14 +207,15 @@ If the service stops, your tools fail fast with a connection error rather than s
 <summary><b>Day-to-day commands</b></summary>
 
 ```bash
-llmtrim status      # health + savings dashboard (aliases: monitor, gain)
-llmtrim doctor      # something off? end-to-end diagnosis; each check names its fix
-llmtrim start       # start the background proxy
-llmtrim stop        # stop it
-llmtrim serve       # run in the foreground instead (Ctrl-C to quit)
-llmtrim wrap claude # run an agent, guaranteeing this session routes through llmtrim (fails fast if it can't)
-llmtrim update      # update to the latest release + restart
-llmtrim uninstall   # exact inverse of setup: removes all three changes
+llmtrim status              # health + savings dashboard (aliases: monitor, gain)
+llmtrim statusline install  # add a live status line to Claude Code
+llmtrim doctor              # something off? end-to-end diagnosis; each check names its fix
+llmtrim start               # start the background proxy
+llmtrim stop                # stop it
+llmtrim serve               # run in the foreground instead (Ctrl-C to quit)
+llmtrim wrap claude         # run an agent, guaranteeing this session routes through llmtrim (fails fast if it can't)
+llmtrim update              # update to the latest release + restart
+llmtrim uninstall           # exact inverse of setup: removes all three changes
 ```
 
 `llmtrim status --daily` (or `--weekly` / `--monthly`) gives a time-series report; add `--json` or `--csv` to export.
@@ -293,6 +294,24 @@ The printed block is the standard MCP config; for a client you edit by hand it l
   }
 }
 ```
+
+**Status line for Claude Code.** `llmtrim statusline` renders a single line for Claude Code's
+[custom status line](https://code.claude.com/docs/en/statusline): the model, the subscription
+actually serving the turn when you reroute (`→codex`/`→kimi`), a context-health gauge, and how
+much llmtrim is trimming, plus rate-limit and prompt-cache reuse when Claude Code reports them.
+
+```bash
+llmtrim statusline install          # wire it into ~/.claude/settings.json
+llmtrim statusline install --print  # or print the settings snippet to paste yourself
+```
+
+```text
+◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   5h 24%   ♻ 63% cached
+```
+
+The context gauge is anchored to a fixed 200k budget, not the model's raw window, so a heavy
+context still reads as heavy on a 1M-context model. Segments drop right-to-left on narrow
+terminals, and anything Claude Code doesn't report (no reroute, no rate limits) is simply left out.
 
 ## Works with
 

--- a/README.md
+++ b/README.md
@@ -306,14 +306,17 @@ llmtrim statusline install --print  # or print the settings snippet to paste you
 ```
 
 ```text
-◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24%   ♻ 63% cached
+◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
 ```
 
 The `✂` trim figure is scoped to the current Claude Code session; it reads `✂ –` until llmtrim
-has saved something this session. `◔ 5h·24%` is the share of your Claude.ai 5-hour limit
-used. The context gauge is anchored to a fixed 200k budget, not the model's raw window, so a heavy
-context still reads as heavy on a 1M-context model. Segments drop right-to-left on narrow
-terminals, and anything Claude Code doesn't report (no reroute, no rate limits) is simply left out.
+has saved something this session. `◔ 5h·24% · 7d·12%` is the share of your Claude.ai 5-hour and
+7-day limits used. The context gauge fills against the real window of the model serving
+the turn — the rerouted backend's window under `sub`, not Claude's — green below 40%, orange
+40–65%, red above. `♻` shows this turn's prompt-cache reuse, and turns into `♻ cold · /compact`
+once the session has been idle past the cache TTL, since the next message then pays a cold cache
+write. Segments drop right-to-left on narrow terminals, and anything Claude Code doesn't report
+(no reroute, no rate limits) is simply left out.
 
 ## Works with
 

--- a/README.md
+++ b/README.md
@@ -306,10 +306,12 @@ llmtrim statusline install --print  # or print the settings snippet to paste you
 ```
 
 ```text
-◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   5h 24%   ♻ 63% cached
+◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24%   ♻ 63% cached
 ```
 
-The context gauge is anchored to a fixed 200k budget, not the model's raw window, so a heavy
+The `✂` trim figure is scoped to the current Claude Code session; it reads `✂ –` until llmtrim
+has saved something this session. `◔ 5h·24%` is the share of your Claude.ai 5-hour limit
+used. The context gauge is anchored to a fixed 200k budget, not the model's raw window, so a heavy
 context still reads as heavy on a 1M-context model. Segments drop right-to-left on narrow
 terminals, and anything Claude Code doesn't report (no reroute, no rate limits) is simply left out.
 

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -2388,6 +2388,7 @@ mod tests {
     fn srow(agent: &str, project: Option<&str>, id: &str, turns: i64, bill: i64) -> SessionRow {
         SessionRow {
             session_id: id.to_string(),
+            cc_session_id: None,
             agent: agent.to_string(),
             project: project.map(str::to_string),
             session_name: None,
@@ -2892,6 +2893,7 @@ mod tests {
         let t = Tracker::open_in_memory().unwrap();
         let turn = |sid: &str, agent: &str, proj: &str, name: &str| BreakdownTurn {
             session_id: sid.into(),
+            cc_session_id: None,
             agent: agent.into(),
             project: Some(proj.into()),
             session_name: Some(name.into()),

--- a/crates/llmtrim-cli/src/breakdown/export.rs
+++ b/crates/llmtrim-cli/src/breakdown/export.rs
@@ -137,6 +137,7 @@ mod tests {
     fn session(name: Option<&str>, project: Option<&str>) -> SessionRow {
         SessionRow {
             session_id: "abc123def456".to_string(),
+            cc_session_id: None,
             agent: "claude-code".to_string(),
             project: project.map(str::to_string),
             session_name: name.map(str::to_string),

--- a/crates/llmtrim-cli/src/lib.rs
+++ b/crates/llmtrim-cli/src/lib.rs
@@ -20,6 +20,7 @@ pub mod quality;
 pub mod reroute;
 pub mod serve;
 pub mod setup;
+pub mod statusline;
 pub mod tracking;
 pub mod transport;
 pub mod tray;

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -263,6 +263,16 @@ enum Commands {
         #[command(subcommand)]
         action: Option<McpAction>,
     },
+    /// Render Claude Code's custom status line (or `statusline install` to wire it up)
+    ///
+    /// With no subcommand, reads Claude Code's JSON session blob on stdin and prints one
+    /// elegant line — model·effort→backend, a context-health gauge, compression saved, and
+    /// (when present) rate-limit usage and this turn's prompt-cache reuse. `install` wires it
+    /// into `~/.claude/settings.json`; `install --print` just prints the settings snippet.
+    Statusline {
+        #[command(subcommand)]
+        action: Option<StatuslineCmd>,
+    },
     /// Check the install end-to-end and explain anything broken
     ///
     /// Read-only diagnosis: binary, daemon, port, env wiring (persisted + this shell),
@@ -507,6 +517,18 @@ enum McpAction {
         #[arg(long)]
         force: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum StatuslineCmd {
+    /// Wire the status line into `~/.claude/settings.json`
+    Install {
+        /// Print the settings snippet instead of editing the file.
+        #[arg(long)]
+        print: bool,
+    },
+    /// Remove the status line from `~/.claude/settings.json`
+    Uninstall,
 }
 
 #[derive(clap::Args)]
@@ -1229,6 +1251,11 @@ fn run() -> Result<()> {
         Commands::Mcp { action } => match action {
             None => llmtrim::mcp::run()?,
             Some(McpAction::Install { print, force }) => llmtrim::mcp::install(print, force)?,
+        },
+        Commands::Statusline { action } => match action {
+            None => llmtrim::statusline::run()?,
+            Some(StatuslineCmd::Install { print }) => llmtrim::statusline::install(print)?,
+            Some(StatuslineCmd::Uninstall) => llmtrim::statusline::uninstall()?,
         },
         Commands::Monitor {
             // Deprecated no-op (see the field docs): accepted, then ignored.

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -658,6 +658,8 @@ mod imp {
         blocks: Vec<llmtrim_core::attribution::BlockAttribution>,
         identity: llmtrim_core::attribution::RequestIdentity,
         window: i64,
+        /// Claude Code's own session id (`x-claude-code-session-id` header), when present.
+        cc_session_id: Option<String>,
     }
 
     /// A completed breakdown turn (identity + frozen pricing) plus its reconciled source blocks,
@@ -690,6 +692,7 @@ mod imp {
         json: &str,
         kind: ProviderKind,
         model: Option<&str>,
+        cc_session_id: Option<String>,
     ) -> Option<BreakdownPending> {
         let body: serde_json::Value = serde_json::from_str(json).ok()?;
         let counter = llmtrim_core::tokenizer::counter_for(kind, model).ok()?;
@@ -702,6 +705,7 @@ mod imp {
             blocks,
             identity,
             window: window_for(model),
+            cc_session_id,
         })
     }
 
@@ -805,6 +809,7 @@ mod imp {
                 .session_id
                 .clone()
                 .unwrap_or_else(|| "unknown".to_string()),
+            cc_session_id: xp.cc_session_id.clone(),
             agent: id.agent.clone().unwrap_or_else(|| "unknown".to_string()),
             project: id.project.clone(),
             session_name: None,
@@ -1052,6 +1057,11 @@ mod imp {
                 return req.into();
             }
             let (parts, body) = req.into_parts();
+            let cc_session_id = parts
+                .headers
+                .get("x-claude-code-session-id")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string);
             let bytes = match body.collect().await {
                 Ok(c) => c.to_bytes(),
                 Err(_) => return Request::from_parts(parts, Body::empty()).into(),
@@ -1072,6 +1082,7 @@ mod imp {
                     provider,
                     model_override.as_deref(),
                     &memo,
+                    cc_session_id,
                 )
             })
             .await
@@ -1185,6 +1196,7 @@ mod imp {
             let memo = self.memo.clone();
             let body_for_compress = bytes.clone();
             let started = std::time::Instant::now();
+            let cc_session_id = session_id.clone();
             let compressed = tokio::task::spawn_blocking(move || {
                 compress_blocking(
                     &config,
@@ -1192,6 +1204,7 @@ mod imp {
                     ProviderKind::Anthropic,
                     None,
                     &memo,
+                    cc_session_id,
                 )
             })
             .await
@@ -1897,6 +1910,7 @@ mod imp {
         provider: ProviderKind,
         model_override: Option<&str>,
         memo: &Memo,
+        cc_session_id: Option<String>,
     ) -> Option<(String, Pending)> {
         let text = std::str::from_utf8(body).ok()?;
         if !text.trim_start().starts_with('{') {
@@ -1939,7 +1953,12 @@ mod imp {
                 output_shaped: false,
                 frozen_input_tokens: Some(result.frozen_input_tokens.0 as i64),
                 // Passthrough forwards the original verbatim — attribute that body.
-                breakdown: attribute_for_breakdown(text, kind, result.model.as_deref()),
+                breakdown: attribute_for_breakdown(
+                    text,
+                    kind,
+                    result.model.as_deref(),
+                    cc_session_id.clone(),
+                ),
                 reroute: None,
                 fallback: None,
             };
@@ -1968,7 +1987,12 @@ mod imp {
             frozen_input_tokens: Some(result.frozen_input_tokens.0 as i64),
             // Attribute the compressed body we actually forward — its tokens are what the
             // provider bills, so it matches the usage we reconcile against.
-            breakdown: attribute_for_breakdown(&result.request_json, kind, result.model.as_deref()),
+            breakdown: attribute_for_breakdown(
+                &result.request_json,
+                kind,
+                result.model.as_deref(),
+                cc_session_id,
+            ),
             reroute: None,
             fallback: None,
         };
@@ -3741,9 +3765,9 @@ mod imp {
             let cfg = DenseConfig::default();
             let memo = Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY);
             assert!(
-                compress_blocking(&cfg, b"not json", ProviderKind::OpenAi, None, &memo).is_none()
+                compress_blocking(&cfg, b"not json", ProviderKind::OpenAi, None, &memo, None).is_none()
             );
-            assert!(compress_blocking(&cfg, b"", ProviderKind::OpenAi, None, &memo).is_none());
+            assert!(compress_blocking(&cfg, b"", ProviderKind::OpenAi, None, &memo, None).is_none());
         }
 
         #[test]
@@ -3757,7 +3781,7 @@ mod imp {
             // May return None (net loss) or Some (net win); both are valid.
             // The important assertion: when Some, the compressed form must have fewer input tokens.
             if let Some((compressed, pending)) =
-                compress_blocking(&cfg, body.as_bytes(), ProviderKind::OpenAi, None, &memo)
+                compress_blocking(&cfg, body.as_bytes(), ProviderKind::OpenAi, None, &memo, None)
             {
                 assert!(
                     pending.input_after <= pending.input_before,
@@ -3785,7 +3809,7 @@ mod imp {
             // Dedup is default-on and the spam is contiguous: this must compress, so a
             // `None` here is a regression (the test must not pass vacuously).
             let (compressed, pending) =
-                compress_blocking(&cfg, body.as_bytes(), ProviderKind::OpenAi, None, &memo)
+                compress_blocking(&cfg, body.as_bytes(), ProviderKind::OpenAi, None, &memo, None)
                     .expect("50 identical log lines must produce a net token win");
             assert!(
                 pending.input_after < pending.input_before,
@@ -3885,7 +3909,7 @@ mod imp {
             let cfg = DenseConfig::default();
             let memo = Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY);
             if let Some((compressed_json, pending)) =
-                compress_blocking(&cfg, body.as_bytes(), ProviderKind::OpenAi, None, &memo)
+                compress_blocking(&cfg, body.as_bytes(), ProviderKind::OpenAi, None, &memo, None)
             {
                 // compress_blocking now always returns Some for valid JSON, even on zero-savings
                 // inputs (the caller records the row; `input_after == input_before` means
@@ -3981,6 +4005,7 @@ mod imp {
                         project: None,
                     },
                     window: 200_000,
+                    cc_session_id: None,
                 }),
                 reroute: None,
                 fallback: None,

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -3765,9 +3765,12 @@ mod imp {
             let cfg = DenseConfig::default();
             let memo = Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY);
             assert!(
-                compress_blocking(&cfg, b"not json", ProviderKind::OpenAi, None, &memo, None).is_none()
+                compress_blocking(&cfg, b"not json", ProviderKind::OpenAi, None, &memo, None)
+                    .is_none()
             );
-            assert!(compress_blocking(&cfg, b"", ProviderKind::OpenAi, None, &memo, None).is_none());
+            assert!(
+                compress_blocking(&cfg, b"", ProviderKind::OpenAi, None, &memo, None).is_none()
+            );
         }
 
         #[test]
@@ -3780,9 +3783,14 @@ mod imp {
             let memo = Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY);
             // May return None (net loss) or Some (net win); both are valid.
             // The important assertion: when Some, the compressed form must have fewer input tokens.
-            if let Some((compressed, pending)) =
-                compress_blocking(&cfg, body.as_bytes(), ProviderKind::OpenAi, None, &memo, None)
-            {
+            if let Some((compressed, pending)) = compress_blocking(
+                &cfg,
+                body.as_bytes(),
+                ProviderKind::OpenAi,
+                None,
+                &memo,
+                None,
+            ) {
                 assert!(
                     pending.input_after <= pending.input_before,
                     "net-win guard: compressed must not exceed original ({} vs {})",
@@ -3808,9 +3816,15 @@ mod imp {
             let memo = Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY);
             // Dedup is default-on and the spam is contiguous: this must compress, so a
             // `None` here is a regression (the test must not pass vacuously).
-            let (compressed, pending) =
-                compress_blocking(&cfg, body.as_bytes(), ProviderKind::OpenAi, None, &memo, None)
-                    .expect("50 identical log lines must produce a net token win");
+            let (compressed, pending) = compress_blocking(
+                &cfg,
+                body.as_bytes(),
+                ProviderKind::OpenAi,
+                None,
+                &memo,
+                None,
+            )
+            .expect("50 identical log lines must produce a net token win");
             assert!(
                 pending.input_after < pending.input_before,
                 "50 identical log lines should compress: {} -> {}",
@@ -3908,9 +3922,14 @@ mod imp {
             .to_string();
             let cfg = DenseConfig::default();
             let memo = Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY);
-            if let Some((compressed_json, pending)) =
-                compress_blocking(&cfg, body.as_bytes(), ProviderKind::OpenAi, None, &memo, None)
-            {
+            if let Some((compressed_json, pending)) = compress_blocking(
+                &cfg,
+                body.as_bytes(),
+                ProviderKind::OpenAi,
+                None,
+                &memo,
+                None,
+            ) {
                 // compress_blocking now always returns Some for valid JSON, even on zero-savings
                 // inputs (the caller records the row; `input_after == input_before` means
                 // passthrough). Assert that we never *increase* the token count.

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -621,6 +621,14 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
         "  {}  llmtrim status",
         ui::paint(color, Tone::Dim, "watch savings")
     );
+    // Claude Code users only: hint at the status line without writing their config (setup is
+    // client-agnostic and never touches IDE settings). No-op for users of other agents.
+    if crate::statusline::claude_code_present() {
+        println!(
+            "  {}  llmtrim statusline install",
+            ui::paint(color, Tone::Dim, "status line  ")
+        );
+    }
     #[cfg(windows)]
     println!(
         "{}",

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -1,0 +1,561 @@
+//! `statusline` — one elegant line for Claude Code's custom status line.
+//!
+//! Claude Code pipes a JSON session blob on stdin and renders whatever the command
+//! prints (see <https://code.claude.com/docs/en/statusline>). This module reads that
+//! blob, folds in llmtrim's own live signals from the ledger + config (compression
+//! saved, interceptor health, the active `sub` reroute), and prints a single
+//! width-adaptive line:
+//!
+//! ```text
+//! ◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   5h 24%   ♻ 63% cached
+//! ```
+//!
+//! The three left segments (model·effort→backend, context, ✂ trim) are core and never
+//! truncate; the extras (quota, then this turn's prompt-cache reuse) shed right-to-left as
+//! the terminal narrows (`COLUMNS`). Segments whose data is absent — no reroute, an API-key
+//! user with no rate limits, a non-reasoning model with no effort — simply don't render.
+//!
+//! `install` wires it into `~/.claude/settings.json`; rendering itself never touches the
+//! network or API tokens.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::monitor::{self, DaemonView, Health};
+use crate::tracking::Tracker;
+use crate::ui;
+
+/// Context-health budget: the token count at which the gauge reads full/red. Anchored to a
+/// fixed "this is already a lot" ceiling rather than the model's technical window, so 200k
+/// reads as heavy whether the window is 200k or 1M (a raw window-% would whisper "20%").
+const CTX_BUDGET_TOKENS: i64 = 200_000;
+const CTX_BAR_WIDTH: usize = 8;
+
+// ── ANSI palette ────────────────────────────────────────────────────────────────
+// The status line is captured by Claude Code (never a TTY), but Claude Code renders ANSI,
+// so colour is emitted unconditionally — gated only by NO_COLOR, per the docs' examples.
+
+const BRAND: &str = "38;2;153;204;255"; // llmtrim accent blue
+const CYAN: &str = "36"; // codex
+const VIOLET: &str = "38;2;181;137;255"; // kimi
+const GREEN: &str = "32";
+const AMBER: &str = "33";
+const RED: &str = "31";
+const DIM: &str = "2";
+const BOLD: &str = "1";
+
+fn paint(color: bool, code: &str, s: &str) -> String {
+    if color {
+        format!("\x1b[{code}m{s}\x1b[0m")
+    } else {
+        s.to_string()
+    }
+}
+
+// ── the Claude Code stdin blob (only the fields we render) ────────────────────────
+
+struct CcInput {
+    model: String,
+    effort: Option<String>,
+    /// Total input tokens currently in the context window (fresh + cache), from the last
+    /// API response. `0` before the first response.
+    ctx_tokens: i64,
+    /// 5-hour rate-limit usage %, Claude.ai subscribers only.
+    five_hour_pct: Option<f64>,
+    /// Share of this turn's input served from the prompt cache, % — computed from the last
+    /// API call's `current_usage`. `None` before the first response or right after `/compact`.
+    cache_pct: Option<f64>,
+}
+
+fn parse_cc(input: &str) -> CcInput {
+    let v: Value = serde_json::from_str(input).unwrap_or(Value::Null);
+    let model = v
+        .pointer("/model/display_name")
+        .and_then(Value::as_str)
+        .unwrap_or("?")
+        .to_string();
+    let effort = v
+        .pointer("/effort/level")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let ctx_tokens = v
+        .pointer("/context_window/total_input_tokens")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let five_hour_pct = v
+        .pointer("/rate_limits/five_hour/used_percentage")
+        .and_then(Value::as_f64);
+    let cache_pct = {
+        let cu = v.pointer("/context_window/current_usage");
+        let field = |k: &str| {
+            cu.and_then(|c| c.get(k))
+                .and_then(Value::as_i64)
+                .unwrap_or(0)
+        };
+        let read = field("cache_read_input_tokens");
+        let total = read + field("input_tokens") + field("cache_creation_input_tokens");
+        (total > 0).then(|| read as f64 / total as f64 * 100.0)
+    };
+    CcInput {
+        model,
+        effort,
+        ctx_tokens,
+        five_hour_pct,
+        cache_pct,
+    }
+}
+
+// ── llmtrim's own signals, read from the ledger + config ──────────────────────────
+
+struct Led {
+    health: Health,
+    /// Input compression saved, % of input tokens (lifetime).
+    trim_pct: f64,
+    /// Active reroute provider (`codex`/`kimi`), if `sub` is on.
+    reroute: Option<String>,
+}
+
+/// Minimal [`DaemonView`] for the health check — mirrors `main::daemon_view` but fills only
+/// the fields [`monitor::health`] reads (running/pid/port/port_accepting/env_port/ca), since
+/// the status line needs the health verdict, not the full dashboard header.
+fn proxy_health() -> Health {
+    use crate::daemon;
+    let ca_present = matches!(crate::serve::ca_cert_path(), Ok(p) if p.exists());
+    let env_port = crate::setup::configured_port();
+    let view = |running: bool, pid: u32, port: u16, accepting: bool| DaemonView {
+        running,
+        pid,
+        port,
+        uptime: String::new(),
+        uptime_secs: 0,
+        ca_present,
+        port_accepting: accepting,
+        env_port,
+        autostart: false,
+        restarts: 0,
+        version: None,
+        binary_version: String::new(),
+        log_path: None,
+        last_request: None,
+    };
+    let dv = match daemon::running() {
+        Some(s) => view(true, s.pid, s.port, daemon::probe_port(s.port)),
+        // No pidfile: trust a live probe on the wired port before declaring stopped.
+        None => match env_port.filter(|&p| daemon::probe_port(p)) {
+            Some(p) => view(true, 0, p, true),
+            None => view(false, 0, 0, false),
+        },
+    };
+    monitor::health(&dv)
+}
+
+fn ledger_snapshot() -> Led {
+    let reroute = llmtrim_core::config::RuntimeConfig::get()
+        .sub
+        .clone()
+        .filter(|s| !s.is_empty() && s != "off");
+    let health = proxy_health();
+
+    let trim_pct = Tracker::open()
+        .and_then(|t| t.summary())
+        .map(|s| ui::saved_pct(s.input_before as f64, s.input_after as f64))
+        .unwrap_or(0.0);
+    Led {
+        health,
+        trim_pct,
+        reroute,
+    }
+}
+
+// ── rendering ─────────────────────────────────────────────────────────────────────
+
+/// Colour a value by threshold (`< warn` first colour, `< bad` second, else third).
+fn tier_color(v: f64, warn: f64, bad: f64) -> &'static str {
+    if v >= bad {
+        RED
+    } else if v >= warn {
+        AMBER
+    } else {
+        GREEN
+    }
+}
+
+/// `◆ Opus·high→codex` — health-brand glyph, model, glued effort, reroute arrow. The arrow is
+/// suppressed when the proxy isn't healthy (traffic isn't being intercepted, so it isn't
+/// actually rerouting).
+fn model_segment(cc: &CcInput, led: &Led, color: bool) -> String {
+    let mut s = format!(
+        "{} {}",
+        paint(color, BRAND, "◆"),
+        paint(color, BOLD, &cc.model)
+    );
+    if let Some(effort) = &cc.effort {
+        s.push_str(&paint(color, DIM, &format!("·{effort}")));
+    }
+    if let (Health::Healthy, Some(p)) = (led.health, &led.reroute) {
+        let code = match p.as_str() {
+            "kimi" => VIOLET,
+            _ => CYAN,
+        };
+        s.push_str(&paint(color, code, &format!("→{p}")));
+    }
+    s
+}
+
+/// `▓▓▓▓▓░░░ 142k` — gauge filled against the 200k health budget, coloured by absolute
+/// tokens (green < 80k, amber 80–160k, red ≥ 160k), label in absolute k.
+fn context_segment(ctx_tokens: i64, color: bool) -> String {
+    let tokens = ctx_tokens.max(0);
+    // Clamp to the budget *before* multiplying so a pathologically large token count can't
+    // overflow i64 (the bar pins full past the budget anyway).
+    let clamped = tokens.min(CTX_BUDGET_TOKENS);
+    let filled = (clamped * CTX_BAR_WIDTH as i64 / CTX_BUDGET_TOKENS) as usize;
+    let bar: String = "▓".repeat(filled) + &"░".repeat(CTX_BAR_WIDTH - filled);
+    let k = (tokens as f64 / 1000.0).round() as i64;
+    let code = if tokens == 0 {
+        DIM
+    } else {
+        tier_color(tokens as f64, 80_000.0, 160_000.0)
+    };
+    paint(color, code, &format!("{bar} {k}k"))
+}
+
+/// The third core segment: `✂ 6.8%` when healthy, `⚠ llmtrim degraded` when broken, and
+/// nothing at all when cleanly stopped (llmtrim is simply off — not an error to flag).
+fn trim_or_health_segment(led: &Led, color: bool) -> Option<String> {
+    match led.health {
+        Health::Healthy => Some(paint(color, GREEN, &format!("✂ {:.1}%", led.trim_pct))),
+        Health::Degraded => Some(paint(color, RED, "⚠ llmtrim degraded")),
+        Health::Stopped => None,
+    }
+}
+
+/// Build the ordered extra segments (quota, then per-session cache); later ones drop first.
+fn extra_segments(cc: &CcInput, color: bool) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(p) = cc.five_hour_pct {
+        let code = tier_color(p, 70.0, 90.0);
+        out.push(paint(color, code, &format!("5h {:.0}%", p)));
+    }
+    if let Some(c) = cc.cache_pct {
+        out.push(paint(color, DIM, &format!("♻ {:.0}% cached", c)));
+    }
+    out
+}
+
+const SEP: &str = "   ";
+
+/// Assemble the line: core segments always in, extras appended left-to-right only while they
+/// fit `cols` (0 = unknown width ⇒ no truncation). Once one extra overflows, stop — keeping
+/// the higher-priority leftmost extras.
+fn render_line(cc: &CcInput, led: &Led, cols: usize, color: bool) -> String {
+    let mut core = vec![
+        model_segment(cc, led, color),
+        context_segment(cc.ctx_tokens, color),
+    ];
+    if let Some(seg) = trim_or_health_segment(led, color) {
+        core.push(seg);
+    }
+    let mut line = core.join(SEP);
+
+    for extra in extra_segments(cc, color) {
+        let candidate = format!("{line}{SEP}{extra}");
+        if cols == 0 || ui::visible_width(&candidate) <= cols {
+            line = candidate;
+        } else {
+            break;
+        }
+    }
+    line
+}
+
+/// Render the status line from a Claude Code JSON blob (stdin). Pure apart from the ledger
+/// read, so tests drive `render_line` directly.
+pub fn run() -> Result<()> {
+    use std::io::Read;
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).ok();
+
+    let cc = parse_cc(&input);
+    let led = ledger_snapshot();
+    let cols = std::env::var("COLUMNS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(0);
+    let color = std::env::var_os("NO_COLOR").is_none();
+
+    println!("{}", render_line(&cc, &led, cols, color));
+    Ok(())
+}
+
+// ── install / uninstall (wire ~/.claude/settings.json) ────────────────────────────
+
+fn claude_settings_path() -> Result<PathBuf> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .context("neither HOME nor USERPROFILE is set")?;
+    Ok(PathBuf::from(home).join(".claude").join("settings.json"))
+}
+
+/// The `statusLine` object we write. `command` is this binary's absolute path plus the
+/// subcommand, so it works regardless of PATH.
+fn statusline_config() -> Value {
+    let exe = std::env::current_exe()
+        .ok()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "llmtrim".to_string());
+    let command = if exe.contains(' ') {
+        format!("\"{exe}\" statusline")
+    } else {
+        format!("{exe} statusline")
+    };
+    serde_json::json!({ "type": "command", "command": command, "padding": 0 })
+}
+
+/// Set our `statusLine` key on a parsed settings object, preserving every other key. Pure
+/// transform (no I/O) so [`install`]'s merge is unit-testable.
+fn set_statusline(settings: &mut Value, path: &std::path::Path) -> Result<()> {
+    let obj = settings
+        .as_object_mut()
+        .with_context(|| format!("{} is not a JSON object", path.display()))?;
+    obj.insert("statusLine".to_string(), statusline_config());
+    Ok(())
+}
+
+/// Remove our `statusLine` key, returning whether one was present. Pure transform.
+fn clear_statusline(settings: &mut Value, path: &std::path::Path) -> Result<bool> {
+    let obj = settings
+        .as_object_mut()
+        .with_context(|| format!("{} is not a JSON object", path.display()))?;
+    Ok(obj.remove("statusLine").is_some())
+}
+
+/// Wire the status line into `~/.claude/settings.json` (merging, not clobbering). `print`
+/// just emits the settings snippet instead of editing the file.
+pub fn install(print: bool) -> Result<()> {
+    if print {
+        let snippet = serde_json::json!({ "statusLine": statusline_config() });
+        println!("{}", serde_json::to_string_pretty(&snippet)?);
+        return Ok(());
+    }
+
+    let path = claude_settings_path()?;
+    let mut settings: Value = match std::fs::read_to_string(&path) {
+        Ok(s) => serde_json::from_str(&s)
+            .with_context(|| format!("{} is not valid JSON", path.display()))?,
+        Err(_) => Value::Object(Default::default()),
+    };
+    set_statusline(&mut settings, &path)?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    std::fs::write(&path, serde_json::to_string_pretty(&settings)?)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+
+    println!(
+        "Wired the llmtrim status line into {}. Restart Claude Code to see it.",
+        path.display()
+    );
+    Ok(())
+}
+
+/// Remove the `statusLine` key we wrote (leaves the rest of `settings.json` untouched).
+pub fn uninstall() -> Result<()> {
+    let path = claude_settings_path()?;
+    let Ok(s) = std::fs::read_to_string(&path) else {
+        println!("No {} to edit — nothing to remove.", path.display());
+        return Ok(());
+    };
+    let mut settings: Value = serde_json::from_str(&s)
+        .with_context(|| format!("{} is not valid JSON", path.display()))?;
+    if clear_statusline(&mut settings, &path)? {
+        std::fs::write(&path, serde_json::to_string_pretty(&settings)?)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        println!("Removed the llmtrim status line from {}.", path.display());
+    } else {
+        println!("No llmtrim status line found in {}.", path.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn led(health: Health) -> Led {
+        Led {
+            health,
+            trim_pct: 6.8,
+            reroute: Some("codex".to_string()),
+        }
+    }
+
+    fn cc(ctx: i64) -> CcInput {
+        CcInput {
+            model: "Opus".to_string(),
+            effort: Some("high".to_string()),
+            ctx_tokens: ctx,
+            five_hour_pct: Some(24.0),
+            cache_pct: Some(63.0),
+        }
+    }
+
+    #[test]
+    fn full_line_has_every_segment_when_wide() {
+        let out = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
+        assert_eq!(
+            out,
+            "◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   5h 24%   ♻ 63% cached"
+        );
+    }
+
+    #[test]
+    fn context_gauge_anchors_to_budget_not_window() {
+        // 200k reads full regardless of the model's window: absolute label, pinned bar.
+        let out = render_line(&cc(210_000), &led(Health::Healthy), 0, false);
+        assert!(
+            out.contains("▓▓▓▓▓▓▓▓ 210k"),
+            "over budget pins full: {out}"
+        );
+        // A comfortable 48k is not full.
+        let out = render_line(&cc(48_000), &led(Health::Healthy), 0, false);
+        assert!(
+            out.contains("▓░░░░░░░ 48k"),
+            "48k is 1/8 blocks (floor): {out}"
+        );
+    }
+
+    #[test]
+    fn reroute_arrow_hidden_when_not_healthy() {
+        let out = render_line(&cc(142_000), &led(Health::Degraded), 0, false);
+        assert!(!out.contains("→codex"), "no arrow when degraded: {out}");
+        assert!(
+            out.contains("⚠ llmtrim degraded"),
+            "warns instead of ✂: {out}"
+        );
+    }
+
+    #[test]
+    fn stopped_omits_trim_and_arrow_without_warning() {
+        let mut l = led(Health::Stopped);
+        l.reroute = None;
+        let out = render_line(&cc(48_000), &l, 0, false);
+        assert!(!out.contains('✂'), "no trim when off: {out}");
+        assert!(!out.contains('⚠'), "clean off is not an error: {out}");
+        assert!(out.starts_with("◆ Opus·high"), "model still shown: {out}");
+    }
+
+    #[test]
+    fn narrow_terminal_sheds_extras_right_to_left() {
+        // Wide enough for core + quota, but not the cache extra.
+        let full = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
+        let width = ui::visible_width("◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   5h 24%");
+        let out = render_line(&cc(142_000), &led(Health::Healthy), width, false);
+        assert!(out.ends_with("5h 24%"), "keeps quota, sheds cache: {out}");
+        assert!(!out.contains("cached"), "cache dropped first: {out}");
+        assert!(full.len() > out.len());
+    }
+
+    #[test]
+    fn absent_data_segments_do_not_render() {
+        let mut c = cc(48_000);
+        c.effort = None; // non-reasoning model
+        c.five_hour_pct = None; // API-key user
+        c.cache_pct = None; // before first API response
+        let mut l = led(Health::Healthy);
+        l.reroute = None; // no reroute
+        let out = render_line(&c, &l, 0, false);
+        assert_eq!(out, "◆ Opus   ▓░░░░░░░ 48k   ✂ 6.8%");
+    }
+
+    #[test]
+    fn kimi_reroute_when_healthy() {
+        let mut l = led(Health::Healthy);
+        l.reroute = Some("kimi".to_string());
+        let out = render_line(&cc(72_000), &l, 0, true);
+        assert!(out.contains("→kimi"), "kimi arrow present: {out}");
+    }
+
+    #[test]
+    fn parse_cc_reads_nested_fields() {
+        let blob = r#"{"model":{"display_name":"Sonnet"},"effort":{"level":"medium"},
+            "context_window":{"total_input_tokens":123456,
+              "current_usage":{"input_tokens":10,"cache_creation_input_tokens":10,"cache_read_input_tokens":80}},
+            "rate_limits":{"five_hour":{"used_percentage":41.2}}}"#;
+        let cc = parse_cc(blob);
+        assert_eq!(cc.model, "Sonnet");
+        assert_eq!(cc.effort.as_deref(), Some("medium"));
+        assert_eq!(cc.ctx_tokens, 123456);
+        assert_eq!(cc.five_hour_pct, Some(41.2));
+        // 80 cache reads of 100 total input = 80%.
+        assert_eq!(cc.cache_pct, Some(80.0));
+    }
+
+    #[test]
+    fn install_merge_preserves_unrelated_keys() {
+        let p = std::path::Path::new("settings.json");
+        let mut settings = serde_json::json!({
+            "theme": "dark",
+            "permissions": { "allow": ["Bash"] },
+        });
+        set_statusline(&mut settings, p).unwrap();
+        // Our key is present with a command...
+        assert_eq!(settings["statusLine"]["type"], "command");
+        // ...and the pre-existing keys are untouched.
+        assert_eq!(settings["theme"], "dark");
+        assert_eq!(settings["permissions"]["allow"][0], "Bash");
+    }
+
+    #[test]
+    fn uninstall_removes_only_our_key_and_reports_presence() {
+        let p = std::path::Path::new("settings.json");
+        let mut settings = serde_json::json!({ "theme": "dark", "statusLine": { "x": 1 } });
+        assert!(
+            clear_statusline(&mut settings, p).unwrap(),
+            "reports it was present"
+        );
+        assert!(settings.get("statusLine").is_none(), "our key gone");
+        assert_eq!(settings["theme"], "dark", "other keys kept");
+        // Second removal reports absence and is a no-op.
+        assert!(!clear_statusline(&mut settings, p).unwrap());
+    }
+
+    #[test]
+    fn merge_rejects_a_non_object_settings_file() {
+        let p = std::path::Path::new("settings.json");
+        let mut settings = serde_json::json!([1, 2, 3]);
+        assert!(set_statusline(&mut settings, p).is_err());
+        assert!(clear_statusline(&mut settings, p).is_err());
+    }
+
+    #[test]
+    fn cache_pct_absent_without_current_usage() {
+        let cc = parse_cc(
+            r#"{"model":{"display_name":"Opus"},"context_window":{"total_input_tokens":100}}"#,
+        );
+        assert!(
+            cc.cache_pct.is_none(),
+            "no current_usage ⇒ no cache segment"
+        );
+    }
+
+    #[test]
+    fn parse_cc_tolerates_garbage_and_missing_fields() {
+        let cc = parse_cc("not json");
+        assert_eq!(cc.model, "?");
+        assert_eq!(cc.ctx_tokens, 0);
+        assert!(cc.effort.is_none());
+    }
+
+    #[test]
+    fn context_gauge_handles_extreme_token_counts() {
+        // Negative clamps to empty/0k; a pathologically huge count pins full without
+        // overflowing i64 (regression: `tokens * 8` used to overflow before clamping).
+        assert!(context_segment(-5000, false).starts_with("░░░░░░░░ 0k"));
+        assert!(context_segment(i64::MAX / 4, false).starts_with("▓▓▓▓▓▓▓▓"));
+    }
+}

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -292,6 +292,16 @@ pub fn run() -> Result<()> {
 
 // ── install / uninstall (wire ~/.claude/settings.json) ────────────────────────────
 
+/// Whether Claude Code appears to be installed (its `~/.claude` config dir exists). Used by
+/// `setup` to hint at the status line for Claude Code users only, not users of other agents —
+/// setup itself is client-agnostic and never writes this file.
+pub fn claude_code_present() -> bool {
+    claude_settings_path()
+        .ok()
+        .and_then(|p| p.parent().map(std::path::Path::is_dir))
+        .unwrap_or(false)
+}
+
 fn claude_settings_path() -> Result<PathBuf> {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -218,12 +218,17 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
         .and_then(|p| reroute_real_window(p, &cc.model_id, &cfg.sub_tiers));
     let health = proxy_health();
 
-    // One session-row read serves both trim and cache-cold.
+    // One session-row read serves both trim and cache-cold. Match on `cc_session_id` — the real
+    // Claude Code session id the proxy now records — not the ledger's `session_id`, which is a
+    // hash of the system prompt and never equals Claude Code's UUID.
     let row = cc.session_id.as_deref().and_then(|sid| {
         crate::breakdown::db::BreakdownDb::open()
             .ok()
             .and_then(|db| db.sessions().ok())
-            .and_then(|rows| rows.into_iter().find(|r| r.session_id == sid))
+            .and_then(|rows| {
+                rows.into_iter()
+                    .find(|r| r.cc_session_id.as_deref() == Some(sid))
+            })
     });
     let trim_pct = match &row {
         Some(r) => (r.input_before > 0)

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -7,17 +7,16 @@
 //! width-adaptive line:
 //!
 //! ```text
-//! ◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
+//! ◆ Opus→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
 //! ```
 //!
-//! The three left segments (model·effort→backend, context, ✂ trim) are core and never
+//! The three left segments (model→backend, context, ✂ trim) are core and never
 //! truncate; the extras (5h/7d quota, then this turn's prompt-cache reuse) shed right-to-left
 //! as the terminal narrows (`COLUMNS`). The context gauge fills and colours against the *real*
 //! window of the model serving the turn — the rerouted backend's window under `sub`, not
 //! Claude's — green below 40%, orange 40–65%, red above; and red whenever the prompt cache has
 //! gone cold, where the cache segment becomes `♻ cold · /compact`. Segments whose data is
-//! absent — no reroute, an API-key user with no rate limits, a non-reasoning model with no
-//! effort — simply don't render.
+//! absent — no reroute, an API-key user with no rate limits — simply don't render.
 //!
 //! `install` wires it into `~/.claude/settings.json`; rendering itself never touches the
 //! network or API tokens.
@@ -72,6 +71,10 @@ fn paint(color: bool, code: &str, s: &str) -> String {
 
 struct CcInput {
     model: String,
+    /// Claude Code's `effort.level`. Parsed but not currently rendered — the field doesn't track
+    /// the `/model` effort override, so showing it is misleading (see [`model_segment`]). Kept so
+    /// re-enabling is a one-liner once Claude Code fixes it.
+    #[allow(dead_code)]
     effort: Option<String>,
     /// Claude Code's own session id (the `x-claude-code-session-id` it also tags on every
     /// intercepted request), used to scope trim to *this* session's ledger rows. `None` if
@@ -209,10 +212,7 @@ fn proxy_health() -> Health {
 
 fn ledger_snapshot(cc: &CcInput) -> Led {
     let cfg = llmtrim_core::config::RuntimeConfig::get();
-    let reroute = cfg
-        .sub
-        .clone()
-        .filter(|s| !s.is_empty() && s != "off");
+    let reroute = cfg.sub.clone().filter(|s| !s.is_empty() && s != "off");
     let reroute_window = reroute
         .as_deref()
         .and_then(|p| reroute_real_window(p, &cc.model_id, &cfg.sub_tiers));
@@ -230,15 +230,16 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
                     .find(|r| r.cc_session_id.as_deref() == Some(sid))
             })
     });
-    let trim_pct = match &row {
-        Some(r) => (r.input_before > 0)
-            .then(|| ui::saved_pct(r.input_before as f64, r.input_after as f64)),
-        None => Tracker::open()
+    // Lifetime figure, read only when we have no session to scope to.
+    let lifetime = || {
+        Tracker::open()
             .and_then(|t| t.summary())
             .ok()
             .filter(|s| s.input_before > 0)
-            .map(|s| ui::saved_pct(s.input_before as f64, s.input_after as f64)),
+            .map(|s| ui::saved_pct(s.input_before as f64, s.input_after as f64))
     };
+    let session_savings = row.as_ref().map(|r| (r.input_before, r.input_after));
+    let trim_pct = trim_for(cc.session_id.as_deref(), session_savings, lifetime);
     let cache_cold = row.as_ref().is_some_and(|r| cache_cold(&r.last_ts));
 
     Led {
@@ -247,6 +248,24 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
         reroute,
         reroute_window,
         cache_cold,
+    }
+}
+
+/// Decide the trim figure: this session's own savings when we have its row; idle (`None`) for a
+/// known Claude Code session with no recorded turn yet — *not* the lifetime figure, which would
+/// flash a misleading number for a beat before the first turn lands; and only the lifetime figure
+/// (via `lifetime`) when there is no session id to scope to at all.
+fn trim_for(
+    session_id: Option<&str>,
+    session_savings: Option<(i64, i64)>,
+    lifetime: impl FnOnce() -> Option<f64>,
+) -> Option<f64> {
+    match (session_savings, session_id) {
+        (Some((before, after)), _) => {
+            (before > 0).then(|| ui::saved_pct(before as f64, after as f64))
+        }
+        (None, Some(_)) => None,
+        (None, None) => lifetime(),
     }
 }
 
@@ -286,29 +305,32 @@ fn cache_cold(last_ts: &str) -> bool {
 
 // ── rendering ─────────────────────────────────────────────────────────────────────
 
-/// Colour a value by threshold (`< warn` first colour, `< bad` second, else third).
-fn tier_color(v: f64, warn: f64, bad: f64) -> &'static str {
-    if v >= bad {
+/// Colour a rate-limit % with an extra orange step before red: green < 70, amber 70–80,
+/// orange 80–90, red ≥ 90 — so a filling quota escalates in visible stages, not one jump to red.
+fn quota_color(pct: f64) -> &'static str {
+    if pct >= 90.0 {
         RED
-    } else if v >= warn {
+    } else if pct >= 80.0 {
+        ORANGE
+    } else if pct >= 70.0 {
         AMBER
     } else {
         GREEN
     }
 }
 
-/// `◆ Opus·high→codex` — health-brand glyph, model, glued effort, reroute arrow. The arrow is
-/// suppressed when the proxy isn't healthy (traffic isn't being intercepted, so it isn't
-/// actually rerouting).
+/// `◆ Opus→codex` — health-brand glyph, model, reroute arrow. The arrow is suppressed when the
+/// proxy isn't healthy (traffic isn't being intercepted, so it isn't actually rerouting).
+///
+/// Effort is intentionally not shown: Claude Code's `effort.level` field doesn't track the
+/// `/model` effort override (it reports a stale/base level), so rendering it is misleading. The
+/// field is still parsed — re-append `·{effort}` here once Claude Code fixes the field.
 fn model_segment(cc: &CcInput, led: &Led, color: bool) -> String {
     let mut s = format!(
         "{} {}",
         paint(color, BRAND, "◆"),
         paint(color, BOLD, &cc.model)
     );
-    if let Some(effort) = &cc.effort {
-        s.push_str(&paint(color, DIM, &format!("·{effort}")));
-    }
     if let (Health::Healthy, Some(p)) = (led.health, &led.reroute) {
         let code = match p.as_str() {
             "kimi" => VIOLET,
@@ -378,16 +400,25 @@ fn trim_or_health_segment(led: &Led, color: bool) -> Option<String> {
 fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
     let mut out = Vec::new();
     // One quota segment carrying both rolling windows: `◔ 5h·15% · 7d·12%`. `◔` = a window
-    // filling up; `·` keeps `5h`/`7d` from reading as durations. Each window is coloured on its
-    // own value, so a maxed 5h doesn't paint a comfortable 7d red (and vice-versa).
+    // filling up; `·` keeps `5h`/`7d` from reading as durations. Only the *percentage* is
+    // coloured on its own value (a maxed 5h doesn't paint a comfortable 7d) — the `5h`/`7d`
+    // labels are constant, so colouring them is noise; they stay dim.
     let quota = |label: &str, p: f64| {
-        paint(color, tier_color(p, 70.0, 90.0), &format!("{label}·{}%", p.floor() as i64))
+        format!(
+            "{}{}",
+            paint(color, DIM, &format!("{label}·")),
+            paint(color, quota_color(p), &format!("{}%", p.floor() as i64))
+        )
     };
     let glyph = paint(color, DIM, "◔");
     let sep = paint(color, DIM, "·");
     match (cc.five_hour_pct, cc.seven_day_pct) {
         (Some(h), Some(d)) => {
-            out.push(format!("{glyph} {} {sep} {}", quota("5h", h), quota("7d", d)));
+            out.push(format!(
+                "{glyph} {} {sep} {}",
+                quota("5h", h),
+                quota("7d", d)
+            ));
         }
         (Some(h), None) => out.push(format!("{glyph} {}", quota("5h", h))),
         (None, Some(d)) => out.push(format!("{glyph} {}", quota("7d", d))),
@@ -399,7 +430,11 @@ fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
         out.push(paint(color, RED, "♻ cold · /compact"));
     } else if let Some(c) = cc.cache_pct {
         // Floor, not round: only a genuine 100% cache shows `100%` (99.9 stays `99%`).
-        out.push(paint(color, DIM, &format!("♻ {}% cached", c.floor() as i64)));
+        out.push(paint(
+            color,
+            DIM,
+            &format!("♻ {}% cached", c.floor() as i64),
+        ));
     }
     out
 }
@@ -412,7 +447,12 @@ const SEP: &str = "   ";
 fn render_line(cc: &CcInput, led: &Led, cols: usize, color: bool) -> String {
     let mut core = vec![
         model_segment(cc, led, color),
-        context_segment(cc.ctx_tokens, effective_window(cc, led), led.cache_cold, color),
+        context_segment(
+            cc.ctx_tokens,
+            effective_window(cc, led),
+            led.cache_cold,
+            color,
+        ),
     ];
     if let Some(seg) = trim_or_health_segment(led, color) {
         core.push(seg);
@@ -585,7 +625,7 @@ mod tests {
         let out = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
         assert_eq!(
             out,
-            "◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached"
+            "◆ Opus→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached"
         );
     }
 
@@ -607,7 +647,10 @@ mod tests {
     #[test]
     fn context_gauge_pins_full_over_window() {
         let out = render_line(&cc(210_000), &led(Health::Healthy), 0, false);
-        assert!(out.contains("▓▓▓▓▓▓▓▓ 210k"), "over window pins full: {out}");
+        assert!(
+            out.contains("▓▓▓▓▓▓▓▓ 210k"),
+            "over window pins full: {out}"
+        );
     }
 
     #[test]
@@ -636,15 +679,14 @@ mod tests {
         let out = render_line(&cc(48_000), &l, 0, false);
         assert!(!out.contains('✂'), "no trim when off: {out}");
         assert!(!out.contains('⚠'), "clean off is not an error: {out}");
-        assert!(out.starts_with("◆ Opus·high"), "model still shown: {out}");
+        assert!(out.starts_with("◆ Opus"), "model still shown: {out}");
     }
 
     #[test]
     fn narrow_terminal_sheds_extras_right_to_left() {
         // Wide enough for core + quota, but not the cache extra.
         let full = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
-        let width =
-            ui::visible_width("◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%");
+        let width = ui::visible_width("◆ Opus→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%");
         let out = render_line(&cc(142_000), &led(Health::Healthy), width, false);
         assert!(out.ends_with("7d·12%"), "keeps quota, sheds cache: {out}");
         assert!(!out.contains("cached"), "cache dropped first: {out}");
@@ -674,23 +716,55 @@ mod tests {
     }
 
     #[test]
+    fn quota_color_escalates_green_amber_orange_red() {
+        assert_eq!(quota_color(50.0), GREEN);
+        assert_eq!(quota_color(75.0), AMBER);
+        assert_eq!(quota_color(85.0), ORANGE); // the added 80%+ step
+        assert_eq!(quota_color(95.0), RED);
+    }
+
+    #[test]
     fn quota_windows_colour_independently() {
         // A maxed 5h next to a comfortable 7d: 5h red, 7d green — not both painted by the worse.
         let mut c = cc(48_000);
         c.five_hour_pct = Some(95.0);
         c.seven_day_pct = Some(12.0);
         let segs = extra_segments(&c, &led(Health::Healthy), true);
-        let quota = segs.iter().find(|s| s.contains("5h")).expect("quota segment");
-        assert!(quota.contains(&format!("\x1b[{RED}m5h·95%")), "5h red: {quota}");
-        assert!(quota.contains(&format!("\x1b[{GREEN}m7d·12%")), "7d green: {quota}");
+        let quota = segs
+            .iter()
+            .find(|s| s.contains("5h"))
+            .expect("quota segment");
+        // Only the percentage is coloured; the `5h`/`7d` labels stay dim.
+        assert!(
+            quota.contains(&format!("\x1b[{DIM}m5h·")),
+            "5h label dim: {quota}"
+        );
+        assert!(
+            quota.contains(&format!("\x1b[{RED}m95%")),
+            "5h pct red: {quota}"
+        );
+        assert!(
+            quota.contains(&format!("\x1b[{DIM}m7d·")),
+            "7d label dim: {quota}"
+        );
+        assert!(
+            quota.contains(&format!("\x1b[{GREEN}m12%")),
+            "7d pct green: {quota}"
+        );
     }
 
     #[test]
     fn trim_is_not_coloured_by_tier() {
         // The savings figure is dim, not green — colour is for state signals only.
         let seg = trim_or_health_segment(&led(Health::Healthy), true).unwrap();
-        assert!(seg.contains(&format!("\x1b[{DIM}m✂ 6.8%")), "trim dim: {seg}");
-        assert!(!seg.contains(&format!("\x1b[{GREEN}m✂")), "not green: {seg}");
+        assert!(
+            seg.contains(&format!("\x1b[{DIM}m✂ 6.8%")),
+            "trim dim: {seg}"
+        );
+        assert!(
+            !seg.contains(&format!("\x1b[{GREEN}m✂")),
+            "not green: {seg}"
+        );
     }
 
     #[test]
@@ -701,7 +775,10 @@ mod tests {
         let mut c = cc(48_000);
         c.seven_day_pct = None;
         let out = render_line(&c, &led(Health::Healthy), 0, false);
-        assert!(out.contains("◔ 5h·24%") && !out.contains("7d"), "5h only: {out}");
+        assert!(
+            out.contains("◔ 5h·24%") && !out.contains("7d"),
+            "5h only: {out}"
+        );
     }
 
     #[test]
@@ -710,6 +787,19 @@ mod tests {
         l.reroute = Some("kimi".to_string());
         let out = render_line(&cc(72_000), &l, 0, true);
         assert!(out.contains("→kimi"), "kimi arrow present: {out}");
+    }
+
+    #[test]
+    fn trim_for_does_not_flash_lifetime_on_a_fresh_session() {
+        let lifetime = || Some(6.8);
+        // A known session with no recorded turn yet ⇒ idle (None), NOT the lifetime figure —
+        // the "6.8% then flips to the real number" flash we're fixing.
+        assert_eq!(trim_for(Some("sess-uuid"), None, lifetime), None);
+        // Its own rows ⇒ the per-session figure (300→200 = 33.3%).
+        let own = trim_for(Some("sess-uuid"), Some((300, 200)), lifetime).unwrap();
+        assert!((own - 33.333).abs() < 0.01, "per-session figure: {own}");
+        // No session id at all (non-Claude-Code client) ⇒ lifetime is the only honest figure.
+        assert_eq!(trim_for(None, None, lifetime), Some(6.8));
     }
 
     #[test]
@@ -829,7 +919,8 @@ mod tests {
         assert!(!cache_cold("garbage"), "unparseable ⇒ not cold");
         let fresh = chrono::Utc::now().to_rfc3339();
         assert!(!cache_cold(&fresh), "just now ⇒ warm");
-        let stale = (chrono::Utc::now() - chrono::Duration::seconds(CACHE_TTL_SECS + 60)).to_rfc3339();
+        let stale =
+            (chrono::Utc::now() - chrono::Duration::seconds(CACHE_TTL_SECS + 60)).to_rfc3339();
         assert!(cache_cold(&stale), "past the TTL ⇒ cold");
     }
 

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -220,16 +220,9 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
 
     // One session-row read serves both trim and cache-cold. Match on `cc_session_id` — the real
     // Claude Code session id the proxy now records — not the ledger's `session_id`, which is a
-    // hash of the system prompt and never equals Claude Code's UUID.
-    let row = cc.session_id.as_deref().and_then(|sid| {
-        crate::breakdown::db::BreakdownDb::open()
-            .ok()
-            .and_then(|db| db.sessions().ok())
-            .and_then(|rows| {
-                rows.into_iter()
-                    .find(|r| r.cc_session_id.as_deref() == Some(sid))
-            })
-    });
+    // hash of the system prompt and never equals Claude Code's UUID. The per-session ledger view
+    // lives behind the `breakdown` feature; without it we scope nothing and fall back to lifetime.
+    let row = cc.session_id.as_deref().and_then(session_row);
     // Lifetime figure, read only when we have no session to scope to.
     let lifetime = || {
         Tracker::open()
@@ -249,6 +242,38 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
         reroute_window,
         cache_cold,
     }
+}
+
+/// The ledger fields the status line needs from a session's row: its summed savings and the
+/// timestamp of its last turn (for the cold-cache check).
+struct SessionLedgerRow {
+    input_before: i64,
+    input_after: i64,
+    last_ts: String,
+}
+
+/// This Claude Code session's aggregated ledger row, matched on the real `cc_session_id`. Behind
+/// the `breakdown` feature (the per-session query lives there); `None` without it, so trim falls
+/// back to lifetime and cold-cache is never flagged.
+#[cfg(feature = "breakdown")]
+fn session_row(sid: &str) -> Option<SessionLedgerRow> {
+    crate::breakdown::db::BreakdownDb::open()
+        .ok()
+        .and_then(|db| db.sessions().ok())
+        .and_then(|rows| {
+            rows.into_iter()
+                .find(|r| r.cc_session_id.as_deref() == Some(sid))
+        })
+        .map(|r| SessionLedgerRow {
+            input_before: r.input_before,
+            input_after: r.input_after,
+            last_ts: r.last_ts,
+        })
+}
+
+#[cfg(not(feature = "breakdown"))]
+fn session_row(_sid: &str) -> Option<SessionLedgerRow> {
+    None
 }
 
 /// Decide the trim figure: this session's own savings when we have its row; idle (`None`) for a
@@ -273,6 +298,10 @@ fn trim_for(
 /// model registry. Claude Code reports its own Claude window on the wire, so under reroute we
 /// must resolve the backend model id and look *it* up. `None` if unknown (gauge keeps the blob
 /// window). Kimi's internal id isn't a registry key, so it's mapped to its public model id.
+///
+/// Reroute resolution lives behind the `intercept` feature; without it a `sub` reroute can't be
+/// active anyway, so the gauge just uses the blob's window.
+#[cfg(feature = "intercept")]
 fn reroute_real_window(
     provider: &str,
     incoming_model_id: &str,
@@ -292,6 +321,15 @@ fn reroute_real_window(
         resolved.as_str()
     };
     llmtrim_core::context_window(lookup).map(|w| w as i64)
+}
+
+#[cfg(not(feature = "intercept"))]
+fn reroute_real_window(
+    _provider: &str,
+    _incoming_model_id: &str,
+    _tiers: &std::collections::BTreeMap<String, String>,
+) -> Option<i64> {
+    None
 }
 
 /// Whether the prompt cache has gone cold: `last_ts` (rfc3339, the most recent intercepted

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -7,13 +7,17 @@
 //! width-adaptive line:
 //!
 //! ```text
-//! ◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24%   ♻ 63% cached
+//! ◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
 //! ```
 //!
 //! The three left segments (model·effort→backend, context, ✂ trim) are core and never
-//! truncate; the extras (quota, then this turn's prompt-cache reuse) shed right-to-left as
-//! the terminal narrows (`COLUMNS`). Segments whose data is absent — no reroute, an API-key
-//! user with no rate limits, a non-reasoning model with no effort — simply don't render.
+//! truncate; the extras (5h/7d quota, then this turn's prompt-cache reuse) shed right-to-left
+//! as the terminal narrows (`COLUMNS`). The context gauge fills and colours against the *real*
+//! window of the model serving the turn — the rerouted backend's window under `sub`, not
+//! Claude's — green below 40%, orange 40–65%, red above; and red whenever the prompt cache has
+//! gone cold, where the cache segment becomes `♻ cold · /compact`. Segments whose data is
+//! absent — no reroute, an API-key user with no rate limits, a non-reasoning model with no
+//! effort — simply don't render.
 //!
 //! `install` wires it into `~/.claude/settings.json`; rendering itself never touches the
 //! network or API tokens.
@@ -27,11 +31,20 @@ use crate::monitor::{self, DaemonView, Health};
 use crate::tracking::Tracker;
 use crate::ui;
 
-/// Context-health budget: the token count at which the gauge reads full/red. Anchored to a
-/// fixed "this is already a lot" ceiling rather than the model's technical window, so 200k
-/// reads as heavy whether the window is 200k or 1M (a raw window-% would whisper "20%").
-const CTX_BUDGET_TOKENS: i64 = 200_000;
+/// Default context window (tokens) when neither the Claude Code blob nor the model registry
+/// reports one — a conservative floor so the gauge still renders.
+const CTX_WINDOW_DEFAULT: i64 = 200_000;
 const CTX_BAR_WIDTH: usize = 8;
+/// Fill fraction of the *real* window at which the gauge leaves green (< 40%) and enters red
+/// (>= 65%); the band between is amber. Percent of the window, per the user's spec — a capacity
+/// reading, not the fixed quality budget.
+const CTX_GREEN_PCT: i64 = 40;
+const CTX_AMBER_PCT: i64 = 65;
+/// Prompt-cache TTL. Claude Code sends `cache_control: {ttl: "1h"}` on ~92% of breakpoints
+/// (verified from the capture corpus: 3333×1h vs 288×5m), and the cache stays warm up to the
+/// TTL since the last intercepted request. Past this idle gap the cache is cold, so a stale
+/// "cached %" would lie about the next turn paying a cold write — show it cold instead.
+const CACHE_TTL_SECS: i64 = 3600;
 
 // ── ANSI palette ────────────────────────────────────────────────────────────────
 // The status line is captured by Claude Code (never a TTY), but Claude Code renders ANSI,
@@ -42,6 +55,7 @@ const CYAN: &str = "36"; // codex
 const VIOLET: &str = "38;2;181;137;255"; // kimi
 const GREEN: &str = "32";
 const AMBER: &str = "33";
+const ORANGE: &str = "38;2;255;140;0"; // true orange, distinct from amber quota tiers
 const RED: &str = "31";
 const DIM: &str = "2";
 const BOLD: &str = "1";
@@ -66,8 +80,16 @@ struct CcInput {
     /// Total input tokens currently in the context window (fresh + cache), from the last
     /// API response. `0` before the first response.
     ctx_tokens: i64,
-    /// 5-hour rate-limit usage %, Claude.ai subscribers only.
+    /// Claude Code's model id (`model.id`, e.g. `claude-opus-4-8[1m]`), used to resolve the real
+    /// window under a `sub` reroute (where CC still reports its own Claude window, not the
+    /// backend's).
+    model_id: String,
+    /// The model's context window in tokens, as Claude Code reports it (`context_window_size`).
+    /// `None` when absent — the gauge then falls back to the registry or a default.
+    window: Option<i64>,
+    /// 5-hour and 7-day rate-limit usage %, Claude.ai subscribers only.
     five_hour_pct: Option<f64>,
+    seven_day_pct: Option<f64>,
     /// Share of this turn's input served from the prompt cache, % — computed from the last
     /// API call's `current_usage`. `None` before the first response or right after `/compact`.
     cache_pct: Option<f64>,
@@ -79,6 +101,11 @@ fn parse_cc(input: &str) -> CcInput {
         .pointer("/model/display_name")
         .and_then(Value::as_str)
         .unwrap_or("?")
+        .to_string();
+    let model_id = v
+        .pointer("/model/id")
+        .and_then(Value::as_str)
+        .unwrap_or("")
         .to_string();
     let effort = v
         .pointer("/effort/level")
@@ -93,8 +120,15 @@ fn parse_cc(input: &str) -> CcInput {
         .pointer("/context_window/total_input_tokens")
         .and_then(Value::as_i64)
         .unwrap_or(0);
+    let window = v
+        .pointer("/context_window/context_window_size")
+        .and_then(Value::as_i64)
+        .filter(|&w| w > 0);
     let five_hour_pct = v
         .pointer("/rate_limits/five_hour/used_percentage")
+        .and_then(Value::as_f64);
+    let seven_day_pct = v
+        .pointer("/rate_limits/seven_day/used_percentage")
         .and_then(Value::as_f64);
     let cache_pct = {
         let cu = v.pointer("/context_window/current_usage");
@@ -111,8 +145,11 @@ fn parse_cc(input: &str) -> CcInput {
         model,
         effort,
         session_id,
+        model_id,
         ctx_tokens,
+        window,
         five_hour_pct,
+        seven_day_pct,
         cache_pct,
     }
 }
@@ -127,6 +164,13 @@ struct Led {
     trim_pct: Option<f64>,
     /// Active reroute provider (`codex`/`kimi`), if `sub` is on.
     reroute: Option<String>,
+    /// The real window (tokens) of the model actually serving the turn, when a `sub` reroute is
+    /// active — looked up from the model registry, since Claude Code reports its own Claude
+    /// window on the wire, not the backend's. `None` when not rerouted (use the blob's window).
+    reroute_window: Option<i64>,
+    /// The prompt cache has gone cold: the session has been idle past the TTL, so the next turn
+    /// pays a cold write. Renders the cache segment red with a `/compact` nudge.
+    cache_cold: bool,
 }
 
 /// Minimal [`DaemonView`] for the health check — mirrors `main::daemon_view` but fills only
@@ -163,35 +207,76 @@ fn proxy_health() -> Health {
     monitor::health(&dv)
 }
 
-fn ledger_snapshot(session_id: Option<&str>) -> Led {
-    let reroute = llmtrim_core::config::RuntimeConfig::get()
+fn ledger_snapshot(cc: &CcInput) -> Led {
+    let cfg = llmtrim_core::config::RuntimeConfig::get();
+    let reroute = cfg
         .sub
         .clone()
         .filter(|s| !s.is_empty() && s != "off");
+    let reroute_window = reroute
+        .as_deref()
+        .and_then(|p| reroute_real_window(p, &cc.model_id, &cfg.sub_tiers));
     let health = proxy_health();
-    let trim_pct = session_trim_pct(session_id);
+
+    // One session-row read serves both trim and cache-cold.
+    let row = cc.session_id.as_deref().and_then(|sid| {
+        crate::breakdown::db::BreakdownDb::open()
+            .ok()
+            .and_then(|db| db.sessions().ok())
+            .and_then(|rows| rows.into_iter().find(|r| r.session_id == sid))
+    });
+    let trim_pct = match &row {
+        Some(r) => (r.input_before > 0)
+            .then(|| ui::saved_pct(r.input_before as f64, r.input_after as f64)),
+        None => Tracker::open()
+            .and_then(|t| t.summary())
+            .ok()
+            .filter(|s| s.input_before > 0)
+            .map(|s| ui::saved_pct(s.input_before as f64, s.input_after as f64)),
+    };
+    let cache_cold = row.as_ref().is_some_and(|r| cache_cold(&r.last_ts));
+
     Led {
         health,
         trim_pct,
         reroute,
+        reroute_window,
+        cache_cold,
     }
 }
 
-/// Compression saved for `session_id` (its ledger rows), falling back to the lifetime figure
-/// when the id is unknown. `None` — no measurable input yet — renders the idle marker.
-fn session_trim_pct(session_id: Option<&str>) -> Option<f64> {
-    let (before, after) = match session_id {
-        Some(sid) => crate::breakdown::db::BreakdownDb::open()
-            .ok()
-            .and_then(|db| db.sessions().ok())
-            .and_then(|rows| rows.into_iter().find(|r| r.session_id == sid))
-            .map(|r| (r.input_before, r.input_after))?,
-        None => {
-            let s = Tracker::open().and_then(|t| t.summary()).ok()?;
-            (s.input_before, s.input_after)
-        }
+/// The real context window of the model a `sub` reroute actually serves this turn, from the
+/// model registry. Claude Code reports its own Claude window on the wire, so under reroute we
+/// must resolve the backend model id and look *it* up. `None` if unknown (gauge keeps the blob
+/// window). Kimi's internal id isn't a registry key, so it's mapped to its public model id.
+fn reroute_real_window(
+    provider: &str,
+    incoming_model_id: &str,
+    tiers: &std::collections::BTreeMap<String, String>,
+) -> Option<i64> {
+    use crate::reroute::SubProvider;
+    let sp = match provider {
+        "codex" => SubProvider::Codex,
+        "kimi" => SubProvider::Kimi,
+        _ => return None,
     };
-    (before > 0).then(|| ui::saved_pct(before as f64, after as f64))
+    let resolved = crate::reroute::resolve_model(sp, incoming_model_id, tiers);
+    // `kimi-for-coding` is an internal routing id, not a models.dev key — map to the public one.
+    let lookup = if resolved == crate::reroute::KIMI_MODEL {
+        "moonshotai/kimi-k2"
+    } else {
+        resolved.as_str()
+    };
+    llmtrim_core::context_window(lookup).map(|w| w as i64)
+}
+
+/// Whether the prompt cache has gone cold: `last_ts` (rfc3339, the most recent intercepted
+/// request) is older than the TTL. An unparseable timestamp is treated as not-cold (don't warn
+/// on a data glitch).
+fn cache_cold(last_ts: &str) -> bool {
+    chrono::DateTime::parse_from_rfc3339(last_ts)
+        .map(|t| chrono::Utc::now().signed_duration_since(t).num_seconds() >= CACHE_TTL_SECS)
+        .unwrap_or(false)
 }
 
 // ── rendering ─────────────────────────────────────────────────────────────────────
@@ -229,20 +314,39 @@ fn model_segment(cc: &CcInput, led: &Led, color: bool) -> String {
     s
 }
 
-/// `▓▓▓▓▓░░░ 142k` — gauge filled against the 200k health budget, coloured by absolute
-/// tokens (green < 80k, amber 80–160k, red ≥ 160k), label in absolute k.
-fn context_segment(ctx_tokens: i64, color: bool) -> String {
+/// The real context window in play: the model actually serving the turn. Under a `sub` reroute
+/// that's the backend model's window (from the registry); otherwise Claude Code's reported
+/// `context_window_size`; falling back to a default when neither is known.
+fn effective_window(cc: &CcInput, led: &Led) -> i64 {
+    led.reroute_window
+        .or(cc.window)
+        .filter(|&w| w > 0)
+        .unwrap_or(CTX_WINDOW_DEFAULT)
+}
+
+/// `▓▓▓▓▓░░░ 142k` — gauge filled and coloured against the *real* window: green below 40% of the
+/// window, orange 40–65%, red at/above 65% — and red unconditionally when the prompt cache has
+/// gone cold (idle past the TTL), since the next turn then pays a cold write regardless of fill.
+/// Label is absolute k.
+fn context_segment(ctx_tokens: i64, window: i64, cache_cold: bool, color: bool) -> String {
     let tokens = ctx_tokens.max(0);
-    // Clamp to the budget *before* multiplying so a pathologically large token count can't
-    // overflow i64 (the bar pins full past the budget anyway).
-    let clamped = tokens.min(CTX_BUDGET_TOKENS);
-    let filled = (clamped * CTX_BAR_WIDTH as i64 / CTX_BUDGET_TOKENS) as usize;
+    let window = window.max(1);
+    // Clamp before multiplying so a pathological token count can't overflow (bar pins full anyway).
+    let filled = (tokens.min(window) * CTX_BAR_WIDTH as i64 / window) as usize;
     let bar: String = "▓".repeat(filled) + &"░".repeat(CTX_BAR_WIDTH - filled);
     let k = (tokens as f64 / 1000.0).round() as i64;
-    let code = if tokens == 0 {
+    // Ratio in f64 so a pathologically large token count can't overflow the multiply.
+    let pct = (tokens as f64 / window as f64 * 100.0) as i64;
+    let code = if cache_cold {
+        RED
+    } else if tokens == 0 {
         DIM
+    } else if pct >= CTX_AMBER_PCT {
+        RED
+    } else if pct >= CTX_GREEN_PCT {
+        ORANGE
     } else {
-        tier_color(tokens as f64, 80_000.0, 160_000.0)
+        GREEN
     };
     paint(color, code, &format!("{bar} {k}k"))
 }
@@ -253,8 +357,10 @@ fn context_segment(ctx_tokens: i64, color: bool) -> String {
 /// cleanly stopped (llmtrim is simply off — not an error to flag).
 fn trim_or_health_segment(led: &Led, color: bool) -> Option<String> {
     match led.health {
+        // Trim is a savings figure, not a tier — no "bad" value to warn on — so it stays dim;
+        // colour is reserved for state signals (health, quota, context, cold cache).
         Health::Healthy => Some(match led.trim_pct {
-            Some(pct) => paint(color, GREEN, &format!("✂ {pct:.1}%")),
+            Some(pct) => paint(color, DIM, &format!("✂ {pct:.1}%")),
             None => paint(color, DIM, "✂ –"),
         }),
         Health::Degraded => Some(paint(color, RED, "⚠ llmtrim degraded")),
@@ -262,15 +368,31 @@ fn trim_or_health_segment(led: &Led, color: bool) -> Option<String> {
     }
 }
 
-/// Build the ordered extra segments (quota, then per-session cache); later ones drop first.
-fn extra_segments(cc: &CcInput, color: bool) -> Vec<String> {
+/// Build the ordered extra segments (quota, then this session's cache); later ones drop first on
+/// a narrow terminal.
+fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
     let mut out = Vec::new();
-    if let Some(p) = cc.five_hour_pct {
-        let code = tier_color(p, 70.0, 90.0);
-        // `◔` = the 5-hour window filling up; `·` keeps `5h` from reading as a duration.
-        out.push(paint(color, code, &format!("◔ 5h·{}%", p.floor() as i64)));
+    // One quota segment carrying both rolling windows: `◔ 5h·15% · 7d·12%`. `◔` = a window
+    // filling up; `·` keeps `5h`/`7d` from reading as durations. Each window is coloured on its
+    // own value, so a maxed 5h doesn't paint a comfortable 7d red (and vice-versa).
+    let quota = |label: &str, p: f64| {
+        paint(color, tier_color(p, 70.0, 90.0), &format!("{label}·{}%", p.floor() as i64))
+    };
+    let glyph = paint(color, DIM, "◔");
+    let sep = paint(color, DIM, "·");
+    match (cc.five_hour_pct, cc.seven_day_pct) {
+        (Some(h), Some(d)) => {
+            out.push(format!("{glyph} {} {sep} {}", quota("5h", h), quota("7d", d)));
+        }
+        (Some(h), None) => out.push(format!("{glyph} {}", quota("5h", h))),
+        (None, Some(d)) => out.push(format!("{glyph} {}", quota("7d", d))),
+        (None, None) => {}
     }
-    if let Some(c) = cc.cache_pct {
+    if led.cache_cold {
+        // Cache expired: the next turn pays a cold write, so `/compact` (re-baselines the prompt)
+        // pays off here. `cold` communicates the state faster than a stale `0% cached`.
+        out.push(paint(color, RED, "♻ cold · /compact"));
+    } else if let Some(c) = cc.cache_pct {
         // Floor, not round: only a genuine 100% cache shows `100%` (99.9 stays `99%`).
         out.push(paint(color, DIM, &format!("♻ {}% cached", c.floor() as i64)));
     }
@@ -285,14 +407,14 @@ const SEP: &str = "   ";
 fn render_line(cc: &CcInput, led: &Led, cols: usize, color: bool) -> String {
     let mut core = vec![
         model_segment(cc, led, color),
-        context_segment(cc.ctx_tokens, color),
+        context_segment(cc.ctx_tokens, effective_window(cc, led), led.cache_cold, color),
     ];
     if let Some(seg) = trim_or_health_segment(led, color) {
         core.push(seg);
     }
     let mut line = core.join(SEP);
 
-    for extra in extra_segments(cc, color) {
+    for extra in extra_segments(cc, led, color) {
         let candidate = format!("{line}{SEP}{extra}");
         if cols == 0 || ui::visible_width(&candidate) <= cols {
             line = candidate;
@@ -311,7 +433,7 @@ pub fn run() -> Result<()> {
     std::io::stdin().read_to_string(&mut input).ok();
 
     let cc = parse_cc(&input);
-    let led = ledger_snapshot(cc.session_id.as_deref());
+    let led = ledger_snapshot(&cc);
     let cols = std::env::var("COLUMNS")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
@@ -433,6 +555,8 @@ mod tests {
             health,
             trim_pct: Some(6.8),
             reroute: Some("codex".to_string()),
+            reroute_window: None,
+            cache_cold: false,
         }
     }
 
@@ -441,35 +565,53 @@ mod tests {
             model: "Opus".to_string(),
             effort: Some("high".to_string()),
             session_id: None,
+            model_id: "claude-opus-4-8".to_string(),
             ctx_tokens: ctx,
+            window: Some(200_000),
             five_hour_pct: Some(24.0),
+            seven_day_pct: Some(12.0),
             cache_pct: Some(63.0),
         }
     }
 
     #[test]
     fn full_line_has_every_segment_when_wide() {
+        // 142k of a 200k window = 71% ⇒ red gauge; both rolling quota windows shown.
         let out = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
         assert_eq!(
             out,
-            "◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24%   ♻ 63% cached"
+            "◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached"
         );
     }
 
     #[test]
-    fn context_gauge_anchors_to_budget_not_window() {
-        // 200k reads full regardless of the model's window: absolute label, pinned bar.
+    fn context_gauge_colors_by_percent_of_real_window() {
+        // Bands are % of the model's real window. On a 1M window, 142k is only 14% ⇒ green.
+        let mut c = cc(142_000);
+        c.window = Some(1_000_000);
+        let out = context_segment(c.ctx_tokens, 1_000_000, false, true);
+        assert!(out.contains(GREEN), "14% of 1M is green: {out}");
+        // Same 142k on a 200k window is 71% ⇒ red.
+        let out = context_segment(142_000, 200_000, false, true);
+        assert!(out.contains(RED), "71% of 200k is red: {out}");
+        // 50% lands in the orange band (40–65%).
+        let out = context_segment(100_000, 200_000, false, true);
+        assert!(out.contains(ORANGE), "50% is orange: {out}");
+    }
+
+    #[test]
+    fn context_gauge_pins_full_over_window() {
         let out = render_line(&cc(210_000), &led(Health::Healthy), 0, false);
-        assert!(
-            out.contains("▓▓▓▓▓▓▓▓ 210k"),
-            "over budget pins full: {out}"
-        );
-        // A comfortable 48k is not full.
-        let out = render_line(&cc(48_000), &led(Health::Healthy), 0, false);
-        assert!(
-            out.contains("▓░░░░░░░ 48k"),
-            "48k is 1/8 blocks (floor): {out}"
-        );
+        assert!(out.contains("▓▓▓▓▓▓▓▓ 210k"), "over window pins full: {out}");
+    }
+
+    #[test]
+    fn cold_cache_forces_red_gauge_regardless_of_fill() {
+        // A near-empty context still reddens the gauge when the cache is cold.
+        let mut l = led(Health::Healthy);
+        l.cache_cold = true;
+        let out = context_segment(1_000, 1_000_000, true, true);
+        assert!(out.contains(RED), "cold cache reddens even at 0.1%: {out}");
     }
 
     #[test]
@@ -496,9 +638,10 @@ mod tests {
     fn narrow_terminal_sheds_extras_right_to_left() {
         // Wide enough for core + quota, but not the cache extra.
         let full = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
-        let width = ui::visible_width("◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24%");
+        let width =
+            ui::visible_width("◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%");
         let out = render_line(&cc(142_000), &led(Health::Healthy), width, false);
-        assert!(out.ends_with("5h·24%"), "keeps quota, sheds cache: {out}");
+        assert!(out.ends_with("7d·12%"), "keeps quota, sheds cache: {out}");
         assert!(!out.contains("cached"), "cache dropped first: {out}");
         assert!(full.len() > out.len());
     }
@@ -508,11 +651,52 @@ mod tests {
         let mut c = cc(48_000);
         c.effort = None; // non-reasoning model
         c.five_hour_pct = None; // API-key user
+        c.seven_day_pct = None;
         c.cache_pct = None; // before first API response
         let mut l = led(Health::Healthy);
         l.reroute = None; // no reroute
         let out = render_line(&c, &l, 0, false);
         assert_eq!(out, "◆ Opus   ▓░░░░░░░ 48k   ✂ 6.8%");
+    }
+
+    #[test]
+    fn cold_cache_shows_compact_hint_not_stale_pct() {
+        let mut l = led(Health::Healthy);
+        l.cache_cold = true;
+        let out = render_line(&cc(48_000), &l, 0, false);
+        assert!(out.contains("♻ cold · /compact"), "cold hint shown: {out}");
+        assert!(!out.contains("cached"), "no stale % when cold: {out}");
+    }
+
+    #[test]
+    fn quota_windows_colour_independently() {
+        // A maxed 5h next to a comfortable 7d: 5h red, 7d green — not both painted by the worse.
+        let mut c = cc(48_000);
+        c.five_hour_pct = Some(95.0);
+        c.seven_day_pct = Some(12.0);
+        let segs = extra_segments(&c, &led(Health::Healthy), true);
+        let quota = segs.iter().find(|s| s.contains("5h")).expect("quota segment");
+        assert!(quota.contains(&format!("\x1b[{RED}m5h·95%")), "5h red: {quota}");
+        assert!(quota.contains(&format!("\x1b[{GREEN}m7d·12%")), "7d green: {quota}");
+    }
+
+    #[test]
+    fn trim_is_not_coloured_by_tier() {
+        // The savings figure is dim, not green — colour is for state signals only.
+        let seg = trim_or_health_segment(&led(Health::Healthy), true).unwrap();
+        assert!(seg.contains(&format!("\x1b[{DIM}m✂ 6.8%")), "trim dim: {seg}");
+        assert!(!seg.contains(&format!("\x1b[{GREEN}m✂")), "not green: {seg}");
+    }
+
+    #[test]
+    fn quota_shows_worse_window_and_folds_to_one_segment() {
+        // Both windows in one `◔` segment; only one present ⇒ just that one.
+        let out = render_line(&cc(48_000), &led(Health::Healthy), 0, false);
+        assert!(out.contains("◔ 5h·24% · 7d·12%"), "both windows: {out}");
+        let mut c = cc(48_000);
+        c.seven_day_pct = None;
+        let out = render_line(&c, &led(Health::Healthy), 0, false);
+        assert!(out.contains("◔ 5h·24%") && !out.contains("7d"), "5h only: {out}");
     }
 
     #[test]
@@ -555,15 +739,18 @@ mod tests {
 
     #[test]
     fn parse_cc_reads_nested_fields() {
-        let blob = r#"{"model":{"display_name":"Sonnet"},"effort":{"level":"medium"},
-            "context_window":{"total_input_tokens":123456,
+        let blob = r#"{"model":{"display_name":"Sonnet","id":"claude-sonnet-5"},"effort":{"level":"medium"},
+            "context_window":{"total_input_tokens":123456,"context_window_size":1000000,
               "current_usage":{"input_tokens":10,"cache_creation_input_tokens":10,"cache_read_input_tokens":80}},
-            "rate_limits":{"five_hour":{"used_percentage":41.2}}}"#;
+            "rate_limits":{"five_hour":{"used_percentage":41.2},"seven_day":{"used_percentage":9.0}}}"#;
         let cc = parse_cc(blob);
         assert_eq!(cc.model, "Sonnet");
+        assert_eq!(cc.model_id, "claude-sonnet-5");
         assert_eq!(cc.effort.as_deref(), Some("medium"));
         assert_eq!(cc.ctx_tokens, 123456);
+        assert_eq!(cc.window, Some(1_000_000));
         assert_eq!(cc.five_hour_pct, Some(41.2));
+        assert_eq!(cc.seven_day_pct, Some(9.0));
         // 80 cache reads of 100 total input = 80%.
         assert_eq!(cc.cache_pct, Some(80.0));
     }
@@ -627,8 +814,32 @@ mod tests {
     #[test]
     fn context_gauge_handles_extreme_token_counts() {
         // Negative clamps to empty/0k; a pathologically huge count pins full without
-        // overflowing i64 (regression: `tokens * 8` used to overflow before clamping).
-        assert!(context_segment(-5000, false).starts_with("░░░░░░░░ 0k"));
-        assert!(context_segment(i64::MAX / 4, false).starts_with("▓▓▓▓▓▓▓▓"));
+        // overflowing i64 (regression: `tokens * width` used to overflow before clamping).
+        assert!(context_segment(-5000, 200_000, false, false).starts_with("░░░░░░░░ 0k"));
+        assert!(context_segment(i64::MAX / 4, 200_000, false, false).starts_with("▓▓▓▓▓▓▓▓"));
+    }
+
+    #[test]
+    fn cache_cold_parses_timestamps() {
+        assert!(!cache_cold("garbage"), "unparseable ⇒ not cold");
+        let fresh = chrono::Utc::now().to_rfc3339();
+        assert!(!cache_cold(&fresh), "just now ⇒ warm");
+        let stale = (chrono::Utc::now() - chrono::Duration::seconds(CACHE_TTL_SECS + 60)).to_rfc3339();
+        assert!(cache_cold(&stale), "past the TTL ⇒ cold");
+    }
+
+    #[test]
+    fn effective_window_prefers_reroute_then_blob() {
+        let mut l = led(Health::Healthy);
+        // Reroute window (backend's real window) wins over the blob's Claude window.
+        l.reroute_window = Some(262_144);
+        assert_eq!(effective_window(&cc(0), &l), 262_144);
+        // No reroute ⇒ the blob's context_window_size.
+        l.reroute_window = None;
+        assert_eq!(effective_window(&cc(0), &l), 200_000);
+        // Neither ⇒ the default floor.
+        let mut c = cc(0);
+        c.window = None;
+        assert_eq!(effective_window(&c, &l), CTX_WINDOW_DEFAULT);
     }
 }

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -7,7 +7,7 @@
 //! width-adaptive line:
 //!
 //! ```text
-//! ◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   5h 24%   ♻ 63% cached
+//! ◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24%   ♻ 63% cached
 //! ```
 //!
 //! The three left segments (model·effort→backend, context, ✂ trim) are core and never
@@ -59,6 +59,10 @@ fn paint(color: bool, code: &str, s: &str) -> String {
 struct CcInput {
     model: String,
     effort: Option<String>,
+    /// Claude Code's own session id (the `x-claude-code-session-id` it also tags on every
+    /// intercepted request), used to scope trim to *this* session's ledger rows. `None` if
+    /// absent — trim then falls back to the lifetime figure.
+    session_id: Option<String>,
     /// Total input tokens currently in the context window (fresh + cache), from the last
     /// API response. `0` before the first response.
     ctx_tokens: i64,
@@ -79,6 +83,11 @@ fn parse_cc(input: &str) -> CcInput {
     let effort = v
         .pointer("/effort/level")
         .and_then(Value::as_str)
+        .map(str::to_string);
+    let session_id = v
+        .pointer("/session_id")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
         .map(str::to_string);
     let ctx_tokens = v
         .pointer("/context_window/total_input_tokens")
@@ -101,6 +110,7 @@ fn parse_cc(input: &str) -> CcInput {
     CcInput {
         model,
         effort,
+        session_id,
         ctx_tokens,
         five_hour_pct,
         cache_pct,
@@ -111,8 +121,10 @@ fn parse_cc(input: &str) -> CcInput {
 
 struct Led {
     health: Health,
-    /// Input compression saved, % of input tokens (lifetime).
-    trim_pct: f64,
+    /// Input compression saved, % of input tokens — scoped to this Claude Code session when
+    /// its id is known, else lifetime. `None` when there are no rows to measure yet (a fresh
+    /// session), which renders an idle `✂ –` rather than a misleading `✂ 0.0%`.
+    trim_pct: Option<f64>,
     /// Active reroute provider (`codex`/`kimi`), if `sub` is on.
     reroute: Option<String>,
 }
@@ -151,22 +163,35 @@ fn proxy_health() -> Health {
     monitor::health(&dv)
 }
 
-fn ledger_snapshot() -> Led {
+fn ledger_snapshot(session_id: Option<&str>) -> Led {
     let reroute = llmtrim_core::config::RuntimeConfig::get()
         .sub
         .clone()
         .filter(|s| !s.is_empty() && s != "off");
     let health = proxy_health();
-
-    let trim_pct = Tracker::open()
-        .and_then(|t| t.summary())
-        .map(|s| ui::saved_pct(s.input_before as f64, s.input_after as f64))
-        .unwrap_or(0.0);
+    let trim_pct = session_trim_pct(session_id);
     Led {
         health,
         trim_pct,
         reroute,
     }
+}
+
+/// Compression saved for `session_id` (its ledger rows), falling back to the lifetime figure
+/// when the id is unknown. `None` — no measurable input yet — renders the idle marker.
+fn session_trim_pct(session_id: Option<&str>) -> Option<f64> {
+    let (before, after) = match session_id {
+        Some(sid) => crate::breakdown::db::BreakdownDb::open()
+            .ok()
+            .and_then(|db| db.sessions().ok())
+            .and_then(|rows| rows.into_iter().find(|r| r.session_id == sid))
+            .map(|r| (r.input_before, r.input_after))?,
+        None => {
+            let s = Tracker::open().and_then(|t| t.summary()).ok()?;
+            (s.input_before, s.input_after)
+        }
+    };
+    (before > 0).then(|| ui::saved_pct(before as f64, after as f64))
 }
 
 // ── rendering ─────────────────────────────────────────────────────────────────────
@@ -222,11 +247,16 @@ fn context_segment(ctx_tokens: i64, color: bool) -> String {
     paint(color, code, &format!("{bar} {k}k"))
 }
 
-/// The third core segment: `✂ 6.8%` when healthy, `⚠ llmtrim degraded` when broken, and
-/// nothing at all when cleanly stopped (llmtrim is simply off — not an error to flag).
+/// The third core segment: `✂ 6.8%` when healthy and this session has saved something, a dim
+/// `✂ –` when healthy but idle (nothing trimmed yet — avoids a misleading `✂ 0.0%` while still
+/// signalling "llmtrim is on"), `⚠ llmtrim degraded` when broken, and nothing at all when
+/// cleanly stopped (llmtrim is simply off — not an error to flag).
 fn trim_or_health_segment(led: &Led, color: bool) -> Option<String> {
     match led.health {
-        Health::Healthy => Some(paint(color, GREEN, &format!("✂ {:.1}%", led.trim_pct))),
+        Health::Healthy => Some(match led.trim_pct {
+            Some(pct) => paint(color, GREEN, &format!("✂ {pct:.1}%")),
+            None => paint(color, DIM, "✂ –"),
+        }),
         Health::Degraded => Some(paint(color, RED, "⚠ llmtrim degraded")),
         Health::Stopped => None,
     }
@@ -237,10 +267,12 @@ fn extra_segments(cc: &CcInput, color: bool) -> Vec<String> {
     let mut out = Vec::new();
     if let Some(p) = cc.five_hour_pct {
         let code = tier_color(p, 70.0, 90.0);
-        out.push(paint(color, code, &format!("5h {:.0}%", p)));
+        // `◔` = the 5-hour window filling up; `·` keeps `5h` from reading as a duration.
+        out.push(paint(color, code, &format!("◔ 5h·{}%", p.floor() as i64)));
     }
     if let Some(c) = cc.cache_pct {
-        out.push(paint(color, DIM, &format!("♻ {:.0}% cached", c)));
+        // Floor, not round: only a genuine 100% cache shows `100%` (99.9 stays `99%`).
+        out.push(paint(color, DIM, &format!("♻ {}% cached", c.floor() as i64)));
     }
     out
 }
@@ -279,7 +311,7 @@ pub fn run() -> Result<()> {
     std::io::stdin().read_to_string(&mut input).ok();
 
     let cc = parse_cc(&input);
-    let led = ledger_snapshot();
+    let led = ledger_snapshot(cc.session_id.as_deref());
     let cols = std::env::var("COLUMNS")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
@@ -399,7 +431,7 @@ mod tests {
     fn led(health: Health) -> Led {
         Led {
             health,
-            trim_pct: 6.8,
+            trim_pct: Some(6.8),
             reroute: Some("codex".to_string()),
         }
     }
@@ -408,6 +440,7 @@ mod tests {
         CcInput {
             model: "Opus".to_string(),
             effort: Some("high".to_string()),
+            session_id: None,
             ctx_tokens: ctx,
             five_hour_pct: Some(24.0),
             cache_pct: Some(63.0),
@@ -419,7 +452,7 @@ mod tests {
         let out = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
         assert_eq!(
             out,
-            "◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   5h 24%   ♻ 63% cached"
+            "◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24%   ♻ 63% cached"
         );
     }
 
@@ -463,9 +496,9 @@ mod tests {
     fn narrow_terminal_sheds_extras_right_to_left() {
         // Wide enough for core + quota, but not the cache extra.
         let full = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
-        let width = ui::visible_width("◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   5h 24%");
+        let width = ui::visible_width("◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24%");
         let out = render_line(&cc(142_000), &led(Health::Healthy), width, false);
-        assert!(out.ends_with("5h 24%"), "keeps quota, sheds cache: {out}");
+        assert!(out.ends_with("5h·24%"), "keeps quota, sheds cache: {out}");
         assert!(!out.contains("cached"), "cache dropped first: {out}");
         assert!(full.len() > out.len());
     }
@@ -488,6 +521,36 @@ mod tests {
         l.reroute = Some("kimi".to_string());
         let out = render_line(&cc(72_000), &l, 0, true);
         assert!(out.contains("→kimi"), "kimi arrow present: {out}");
+    }
+
+    #[test]
+    fn healthy_but_idle_shows_dim_marker_not_zero() {
+        // Nothing trimmed yet in this session: `✂ –`, never a misleading `✂ 0.0%`.
+        let mut l = led(Health::Healthy);
+        l.trim_pct = None;
+        let out = render_line(&cc(48_000), &l, 0, false);
+        assert!(out.contains("✂ –"), "idle marker shown: {out}");
+        assert!(!out.contains("0.0%"), "no fake zero: {out}");
+    }
+
+    #[test]
+    fn quota_and_cache_floor_not_round() {
+        // 99.9% cache is not 100%; 89.9% quota is not 90%.
+        let mut c = cc(48_000);
+        c.five_hour_pct = Some(89.9);
+        c.cache_pct = Some(99.9);
+        let out = render_line(&c, &led(Health::Healthy), 0, false);
+        assert!(out.contains("5h·89%"), "quota floored: {out}");
+        assert!(out.contains("♻ 99% cached"), "cache floored: {out}");
+    }
+
+    #[test]
+    fn parse_cc_reads_session_id() {
+        let cc = parse_cc(r#"{"model":{"display_name":"Opus"},"session_id":"abc-123"}"#);
+        assert_eq!(cc.session_id.as_deref(), Some("abc-123"));
+        // Empty id is treated as absent (falls back to lifetime trim).
+        let cc = parse_cc(r#"{"model":{"display_name":"Opus"},"session_id":""}"#);
+        assert!(cc.session_id.is_none());
     }
 
     #[test]

--- a/crates/llmtrim-ledger/src/breakdown_db.rs
+++ b/crates/llmtrim-ledger/src/breakdown_db.rs
@@ -14,6 +14,7 @@ use rusqlite::{Connection, params};
 #[derive(Debug, Clone)]
 pub struct SessionRow {
     pub session_id: String,
+    pub cc_session_id: Option<String>,
     pub agent: String,
     pub project: Option<String>,
     pub session_name: Option<String>,
@@ -104,7 +105,7 @@ impl BreakdownDb {
                 // so the latest `session_name` is `rn = 1`, then aggregate — instead of a
                 // correlated subquery that re-scanned the table once per session group.
                 "WITH ranked AS (
-                     SELECT session_id, agent, project, session_name, ts, id,
+                     SELECT session_id, cc_session_id, agent, project, session_name, ts, id,
                             fresh_input, cache_read, cache_write, output_tok,
                             bill_micros, input_before, input_after,
                             ROW_NUMBER() OVER (
@@ -122,7 +123,8 @@ impl BreakdownDb {
                         COALESCE(SUM(bill_micros), 0),
                         COALESCE(SUM(input_before), 0),
                         COALESCE(SUM(input_after), 0),
-                        MAX(ts)
+                        MAX(ts),
+                        MAX(cc_session_id)
                  FROM ranked
                  GROUP BY session_id, agent, project
                  ORDER BY MAX(ts) DESC",
@@ -148,6 +150,7 @@ impl BreakdownDb {
                     input_before: r.get(9)?,
                     input_after: r.get(10)?,
                     last_ts: r.get(11)?,
+                    cc_session_id: r.get(12)?,
                 })
             })
             .context("failed to query sessions")?;
@@ -263,6 +266,7 @@ mod tests {
     fn turn(session: &str) -> BreakdownTurn {
         BreakdownTurn {
             session_id: session.to_string(),
+            cc_session_id: None,
             agent: "claude-code".to_string(),
             project: Some("/proj".to_string()),
             session_name: Some("my session".to_string()),
@@ -322,6 +326,25 @@ mod tests {
             )
             .unwrap();
         BreakdownDb::from_connection(tracker.into_connection())
+    }
+
+    #[test]
+    fn sessions_round_trip_the_cc_session_id() {
+        // The real Claude Code session id (a dashed UUID, distinct from the system-prompt-hash
+        // `session_id`) survives insert → aggregate, so the status line can match a live session.
+        let tracker = Tracker::open_in_memory().unwrap();
+        let mut t = turn("sess-a");
+        t.cc_session_id = Some("968ad7ea-6e4a-430e-a708-4eda80c8b858".to_string());
+        tracker
+            .record_breakdown(&t, &[block("Static", "System prompt", None, 50.0, 100.0)])
+            .unwrap();
+        let db = BreakdownDb::from_connection(tracker.into_connection());
+        let rows = db.sessions().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].cc_session_id.as_deref(),
+            Some("968ad7ea-6e4a-430e-a708-4eda80c8b858")
+        );
     }
 
     #[test]

--- a/crates/llmtrim-ledger/src/dashboard.rs
+++ b/crates/llmtrim-ledger/src/dashboard.rs
@@ -553,6 +553,7 @@ mod tests {
     fn metered_turn(agent: &str, before: i64, after: i64, bill: i64) -> BreakdownTurn {
         BreakdownTurn {
             session_id: format!("sess-{agent}"),
+            cc_session_id: None,
             agent: agent.to_string(),
             project: Some("/some/project".to_string()),
             session_name: Some("my session".to_string()),

--- a/crates/llmtrim-ledger/src/tracking.rs
+++ b/crates/llmtrim-ledger/src/tracking.rs
@@ -53,6 +53,10 @@ pub struct Record {
 #[derive(Debug, Clone, Default)]
 pub struct BreakdownTurn {
     pub session_id: String,
+    /// Claude Code's own session id (`x-claude-code-session-id` header), when present.
+    /// Distinct from `session_id` (a hash of the system prompt) — this lets the status
+    /// line match a session exactly. `None` for non-Claude-Code traffic or older rows.
+    pub cc_session_id: Option<String>,
     pub agent: String,
     pub project: Option<String>,
     pub session_name: Option<String>,
@@ -360,6 +364,7 @@ impl Tracker {
                     id            INTEGER PRIMARY KEY,
                     ts            TEXT NOT NULL,
                     session_id    TEXT NOT NULL,
+                    cc_session_id TEXT,
                     agent         TEXT NOT NULL,
                     project       TEXT,
                     session_name  TEXT,
@@ -434,6 +439,14 @@ impl Tracker {
             {
                 return Err(e).with_context(|| format!("failed to add breakdown column {col}"));
             }
+        }
+        // cc_session_id is TEXT, not INTEGER — additive ALTER kept separate from the loop above.
+        if let Err(e) = self
+            .conn
+            .execute("ALTER TABLE breakdown_turns ADD COLUMN cc_session_id TEXT", [])
+            && !is_duplicate_column(&e)
+        {
+            return Err(e).context("failed to add breakdown column cc_session_id");
         }
         Ok(())
     }
@@ -527,14 +540,15 @@ impl Tracker {
         self.conn
             .execute(
                 "INSERT INTO breakdown_turns
-                    (ts, session_id, agent, project, session_name, provider, model, window,
-                     fresh_input, cache_read, cache_write, output_tok,
+                    (ts, session_id, cc_session_id, agent, project, session_name, provider, model,
+                     window, fresh_input, cache_read, cache_write, output_tok,
                      input_rate, output_rate, cache_read_rate, cache_write_rate, bill_micros,
                      input_before, input_after)
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19)",
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)",
                 params![
                     ts,
                     turn.session_id,
+                    turn.cc_session_id,
                     turn.agent,
                     turn.project,
                     turn.session_name,
@@ -642,14 +656,15 @@ impl Tracker {
         self.conn
             .execute(
                 "INSERT INTO breakdown_turns
-                    (ts, session_id, agent, project, session_name, provider, model, window,
-                     fresh_input, cache_read, cache_write, output_tok,
+                    (ts, session_id, cc_session_id, agent, project, session_name, provider, model,
+                     window, fresh_input, cache_read, cache_write, output_tok,
                      input_rate, output_rate, cache_read_rate, cache_write_rate, bill_micros,
                      input_before, input_after)
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19)",
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)",
                 params![
                     ts,
                     turn.session_id,
+                    turn.cc_session_id,
                     turn.agent,
                     turn.project,
                     turn.session_name,
@@ -965,6 +980,7 @@ mod tests {
     fn breakdown_turn(session: &str) -> BreakdownTurn {
         BreakdownTurn {
             session_id: session.to_string(),
+            cc_session_id: None,
             agent: "claude-code".to_string(),
             project: Some("/proj".to_string()),
             session_name: None,

--- a/crates/llmtrim-ledger/src/tracking.rs
+++ b/crates/llmtrim-ledger/src/tracking.rs
@@ -441,10 +441,10 @@ impl Tracker {
             }
         }
         // cc_session_id is TEXT, not INTEGER — additive ALTER kept separate from the loop above.
-        if let Err(e) = self
-            .conn
-            .execute("ALTER TABLE breakdown_turns ADD COLUMN cc_session_id TEXT", [])
-            && !is_duplicate_column(&e)
+        if let Err(e) = self.conn.execute(
+            "ALTER TABLE breakdown_turns ADD COLUMN cc_session_id TEXT",
+            [],
+        ) && !is_duplicate_column(&e)
         {
             return Err(e).context("failed to add breakdown column cc_session_id");
         }


### PR DESCRIPTION
## What

Adds `llmtrim statusline`, a custom status line for [Claude Code](https://code.claude.com/docs/en/statusline). It reads Claude Code's JSON session blob on stdin and prints one width-adaptive line:

```
◆ Opus·high→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   5h 24%   ♻ 63% cached
```

Left to right: health-tinted brand glyph + model + effort + the subscription actually serving the turn when `sub` reroute is on (`→codex`/`→kimi`), a context-health gauge, compression saved, then 5-hour rate-limit usage and this turn's prompt-cache reuse when Claude Code reports them.

## Design decisions

- **Context gauge anchored to a fixed 200k health budget**, not the model's raw window. On a 1M-context model, 200k tokens still reads as full/red instead of a misleading "20%". Label is absolute (`142k`); color is green `<80k` / amber `80–160k` / red `≥160k`, pinned past budget.
- **Cache reuse is per-session**, computed from `context_window.current_usage` (not the lifetime ledger), so it moves as you work.
- **Health is silent when healthy**; a `⚠ llmtrim degraded` replaces the savings segment when the proxy is broken, and the reroute arrow is hidden then (traffic is not being intercepted).
- **Core segments never truncate** (model→backend, context, trim); extras shed right-to-left as `COLUMNS` shrinks. Absent data (no reroute, API-key user with no rate limits, non-reasoning model) simply does not render.

## Install

```bash
llmtrim statusline install          # wire into ~/.claude/settings.json (merges, does not clobber)
llmtrim statusline install --print  # print the snippet instead
llmtrim statusline uninstall
```

## Testing / review

- 16 unit tests: rendering states, health gating, budget-anchored gauge math, right-to-left truncation on ANSI strings, settings-merge safety, parse edge cases, and an overflow/negative regression for extreme token counts. Full suite: 967 pass, clippy clean.
- Reviewed by two agents before this PR (correctness + conventions). Fixes folded in: an integer-overflow harden in the gauge, dropped a speculative field, extracted the settings merge into pure testable transforms, corrected stale help text.

Rendering never touches the network or API tokens.