### PR TITLE
fix(ci): restore release workflow checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,7 +500,7 @@ jobs:
       - uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           package: llmtrim-core, llmtrim
-          args: "--release-type major"
+          release-type: major
 
   # Unused-dependency check. Dead deps inflate the binary and slow the build/startup that
   # this CLI optimizes for. cargo-machete is fast (manifest scan, no compile).

--- a/crates/llmtrim-cli/src/reroute/sse.rs
+++ b/crates/llmtrim-cli/src/reroute/sse.rs
@@ -313,6 +313,8 @@ mod tests {
                 ReduceEvent::Finish {
                     stop_reason: StopReason::EndTurn,
                     usage: Usage::default(),
+                    response_id: None,
+                    continuation_eligible: false,
                 },
             ],
         );


### PR DESCRIPTION
## Summary
- complete the `ReduceEvent::Finish` test fixture with continuation metadata
- use the supported `release-type` input for cargo-semver-checks

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `cargo test --doc`

Fixes the failures reported by [CI run 29177423482](https://github.com/fkiene/llmtrim/actions/runs/29177423482). 