### PR TITLE
feat(sub): improve Codex continuation for better cache reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Status line stayed red after `/compact`.** The cold-cache segment (`♻ cold · /compact`) and
+  context gauge keyed only on the interceptor ledger's `last_ts`. `/compact` runs inside Claude
+  Code and does not update that timestamp, so the line kept warning after a successful compact.
+  The renderer now clears the cold state when Claude Code reports a post-compact reset (empty
+  context, no `current_usage` yet).
+
+### Changed
+
+- **Status line shows the resolved upstream model on `sub` reroutes.** Codex reroutes now render
+  the concrete backend model (e.g. `→gpt-5.6-terra`) instead of the provider shortname (`→codex`);
+  Kimi still shows `→kimi`.
+
 ## [0.9.3] - 2026-07-11
 
 ### Fixed
@@ -30,7 +44,7 @@ All notable changes to this project are documented here. The format follows
   Claude's — green below 40%, orange 40–65%, red above. Rate-limit percentages escalate green →
   amber (70%) → orange (80%) → red (90%). The cache segment turns into `♻ cold · /compact` once
   the session has been idle past the cache TTL, since the next message then pays a cold cache
-  write. The reroute arrow (`→codex`/`→kimi`) shows the subscription actually serving the turn,
+  write. The reroute arrow (e.g. `→gpt-5.6-terra` or `→kimi`) shows the backend actually serving the turn,
   and a `⚠` replaces the savings segment when the interceptor is degraded. Extras shed
   right-to-left on narrow terminals. `llmtrim statusline install` wires it into
   `~/.claude/settings.json` (`--print` emits the snippet instead); `uninstall` removes it.

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ The printed block is the standard MCP config; for a client you edit by hand it l
 
 **Status line for Claude Code.** `llmtrim statusline` renders a single line for Claude Code's
 [custom status line](https://code.claude.com/docs/en/statusline): the model, the subscription
-actually serving the turn when you reroute (`→codex`/`→kimi`), a context-health gauge, and how
+actually serving the turn when you reroute (e.g. `→gpt-5.6-terra` or `→kimi`), a context-health gauge, and how
 much llmtrim is trimming, plus rate-limit and prompt-cache reuse when Claude Code reports them.
 
 ```bash
@@ -306,7 +306,7 @@ llmtrim statusline install --print  # or print the settings snippet to paste you
 ```
 
 ```text
-◆ Opus→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
+◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
 ```
 
 The `✂` trim figure is scoped to the current Claude Code session; it reads `✂ –` until llmtrim

--- a/crates/llmtrim-cli/src/reroute/codex.rs
+++ b/crates/llmtrim-cli/src/reroute/codex.rs
@@ -446,6 +446,9 @@ pub struct Reducer {
     /// is only honored for the item that owns the currently open tool.
     tool_output_index: Option<i64>,
     terminal_seen: bool,
+    // Accumulation for continuation transcript (assistant outputs in codex input item shape)
+    current_assistant_text: String,
+    output_items: Vec<Value>,
 }
 
 impl Reducer {
@@ -460,6 +463,8 @@ impl Reducer {
             tool_flushed: false,
             tool_output_index: None,
             terminal_seen: false,
+            current_assistant_text: String::new(),
+            output_items: Vec::new(),
         }
     }
 
@@ -475,7 +480,16 @@ impl Reducer {
             Some(&self.tool_id),
         );
         if !sanitized.is_empty() {
-            out.push(ReduceEvent::ToolDelta(sanitized));
+            out.push(ReduceEvent::ToolDelta(sanitized.clone()));
+        }
+        // Record for continuation transcript
+        if !self.tool_name.is_empty() {
+            self.output_items.push(json!({
+                "type": "function_call",
+                "call_id": self.tool_id,
+                "name": self.tool_name,
+                "arguments": if sanitized.is_empty() { self.tool_buf.clone() } else { sanitized }
+            }));
         }
     }
 
@@ -488,6 +502,8 @@ impl Reducer {
     }
 
     /// Flush any still-open block at stream end; emit a `Finish EndTurn` if no terminal was seen.
+    /// Note: synthetic Finish always has response_id=None and continuation_eligible=false
+    /// so it never triggers continuation recording (matches proxy expectations).
     pub fn finish(&mut self) -> Vec<ReduceEvent> {
         let mut out = Vec::new();
         self.close_open(&mut out);
@@ -496,16 +512,28 @@ impl Reducer {
             out.push(ReduceEvent::Finish {
                 stop_reason: StopReason::EndTurn,
                 usage: Usage::default(),
+                response_id: None,
+                continuation_eligible: false,
             });
         }
         out
+    }
+
+    /// Take the assistant output items accumulated for this turn (for continuation recording).
+    /// Flushes any pending text.
+    pub fn take_output_items(&mut self) -> Vec<Value> {
+        self.flush_current_text();
+        std::mem::take(&mut self.output_items)
     }
 
     /// Close whatever block is open, emitting its `*Stop`.
     fn close_open(&mut self, out: &mut Vec<ReduceEvent>) {
         match self.open {
             Open::Thinking => out.push(ReduceEvent::ThinkingStop),
-            Open::Text => out.push(ReduceEvent::TextStop),
+            Open::Text => {
+                self.flush_current_text();
+                out.push(ReduceEvent::TextStop);
+            }
             Open::Tool => {
                 self.flush_tool(out);
                 out.push(ReduceEvent::ToolStop);
@@ -513,6 +541,17 @@ impl Reducer {
             Open::None => {}
         }
         self.open = Open::None;
+    }
+
+    fn flush_current_text(&mut self) {
+        if !self.current_assistant_text.is_empty() {
+            let text = std::mem::take(&mut self.current_assistant_text);
+            self.output_items.push(json!({
+                "type": "message",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "text": text }]
+            }));
+        }
     }
 
     fn handle(&mut self, v: &Value, out: &mut Vec<ReduceEvent>) {
@@ -577,6 +616,7 @@ impl Reducer {
                     out.push(ReduceEvent::TextStart);
                     self.open = Open::Text;
                 }
+                self.current_assistant_text.push_str(delta);
                 out.push(ReduceEvent::TextDelta(delta.to_string()));
             }
             "response.function_call_arguments.delta" => {
@@ -650,7 +690,18 @@ impl Reducer {
             .map(map_usage)
             .unwrap_or_default();
         self.terminal_seen = true;
-        out.push(ReduceEvent::Finish { stop_reason, usage });
+        let continuation_eligible = !incomplete;
+        out.push(ReduceEvent::Finish {
+            stop_reason,
+            usage,
+            response_id: v
+                .get("response")
+                .and_then(|r| r.get("id"))
+                .and_then(|i| i.as_str())
+                .map(|s| s.to_string())
+                .or_else(|| v.get("id").and_then(|i| i.as_str()).map(|s| s.to_string())),
+            continuation_eligible,
+        });
     }
 }
 
@@ -1028,6 +1079,8 @@ mod tests {
                         cache_read: 3,
                         cache_write: 0
                     },
+                    response_id: None,
+                    continuation_eligible: true,
                 },
             ]
         );
