### PR TITLE
fix(tray): render the popover in release builds (enable custom-protocol)

### DIFF
--- a/crates/llmtrim-tray/Cargo.toml
+++ b/crates/llmtrim-tray/Cargo.toml
@@ -29,6 +29,19 @@ chrono = "0.4"
 # so it can't be read from SQLite like the savings figures are.
 serde_json.workspace = true
 
+# Tauri decides "dev vs production" from the `custom-protocol` feature: its build
+# script sets `dev = !custom_protocol`. In dev mode the webview loads `build.devUrl`
+# (the Vite dev server on :43217); only with `custom-protocol` on does it serve the
+# embedded `dist/` assets over the `tauri://` protocol. `cargo tauri build` would add
+# this feature automatically, but every shipping path here uses plain cargo instead —
+# CI (`tray.yml`), `release.yml`, the Homebrew `cargo install`, and the npm repackage —
+# so it must be a DEFAULT feature or the released tray is a blank window that logs
+# "could not connect to the server" (issue #149). DO NOT REMOVE from `default`.
+# For UI hot-reload, build the dev binary with `--no-default-features` so it uses devUrl.
+[features]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]
+
 # Tauri macro-generated scaffolding contains `unsafe` blocks, so this crate cannot
 # inherit the workspace `unsafe_code = "forbid"`. Re-declare lints here without it,
 # mirroring crates/llmtrim-uniffi/Cargo.toml.

--- a/crates/llmtrim-tray/README.md
+++ b/crates/llmtrim-tray/README.md
@@ -44,7 +44,10 @@ dependency).
 ```bash
 cd crates/llmtrim-tray
 npm install
-npm run tauri dev      # hot-reload the UI and the Rust shell
+npm run dev            # terminal 1: Vite dev server on :43217 (hot-reloads the UI)
+# terminal 2: run the shell against that dev server. `--no-default-features` drops
+# `custom-protocol` so the webview loads build.devUrl instead of the embedded dist/.
+cargo run -p llmtrim-tray --no-default-features
 ```
 
 The popover reads the same ledger the proxy writes, resolved via


### PR DESCRIPTION
The desktop tray shipped a blank white popover on every installed machine (#149). The webview logged "could not connect to the server" because it was loading the Vite dev URL (http://localhost:43217) instead of the embedded dist/ assets.

Root cause: Tauri decides dev-vs-production from the `custom-protocol` feature — its build script computes `dev = !custom_protocol` (tauri build.rs), and `get_app_url` serves `build.devUrl` under `cfg(dev)` and the embedded `frontendDist` over `tauri://` otherwise. `cargo tauri build` enables that feature automatically, but every shipping path here uses plain cargo instead (tray.yml, release.yml, the Homebrew `cargo install`, and the npm repackage), so each "release" binary ran in dev mode and pointed at a dev server that does not exist on a user's machine.

Make `custom-protocol` a default feature so every raw-cargo release build embeds and serves dist/. This fixes all three platforms, since they were all built the same way. Hot-reload dev now uses `--no-default-features` to fall back to the dev server; the README is updated to match.

Verified: the release binary rendered blank on its own but rendered the full UI once a dev server was up; after this change it renders correctly with no dev server running. No new dependencies and no Cargo.lock churn (`custom-protocol` chains only to an empty tauri-macros feature).