### PR TITLE
fix(sub): use GPT-5.6 Codex tier ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project are documented here. The format follows
 ### Changed
 
 - **`llmtrim sub codex`: updated default tier models.** The balanced preset now maps Opus to
-  `gpt-5.5-terra`, Sonnet to `gpt-5.5-luna`, and Fable to `gpt-5.5-sol`; Haiku stays on the
+  `gpt-5.6-terra`, Sonnet to `gpt-5.6-luna`, and Fable to `gpt-5.6-sol`; Haiku stays on the
   cheap `gpt-5.4-mini`. Custom `[sub.codex.tiers]` overrides are unaffected.
 
 - **`llmtrim sub`: clearer on/off verbs.** Enabling a reroute is now `sub on <provider>`

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -227,16 +227,16 @@ pub fn classify_tier(model: &str) -> Option<Tier> {
 }
 
 /// The built-in default preset for Codex (the single `balanced` preset). Opus maps to the deep
-/// reasoning flagship (`gpt-5.5-terra`), Sonnet to the balanced flagship (`gpt-5.5-luna`), Fable
-/// to the fast flagship (`gpt-5.5-sol`), and Haiku to the small/fast model (Claude Code's
+/// reasoning flagship (`gpt-5.6-terra`), Sonnet to the balanced flagship (`gpt-5.6-luna`), Fable
+/// to the fast flagship (`gpt-5.6-sol`), and Haiku to the small/fast model (Claude Code's
 /// background title/token calls land on Haiku, so it should be cheap). Kimi has one model and
 /// ignores tiers.
 pub fn default_codex_tier_model(tier: Tier) -> &'static str {
     match tier {
-        Tier::Opus => "gpt-5.5-terra",
-        Tier::Sonnet => "gpt-5.5-luna",
+        Tier::Opus => "gpt-5.6-terra",
+        Tier::Sonnet => "gpt-5.6-luna",
         Tier::Haiku => "gpt-5.4-mini",
-        Tier::Fable => "gpt-5.5-sol",
+        Tier::Fable => "gpt-5.6-sol",
     }
 }
 
@@ -351,11 +351,11 @@ mod tests {
         let ov = BTreeMap::new();
         assert_eq!(
             resolve_model(SubProvider::Codex, "claude-opus-4-8", &ov),
-            "gpt-5.5-terra"
+            "gpt-5.6-terra"
         );
         assert_eq!(
             resolve_model(SubProvider::Codex, "sonnet", &ov),
-            "gpt-5.5-luna"
+            "gpt-5.6-luna"
         );
         assert_eq!(
             resolve_model(SubProvider::Codex, "haiku", &ov),
@@ -363,7 +363,7 @@ mod tests {
         );
         assert_eq!(
             resolve_model(SubProvider::Codex, "claude-fable-5", &ov),
-            "gpt-5.5-sol"
+            "gpt-5.6-sol"
         );
     }
 
@@ -411,7 +411,7 @@ mod tests {
         let ov = BTreeMap::new();
         assert_eq!(
             resolve_model(SubProvider::Codex, "mystery-model", &ov),
-            "gpt-5.5-luna"
+            "gpt-5.6-luna"
         );
     }
 }


### PR DESCRIPTION
Correct the Codex default mappings from GPT-5.5 to GPT-5.6: Opus maps to `gpt-5.6-terra`, Sonnet to `gpt-5.6-luna`, and Fable to `gpt-5.6-sol`. Updated unit tests and the changelog.\n\nTested: `cargo nextest run --features intercept -p llmtrim reroute` (102 passed).