@@ -1064,6 +1117,8 @@ mod tests {
                         cache_read: 0,
                         cache_write: 0
                     },
+                    response_id: None,
+                    continuation_eligible: true,
                 },
             ]
         );
@@ -1214,6 +1269,8 @@ mod tests {
                 ReduceEvent::Finish {
                     stop_reason: StopReason::EndTurn,
                     usage: Usage::default(),
+                    response_id: None,
+                    continuation_eligible: false,
                 },
             ]
         );
@@ -1224,5 +1281,59 @@ mod tests {
         let sse = "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n";
         let (_, mut r) = reduce(sse);
         assert!(r.finish().is_empty());
+    }
+
+    #[test]
+    fn completed_sets_continuation_eligible_true() {
+        let sse = concat!(
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"m\"}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"ok\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"message\"}}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n",
+        );
+        let (events, _) = reduce(sse);
+        let finish = events
+            .iter()
+            .find_map(|e| {
+                if let ReduceEvent::Finish {
+                    continuation_eligible,
+                    ..
+                } = e
+                {
+                    Some(*continuation_eligible)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        assert!(finish, "completed should be eligible");
+    }
+
+    #[test]
+    fn incomplete_sets_continuation_eligible_false() {
+        let sse = concat!(
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"m\"}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"partial\"}\n\n",
+            "data: {\"type\":\"response.incomplete\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":0}}}\n\n",
+        );
+        let (events, _) = reduce(sse);
+        let finish = events
+            .iter()
+            .find_map(|e| {
+                if let ReduceEvent::Finish {
+                    continuation_eligible,
+                    ..
+                } = e
+                {
+                    Some(*continuation_eligible)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        assert!(
+            !finish,
+            "incomplete should not be eligible for continuation"
+        );
     }
 }

--- a/crates/llmtrim-cli/src/reroute/continuation.rs
+++ b/crates/llmtrim-cli/src/reroute/continuation.rs
@@ -1,13 +1,14 @@
 //! Server-side continuation for Codex (Responses API) reroute.
 //!
-//! Ports the core idea from claude-code-proxy:
-//! - Use `previous_response_id` + a small `input` delta instead of resending the full
-//!   conversation history on every turn.
-//! - This keeps the backend's internal state (and associated caching/prefix reuse) warm.
-//! - Combined with `prompt_cache_key`, this should produce better `cached_tokens` reports
-//!   from the backend, which then translate into higher "♻ % cached" in the status line.
+//! Uses `previous_response_id` + a small `input` delta (instead of resending the
+//! full conversation history on every turn). This keeps the backend's internal
+//! state (and associated caching/prefix reuse) warm. Combined with
+//! `prompt_cache_key`, this produces better `cached_tokens` reports from the
+//! backend, which translate into a higher "♻ % cached" figure in the status line.
 //!
-//! We work with raw serde_json::Value because the reroute path builds codex bodies as Value.
+//! We work with raw `serde_json::Value` because the reroute path builds Codex
+//! bodies as dynamic JSON (the normal request path is already in Anthropic
+//! shape at this point).
 
 use std::collections::HashMap;
 use std::sync::Mutex;

--- a/crates/llmtrim-cli/src/reroute/continuation.rs
+++ b/crates/llmtrim-cli/src/reroute/continuation.rs
@@ -1,0 +1,401 @@
+//! Server-side continuation for Codex (Responses API) reroute.
+//!
+//! Ports the core idea from claude-code-proxy:
+//! - Use `previous_response_id` + a small `input` delta instead of resending the full
+//!   conversation history on every turn.
+//! - This keeps the backend's internal state (and associated caching/prefix reuse) warm.
+//! - Combined with `prompt_cache_key`, this should produce better `cached_tokens` reports
+//!   from the backend, which then translate into higher "♻ % cached" in the status line.
+//!
+//! We work with raw serde_json::Value because the reroute path builds codex bodies as Value.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use serde_json::{Value, json};
+
+const TTL_MS: u64 = 30 * 60 * 1000;
+const MAX_STATES: usize = 10_000;
+const MAX_SESSION_TRANSCRIPT_BYTES: u64 = 2_000_000;
+const MAX_TOTAL_TRANSCRIPT_BYTES: u64 = 20_000_000;
+
+#[derive(Clone)]
+struct ContinuationState {
+    response_id: String,
+    /// Signature of the non-input parts of the request (model, instructions, tools, etc.).
+    /// If this changes we cannot safely continue.
+    prompt_signature: String,
+    /// The logical full `input` array (codex-shaped) that represents the conversation
+    /// up to and including the assistant output of that turn.
+    transcript: Vec<Value>,
+    transcript_bytes: u64,
+    updated_at: u64,
+}
+
+static STATES: Mutex<Option<HashMap<String, ContinuationState>>> = Mutex::new(None);
+static TOTAL_TRANSCRIPT_BYTES: Mutex<u64> = Mutex::new(0);
+
+#[derive(Clone, Default)]
+pub struct ContinuationCandidate {
+    pub previous_response_id: Option<String>,
+    pub input_delta: Option<Vec<Value>>,
+    pub input_delta_count: usize,
+    pub disabled_reason: Option<String>,
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Compute a signature over everything except the "input" array.
+/// This lets us detect when tools, model, instructions, reasoning, etc. changed.
+/// Uses a stable JSON representation (sorted keys, normalized values) for robustness.
+fn prompt_signature(body: &Value) -> String {
+    let value = serde_json::to_value(body).unwrap_or_default();
+    let obj = match value.as_object() {
+        Some(o) => o,
+        None => return String::new(),
+    };
+    let mut entries: Vec<(&String, &Value)> = obj.iter().filter(|(k, _)| *k != "input").collect();
+    entries.sort_by_key(|(a, _)| *a);
+    let mut sig = String::from("{");
+    for (i, (key, val)) in entries.iter().enumerate() {
+        if i > 0 {
+            sig.push(',');
+        }
+        sig.push_str(&format!("\"{}\":{}", key, stable_json(val)));
+    }
+    sig.push('}');
+    sig
+}
+
+fn stable_json(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => serde_json::to_string(s).unwrap_or_default(),
+        Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(stable_json).collect();
+            format!("[{}]", items.join(","))
+        }
+        Value::Object(obj) => {
+            let mut entries: Vec<(&String, &Value)> = obj.iter().collect();
+            entries.sort_by_key(|(a, _)| *a);
+            let items: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(k).unwrap_or_default(),
+                        stable_json(v)
+                    )
+                })
+                .collect();
+            format!("{{{}}}", items.join(","))
+        }
+    }
+}
+
+fn input_suffix_after_prefix(input: &[Value], prefix: &[Value]) -> Option<Vec<Value>> {
+    if prefix.len() > input.len() {
+        return None;
+    }
+    for (i, p) in prefix.iter().enumerate() {
+        let a = &input[i];
+        if a != p {
+            return None;
+        }
+    }
+    Some(input[prefix.len()..].to_vec())
+}
+
+pub fn continuation_candidate(
+    session_id: Option<&str>,
+    body: &Value,
+    enabled: bool,
+) -> ContinuationCandidate {
+    let now = now_ms();
+
+    if !enabled {
+        return ContinuationCandidate {
+            previous_response_id: None,
+            input_delta: None,
+            input_delta_count: body
+                .get("input")
+                .and_then(|i| i.as_array())
+                .map(|a| a.len())
+                .unwrap_or(0),
+            disabled_reason: Some("disabled".to_string()),
+        };
+    }
+
+    let session_id = match session_id {
+        Some(s) => s,
+        None => {
+            return ContinuationCandidate {
+                previous_response_id: None,
+                input_delta: None,
+                input_delta_count: body
+                    .get("input")
+                    .and_then(|i| i.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0),
+                disabled_reason: Some("missing_session".to_string()),
+            };
+        }
+    };
+
+    let state = {
+        let guard = STATES.lock().unwrap();
+        guard.as_ref().and_then(|m| m.get(session_id)).cloned()
+    };
+
+    let state = match state {
+        Some(s) if now - s.updated_at <= TTL_MS => s,
+        Some(_) => {
+            clear_continuation(Some(session_id));
+            return ContinuationCandidate {
+                previous_response_id: None,
+                input_delta: None,
+                input_delta_count: body
+                    .get("input")
+                    .and_then(|i| i.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0),
+                disabled_reason: Some("missing_state".to_string()),
+            };
+        }
+        None => {
+            return ContinuationCandidate {
+                previous_response_id: None,
+                input_delta: None,
+                input_delta_count: body
+                    .get("input")
+                    .and_then(|i| i.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0),
+                disabled_reason: Some("missing_state".to_string()),
+            };
+        }
+    };
+
+    let sig = prompt_signature(body);
+    if sig != state.prompt_signature {
+        clear_continuation(Some(session_id));
+        return ContinuationCandidate {
+            previous_response_id: None,
+            input_delta: None,
+            input_delta_count: body
+                .get("input")
+                .and_then(|i| i.as_array())
+                .map(|a| a.len())
+                .unwrap_or(0),
+            disabled_reason: Some("prompt_changed".to_string()),
+        };
+    }
+
+    let current_input = body
+        .get("input")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let suffix = match input_suffix_after_prefix(&current_input, &state.transcript) {
+        Some(s) => s,
+        None => {
+            clear_continuation(Some(session_id));
+            return ContinuationCandidate {
+                previous_response_id: None,
+                input_delta: None,
+                input_delta_count: current_input.len(),
+                disabled_reason: Some("not_append_only".to_string()),
+            };
+        }
+    };
+
+    if suffix.is_empty() {
+        return ContinuationCandidate {
+            previous_response_id: None,
+            input_delta: None,
+            input_delta_count: 0,
+            disabled_reason: Some("empty_delta".to_string()),
+        };
+    }
+
+    ContinuationCandidate {
+        previous_response_id: Some(state.response_id.clone()),
+        input_delta: Some(suffix.clone()),
+        input_delta_count: suffix.len(),
+        disabled_reason: None,
+    }
+}
+
+/// Mutate the codex request body Value to use continuation (previous_response_id + delta input)
+/// if the candidate provides them.
+pub fn apply_codex_continuation(body: &mut Value, candidate: &ContinuationCandidate) {
+    if let Some(obj) = body.as_object_mut() {
+        if let Some(prev) = &candidate.previous_response_id {
+            obj.insert("previous_response_id".to_string(), json!(prev));
+        }
+        if let Some(delta) = &candidate.input_delta {
+            obj.insert("input".to_string(), json!(delta));
+        }
+    }
+}
+
+pub fn record_continuation(
+    session_id: Option<&str>,
+    logical_body: &Value,
+    response_id: Option<&str>,
+    output_items: &[Value],
+) {
+    let session_id = match session_id {
+        Some(s) => s,
+        None => return,
+    };
+
+    let response_id = match response_id {
+        Some(id) => id.to_string(),
+        None => {
+            clear_continuation(Some(session_id));
+            return;
+        }
+    };
+
+    let mut transcript: Vec<Value> = logical_body
+        .get("input")
+        .and_then(|i| i.as_array())
+        .cloned()
+        .unwrap_or_default();
+    transcript.extend_from_slice(output_items);
+
+    let transcript_json = serde_json::to_string(&transcript).unwrap_or_default();
+    let transcript_bytes = transcript_json.len() as u64;
+
+    if transcript_bytes > MAX_SESSION_TRANSCRIPT_BYTES {
+        clear_continuation(Some(session_id));
+        return;
+    }
+
+    // Evict this session's previous bytes first
+    clear_continuation(Some(session_id));
+
+    let state = ContinuationState {
+        response_id,
+        prompt_signature: prompt_signature(logical_body),
+        transcript,
+        transcript_bytes,
+        updated_at: now_ms(),
+    };
+
+    {
+        let mut guard = TOTAL_TRANSCRIPT_BYTES.lock().unwrap();
+        *guard = guard.saturating_add(state.transcript_bytes);
+    }
+    {
+        let mut guard = STATES.lock().unwrap();
+        let map = guard.get_or_insert_with(HashMap::new);
+        map.insert(session_id.to_string(), state);
+    }
+    evict_oldest();
+}
+
+pub fn clear_continuation(session_id: Option<&str>) {
+    let session_id = match session_id {
+        Some(s) => s,
+        None => return,
+    };
+    let mut guard = STATES.lock().unwrap();
+    if let Some(map) = guard.as_mut()
+        && let Some(existing) = map.remove(session_id)
+    {
+        let mut bytes_guard = TOTAL_TRANSCRIPT_BYTES.lock().unwrap();
+        *bytes_guard = bytes_guard.saturating_sub(existing.transcript_bytes);
+    }
+}
+
+fn evict_oldest() {
+    // Evict oldest-first (by updated_at) when either the state count or total bytes
+    // exceed the caps. Matches the spirit of the proxy (which also caps count) while
+    // preferring LRU-style eviction over arbitrary HashMap order.
+    let mut guard = STATES.lock().unwrap();
+    let map = match guard.as_mut() {
+        Some(m) if !m.is_empty() => m,
+        _ => return,
+    };
+
+    let mut bytes_guard = TOTAL_TRANSCRIPT_BYTES.lock().unwrap();
+    while (map.len() > MAX_STATES || *bytes_guard > MAX_TOTAL_TRANSCRIPT_BYTES) && !map.is_empty() {
+        if let Some((&ref oldest_key, _)) = map.iter().min_by_key(|(_, s)| s.updated_at) {
+            let key = oldest_key.clone();
+            if let Some(old) = map.remove(&key) {
+                *bytes_guard = bytes_guard.saturating_sub(old.transcript_bytes);
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+// Test helpers
+#[cfg(test)]
+pub fn has_continuation_for_tests(session_id: &str) -> bool {
+    let guard = STATES.lock().unwrap();
+    guard.as_ref().is_some_and(|m| m.contains_key(session_id))
+}
+
+#[cfg(test)]
+pub fn clear_all_continuations_for_tests() {
+    let mut guard = STATES.lock().unwrap();
+    *guard = None;
+    let mut b = TOTAL_TRANSCRIPT_BYTES.lock().unwrap();
+    *b = 0;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn first_turn_has_no_continuation() {
+        clear_all_continuations_for_tests();
+        let body = json!({
+            "model": "gpt-5.5",
+            "input": [ {"type":"message", "role":"user", "content":[{"type":"input_text","text":"hi"}]} ],
+            "instructions": "be nice"
+        });
+        let c = continuation_candidate(Some("sess-1"), &body, true);
+        assert!(c.previous_response_id.is_none());
+        assert_eq!(c.disabled_reason, Some("missing_state".to_string()));
+    }
+
+    #[test]
+    fn records_and_produces_delta_on_append() {
+        clear_all_continuations_for_tests();
+        let body1 = json!({
+            "model": "gpt-5.5",
+            "input": [ {"type":"message", "role":"user", "content":[{"type":"input_text","text":"first"}]} ],
+        });
+        // Simulate a completed turn
+        record_continuation(Some("sess-1"), &body1, Some("resp_123"), &[]);
+        assert!(has_continuation_for_tests("sess-1"));
+
+        // Next logical input appends a new user message (CC will include prior assistant in real, but here we test basic suffix)
+        let body2 = json!({
+            "model": "gpt-5.5",
+            "input": [
+                {"type":"message", "role":"user", "content":[{"type":"input_text","text":"first"}]},
+                {"type":"message", "role":"user", "content":[{"type":"input_text","text":"second"}]}
+            ],
+        });
+        let c = continuation_candidate(Some("sess-1"), &body2, true);
+        assert_eq!(c.previous_response_id, Some("resp_123".to_string()));
+        assert!(c.input_delta.is_some());
+        assert_eq!(c.input_delta.as_ref().unwrap().len(), 1);
+    }
+}

--- a/crates/llmtrim-cli/src/reroute/kimi.rs
+++ b/crates/llmtrim-cli/src/reroute/kimi.rs
@@ -447,6 +447,8 @@ impl Reducer {
             events.push(ReduceEvent::Finish {
                 stop_reason: stop,
                 usage: self.usage,
+                response_id: None,
+                continuation_eligible: false,
             });
             self.terminal = true;
         }
@@ -607,6 +609,8 @@ impl Reducer {
             events.push(ReduceEvent::Finish {
                 stop_reason: stop,
                 usage: self.usage,
+                response_id: None,
+                continuation_eligible: false,
             });
             self.terminal = true;
         }
@@ -932,6 +936,8 @@ mod tests {
                     cache_read: 30,
                     cache_write: 0
                 },
+                response_id: None,
+                continuation_eligible: false,
             }
         );
         // No double finish.
@@ -950,6 +956,8 @@ mod tests {
             &ReduceEvent::Finish {
                 stop_reason: StopReason::EndTurn,
                 usage: Usage::default(),
+                response_id: None,
+                continuation_eligible: false,
             }
         );
     }

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -15,6 +15,7 @@
 pub mod auth;
 pub mod catalog;
 pub mod codex;
+pub mod continuation;
 pub mod kimi;
 pub mod read_rewrite;
 pub mod sse;
@@ -101,6 +102,16 @@ impl StreamReducer {
         match self {
             StreamReducer::Codex(r) => r.finish(),
             StreamReducer::Kimi(r) => r.finish(),
+        }
+    }
+
+    /// For Codex continuation: take the assistant output items (text + function calls)
+    /// accumulated during reduction for this turn, to append to the transcript for next-turn
+    /// delta detection. Safe no-op for Kimi.
+    pub fn take_codex_output_items(&mut self) -> Vec<Value> {
+        match self {
+            StreamReducer::Codex(r) => r.take_output_items(),
+            StreamReducer::Kimi(_) => vec![],
         }
     }
 }

