### PR TITLE
feat(sub): default Codex tiers to gpt-5.5 terra/luna/sol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. The format follows
 
 ### Changed
 
+- **`llmtrim sub codex`: updated default tier models.** The balanced preset now maps Opus to
+  `gpt-5.5-terra`, Sonnet to `gpt-5.5-luna`, and Fable to `gpt-5.5-sol`; Haiku stays on the
+  cheap `gpt-5.4-mini`. Custom `[sub.codex.tiers]` overrides are unaffected.
+
 - **`llmtrim sub`: clearer on/off verbs.** Enabling a reroute is now `sub on <provider>`
   (with `sub use` and `sub start` accepted as aliases); disabling stays `sub off` (with
   `sub stop` as an alias). A bare `sub on` re-enables the last provider you used without

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -226,15 +226,17 @@ pub fn classify_tier(model: &str) -> Option<Tier> {
     }
 }
 
-/// The built-in default preset for Codex (the single `balanced` preset). Opus and Fable get the
-/// flagship, Sonnet the balanced model, Haiku the small/fast model (Claude Code's background
-/// title/token calls land on Haiku, so it should be cheap). Kimi has one model and ignores tiers.
+/// The built-in default preset for Codex (the single `balanced` preset). Opus maps to the deep
+/// reasoning flagship (`gpt-5.5-terra`), Sonnet to the balanced flagship (`gpt-5.5-luna`), Fable
+/// to the fast flagship (`gpt-5.5-sol`), and Haiku to the small/fast model (Claude Code's
+/// background title/token calls land on Haiku, so it should be cheap). Kimi has one model and
+/// ignores tiers.
 pub fn default_codex_tier_model(tier: Tier) -> &'static str {
     match tier {
-        Tier::Opus => "gpt-5.5",
-        Tier::Sonnet => "gpt-5.4",
+        Tier::Opus => "gpt-5.5-terra",
+        Tier::Sonnet => "gpt-5.5-luna",
         Tier::Haiku => "gpt-5.4-mini",
-        Tier::Fable => "gpt-5.5",
+        Tier::Fable => "gpt-5.5-sol",
     }
 }
 
@@ -349,16 +351,19 @@ mod tests {
         let ov = BTreeMap::new();
         assert_eq!(
             resolve_model(SubProvider::Codex, "claude-opus-4-8", &ov),
-            "gpt-5.5"
+            "gpt-5.5-terra"
         );
-        assert_eq!(resolve_model(SubProvider::Codex, "sonnet", &ov), "gpt-5.4");
+        assert_eq!(
+            resolve_model(SubProvider::Codex, "sonnet", &ov),
+            "gpt-5.5-luna"
+        );
         assert_eq!(
             resolve_model(SubProvider::Codex, "haiku", &ov),
             "gpt-5.4-mini"
         );
         assert_eq!(
             resolve_model(SubProvider::Codex, "claude-fable-5", &ov),
-            "gpt-5.5"
+            "gpt-5.5-sol"
         );
     }
 
@@ -406,7 +411,7 @@ mod tests {
         let ov = BTreeMap::new();
         assert_eq!(
             resolve_model(SubProvider::Codex, "mystery-model", &ov),
-            "gpt-5.4"
+            "gpt-5.5-luna"
         );
     }
 }


### PR DESCRIPTION
## What

Point the balanced Codex reroute preset at the current GPT-5.5 flagship variants:

| Tier | Before | After |
|------|--------|-------|
| Opus | `gpt-5.5` | `gpt-5.5-terra` (deep reasoning) |
| Sonnet | `gpt-5.4` | `gpt-5.5-luna` (balanced) |
| Fable | `gpt-5.5` | `gpt-5.5-sol` (fast) |
| Haiku | `gpt-5.4-mini` | `gpt-5.4-mini` (unchanged) |

Haiku stays on the cheap model since Claude Code's background title/token calls land there. Custom `[sub.codex.tiers]` overrides are unaffected.

## Note

At the time of writing, a live ping of the ChatGPT/Codex backend returns HTTP 400 `"not supported when using Codex with a ChatGPT account"` for the `-terra/-luna/-sol` ids; only `gpt-5.5` and `gpt-5.4-mini` currently serve. These defaults are ahead of backend availability by design.

## Test

- Updated the `default_preset_maps_fable_to_flagship` and `unknown_non_codex_falls_back_to_sonnet` unit tests.
- `cargo nextest run --features intercept -p llmtrim reroute` — 102 passed.

Stacked on #146.