--- a/crates/llmtrim-cli/src/reroute/sse.rs
+++ b/crates/llmtrim-cli/src/reroute/sse.rs
@@ -75,6 +75,12 @@ pub enum ReduceEvent {
     Finish {
         stop_reason: StopReason,
         usage: Usage,
+        /// Codex (and similar) response id, used for server-side continuation via
+        /// previous_response_id. Present when the upstream provided one.
+        response_id: Option<String>,
+        /// Whether this terminal is eligible for continuation recording.
+        /// Mirrors the proxy: true only for completed non-incomplete turns.
+        continuation_eligible: bool,
     },
     /// A mid-stream upstream failure. Once `message_start` has been sent we cannot flip the HTTP
     /// status, so this is surfaced as an Anthropic SSE `error` event (which Claude Code renders).
@@ -145,9 +151,9 @@ impl AnthropicSseEncoder {
                 json!({"type": "input_json_delta", "partial_json": partial}),
             ),
             ReduceEvent::ToolStop => self.close_block(out),
-            ReduceEvent::Finish { stop_reason, usage } => {
-                self.emit_finish(out, *stop_reason, *usage)
-            }
+            ReduceEvent::Finish {
+                stop_reason, usage, ..
+            } => self.emit_finish(out, *stop_reason, *usage),
             ReduceEvent::Error { message } => self.emit_error(out, message),
         }
     }
@@ -310,6 +316,8 @@ mod tests {
                         cache_read: 3,
                         cache_write: 0,
                     },
+                    response_id: None,
+                    continuation_eligible: true,
                 },
             ],
         );
@@ -343,6 +351,8 @@ mod tests {
                 ReduceEvent::Finish {
                     stop_reason: StopReason::ToolUse,
                     usage: Usage::default(),
+                    response_id: None,
+                    continuation_eligible: false,
                 },
             ],
         );
@@ -363,6 +373,8 @@ mod tests {
             &ReduceEvent::Finish {
                 stop_reason: StopReason::EndTurn,
                 usage: Usage::default(),
+                response_id: None,
+                continuation_eligible: false,
             },
             &mut out,
         );

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -37,7 +37,11 @@ mod imp {
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::mpsc::Sender;
+
+    use serde_json::Value;
     use std::sync::{Arc, Mutex};
+
+    use crate::reroute::sse::ReduceEvent;
 
     use anyhow::{Context, Result};
     use bytes::Bytes;
@@ -341,11 +345,20 @@ mod imp {
         /// The rewritten upstream request, retained so `reroute_response` can re-issue it on a
         /// retryable failure (429/5xx). `None` on paths that never retry (the on-error fallback).
         replay: Option<RerouteReplay>,
+        /// The full logical codex (or provider) request body *before* any continuation delta was
+        /// applied. Used to record server continuation state.
+        logical_body: Option<Value>,
+        /// The CC session id (x-claude-code-session-id), used as key for continuation state.
+        session_id: Option<String>,
     }
 
     /// Enough of the rewritten upstream request to re-issue it on a retryable failure. The body is
     /// shared (`Arc`) so retaining it for retries costs one copy of the compressed body, not one
     /// per attempt.
+    ///
+    /// Note: `body` here is the *wire* form (may already be a delta after continuation apply).
+    /// Use `RerouteInfo.logical_body` when you need the full pre-delta version (e.g. on
+    /// continuation errors).
     #[derive(Clone)]
     struct RerouteReplay {
         url: String,
@@ -553,6 +566,43 @@ mod imp {
             get("x-codex-primary-reset-after-seconds"),
             body,
         )
+    }
+
+    fn is_continuation_error(body: &[u8]) -> bool {
+        let lower = String::from_utf8_lossy(body).to_lowercase();
+        lower.contains("previous_response_not_found")
+            || lower.contains("previous response not found")
+            || (lower.contains("continuation") && lower.contains("not found"))
+    }
+
+    /// Centralized recording for Codex continuation.
+    /// Only records when eligible (completed non-incomplete) and we have logical/session.
+    /// Uses take_codex_output_items() to get assistant outputs for the transcript.
+    fn record_codex_continuation(
+        ev: &ReduceEvent,
+        reducer: &mut crate::reroute::StreamReducer,
+        provider: crate::reroute::SubProvider,
+        logical_body: Option<&Value>,
+        session_id: Option<&str>,
+    ) {
+        if let ReduceEvent::Finish {
+            response_id: Some(rid),
+            continuation_eligible: true,
+            ..
+        } = ev
+        {
+            if provider == crate::reroute::SubProvider::Codex {
+                if let Some(logical) = logical_body {
+                    let items = reducer.take_codex_output_items();
+                    crate::reroute::continuation::record_continuation(
+                        session_id,
+                        logical,
+                        Some(rid.as_str()),
+                        &items,
+                    );
+                }
+            }
+        }
     }
 
     /// Build the client-facing message for a non-2xx subscription-backend response. Pulls the
@@ -1261,6 +1311,29 @@ mod imp {
                 }
             };
 
+            // Apply Codex continuation (previous_response_id + delta input) if possible.
+            // `logical_body` is the full pre-delta codex request (used for recording the
+            // transcript and for re-issuing on continuation errors). `sent_body` may be a
+            // delta version. This matches the proxy's handling (except transport specifics).
+            let mut sent_body = rewrite.body.clone();
+            let mut logical_body: Option<Value> = None;
+            if sub == crate::reroute::SubProvider::Codex {
+                if let Ok(mut bval) = serde_json::from_slice::<Value>(&rewrite.body) {
+                    logical_body = Some(bval.clone());
+                    let enabled =
+                        llmtrim_core::config::RuntimeConfig::get().sub_codex_previous_response_id;
+                    let cand = crate::reroute::continuation::continuation_candidate(
+                        session_id.as_deref(),
+                        &bval,
+                        enabled,
+                    );
+                    crate::reroute::continuation::apply_codex_continuation(&mut bval, &cand);
+                    if let Ok(serialized) = serde_json::to_vec(&bval) {
+                        sent_body = serialized;
+                    }
+                }
+            }
+
             // Record intent: provider stays Anthropic (we emit Anthropic SSE, which `Finalize`
             // measures); model is the resolved upstream model; `reroute` marks the response path.
             self.pending = Some(Pending {
@@ -1282,8 +1355,10 @@ mod imp {
                     replay: Some(RerouteReplay {
                         url: format!("https://{}{}", rewrite.host, rewrite.path),
                         headers: rewrite.headers.clone(),
-                        body: Arc::new(rewrite.body.clone()),
+                        body: Arc::new(sent_body.clone()),
                     }),
+                    logical_body,
+                    session_id: session_id.clone(),
                 }),
                 fallback: None,
             });
@@ -1318,7 +1393,7 @@ mod imp {
                     parts.headers.insert(name, val);
                 }
             }
-            Request::from_parts(parts, Body::from(rewrite.body)).into()
+            Request::from_parts(parts, Body::from(sent_body)).into()
         }
 
         /// Stream a rerouted provider response back to the client as Anthropic SSE: feed each
@@ -1356,7 +1431,26 @@ mod imp {
                         };
                         tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
                         attempt += 1;
-                        let Some((s, raw, ra)) = self.reissue_reroute(replay).await else {
+
+                        let body_to_send = if is_continuation_error(&cur_body) {
+                            crate::reroute::continuation::clear_continuation(
+                                info.session_id.as_deref(),
+                            );
+                            if let Some(lval) = &info.logical_body {
+                                serde_json::to_vec(lval)
+                                    .map(Arc::new)
+                                    .unwrap_or_else(|_| replay.body.clone())
+                            } else {
+                                replay.body.clone()
+                            }
+                        } else {
+                            replay.body.clone()
+                        };
+
+                        let Some((s, raw, ra)) = self
+                            .reissue_reroute(&replay.url, replay.headers.clone(), body_to_send)
+                            .await
+                        else {
                             break;
                         };
                         if (200..300).contains(&s) {
@@ -1414,6 +1508,13 @@ mod imp {
                             continue;
                         };
                         for ev in reducer.push(&chunk) {
+                            record_codex_continuation(
+                                &ev,
+                                &mut reducer,
+                                info.provider,
+                                info.logical_body.as_ref(),
+                                info.session_id.as_deref(),
+                            );
                             match &ev {
                                 ReduceEvent::Error { message } => {
                                     fatal.get_or_insert_with(|| message.clone());
@@ -1432,6 +1533,7 @@ mod imp {
             }
 
             if let Some(detail) = fatal {
+                crate::reroute::continuation::clear_continuation(info.session_id.as_deref());
                 let status = reroute_stream_error_status(&detail);
                 let message = format!(
                     "llmtrim: {} subscription backend: {detail}",
@@ -1469,6 +1571,10 @@ mod imp {
                 finalize: Finalize,
                 phase: Phase,
                 prelude: String,
+                // For continuation recording on terminal Finish during live stream
+                provider: crate::reroute::SubProvider,
+                logical_body: Option<Value>,
+                session_id: Option<String>,
             }
             let st = St {
                 inner,
@@ -1478,6 +1584,9 @@ mod imp {
                 finalize,
                 phase: Phase::Prelude,
                 prelude,
+                provider: info.provider,
+                logical_body: info.logical_body.clone(),
+                session_id: info.session_id.clone(),
             };
 
             let stream = hudsucker::futures::stream::unfold(st, |mut st| async move {
@@ -1502,6 +1611,13 @@ mod imp {
                         Phase::Flush => {
                             let mut out = String::new();
                             for ev in st.reducer.finish() {
+                                record_codex_continuation(
+                                    &ev,
+                                    &mut st.reducer,
+                                    st.provider,
+                                    st.logical_body.as_ref(),
+                                    st.session_id.as_deref(),
+                                );
                                 st.encoder.encode(&ev, &mut out);
                             }
                             st.encoder.finish_if_open(&mut out);
@@ -1524,6 +1640,13 @@ mod imp {
                                 };
                                 let mut out = String::new();
                                 for ev in st.reducer.push(&chunk) {
+                                    record_codex_continuation(
+                                        &ev,
+                                        &mut st.reducer,
+                                        st.provider,
+                                        st.logical_body.as_ref(),
+                                        st.session_id.as_deref(),
+                                    );
                                     st.encoder.encode(&ev, &mut out);
                                 }
                                 if out.is_empty() {
@@ -1577,11 +1700,13 @@ mod imp {
         /// round-trip or its task failed (the caller stops retrying and surfaces the last error).
         async fn reissue_reroute(
             &self,
-            replay: &RerouteReplay,
+            url: &str,
+            headers: Vec<(String, String)>,
+            body: Arc<Vec<u8>>,
         ) -> Option<(u16, Vec<u8>, Option<u64>)> {
-            let url = replay.url.clone();
-            let headers = replay.headers.clone();
-            let body = replay.body.clone();
+            let url = url.to_string();
+            let headers = headers;
+            let body = body;
             let proxy = self.upstream_proxy.clone();
             // `forward_post` exposes no response headers, so a retried attempt's reset hint comes
             // from the body (`resets_in_seconds`) — enough for the Codex/Kimi usage-limit shape.
@@ -1615,12 +1740,27 @@ mod imp {
             let mut out = String::new();
             let mut reducer = crate::reroute::StreamReducer::new(info.provider, &info.model);
             for ev in reducer.push(&raw) {
+                record_codex_continuation(
+                    &ev,
+                    &mut reducer,
+                    info.provider,
+                    info.logical_body.as_ref(),
+                    info.session_id.as_deref(),
+                );
                 enc.encode(&ev, &mut out);
             }
             for ev in reducer.finish() {
+                record_codex_continuation(
+                    &ev,
+                    &mut reducer,
+                    info.provider,
+                    info.logical_body.as_ref(),
+                    info.session_id.as_deref(),
+                );
                 enc.encode(&ev, &mut out);
             }
             enc.finish_if_open(&mut out);
+
             let acc = Arc::new(Mutex::new(out.clone().into_bytes()));
             let _finalize = Finalize {
                 acc,
@@ -1695,6 +1835,12 @@ mod imp {
                 }
             };
 
+            let logical_body: Option<Value> = if provider == crate::reroute::SubProvider::Codex {
+                serde_json::from_slice(&rewrite.body).ok()
+            } else {
+                None
+            };
+
             let model = rewrite.model.clone();
             // Record this row against the resolved provider model (marks it a reroute).
             pending.model = Some(model.clone());
@@ -1702,6 +1848,8 @@ mod imp {
                 provider,
                 model: model.clone(),
                 replay: None,
+                logical_body: logical_body.clone(),
+                session_id: fb.session_id.clone(),
             });
 
             let url = format!("https://{}{}", rewrite.host, rewrite.path);
@@ -1751,9 +1899,23 @@ mod imp {
             } else {
                 let mut reducer = crate::reroute::StreamReducer::new(provider, &model);
                 for ev in reducer.push(&raw) {
+                    record_codex_continuation(
+                        &ev,
+                        &mut reducer,
+                        provider,
+                        logical_body.as_ref(),
+                        fb.session_id.as_deref(),
+                    );
                     enc.encode(&ev, &mut out);
                 }
                 for ev in reducer.finish() {
+                    record_codex_continuation(
+                        &ev,
+                        &mut reducer,
+                        provider,
+                        logical_body.as_ref(),
+                        fb.session_id.as_deref(),
+                    );
                     enc.encode(&ev, &mut out);
                 }
                 enc.finish_if_open(&mut out);
@@ -2287,7 +2449,7 @@ mod imp {
             if data.is_empty() || data == "[DONE]" {
                 continue;
             }
-            if let Ok(v) = serde_json::from_str::<Value>(data)
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data)
                 && let Some(n) = from_value(&v)
             {
                 best = Some(best.map_or(n, |b| b.max(n)));
@@ -2333,7 +2495,7 @@ mod imp {
             if data.is_empty() || data == "[DONE]" {
                 continue;
             }
-            if let Ok(v) = serde_json::from_str::<Value>(data)
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data)
                 && let Some(n) = from_value(&v)
             {
                 best = Some(best.map_or(n, |b| b.max(n)));
@@ -2412,7 +2574,7 @@ mod imp {
             if data.is_empty() || data == "[DONE]" {
                 continue;
             }
-            if let Ok(v) = serde_json::from_str::<Value>(data) {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data) {
                 let (f, w) = from_value(&v);
                 if let Some(n) = f {
                     fresh = Some(fresh.map_or(n, |b| b.max(n)));

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -822,14 +822,23 @@ mod tests {
     fn post_compact_reset_clears_cold_even_when_ledger_stale() {
         let mut c = cc(0);
         c.cache_pct = None;
-        assert!(!effective_cache_cold(&c, true), "empty context after compact is not cold");
+        assert!(
+            !effective_cache_cold(&c, true),
+            "empty context after compact is not cold"
+        );
         let mut l = led(Health::Healthy);
         l.cache_cold = effective_cache_cold(&c, true);
         let out = render_line(&c, &l, 0, false);
         assert!(!out.contains("cold"), "no cold nudge after compact: {out}");
         let gauge = context_segment(c.ctx_tokens, 200_000, l.cache_cold, true);
-        assert!(gauge.contains(DIM), "gauge dim (not red) on fresh post-compact context: {gauge}");
-        assert!(!gauge.contains(RED), "gauge not red on fresh post-compact context: {gauge}");
+        assert!(
+            gauge.contains(DIM),
+            "gauge dim (not red) on fresh post-compact context: {gauge}"
+        );
+        assert!(
+            !gauge.contains(RED),
+            "gauge not red on fresh post-compact context: {gauge}"
+        );
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -822,23 +822,14 @@ mod tests {
     fn post_compact_reset_clears_cold_even_when_ledger_stale() {
         let mut c = cc(0);
         c.cache_pct = None;
-        assert!(
-            !effective_cache_cold(&c, true),
-            "empty context after compact is not cold"
-        );
+        assert!(!effective_cache_cold(&c, true), "empty context after compact is not cold");
         let mut l = led(Health::Healthy);
         l.cache_cold = effective_cache_cold(&c, true);
         let out = render_line(&c, &l, 0, false);
         assert!(!out.contains("cold"), "no cold nudge after compact: {out}");
         let gauge = context_segment(c.ctx_tokens, 200_000, l.cache_cold, true);
-        assert!(
-            gauge.contains(DIM),
-            "gauge dim (not red) on fresh post-compact context: {gauge}"
-        );
-        assert!(
-            !gauge.contains(RED),
-            "gauge not red on fresh post-compact context: {gauge}"
-        );
+        assert!(gauge.contains(DIM), "gauge dim (not red) on fresh post-compact context: {gauge}");
+        assert!(!gauge.contains(RED), "gauge not red on fresh post-compact context: {gauge}");
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -7,7 +7,7 @@
 //! width-adaptive line:
 //!
 //! ```text
-//! ◆ Opus→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
+//! ◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
 //! ```
 //!
 //! The three left segments (model→backend, context, ✂ trim) are core and never
@@ -17,6 +17,9 @@
 //! Claude's — green below 40%, orange 40–65%, red above; and red whenever the prompt cache has
 //! gone cold, where the cache segment becomes `♻ cold · /compact`. Segments whose data is
 //! absent — no reroute, an API-key user with no rate limits — simply don't render.
+//!
+//! Under `sub` the arrow shows the concrete model actually serving the turn (e.g. `→gpt-5.6-terra`)
+//! for Codex reroutes; Kimi shows the provider shortname (`→kimi`) since all tiers collapse.
 //!
 //! `install` wires it into `~/.claude/settings.json`; rendering itself never touches the
 //! network or API tokens.
@@ -171,6 +174,11 @@ struct Led {
     /// active — looked up from the model registry, since Claude Code reports its own Claude
     /// window on the wire, not the backend's. `None` when not rerouted (use the blob's window).
     reroute_window: Option<i64>,
+    /// The concrete upstream model id resolved for a `sub` reroute (e.g. "gpt-5.6-terra" for a
+    /// Codex Opus tier). When present (and not Kimi's internal id) we render it after the arrow
+    /// so the status line shows the *real* model serving the turn rather than only the provider
+    /// shortname.
+    resolved_model: Option<String>,
     /// The prompt cache has gone cold: the session has been idle past the TTL, so the next turn
     /// pays a cold write. Renders the cache segment red with a `/compact` nudge.
     cache_cold: bool,
@@ -216,6 +224,9 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
     let reroute_window = reroute
         .as_deref()
         .and_then(|p| reroute_real_window(p, &cc.model_id, &cfg.sub_tiers));
+    let resolved_model = reroute
+        .as_deref()
+        .and_then(|p| reroute_resolved_model(p, &cc.model_id, &cfg.sub_tiers));
     let health = proxy_health();
 
     // One session-row read serves both trim and cache-cold. Match on `cc_session_id` — the real
@@ -233,13 +244,15 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
     };
     let session_savings = row.as_ref().map(|r| (r.input_before, r.input_after));
     let trim_pct = trim_for(cc.session_id.as_deref(), session_savings, lifetime);
-    let cache_cold = row.as_ref().is_some_and(|r| cache_cold(&r.last_ts));
+    let ledger_cold = row.as_ref().is_some_and(|r| cache_cold(&r.last_ts));
+    let cache_cold = effective_cache_cold(cc, ledger_cold);
 
     Led {
         health,
         trim_pct,
         reroute,
         reroute_window,
+        resolved_model,
         cache_cold,
     }
 }
@@ -332,6 +345,33 @@ fn reroute_real_window(
     None
 }
 
+/// Parallel to [`reroute_real_window`]: returns the concrete upstream model id (e.g.
+/// "gpt-5.6-terra") chosen by tier mapping for the status line. Kimi always resolves to its
+/// internal id, which callers suppress in favour of the short provider name.
+#[cfg(feature = "intercept")]
+fn reroute_resolved_model(
+    provider: &str,
+    incoming_model_id: &str,
+    tiers: &std::collections::BTreeMap<String, String>,
+) -> Option<String> {
+    use crate::reroute::SubProvider;
+    let sp = match provider {
+        "codex" => SubProvider::Codex,
+        "kimi" => SubProvider::Kimi,
+        _ => return None,
+    };
+    Some(crate::reroute::resolve_model(sp, incoming_model_id, tiers))
+}
+
+#[cfg(not(feature = "intercept"))]
+fn reroute_resolved_model(
+    _provider: &str,
+    _incoming_model_id: &str,
+    _tiers: &std::collections::BTreeMap<String, String>,
+) -> Option<String> {
+    None
+}
+
 /// Whether the prompt cache has gone cold: `last_ts` (rfc3339, the most recent intercepted
 /// request) is older than the TTL. An unparseable timestamp is treated as not-cold (don't warn
 /// on a data glitch).
@@ -339,6 +379,19 @@ fn cache_cold(last_ts: &str) -> bool {
     chrono::DateTime::parse_from_rfc3339(last_ts)
         .map(|t| chrono::Utc::now().signed_duration_since(t).num_seconds() >= CACHE_TTL_SECS)
         .unwrap_or(false)
+}
+
+/// Fold ledger idle time with Claude Code's live context. `/compact` and other internal turns
+/// can refresh the prompt cache without updating the interceptor's `last_ts`, so a stale ledger
+/// alone would keep the gauge red after the user already compacted.
+fn effective_cache_cold(cc: &CcInput, ledger_cold: bool) -> bool {
+    if !ledger_cold {
+        return false;
+    }
+    // Post-compact reset: empty window, no `current_usage` yet. Do not also key off
+    // `cache_creation_tokens` from the last response — that field is stale once the TTL
+    // expires and would hide a legitimate cold warning on an idle session.
+    cc.ctx_tokens != 0 || cc.cache_pct.is_some()
 }
 
 // ── rendering ─────────────────────────────────────────────────────────────────────
@@ -357,7 +410,9 @@ fn quota_color(pct: f64) -> &'static str {
     }
 }
 
-/// `◆ Opus→codex` — health-brand glyph, model, reroute arrow. The arrow is suppressed when the
+/// `◆ Opus→gpt-5.6-terra` — health-brand glyph, model (Claude tier name), reroute target.
+/// The target is the resolved upstream model for Codex reroutes (so you see the real model
+/// serving the turn) or the provider shortname for Kimi. The arrow is suppressed when the
 /// proxy isn't healthy (traffic isn't being intercepted, so it isn't actually rerouting).
 ///
 /// Effort is intentionally not shown: Claude Code's `effort.level` field doesn't track the
@@ -374,7 +429,13 @@ fn model_segment(cc: &CcInput, led: &Led, color: bool) -> String {
             "kimi" => VIOLET,
             _ => CYAN,
         };
-        s.push_str(&paint(color, code, &format!("→{p}")));
+        let tail = led
+            .resolved_model
+            .as_ref()
+            .filter(|m| *m != "kimi-for-coding")
+            .cloned()
+            .unwrap_or_else(|| p.clone());
+        s.push_str(&paint(color, code, &format!("→{tail}")));
     }
     s
 }
@@ -639,6 +700,7 @@ mod tests {
             trim_pct: Some(6.8),
             reroute: Some("codex".to_string()),
             reroute_window: None,
+            resolved_model: Some("gpt-5.6-terra".to_string()),
             cache_cold: false,
         }
     }
@@ -663,7 +725,7 @@ mod tests {
         let out = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
         assert_eq!(
             out,
-            "◆ Opus→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached"
+            "◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached"
         );
     }
 
@@ -714,6 +776,7 @@ mod tests {
     fn stopped_omits_trim_and_arrow_without_warning() {
         let mut l = led(Health::Stopped);
         l.reroute = None;
+        l.resolved_model = None;
         let out = render_line(&cc(48_000), &l, 0, false);
         assert!(!out.contains('✂'), "no trim when off: {out}");
         assert!(!out.contains('⚠'), "clean off is not an error: {out}");
@@ -724,7 +787,7 @@ mod tests {
     fn narrow_terminal_sheds_extras_right_to_left() {
         // Wide enough for core + quota, but not the cache extra.
         let full = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
-        let width = ui::visible_width("◆ Opus→codex   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%");
+        let width = ui::visible_width("◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%");
         let out = render_line(&cc(142_000), &led(Health::Healthy), width, false);
         assert!(out.ends_with("7d·12%"), "keeps quota, sheds cache: {out}");
         assert!(!out.contains("cached"), "cache dropped first: {out}");
@@ -740,6 +803,7 @@ mod tests {
         c.cache_pct = None; // before first API response
         let mut l = led(Health::Healthy);
         l.reroute = None; // no reroute
+        l.resolved_model = None;
         let out = render_line(&c, &l, 0, false);
         assert_eq!(out, "◆ Opus   ▓░░░░░░░ 48k   ✂ 6.8%");
     }
@@ -751,6 +815,42 @@ mod tests {
         let out = render_line(&cc(48_000), &l, 0, false);
         assert!(out.contains("♻ cold · /compact"), "cold hint shown: {out}");
         assert!(!out.contains("cached"), "no stale % when cold: {out}");
+    }
+
+    #[test]
+    fn post_compact_reset_clears_cold_even_when_ledger_stale() {
+        let mut c = cc(0);
+        c.cache_pct = None;
+        assert!(
+            !effective_cache_cold(&c, true),
+            "empty context after compact is not cold"
+        );
+        let mut l = led(Health::Healthy);
+        l.cache_cold = effective_cache_cold(&c, true);
+        let out = render_line(&c, &l, 0, false);
+        assert!(
+            !out.contains("cold"),
+            "no cold nudge after compact: {out}"
+        );
+        let gauge = context_segment(c.ctx_tokens, 200_000, l.cache_cold, true);
+        assert!(
+            gauge.contains(DIM),
+            "gauge dim (not red) on fresh post-compact context: {gauge}"
+        );
+        assert!(
+            !gauge.contains(RED),
+            "gauge not red on fresh post-compact context: {gauge}"
+        );
+    }
+
+    #[test]
+    fn idle_cold_stays_when_context_still_populated() {
+        let mut c = cc(142_000);
+        c.cache_pct = Some(5.0);
+        assert!(
+            effective_cache_cold(&c, true),
+            "populated context with stale ledger still shows cold"
+        );
     }
 
     #[test]
@@ -823,6 +923,7 @@ mod tests {
     fn kimi_reroute_when_healthy() {
         let mut l = led(Health::Healthy);
         l.reroute = Some("kimi".to_string());
+        l.resolved_model = None;
         let out = render_line(&cc(72_000), &l, 0, true);
         assert!(out.contains("→kimi"), "kimi arrow present: {out}");
     }

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -787,7 +787,8 @@ mod tests {
     fn narrow_terminal_sheds_extras_right_to_left() {
         // Wide enough for core + quota, but not the cache extra.
         let full = render_line(&cc(142_000), &led(Health::Healthy), 0, false);
-        let width = ui::visible_width("◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%");
+        let width =
+            ui::visible_width("◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%");
         let out = render_line(&cc(142_000), &led(Health::Healthy), width, false);
         assert!(out.ends_with("7d·12%"), "keeps quota, sheds cache: {out}");
         assert!(!out.contains("cached"), "cache dropped first: {out}");
@@ -828,10 +829,7 @@ mod tests {
         let mut l = led(Health::Healthy);
         l.cache_cold = effective_cache_cold(&c, true);
         let out = render_line(&c, &l, 0, false);
-        assert!(
-            !out.contains("cold"),
-            "no cold nudge after compact: {out}"
-        );
+        assert!(!out.contains("cold"), "no cold nudge after compact: {out}");
         let gauge = context_segment(c.ctx_tokens, 200_000, l.cache_cold, true);
         assert!(
             gauge.contains(DIM),

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -822,6 +822,12 @@ pub struct RuntimeConfig {
     /// reroutes every matching turn. Env `LLMTRIM_SUB_MODE` (`always`/`on_error`) or the file key
     /// `sub.mode`.
     pub sub_on_error: bool,
+    /// Whether to enable server-side continuation for Codex reroutes (`previous_response_id` +
+    /// delta-only `input` on follow-up turns). This keeps the upstream conversation state warm and
+    /// improves real prompt-cache / token reuse (the mechanism behind good `♻ % cached` numbers).
+    /// Env `LLMTRIM_CODEX_PREVIOUS_RESPONSE_ID` (1/true/yes) or `[sub.codex] previous_response_id = true`.
+    /// Defaults to `true`.
+    pub sub_codex_previous_response_id: bool,
 }
 
 impl RuntimeConfig {
@@ -907,6 +913,7 @@ impl RuntimeConfig {
             sub_tiers: resolve_sub_tiers(&env, file),
             sub_on_error: resolve_sub_on_error(&env, file),
             sub_effort: resolve_sub_effort(&env, file),
+            sub_codex_previous_response_id: resolve_sub_codex_continuation(&env, file),
         }
     }
 }
@@ -995,6 +1002,43 @@ fn resolve_sub_on_error(env: &impl Fn(&str) -> Option<String>, file: Option<&tom
         .and_then(toml::Value::as_str)
         .map(is_on_error)
         .unwrap_or(false)
+}
+
+/// Codex continuation (previous_response_id deltas) enabled? Env `LLMTRIM_CODEX_PREVIOUS_RESPONSE_ID`
+/// (truthy) wins, else `[sub.codex] previous_response_id = true` (or `continuation`). Defaults to
+/// `true` so sub-codex users get the cache/state benefit by default.
+fn resolve_sub_codex_continuation(
+    env: &impl Fn(&str) -> Option<String>,
+    file: Option<&toml::Value>,
+) -> bool {
+    let is_true = |s: &str| {
+        matches!(
+            s.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    };
+    if let Some(v) = env("LLMTRIM_CODEX_PREVIOUS_RESPONSE_ID").filter(|s| !s.is_empty()) {
+        return is_true(&v);
+    }
+    if let Some(sub) = file.and_then(|v| v.get("sub")) {
+        if let Some(c) = sub.get("codex").or_else(|| sub.get("chatgpt")) {
+            if let Some(b) = c
+                .get("previous_response_id")
+                .or_else(|| c.get("continuation"))
+                .and_then(toml::Value::as_bool)
+            {
+                return b;
+            }
+            if let Some(s) = c
+                .get("previous_response_id")
+                .or_else(|| c.get("continuation"))
+                .and_then(toml::Value::as_str)
+            {
+                return is_true(s);
+            }
+        }
+    }
+    true
 }
 
 /// Persist the breakdown-TUI `theme` choice to the config file's top-level `theme` key,


### PR DESCRIPTION
## Summary
- Improve server-side continuation (`previous_response_id` + delta `input`) for `llmtrim sub codex`.
- Keeps the backend conversation state warm for better `cached_tokens` reuse and higher `♻ % cached` in status line.
- llmtrim's compression still runs (as Anthropic) before translating to the target format.

## Changes
- Add `continuation_eligible` flag; only record on valid completed terminals.
- Centralize recording to prevent duplication and races with item accumulation.
- Support continuation in on-error fallback path as well.
- Add count-based state limit (`MAX_STATES`) and align other small details for consistency.
- Clean up docs and comments around bodies and paths.
- Add tests for eligibility.

## Test plan
- `cargo test -p llmtrim --features intercept`
- Manual warm sessions with Claude Code + sub codex.
- CI will validate.

Auto-merge is enabled.