### PR TITLE
feat(sub): add fallback chains and fix Claude Codex reroutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **GPT-5.6 Codex reroutes.** Claude model requests keep the standard Responses shape and use the
+  official Codex originator and user-agent identity required by the backend.
+
+- **Subscription reroute: Claude Code thinking no longer 502s on Codex.** The Codex
+  reducer streamed `thinking_delta` summaries but never forwarded the upstream
+  `encrypted_content` as Anthropic `signature_delta`, so Claude Code rejected the SSE
+  stream (502 / dropped connection) and follow-up turns could not replay thinking blocks.
+  Signatures now map both ways (`encrypted_content` ↔ `signature`), text waits for a late
+  signature when needed, and adaptive `thinking` without an explicit `output_config.effort`
+  still enables Codex reasoning.
+
 ## [0.9.4] - 2026-07-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -440,10 +440,10 @@ automatically. `llmtrim sub setup codex` opens an interactive editor to change w
 each Claude tier (opus / sonnet / haiku / fable) maps to; `llmtrim sub status` shows the
 current mapping; `llmtrim sub off` disables rerouting and sends traffic back to Anthropic.
 
-By default a set provider reroutes every turn. To use the subscription only as a backup, switch
-to on-error mode: `llmtrim sub mode on-error` forwards to Anthropic as usual and falls back to the
-provider only when Anthropic hits a usage limit or overload (402/403/429/529). `llmtrim sub mode
-always` restores the default.
+By default a set provider reroutes every turn. To use subscriptions only as a backup, switch to
+fallback mode: `llmtrim sub mode fallback` forwards to Anthropic as usual and tries the configured
+provider chain when Anthropic hits a quota, overload, transient server error, or transport failure.
+Set the order with `llmtrim sub chain codex,kimi`; `llmtrim sub mode always` restores the default.
 
 The mapping is not limited to the four Claude tiers. `llmtrim sub map codex <from> <to>` remaps
 one model, where `from` is a tier name or an exact incoming model id, so any Anthropic-speaking
@@ -454,7 +454,8 @@ codex` lists the candidate provider models. `llmtrim sub status --json` and `llm
 | env var | config key | meaning |
 | --- | --- | --- |
 | `LLMTRIM_SUB` | `sub` | active reroute provider (`codex`, `kimi`, or `off`) |
-| `LLMTRIM_SUB_MODE` | `sub.mode` | `always` (default) or `on-error` |
+| `LLMTRIM_SUB_MODE` | `sub.mode` | `always` (default) or `fallback` |
+| `LLMTRIM_SUB_CHAIN` | `sub.chain` | ordered fallback providers, e.g. `codex,kimi` |
 
 Codex reasoning is adaptive by default; `llmtrim sub effort <none|low|medium|high|xhigh>` (env
 `LLMTRIM_CODEX_EFFORT`) pins one effort on every rerouted turn instead.

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -422,12 +422,20 @@ enum SubCmd {
         #[arg(long)]
         no_restart: bool,
     },
-    /// Set the reroute mode: `always` (reroute every turn) or `on-error` (only when Anthropic
-    /// hits a usage/overload limit).
+    /// Set the reroute mode: `always` (reroute every turn) or `fallback` (use the ordered
+    /// subscription chain only when Anthropic cannot serve the turn).
     Mode {
-        /// `always` or `on-error`.
+        /// `always` or `fallback`.
         mode: String,
         /// Don't restart a running interceptor to apply the change (just print the hint).
+        #[arg(long)]
+        no_restart: bool,
+    },
+    /// Set the ordered providers used by `sub mode fallback` (for example `codex,kimi`).
+    Chain {
+        /// Comma-separated providers in try order: codex,kimi.
+        providers: String,
+        /// Don't restart a running interceptor to apply the change.
         #[arg(long)]
         no_restart: bool,
     },
@@ -829,16 +837,39 @@ fn run_sub(action: SubCmd) -> Result<()> {
             Ok(())
         }
         SubCmd::Mode { mode, no_restart } => {
-            let on_error = match mode.trim().to_ascii_lowercase().as_str() {
-                "on-error" | "on_error" | "onerror" | "error" => true,
-                "always" | "all" => false,
-                other => anyhow::bail!("unknown mode '{other}' (always|on-error)"),
+            let fallback = match mode.trim().to_ascii_lowercase().as_str() {
+                "fallback" => true,
+                "always" => false,
+                other => anyhow::bail!("unknown mode '{other}' (always|fallback)"),
             };
-            llmtrim_core::config::write_sub_mode(on_error)?;
+            llmtrim_core::config::write_sub_mode(fallback)?;
             println!(
                 "Reroute mode: {}.",
-                if on_error { "on-error" } else { "always" }
+                if fallback { "fallback" } else { "always" }
             );
+            apply_sub_change(no_restart);
+            Ok(())
+        }
+        SubCmd::Chain {
+            providers,
+            no_restart,
+        } => {
+            let mut chain = Vec::new();
+            for raw in providers.split(',') {
+                let raw = raw.trim();
+                if raw.is_empty() {
+                    continue;
+                }
+                let p = parse(raw)?;
+                if !chain.contains(&p.as_str().to_string()) {
+                    chain.push(p.as_str().to_string());
+                }
+            }
+            if chain.is_empty() {
+                anyhow::bail!("fallback chain is empty (expected codex,kimi)");
+            }
+            llmtrim_core::config::write_sub_chain(&chain)?;
+            println!("Fallback chain: {}.", chain.join(" -> "));
             apply_sub_change(no_restart);
             Ok(())
         }
@@ -930,7 +961,8 @@ fn run_sub(action: SubCmd) -> Result<()> {
                 }
                 let out = serde_json::json!({
                     "provider": active.map(|p| p.as_str()),
-                    "mode": if cfg.sub_on_error { "on_error" } else { "always" },
+                    "mode": if cfg.sub_fallback { "fallback" } else { "always" },
+                    "chain": cfg.sub_chain,
                     "effort": cfg.sub_effort,
                     "mapping": mapping,
                     "auth": {
@@ -947,12 +979,22 @@ fn run_sub(action: SubCmd) -> Result<()> {
                     println!(
                         "Reroute: {} ({})",
                         p.as_str(),
-                        if cfg.sub_on_error {
-                            "on-error"
+                        if cfg.sub_fallback {
+                            "fallback"
                         } else {
                             "always"
                         }
                     );
+                    if cfg.sub_fallback {
+                        println!(
+                            "  chain   -> {}",
+                            if cfg.sub_chain.is_empty() {
+                                p.as_str().to_string()
+                            } else {
+                                cfg.sub_chain.join(" -> ")
+                            }
+                        );
+                    }
                     if p == SubProvider::Codex {
                         println!(
                             "  effort  -> {}",

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -320,8 +320,8 @@ fn render_header(color: bool, d: &DaemonView) -> String {
         if let Some(p) = rc.sub.as_deref() {
             meta.push_str(&format!(
                 " · reroute {p} ({})",
-                if rc.sub_on_error {
-                    "on-error"
+                if rc.sub_fallback {
+                    "fallback"
                 } else {
                     "always"
                 }
@@ -816,7 +816,8 @@ pub fn export_json(
         match cfg.sub.as_deref() {
             Some(p) => json!({
                 "provider": p,
-                "mode": if cfg.sub_on_error { "on_error" } else { "always" },
+                "mode": if cfg.sub_fallback { "fallback" } else { "always" },
+                "chain": cfg.sub_chain,
             }),
             None => serde_json::Value::Null,
         }

--- a/crates/llmtrim-cli/src/reroute/codex.rs
+++ b/crates/llmtrim-cli/src/reroute/codex.rs
@@ -15,8 +15,11 @@ use crate::reroute::sse::{ReduceEvent, SseLineParser, StopReason, Usage};
 
 pub const HOST: &str = "chatgpt.com";
 pub const PATH: &str = "/backend-api/codex/responses";
+/// The GPT-5.6 models are gated on the Codex client identity: the backend answers 404 unless
+/// `originator` is `codex_cli_rs` *and* the `user-agent` starts with `codex_cli_rs`. It only
+/// checks that prefix, so llmtrim keeps its own version and name in the rest of the string
+/// instead of impersonating the official CLI byte for byte.
 const OFFICIAL_CODEX_ORIGINATOR: &str = "codex_cli_rs";
-const OFFICIAL_CODEX_USER_AGENT: &str = "codex_cli_rs";
 
 /// The Claude Code hosted web-search tool. Translated to the Codex `web_search` tool (not a
 /// function tool) so the model can actually search; see [`web_search_tool`].
@@ -488,7 +491,7 @@ pub fn request_headers_with_mode(
         (
             "user-agent".to_string(),
             if official_client {
-                OFFICIAL_CODEX_USER_AGENT.to_string()
+                format!("codex_cli_rs/{} (llmtrim)", env!("CARGO_PKG_VERSION"))
             } else {
                 format!("llmtrim/{}", env!("CARGO_PKG_VERSION"))
             },
@@ -541,9 +544,9 @@ pub struct Reducer {
     /// Text opened on the wire before the reasoning signature arrived; held until
     /// [`Self::close_thinking`] can emit `signature_delta`.
     defer_text_open: bool,
-    /// Whether this turn already emitted `ThinkingSignatureDelta` (Codex repeats the same
-    /// `encrypted_content` on `added` and `done`).
-    reasoning_signature_emitted: bool,
+    /// Last `encrypted_content` emitted as a signature, so the repeated `added`/`done` copies of
+    /// one reasoning item dedupe while a later item still gets its own signature.
+    last_signature: Option<String>,
     /// Text deltas that arrived while thinking was still awaiting its signature.
     deferred_text_deltas: Vec<String>,
     // Accumulation for continuation transcript (assistant outputs in codex input item shape)
@@ -565,7 +568,7 @@ impl Reducer {
             terminal_seen: false,
             thinking_encrypted: None,
             defer_text_open: false,
-            reasoning_signature_emitted: false,
+            last_signature: None,
             deferred_text_deltas: Vec::new(),
             current_assistant_text: String::new(),
             output_items: Vec::new(),
@@ -579,47 +582,56 @@ impl Reducer {
             return;
         }
         if let Some(sig) = self.thinking_encrypted.take()
-            && !self.reasoning_signature_emitted
+            && self.last_signature.as_deref() != Some(sig.as_str())
         {
-            out.push(ReduceEvent::ThinkingSignatureDelta(sig));
-            self.reasoning_signature_emitted = true;
+            out.push(ReduceEvent::ThinkingSignatureDelta(sig.clone()));
+            self.last_signature = Some(sig);
         }
         out.push(ReduceEvent::ThinkingStop);
         self.open = Open::None;
+        self.flush_deferred_text(out);
+    }
+
+    /// Replay text that arrived while thinking was still waiting for its signature.
+    fn flush_deferred_text(&mut self, out: &mut Vec<ReduceEvent>) {
+        if !self.defer_text_open && self.deferred_text_deltas.is_empty() {
+            return;
+        }
+        self.defer_text_open = false;
+        out.push(ReduceEvent::TextStart);
+        self.open = Open::Text;
+        for delta in std::mem::take(&mut self.deferred_text_deltas) {
+            self.current_assistant_text.push_str(&delta);
+            out.push(ReduceEvent::TextDelta(delta));
+        }
     }
 
     /// Record encrypted reasoning content from a Responses `reasoning` item. Opens a thinking
     /// block when the upstream omitted summary text (signature-only / `display: omitted` shape).
-    fn note_reasoning_encrypted(&mut self, out: &mut Vec<ReduceEvent>, encrypted: String) {
-        if self.reasoning_signature_emitted {
+    ///
+    /// Codex repeats the same `encrypted_content` on the item's `added` and `done` events; a turn
+    /// with tool calls emits several distinct reasoning items, each needing its own signature.
+    fn note_reasoning_encrypted(
+        &mut self,
+        out: &mut Vec<ReduceEvent>,
+        encrypted: String,
+        done: bool,
+    ) {
+        if self.last_signature.as_deref() == Some(encrypted.as_str()) {
             return;
         }
         self.thinking_encrypted = Some(encrypted);
-        if self.open == Open::Thinking {
-            self.finish_thinking_if_ready(out);
+        // On `added` the summary deltas are still to come: stash the signature and let the
+        // summary open the block.
+        if !done {
             return;
         }
-        self.close_open(out);
-        out.push(ReduceEvent::ThinkingStart);
-        self.open = Open::Thinking;
-        self.finish_thinking_if_ready(out);
-    }
-
-    /// Close the thinking block once `encrypted_content` is known; open deferred text if needed.
-    fn finish_thinking_if_ready(&mut self, out: &mut Vec<ReduceEvent>) {
-        if self.open != Open::Thinking || self.thinking_encrypted.is_none() {
-            return;
+        if self.open != Open::Thinking {
+            self.close_open(out);
+            out.push(ReduceEvent::ThinkingStart);
+            self.open = Open::Thinking;
         }
         self.close_thinking(out);
-        if self.defer_text_open || !self.deferred_text_deltas.is_empty() {
-            out.push(ReduceEvent::TextStart);
-            self.open = Open::Text;
-            self.defer_text_open = false;
-            for delta in self.deferred_text_deltas.drain(..) {
-                self.current_assistant_text.push_str(&delta);
-                out.push(ReduceEvent::TextDelta(delta));
-            }
-        }
     }
 
     /// Close the open thinking block when its signature is available; otherwise defer the caller's
@@ -695,19 +707,25 @@ impl Reducer {
 
     /// Close whatever block is open, emitting its `*Stop`.
     fn close_open(&mut self, out: &mut Vec<ReduceEvent>) {
-        match self.open {
-            Open::Thinking => self.close_thinking(out),
-            Open::Text => {
-                self.flush_current_text();
-                out.push(ReduceEvent::TextStop);
+        // `close_thinking` can reopen a text block with the deltas it deferred, so drain until
+        // nothing is open.
+        loop {
+            match self.open {
+                // Leaves `open` at `None` or `Text` (deferred text replayed).
+                Open::Thinking => self.close_thinking(out),
+                Open::Text => {
+                    self.flush_current_text();
+                    out.push(ReduceEvent::TextStop);
+                    self.open = Open::None;
+                }
+                Open::Tool => {
+                    self.flush_tool(out);
+                    out.push(ReduceEvent::ToolStop);
+                    self.open = Open::None;
+                }
+                Open::None => return,
             }
-            Open::Tool => {
-                self.flush_tool(out);
-                out.push(ReduceEvent::ToolStop);
-            }
-            Open::None => {}
         }
-        self.open = Open::None;
     }
 
     fn flush_current_text(&mut self) {
@@ -729,7 +747,7 @@ impl Reducer {
                 match item.get("type").and_then(Value::as_str) {
                     Some("reasoning") => {
                         if let Some(enc) = reasoning_encrypted_content(&item) {
-                            self.note_reasoning_encrypted(out, enc);
+                            self.note_reasoning_encrypted(out, enc, false);
                         }
                     }
                     Some("message") => {
@@ -831,7 +849,7 @@ impl Reducer {
                 if let Some(item) = v.get("item")
                     && let Some(enc) = reasoning_encrypted_content(item)
                 {
-                    self.note_reasoning_encrypted(out, enc);
+                    self.note_reasoning_encrypted(out, enc, true);
                     return;
                 }
                 self.close_open(out);
@@ -1013,7 +1031,12 @@ mod tests {
                 .map(|(_, v)| v.as_str())
         };
         assert_eq!(get("originator"), Some("codex_cli_rs"));
-        assert_eq!(get("user-agent"), Some("codex_cli_rs"));
+        let ua = get("user-agent").expect("user-agent");
+        assert!(
+            ua.starts_with("codex_cli_rs/"),
+            "gate is on the prefix: {ua}"
+        );
+        assert!(ua.contains("llmtrim"), "llmtrim stays identifiable: {ua}");
         assert!(get("x-openai-internal-codex-responses-lite").is_none());
     }
 
@@ -1472,6 +1495,52 @@ mod tests {
                 ReduceEvent::TextStart,
                 ReduceEvent::TextDelta("ok".into()),
             ]
+        );
+    }
+
+    #[test]
+    fn each_reasoning_item_gets_its_own_signature() {
+        let sse = concat!(
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"enc1\"}}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"c\",\"call_id\":\"c\",\"name\":\"Read\"}}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"call_id\":\"c\",\"name\":\"Read\",\"arguments\":\"{}\"}}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":2,\"delta\":\"more\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":2,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"enc2\"}}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":3,\"item\":{\"type\":\"message\",\"id\":\"m\"}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"output_index\":3,\"delta\":\"hi\"}\n\n",
+        );
+        let (events, _) = reduce(sse);
+        let sigs: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                ReduceEvent::ThinkingSignatureDelta(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(sigs, vec!["enc1", "enc2"]);
+    }
+
+    #[test]
+    fn deferred_text_survives_a_reasoning_item_without_signature() {
+        let sse = concat!(
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"think\"}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"m\"}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"the answer\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n",
+        );
+        let (events, mut r) = reduce(sse);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ReduceEvent::TextDelta(t) if t == "the answer")),
+            "text deferred behind a never-arriving signature must still be emitted: {events:#?}"
+        );
+        let items = r.take_output_items();
+        assert!(
+            items
+                .iter()
+                .any(|i| i["content"][0]["text"] == "the answer"),
+            "deferred text must also reach the continuation transcript"
         );
     }
 

--- a/crates/llmtrim-cli/src/reroute/codex.rs
+++ b/crates/llmtrim-cli/src/reroute/codex.rs
@@ -15,6 +15,8 @@ use crate::reroute::sse::{ReduceEvent, SseLineParser, StopReason, Usage};
 
 pub const HOST: &str = "chatgpt.com";
 pub const PATH: &str = "/backend-api/codex/responses";
+const OFFICIAL_CODEX_ORIGINATOR: &str = "codex_cli_rs";
+const OFFICIAL_CODEX_USER_AGENT: &str = "codex_cli_rs";
 
 /// The Claude Code hosted web-search tool. Translated to the Codex `web_search` tool (not a
 /// function tool) so the model can actually search; see [`web_search_tool`].
@@ -85,6 +87,12 @@ pub fn build_request_body(
     body.insert("text".into(), Value::Object(text));
 
     Ok(Value::Object(body))
+}
+
+/// GPT-5.6 models require the official Codex client identity even when using the standard
+/// Responses shape.
+pub fn uses_official_codex_client(model: &str) -> bool {
+    matches!(model, "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra")
 }
 
 /// Flatten an Anthropic `system` (string or array of `{type:"text", text}` blocks) to one string.
@@ -166,6 +174,12 @@ fn build_input(anthropic: &Value) -> Vec<Value> {
                 let mut parts: Vec<Value> = Vec::new();
                 for b in &blocks {
                     match b.get("type").and_then(Value::as_str) {
+                        Some("thinking") | Some("redacted_thinking") => {
+                            flush_message(&mut input, "assistant", &mut parts);
+                            if let Some(item) = thinking_input_item(b) {
+                                input.push(item);
+                            }
+                        }
                         Some("text") => {
                             if let Some(t) = b.get("text").and_then(Value::as_str) {
                                 parts.push(json!({ "type": "output_text", "text": t }));
@@ -348,20 +362,74 @@ fn build_tool_choice(tc: Option<&Value>) -> Option<Value> {
     }
 }
 
-/// Resolve the reasoning effort from `output_config.effort`.
+/// Resolve the reasoning effort from `output_config.effort`, with a fallback when Claude Code
+/// enables adaptive thinking without an explicit effort tier.
 ///
-/// `max`/`xhigh` -> `"xhigh"`; `low`/`medium`/`high` pass through; anything else (including
-/// `none`/absent) -> `None`, which drops both `reasoning` and the encrypted-content `include`.
+/// `max`/`xhigh` -> `"xhigh"`; `low`/`medium`/`high` pass through; `thinking.type` of
+/// `enabled`/`adaptive` (without effort) defaults to `"medium"`. `thinking.type: disabled` and
+/// absent/`none` effort drop both `reasoning` and the encrypted-content `include`.
 fn reasoning_effort(anthropic: &Value) -> Option<String> {
-    let effort = anthropic
+    if anthropic
+        .get("thinking")
+        .and_then(|t| t.get("type"))
+        .and_then(Value::as_str)
+        == Some("disabled")
+    {
+        return None;
+    }
+    if let Some(effort) = anthropic
         .get("output_config")
         .and_then(|c| c.get("effort"))
-        .and_then(Value::as_str)?;
-    match effort {
-        "max" | "xhigh" => Some("xhigh".into()),
-        "low" | "medium" | "high" => Some(effort.into()),
-        _ => None,
+        .and_then(Value::as_str)
+    {
+        return match effort {
+            "max" | "xhigh" => Some("xhigh".into()),
+            "low" | "medium" | "high" => Some(effort.into()),
+            _ => None,
+        };
     }
+    let thinking_on = anthropic
+        .get("thinking")
+        .and_then(|t| t.get("type"))
+        .and_then(Value::as_str)
+        .is_some_and(|ty| matches!(ty, "enabled" | "adaptive"));
+    thinking_on.then(|| "medium".into())
+}
+
+/// Extract non-empty Codex `encrypted_content` from a Responses `reasoning` output item.
+fn reasoning_encrypted_content(item: &Value) -> Option<String> {
+    if item.get("type").and_then(Value::as_str) != Some("reasoning") {
+        return None;
+    }
+    item.get("encrypted_content")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Build a Codex `reasoning` input item from an Anthropic thinking block (signature round-trips
+/// as `encrypted_content`). Returns `None` when the block carries nothing Codex can replay.
+fn thinking_input_item(block: &Value) -> Option<Value> {
+    let thinking = block
+        .get("thinking")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let signature = block
+        .get("signature")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if signature.is_empty() {
+        return None;
+    }
+    let mut item = json!({
+        "type": "reasoning",
+        "encrypted_content": signature,
+        "summary": [],
+    });
+    if !thinking.is_empty() {
+        item["summary"] = json!([{"type": "summary_text", "text": thinking}]);
+    }
+    Some(item)
 }
 
 /// Build the Responses `text.format` from an Anthropic `output_config.format`.
@@ -388,6 +456,15 @@ pub fn request_headers(
     account_id: Option<&str>,
     session_id: Option<&str>,
 ) -> Vec<(String, String)> {
+    request_headers_with_mode(access_token, account_id, session_id, false)
+}
+
+pub fn request_headers_with_mode(
+    access_token: &str,
+    account_id: Option<&str>,
+    session_id: Option<&str>,
+    official_client: bool,
+) -> Vec<(String, String)> {
     let mut headers = vec![
         ("content-type".to_string(), "application/json".to_string()),
         ("accept".to_string(), "text/event-stream".to_string()),
@@ -395,14 +472,26 @@ pub fn request_headers(
             "authorization".to_string(),
             format!("Bearer {access_token}"),
         ),
-        ("originator".to_string(), "llmtrim".to_string()),
+        (
+            "originator".to_string(),
+            if official_client {
+                OFFICIAL_CODEX_ORIGINATOR
+            } else {
+                "llmtrim"
+            }
+            .to_string(),
+        ),
         (
             "openai-beta".to_string(),
             "responses=experimental".to_string(),
         ),
         (
             "user-agent".to_string(),
-            format!("llmtrim/{}", env!("CARGO_PKG_VERSION")),
+            if official_client {
+                OFFICIAL_CODEX_USER_AGENT.to_string()
+            } else {
+                format!("llmtrim/{}", env!("CARGO_PKG_VERSION"))
+            },
         ),
     ];
     if let Some(acc) = account_id {
@@ -446,6 +535,17 @@ pub struct Reducer {
     /// is only honored for the item that owns the currently open tool.
     tool_output_index: Option<i64>,
     terminal_seen: bool,
+    /// Codex `encrypted_content` for the open (or most recent) reasoning item, mapped to Anthropic
+    /// `signature_delta` before the thinking block closes.
+    thinking_encrypted: Option<String>,
+    /// Text opened on the wire before the reasoning signature arrived; held until
+    /// [`Self::close_thinking`] can emit `signature_delta`.
+    defer_text_open: bool,
+    /// Whether this turn already emitted `ThinkingSignatureDelta` (Codex repeats the same
+    /// `encrypted_content` on `added` and `done`).
+    reasoning_signature_emitted: bool,
+    /// Text deltas that arrived while thinking was still awaiting its signature.
+    deferred_text_deltas: Vec<String>,
     // Accumulation for continuation transcript (assistant outputs in codex input item shape)
     current_assistant_text: String,
     output_items: Vec<Value>,
@@ -463,9 +563,76 @@ impl Reducer {
             tool_flushed: false,
             tool_output_index: None,
             terminal_seen: false,
+            thinking_encrypted: None,
+            defer_text_open: false,
+            reasoning_signature_emitted: false,
+            deferred_text_deltas: Vec::new(),
             current_assistant_text: String::new(),
             output_items: Vec::new(),
         }
+    }
+
+    /// Emit `ThinkingSignatureDelta` when encrypted reasoning content is known, then close the
+    /// thinking block. Signature must precede `content_block_stop` or Claude Code rejects the turn.
+    fn close_thinking(&mut self, out: &mut Vec<ReduceEvent>) {
+        if self.open != Open::Thinking {
+            return;
+        }
+        if let Some(sig) = self.thinking_encrypted.take()
+            && !self.reasoning_signature_emitted
+        {
+            out.push(ReduceEvent::ThinkingSignatureDelta(sig));
+            self.reasoning_signature_emitted = true;
+        }
+        out.push(ReduceEvent::ThinkingStop);
+        self.open = Open::None;
+    }
+
+    /// Record encrypted reasoning content from a Responses `reasoning` item. Opens a thinking
+    /// block when the upstream omitted summary text (signature-only / `display: omitted` shape).
+    fn note_reasoning_encrypted(&mut self, out: &mut Vec<ReduceEvent>, encrypted: String) {
+        if self.reasoning_signature_emitted {
+            return;
+        }
+        self.thinking_encrypted = Some(encrypted);
+        if self.open == Open::Thinking {
+            self.finish_thinking_if_ready(out);
+            return;
+        }
+        self.close_open(out);
+        out.push(ReduceEvent::ThinkingStart);
+        self.open = Open::Thinking;
+        self.finish_thinking_if_ready(out);
+    }
+
+    /// Close the thinking block once `encrypted_content` is known; open deferred text if needed.
+    fn finish_thinking_if_ready(&mut self, out: &mut Vec<ReduceEvent>) {
+        if self.open != Open::Thinking || self.thinking_encrypted.is_none() {
+            return;
+        }
+        self.close_thinking(out);
+        if self.defer_text_open || !self.deferred_text_deltas.is_empty() {
+            out.push(ReduceEvent::TextStart);
+            self.open = Open::Text;
+            self.defer_text_open = false;
+            for delta in self.deferred_text_deltas.drain(..) {
+                self.current_assistant_text.push_str(&delta);
+                out.push(ReduceEvent::TextDelta(delta));
+            }
+        }
+    }
+
+    /// Close the open thinking block when its signature is available; otherwise defer the caller's
+    /// transition (e.g. text must not open before `signature_delta`).
+    fn close_thinking_when_ready(&mut self, out: &mut Vec<ReduceEvent>) -> bool {
+        if self.open != Open::Thinking {
+            return true;
+        }
+        if self.thinking_encrypted.is_none() {
+            return false;
+        }
+        self.close_thinking(out);
+        true
     }
 
     /// Sanitize + emit the buffered tool args once (idempotent per tool call).
@@ -529,7 +696,7 @@ impl Reducer {
     /// Close whatever block is open, emitting its `*Stop`.
     fn close_open(&mut self, out: &mut Vec<ReduceEvent>) {
         match self.open {
-            Open::Thinking => out.push(ReduceEvent::ThinkingStop),
+            Open::Thinking => self.close_thinking(out),
             Open::Text => {
                 self.flush_current_text();
                 out.push(ReduceEvent::TextStop);
@@ -560,11 +727,19 @@ impl Reducer {
             "response.output_item.added" => {
                 let item = v.get("item").cloned().unwrap_or(Value::Null);
                 match item.get("type").and_then(Value::as_str) {
-                    Some("reasoning") => {} // ignore reasoning items
+                    Some("reasoning") => {
+                        if let Some(enc) = reasoning_encrypted_content(&item) {
+                            self.note_reasoning_encrypted(out, enc);
+                        }
+                    }
                     Some("message") => {
-                        self.close_open(out);
-                        out.push(ReduceEvent::TextStart);
-                        self.open = Open::Text;
+                        if !self.close_thinking_when_ready(out) {
+                            self.defer_text_open = true;
+                        } else {
+                            self.close_open(out);
+                            out.push(ReduceEvent::TextStart);
+                            self.open = Open::Text;
+                        }
                     }
                     Some("function_call") => {
                         self.close_open(out);
@@ -612,12 +787,20 @@ impl Reducer {
             "response.output_text.delta" => {
                 let delta = v.get("delta").and_then(Value::as_str).unwrap_or("");
                 if self.open != Open::Text {
-                    self.close_open(out);
-                    out.push(ReduceEvent::TextStart);
-                    self.open = Open::Text;
+                    if self.open == Open::Thinking && self.thinking_encrypted.is_none() {
+                        self.defer_text_open = true;
+                    } else {
+                        self.close_open(out);
+                        out.push(ReduceEvent::TextStart);
+                        self.open = Open::Text;
+                    }
                 }
-                self.current_assistant_text.push_str(delta);
-                out.push(ReduceEvent::TextDelta(delta.to_string()));
+                if self.open == Open::Text {
+                    self.current_assistant_text.push_str(delta);
+                    out.push(ReduceEvent::TextDelta(delta.to_string()));
+                } else if self.defer_text_open || self.open == Open::Thinking {
+                    self.deferred_text_deltas.push(delta.to_string());
+                }
             }
             "response.function_call_arguments.delta" => {
                 // Buffer, don't stream: the full args are needed to sanitize as one JSON value.
@@ -643,6 +826,12 @@ impl Reducer {
                     && self.tool_output_index.is_some()
                     && Some(done_idx) != self.tool_output_index
                 {
+                    return;
+                }
+                if let Some(item) = v.get("item")
+                    && let Some(enc) = reasoning_encrypted_content(item)
+                {
+                    self.note_reasoning_encrypted(out, enc);
                     return;
                 }
                 self.close_open(out);
@@ -781,6 +970,51 @@ mod tests {
         )
         .expect("build");
         assert_eq!(body["instructions"], "Line 1\nLine 2");
+    }
+
+    #[test]
+    fn gpt56_keeps_standard_responses_shape() {
+        let body = build_request_body(
+            &json!({
+                "system": "Be concise.",
+                "messages": [],
+                "tools": [{
+                    "name": "Read",
+                    "description": "read a file",
+                    "input_schema": { "type": "object" }
+                }],
+                "output_config": { "effort": "high" }
+            }),
+            "gpt-5.6-terra",
+            None,
+        )
+        .expect("build");
+        assert_eq!(body["instructions"], "Be concise.");
+        assert!(body["tools"].is_array());
+        assert_eq!(body["parallel_tool_calls"], true);
+        assert!(body.get("client_metadata").is_none());
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert!(body["reasoning"].get("context").is_none());
+    }
+
+    #[test]
+    fn gpt56_uses_official_codex_identity() {
+        let request = json!({
+            "messages": [],
+        });
+        let body = build_request_body(&request, "gpt-5.6-luna", None).expect("build");
+        assert!(uses_official_codex_client("gpt-5.6-luna"));
+        assert!(body.get("client_metadata").is_none());
+        let headers = request_headers_with_mode("tok", None, None, true);
+        let get = |k: &str| {
+            headers
+                .iter()
+                .find(|(n, _)| n == k)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(get("originator"), Some("codex_cli_rs"));
+        assert_eq!(get("user-agent"), Some("codex_cli_rs"));
+        assert!(get("x-openai-internal-codex-responses-lite").is_none());
     }
 
     #[test]
@@ -1202,6 +1436,7 @@ mod tests {
     fn reasoning_then_text_closes_thinking_first() {
         let sse = concat!(
             "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"pondering\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"enc_sig_1\"}}\n\n",
             "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"m\"}}\n\n",
             "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"answer\"}\n\n",
         );
@@ -1211,11 +1446,110 @@ mod tests {
             vec![
                 ReduceEvent::ThinkingStart,
                 ReduceEvent::ThinkingDelta("pondering".into()),
+                ReduceEvent::ThinkingSignatureDelta("enc_sig_1".into()),
                 ReduceEvent::ThinkingStop,
                 ReduceEvent::TextStart,
                 ReduceEvent::TextDelta("answer".into()),
             ]
         );
+    }
+
+    #[test]
+    fn signature_only_reasoning_opens_thinking_without_summary_deltas() {
+        let sse = concat!(
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"enc_only\"}}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"enc_only\"}}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"m\"}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"ok\"}\n\n",
+        );
+        let (events, _) = reduce(sse);
+        assert_eq!(
+            events,
+            vec![
+                ReduceEvent::ThinkingStart,
+                ReduceEvent::ThinkingSignatureDelta("enc_only".into()),
+                ReduceEvent::ThinkingStop,
+                ReduceEvent::TextStart,
+                ReduceEvent::TextDelta("ok".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn thinking_signature_round_trips_into_reasoning_input() {
+        let body = build_request_body(
+            &json!({
+                "messages": [{
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "pondered", "signature": "enc_rt"},
+                        {"type": "text", "text": "done"}
+                    ]
+                }]
+            }),
+            "gpt-5.5",
+            None,
+        )
+        .expect("build");
+        let input = body["input"].as_array().expect("input");
+        assert_eq!(input[0]["type"], "reasoning");
+        assert_eq!(input[0]["encrypted_content"], "enc_rt");
+        assert_eq!(input[0]["summary"][0]["text"], "pondered");
+        assert_eq!(input[1]["type"], "message");
+        assert_eq!(input[1]["content"][0]["text"], "done");
+    }
+
+    #[test]
+    fn thinking_without_signature_is_not_replayed() {
+        let body = build_request_body(
+            &json!({
+                "messages": [{
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "orphan", "signature": ""}
+                    ]
+                }]
+            }),
+            "gpt-5.5",
+            None,
+        )
+        .expect("build");
+        assert!(body["input"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn text_waits_for_reasoning_signature_when_done_follows_message_added() {
+        // Upstream may emit the assistant message before the reasoning item's terminal `done`.
+        let sse = concat!(
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"hmm\"}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"m\"}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"ans\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"late_sig\"}}\n\n",
+        );
+        let (events, _) = reduce(sse);
+        assert_eq!(
+            events,
+            vec![
+                ReduceEvent::ThinkingStart,
+                ReduceEvent::ThinkingDelta("hmm".into()),
+                ReduceEvent::ThinkingSignatureDelta("late_sig".into()),
+                ReduceEvent::ThinkingStop,
+                ReduceEvent::TextStart,
+                ReduceEvent::TextDelta("ans".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn adaptive_thinking_without_effort_enables_reasoning() {
+        let body = build_request_body(
+            &json!({ "messages": [], "thinking": {"type": "adaptive"} }),
+            "gpt-5.5",
+            None,
+        )
+        .expect("build");
+        assert_eq!(body["reasoning"]["effort"], "medium");
+        assert_eq!(body["include"][0], "reasoning.encrypted_content");
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -57,7 +57,12 @@ pub fn build_upstream(
     let (host, path, body, headers) = match provider {
         SubProvider::Codex => {
             let b = codex::build_request_body(anthropic_body, &model, session_id)?;
-            let h = codex::request_headers(&token.access, token.account_id.as_deref(), session_id);
+            let h = codex::request_headers_with_mode(
+                &token.access,
+                token.account_id.as_deref(),
+                session_id,
+                codex::uses_official_codex_client(&model),
+            );
             (codex::HOST, codex::PATH, serde_json::to_vec(&b)?, h)
         }
         SubProvider::Kimi => {
@@ -366,6 +371,10 @@ mod tests {
         );
         assert_eq!(
             resolve_model(SubProvider::Codex, "sonnet", &ov),
+            "gpt-5.6-luna"
+        );
+        assert_eq!(
+            resolve_model(SubProvider::Codex, "claude-sonnet-5", &ov),
             "gpt-5.6-luna"
         );
         assert_eq!(

--- a/crates/llmtrim-cli/src/reroute/sse.rs
+++ b/crates/llmtrim-cli/src/reroute/sse.rs
@@ -59,6 +59,9 @@ impl Usage {
 pub enum ReduceEvent {
     ThinkingStart,
     ThinkingDelta(String),
+    /// Codex `encrypted_content` / opaque thinking blob, emitted as Anthropic `signature_delta`
+    /// immediately before the thinking block closes. Required for Claude Code multi-turn thinking.
+    ThinkingSignatureDelta(String),
     ThinkingStop,
     TextStart,
     TextDelta(String),
@@ -130,6 +133,10 @@ impl AnthropicSseEncoder {
             ReduceEvent::ThinkingDelta(text) => {
                 self.block_delta(out, json!({"type": "thinking_delta", "thinking": text}))
             }
+            ReduceEvent::ThinkingSignatureDelta(signature) => self.block_delta(
+                out,
+                json!({"type": "signature_delta", "signature": signature}),
+            ),
             ReduceEvent::ThinkingStop => self.close_block(out),
             ReduceEvent::TextStart => {
                 let idx = self.open_block(out, json!({"type": "text", "text": ""}));
@@ -353,6 +360,29 @@ mod tests {
         assert!(out.contains("\"stop_reason\":\"end_turn\""));
         assert!(out.contains("\"cache_read_input_tokens\":3"));
         assert!(out.contains("event: message_stop"));
+    }
+
+    #[test]
+    fn thinking_signature_delta_precedes_block_stop() {
+        let out = encode_all(
+            "m",
+            &[
+                ReduceEvent::ThinkingStart,
+                ReduceEvent::ThinkingDelta("t".into()),
+                ReduceEvent::ThinkingSignatureDelta("sig_blob".into()),
+                ReduceEvent::ThinkingStop,
+                ReduceEvent::Finish {
+                    stop_reason: StopReason::EndTurn,
+                    usage: Usage::default(),
+                    response_id: None,
+                    continuation_eligible: false,
+                },
+            ],
+        );
+        let sig_pos = out.find("\"signature_delta\"").expect("signature_delta");
+        let stop_pos = out.find("content_block_stop").expect("content_block_stop");
+        assert!(sig_pos < stop_pos, "signature must precede block stop");
+        assert!(out.contains("\"signature\":\"sig_blob\""));
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/tui.rs
+++ b/crates/llmtrim-cli/src/reroute/tui.rs
@@ -47,7 +47,7 @@ struct App {
     status: String,
     /// Current reroute mode, shown read-only (set it with `llmtrim sub mode`). The editor edits
     /// the model map only, so it flags where the other half of the setting lives.
-    on_error: bool,
+    fallback: bool,
 }
 
 impl App {
@@ -72,7 +72,7 @@ impl App {
             selected: 0,
             dirty: false,
             status: String::new(),
-            on_error: rc.sub_on_error,
+            fallback: rc.sub_fallback,
         }
     }
 
@@ -153,7 +153,7 @@ impl App {
             ),
             Span::raw(format!(
                 "   mode: {} (set with `llmtrim sub mode`)",
-                if self.on_error { "on-error" } else { "always" }
+                if self.fallback { "fallback" } else { "always" }
             )),
         ]))
         .block(
@@ -249,7 +249,7 @@ mod tests {
             selected: 0,
             dirty: false,
             status: String::new(),
-            on_error: false,
+            fallback: false,
         }
     }
 

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -330,8 +330,8 @@ mod imp {
         /// provider's SSE back into Anthropic SSE. `provider` above is kept `Anthropic` so the
         /// output-usage parser and ledger see the Anthropic-shaped reply we emit to the client.
         reroute: Option<RerouteInfo>,
-        /// Set in `sub` on-error mode: the turn was forwarded to Anthropic normally, but if
-        /// Anthropic answers with a quota/overload status, `handle_response` replays it to this
+        /// Set in `sub` fallback mode: the turn was forwarded to Anthropic normally, but if
+        /// Anthropic cannot serve it, `handle_response` replays it to this
         /// subscription provider instead. Mutually exclusive with `reroute` (which reroutes up
         /// front). See [`FallbackInfo`].
         fallback: Option<FallbackInfo>,
@@ -346,7 +346,7 @@ mod imp {
         /// returning the subscription model makes Claude Code reject the response as unknown.
         client_model: String,
         /// The rewritten upstream request, retained so `reroute_response` can re-issue it on a
-        /// retryable failure (429/5xx). `None` on paths that never retry (the on-error fallback).
+        /// retryable failure (429/5xx). `None` on paths that never retry (the fallback path).
         replay: Option<RerouteReplay>,
         /// The full logical codex (or provider) request body *before* any continuation delta was
         /// applied. Used to record server continuation state.
@@ -369,21 +369,54 @@ mod imp {
         body: Arc<Vec<u8>>,
     }
 
-    /// On-error fallback marker attached to a [`Pending`] (see its `fallback` field). Holds what
+    /// Fallback marker attached to a [`Pending`] (see its `fallback` field). Holds what
     /// `handle_response` needs to replay the turn to the subscription provider: the provider, the
     /// original Anthropic request body to translate, and the Claude Code session id (for the
     /// provider's session header).
     #[derive(Clone)]
     struct FallbackInfo {
+        /// First provider retained for the single-provider compatibility helper below.
         provider: crate::reroute::SubProvider,
+        providers: Vec<crate::reroute::SubProvider>,
         anthropic_body: Vec<u8>,
         session_id: Option<String>,
     }
 
-    /// Anthropic statuses that mean "Anthropic can't serve this turn" (usage limit / payment /
-    /// forbidden / overload) and so trigger the on-error reroute to the subscription provider.
+    struct FallbackAttempt {
+        provider: crate::reroute::SubProvider,
+        model: String,
+        logical_body: Option<Value>,
+        body: Vec<u8>,
+    }
+
+    /// Anthropic statuses that mean "Anthropic can't serve this turn" and so trigger fallback.
     fn is_sub_fallback_status(status: u16) -> bool {
-        matches!(status, 402 | 403 | 429 | 529)
+        // Quota/auth failures plus the transient classes used by the sibling proxy. Do not
+        // fail over validation errors (400/422) or a missing Anthropic credential (401): those
+        // are caller/configuration problems, not provider capacity failures.
+        matches!(
+            status,
+            402 | 403 | 408 | 425 | 429 | 500 | 502 | 503 | 504 | 529
+        )
+    }
+
+    /// Some upstreams report a failed turn inside an HTTP 200 SSE response. In fallback mode the
+    /// Anthropic response is buffered before it is exposed to the client, so this path can still
+    /// fail over without emitting a malformed partial stream.
+    fn is_sub_fallback_body(body: &[u8]) -> bool {
+        let text = String::from_utf8_lossy(body).to_ascii_lowercase();
+        text.lines().any(|line| {
+            let data = line
+                .strip_prefix("data:")
+                .map(str::trim)
+                .unwrap_or(line.trim());
+            if let Ok(value) = serde_json::from_str::<Value>(data) {
+                let kind = value.get("type").and_then(Value::as_str);
+                return kind == Some("error")
+                    || (kind == Some("message_stop") && value.get("error").is_some());
+            }
+            data.contains("\"type\":\"error\"") || data.contains("\"type\": \"error\"")
+        })
     }
 
     /// A verbatim copy of the client's request, for replay-on-error.
@@ -974,12 +1007,14 @@ mod imp {
         /// construction. `None` = normal transparent compress-and-forward. When set, intercepted
         /// Anthropic `/v1/messages` traffic is translated and sent to that subscription's backend.
         sub: Option<crate::reroute::SubProvider>,
+        /// Ordered fallback providers. The active `sub` is used when this is empty.
+        sub_chain: Arc<Vec<crate::reroute::SubProvider>>,
         /// Tier→model overrides for the active `sub` (from `[sub.<provider>.tiers]`); empty = use
         /// the built-in preset. Shared across per-request handler clones.
         sub_tiers: Arc<std::collections::BTreeMap<String, String>>,
-        /// On-error reroute mode: when `true`, a set `sub` only takes over after Anthropic itself
+        /// Fallback mode: when `true`, a set `sub` only takes over after Anthropic itself
         /// returns a quota/overload status; when `false`, `sub` reroutes every matching turn.
-        sub_on_error: bool,
+        sub_fallback: bool,
         /// Proxy-side Codex reasoning effort applied to every rerouted request (`None` = off).
         sub_effort: Option<String>,
     }
@@ -1060,16 +1095,16 @@ mod imp {
             // Anthropic. `count_tokens` is answered locally (it would otherwise be billed against
             // the sub provider, so it can't be proxied to Anthropic). This runs before the normal
             // compress/exclude path so a `sub` selection always takes effect.
-            // On-error mode arms a fallback instead of rerouting up front: the turn goes to
+            // Fallback mode arms a fallback instead of rerouting up front: the turn goes to
             // Anthropic normally, and only replays to the sub provider if Anthropic fails (handled
             // in the response phase). Captured here so we can read the session header and body.
-            let mut fallback_arm: Option<(crate::reroute::SubProvider, Option<String>)> = None;
+            let mut fallback_arm: Option<(Vec<crate::reroute::SubProvider>, Option<String>)> = None;
             if let Some(sub) = self.sub
                 && matches!(provider, Some(ProviderKind::Anthropic))
                 && req.method() == Method::POST
             {
                 let path = req.uri().path();
-                if !self.sub_on_error {
+                if !self.sub_fallback {
                     if path.ends_with("/v1/messages/count_tokens") {
                         return self.reroute_count_tokens(req).await;
                     }
@@ -1082,7 +1117,12 @@ mod imp {
                         .get("x-claude-code-session-id")
                         .and_then(|v| v.to_str().ok())
                         .map(str::to_string);
-                    fallback_arm = Some((sub, session_id));
+                    let providers = if self.sub_chain.is_empty() {
+                        vec![sub]
+                    } else {
+                        self.sub_chain.as_ref().clone()
+                    };
+                    fallback_arm = Some((providers, session_id));
                 }
             }
             // Only compress POST bodies to a known provider; pass everything else through.
@@ -1140,7 +1180,7 @@ mod imp {
             .ok()
             .flatten();
 
-            // Capture the (uncompressed) body for the on-error fallback before the match may move
+            // Capture the (uncompressed) body for the fallback before the match may move
             // `bytes`. The Anthropic call still goes out compressed; only a rare fallback replay
             // re-translates this original body to the provider.
             let fallback_body = fallback_arm.as_ref().map(|_| bytes.to_vec());
@@ -1166,18 +1206,23 @@ mod imp {
                 }
                 None => Body::from(Full::new(bytes)),
             };
-            // On-error mode: attach the provider fallback to the pending (creating a bare pending
+            // Fallback mode: attach the provider fallback to the pending (creating a bare pending
             // when compression produced one), so the response phase can replay to the provider on
             // an Anthropic quota/overload status. We only arm the fallback on a *real* pending:
             // when `compress_blocking` declined (malformed body → no pending), we leave it None so
             // the request is forwarded verbatim and no phantom zero-token row is recorded. Such a
             // body would fail at Anthropic anyway, so losing the fallback there is harmless.
-            if let Some((sub, session_id)) = fallback_arm
+            if let Some((providers, session_id)) = fallback_arm
                 && let Some(body) = fallback_body
                 && let Some(pending) = self.pending.as_mut()
             {
+                let provider = providers
+                    .first()
+                    .copied()
+                    .unwrap_or(crate::reroute::SubProvider::Codex);
                 pending.fallback = Some(FallbackInfo {
-                    provider: sub,
+                    provider,
+                    providers,
                     anthropic_body: body,
                     session_id,
                 });
@@ -1775,23 +1820,18 @@ mod imp {
             sse_response(out)
         }
 
-        /// On-error reroute: Anthropic returned a quota/overload status, so replay the (stashed
-        /// original) turn to the subscription provider and hand the client the provider's answer as
-        /// Anthropic SSE. Uses a blocking provider round-trip (`transport::forward_post`, like the
-        /// replay net) since hudsucker already consumed the request; buffers the provider reply (the
-        /// rare error path, not the hot path) and translates it in one shot. Records the row against
-        /// the provider model via `Finalize` on drop.
-        async fn fallback_to_provider(
+        /// Provider-chain fallback. Each backend gets bounded retries for transient HTTP errors;
+        /// a terminal response, auth failure, translation failure, or failed 200 stream advances
+        /// to the next configured provider.
+        async fn fallback_to_chain(
             &mut self,
             mut pending: Pending,
             fb: FallbackInfo,
         ) -> Response<Body> {
             use crate::reroute::sse::{AnthropicSseEncoder, ReduceEvent};
-            let provider = fb.provider;
-
             let Some(mut anthropic) = std::str::from_utf8(&fb.anthropic_body)
                 .ok()
-                .and_then(|t| serde_json::from_str::<serde_json::Value>(t).ok())
+                .and_then(|t| serde_json::from_str::<Value>(t).ok())
             else {
                 return self.fallback_error(
                     pending,
@@ -1801,155 +1841,165 @@ mod imp {
             };
             let client_model = anthropic
                 .get("model")
-                .and_then(|model| model.as_str())
+                .and_then(Value::as_str)
                 .unwrap_or("unknown")
                 .to_string();
             apply_sub_effort(&mut anthropic, self.sub_effort.as_deref());
 
-            let token = match tokio::task::spawn_blocking(move || {
-                crate::reroute::auth::get_token(provider)
-            })
-            .await
-            {
-                Ok(Ok(t)) => t,
-                Ok(Err(e)) => {
-                    return self.fallback_error(
-                        pending,
-                        &client_model,
-                        &format!(
-                            "llmtrim: {p} not authenticated ({e}). Run `llmtrim sub auth {p} login`.",
-                            p = provider.as_str()
-                        ),
-                    );
+            let mut providers = Vec::new();
+            for provider in fb.providers.iter().copied().chain([fb.provider]) {
+                if !providers.contains(&provider) {
+                    providers.push(provider);
                 }
-                Err(_) => {
-                    return self.fallback_error(
-                        pending,
-                        &client_model,
-                        "llmtrim: auth task failed",
+            }
+            let mut failures = Vec::new();
+            for provider in providers {
+                let attempt = match self
+                    .fallback_attempt(provider, &anthropic, fb.session_id.as_deref())
+                    .await
+                {
+                    Ok(attempt) => attempt,
+                    Err(error) => {
+                        failures.push(format!("{}: {error}", provider.as_str()));
+                        continue;
+                    }
+                };
+                let mut reducer =
+                    crate::reroute::StreamReducer::new(attempt.provider, &attempt.model);
+                let mut encoder = AnthropicSseEncoder::new(&client_model);
+                let mut output = String::new();
+                let mut stream_error = None;
+                for event in reducer.push(&attempt.body) {
+                    record_codex_continuation(
+                        &event,
+                        &mut reducer,
+                        attempt.provider,
+                        attempt.logical_body.as_ref(),
+                        fb.session_id.as_deref(),
                     );
+                    if let ReduceEvent::Error { message } = &event {
+                        stream_error = Some(message.clone());
+                    }
+                    encoder.encode(&event, &mut output);
                 }
-            };
+                if stream_error.is_none() {
+                    for event in reducer.finish() {
+                        record_codex_continuation(
+                            &event,
+                            &mut reducer,
+                            attempt.provider,
+                            attempt.logical_body.as_ref(),
+                            fb.session_id.as_deref(),
+                        );
+                        if let ReduceEvent::Error { message } = &event {
+                            stream_error = Some(message.clone());
+                        }
+                        encoder.encode(&event, &mut output);
+                    }
+                }
+                if let Some(error) = stream_error {
+                    crate::reroute::continuation::clear_continuation(fb.session_id.as_deref());
+                    failures.push(format!("{}: {error}", attempt.provider.as_str()));
+                    continue;
+                }
+                encoder.finish_if_open(&mut output);
+                pending.model = Some(attempt.model.clone());
+                pending.reroute = Some(RerouteInfo {
+                    provider: attempt.provider,
+                    model: attempt.model,
+                    client_model: client_model.clone(),
+                    replay: None,
+                    logical_body: attempt.logical_body,
+                    session_id: fb.session_id.clone(),
+                });
+                let acc = Arc::new(Mutex::new(output.clone().into_bytes()));
+                let _finalize = Finalize {
+                    acc,
+                    pending: Some(pending),
+                    ledger: self.ledger.clone(),
+                    breakdown_ledger: self.breakdown_ledger.clone(),
+                };
+                return sse_response(output);
+            }
+            self.fallback_error(
+                pending,
+                &client_model,
+                &format!(
+                    "llmtrim: all fallback providers failed: {}",
+                    failures.join("; ")
+                ),
+            )
+        }
 
-            let rewrite = match crate::reroute::build_upstream(
+        async fn fallback_attempt(
+            &self,
+            provider: crate::reroute::SubProvider,
+            anthropic: &Value,
+            session_id: Option<&str>,
+        ) -> Result<FallbackAttempt, String> {
+            let token =
+                tokio::task::spawn_blocking(move || crate::reroute::auth::get_token(provider))
+                    .await
+                    .map_err(|_| "auth task failed".to_string())?
+                    .map_err(|e| format!("not authenticated ({e})"))?;
+            let rewrite = crate::reroute::build_upstream(
                 provider,
-                &anthropic,
+                anthropic,
                 &self.sub_tiers,
                 &token,
-                fb.session_id.as_deref(),
-            ) {
-                Ok(r) => r,
-                Err(e) => {
-                    return self.fallback_error(
-                        pending,
-                        &client_model,
-                        &format!("llmtrim: reroute translation failed: {e}"),
-                    );
-                }
-            };
-
-            let logical_body: Option<Value> = if provider == crate::reroute::SubProvider::Codex {
-                serde_json::from_slice(&rewrite.body).ok()
-            } else {
-                None
-            };
-
-            let model = rewrite.model.clone();
-            // Record this row against the resolved provider model (marks it a reroute).
-            pending.model = Some(model.clone());
-            pending.reroute = Some(RerouteInfo {
-                provider,
-                model: model.clone(),
-                client_model: client_model.clone(),
-                replay: None,
-                logical_body: logical_body.clone(),
-                session_id: fb.session_id.clone(),
-            });
-
+                session_id,
+            )
+            .map_err(|e| format!("translation failed: {e}"))?;
+            let logical_body = (provider == crate::reroute::SubProvider::Codex)
+                .then(|| serde_json::from_slice(&rewrite.body).ok())
+                .flatten();
             let url = format!("https://{}{}", rewrite.host, rewrite.path);
             let headers = rewrite.headers.clone();
             let body = String::from_utf8_lossy(&rewrite.body).into_owned();
             let proxy = self.upstream_proxy.clone();
-            let result = tokio::task::spawn_blocking(move || {
-                use std::io::Read;
-                let mut up =
-                    crate::transport::forward_post(&url, &headers, &body, proxy.as_deref())
-                        .map_err(|e| e.to_string())?;
-                let mut buf = Vec::new();
-                up.reader.read_to_end(&mut buf).map_err(|e| e.to_string())?;
-                Ok::<(u16, Vec<u8>), String>((up.status, buf))
-            })
-            .await;
-
-            let (status, raw) = match result {
-                Ok(Ok(v)) => v,
-                Ok(Err(e)) => {
-                    return self.fallback_error(
-                        pending,
-                        &client_model,
-                        &format!("llmtrim: {} request failed: {e}", provider.as_str()),
-                    );
-                }
-                Err(_) => {
-                    return self.fallback_error(
-                        pending,
-                        &client_model,
-                        "llmtrim: fallback task failed",
-                    );
-                }
-            };
-
-            let mut enc = AnthropicSseEncoder::new(&client_model);
-            let mut out = String::new();
-            if !(200..300).contains(&status) {
-                let snippet: String = String::from_utf8_lossy(&raw).chars().take(400).collect();
-                enc.encode(
-                    &ReduceEvent::Error {
-                        message: format!(
-                            "llmtrim: {} upstream HTTP {}: {}",
-                            provider.as_str(),
-                            status,
-                            snippet
-                        ),
-                    },
-                    &mut out,
-                );
-            } else {
-                let mut reducer = crate::reroute::StreamReducer::new(provider, &model);
-                for ev in reducer.push(&raw) {
-                    record_codex_continuation(
-                        &ev,
-                        &mut reducer,
+            let mut attempt = 0;
+            loop {
+                let url = url.clone();
+                let headers = headers.clone();
+                let body = body.clone();
+                let proxy = proxy.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    use std::io::Read;
+                    let mut up =
+                        crate::transport::forward_post(&url, &headers, &body, proxy.as_deref())
+                            .map_err(|e| e.to_string())?;
+                    let mut buf = Vec::new();
+                    up.reader.read_to_end(&mut buf).map_err(|e| e.to_string())?;
+                    let retry_after =
+                        reroute_retry_after_secs(up.retry_after.as_deref(), None, &buf);
+                    Ok::<(u16, Vec<u8>, Option<u64>), String>((up.status, buf, retry_after))
+                })
+                .await
+                .map_err(|_| "fallback task failed".to_string())?
+                .map_err(|e| format!("request failed: {e}"))?;
+                let (status, body, retry_after) = result;
+                if (200..300).contains(&status) {
+                    return Ok(FallbackAttempt {
                         provider,
-                        logical_body.as_ref(),
-                        fb.session_id.as_deref(),
-                    );
-                    enc.encode(&ev, &mut out);
+                        model: rewrite.model,
+                        logical_body,
+                        body,
+                    });
                 }
-                for ev in reducer.finish() {
-                    record_codex_continuation(
-                        &ev,
-                        &mut reducer,
-                        provider,
-                        logical_body.as_ref(),
-                        fb.session_id.as_deref(),
-                    );
-                    enc.encode(&ev, &mut out);
+                if !reroute_should_retry(status) || attempt >= REROUTE_RETRY_MAX {
+                    let snippet: String =
+                        String::from_utf8_lossy(&body).chars().take(300).collect();
+                    return Err(format!("HTTP {status}: {snippet}"));
                 }
-                enc.finish_if_open(&mut out);
+                let Some(wait_ms) = reroute_backoff_ms(attempt, retry_after) else {
+                    return Err(format!("HTTP {status}: retry window exceeds budget"));
+                };
+                tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+                attempt += 1;
             }
-
-            let acc = Arc::new(Mutex::new(out.clone().into_bytes()));
-            let _finalize = Finalize {
-                acc,
-                pending: Some(pending),
-                ledger: self.ledger.clone(),
-                breakdown_ledger: self.breakdown_ledger.clone(),
-            };
-            sse_response(out)
         }
 
-        /// Emit an Anthropic SSE `error` frame for an on-error fallback that failed before/at the
+        /// Emit an Anthropic SSE `error` frame for a fallback that failed before/at the
         /// provider round-trip, still recording the row (output 0) as the `Finalize` drops.
         fn fallback_error(&self, pending: Pending, model: &str, message: &str) -> Response<Body> {
             use crate::reroute::sse::{AnthropicSseEncoder, ReduceEvent};
@@ -1983,12 +2033,37 @@ mod imp {
             if let Some(info) = pending.reroute.clone() {
                 return self.reroute_response(res, pending, info).await;
             }
-            // On-error reroute: Anthropic answered with a quota/overload status, so replay the turn
+            // Fallback reroute: Anthropic answered with a capacity/transient status, so replay the turn
             // to the subscription provider instead of handing the client Anthropic's error.
             if let Some(fb) = pending.fallback.clone()
                 && is_sub_fallback_status(res.status().as_u16())
             {
-                return self.fallback_to_provider(pending, fb).await;
+                return self.fallback_to_chain(pending, fb).await;
+            }
+            // Some providers encode an error as a successful SSE/JSON response. Buffer only in
+            // fallback mode so a failed stream can still advance to the next provider without
+            // exposing a partial response to Claude Code.
+            let mut res = res;
+            if pending.fallback.is_some() && (200..300).contains(&res.status().as_u16()) {
+                let is_stream = res
+                    .headers()
+                    .get(header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .is_some_and(|v| v.contains("event-stream") || v.contains("json"));
+                if is_stream {
+                    let (parts, body) = res.into_parts();
+                    let bytes = body
+                        .collect()
+                        .await
+                        .map(|c| c.to_bytes().to_vec())
+                        .unwrap_or_default();
+                    if is_sub_fallback_body(&bytes)
+                        && let Some(fb) = pending.fallback.clone()
+                    {
+                        return self.fallback_to_chain(pending, fb).await;
+                    }
+                    res = Response::from_parts(parts, Body::from(bytes));
+                }
             }
             // Safety net: if the upstream rejected our compressed request with a *validation*
             // error (400 Bad Request / 422 Unprocessable) — the failure class our body edits can
@@ -2897,8 +2972,15 @@ mod imp {
                 }
                 parsed
             },
+            sub_chain: Arc::new(
+                RuntimeConfig::get()
+                    .sub_chain
+                    .iter()
+                    .filter_map(|p| crate::reroute::SubProvider::parse(p))
+                    .collect(),
+            ),
             sub_tiers: Arc::new(RuntimeConfig::get().sub_tiers.clone()),
-            sub_on_error: RuntimeConfig::get().sub_on_error,
+            sub_fallback: RuntimeConfig::get().sub_fallback,
             sub_effort: RuntimeConfig::get().sub_effort.clone(),
         };
         // Pre-flight bind: hudsucker's `Proxy::start` collapses a bind failure to a bare
@@ -4017,7 +4099,7 @@ mod imp {
             );
         }
 
-        // ── M0-2: replay-on-error gate ──────────────────────────────────────
+        // ── M0-2: fallback gate ─────────────────────────────────────────────
 
         #[test]
         fn replay_triggered_on_4xx() {
@@ -4034,22 +4116,37 @@ mod imp {
         }
 
         #[test]
-        fn sub_fallback_triggers_on_quota_and_overload_only() {
-            // 402/403 (payment/forbidden), 429 (usage limit), 529 (overloaded) reroute to the sub.
-            for s in [402, 403, 429, 529] {
-                assert!(
-                    is_sub_fallback_status(s),
-                    "{s} must trigger the on-error fallback"
-                );
+        fn sub_fallback_triggers_on_capacity_and_transient_failures() {
+            // Quota/forbidden, throttling, overload, and transient server failures reroute.
+            for s in [402, 403, 408, 425, 429, 500, 502, 503, 504, 529] {
+                assert!(is_sub_fallback_status(s), "{s} must trigger the fallback");
             }
-            // A success, a validation error, and a generic 5xx do not — those are the replay net's
-            // or the client's to handle, not the subscription's.
-            for s in [200, 400, 422, 500, 503] {
+            // A success, validation errors, and missing Anthropic auth stay with the client.
+            for s in [200, 400, 401, 422] {
                 assert!(
                     !is_sub_fallback_status(s),
                     "{s} must not trigger the fallback"
                 );
             }
+        }
+
+        #[test]
+        fn sub_fallback_detects_embedded_stream_errors() {
+            assert!(is_sub_fallback_body(
+                br#"data: {"type":"error","error":{"message":"overloaded"}}
+
+"#
+            ));
+            assert!(is_sub_fallback_body(
+                br#"data: {"type": "message_stop", "error": {"type":"api_error"}}
+
+"#
+            ));
+            assert!(!is_sub_fallback_body(
+                br#"data: {"type":"message_stop","stop_reason":"end_turn"}
+
+"#
+            ));
         }
 
         #[test]
@@ -4158,7 +4255,8 @@ mod imp {
                 exclude_providers: Arc::new(Vec::new()),
                 sub: None,
                 sub_tiers: Arc::new(std::collections::BTreeMap::new()),
-                sub_on_error: false,
+                sub_chain: Arc::new(vec![]),
+                sub_fallback: false,
                 sub_effort: None,
             };
             (handler, rx)

--- a/crates/llmtrim-cli/src/transport.rs
+++ b/crates/llmtrim-cli/src/transport.rs
@@ -290,6 +290,8 @@ impl Endpoint {
 pub struct Upstream {
     pub status: u16,
     pub content_type: Option<String>,
+    /// Standard retry hint preserved for fallback/retry callers.
+    pub retry_after: Option<String>,
     pub reader: Box<dyn std::io::Read>,
 }
 
@@ -326,10 +328,16 @@ pub fn forward_post(
         .get("content-type")
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
+    let retry_after = response
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
     let reader = response.into_body().into_reader();
     Ok(Upstream {
         status,
         content_type,
+        retry_after,
         reader: Box::new(reader),
     })
 }
@@ -362,10 +370,16 @@ pub fn forward_get(
         .get("content-type")
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
+    let retry_after = response
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
     let reader = response.into_body().into_reader();
     Ok(Upstream {
         status,
         content_type,
+        retry_after,
         reader: Box::new(reader),
     })
 }

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -831,7 +831,7 @@ pub struct RuntimeConfig {
     /// model, no reasoning knob).
     pub sub_effort: Option<String>,
     /// Reroute only when Anthropic fails. When `true`, the proxy forwards to Anthropic as usual
-    /// and tries the ordered [`sub_chain`] providers on a quota, overload, transport, or
+    /// and tries the ordered [`sub_chain`](Self::sub_chain) providers on a quota, overload, transport, or
     /// retryable upstream failure; when `false` (default), a set `sub` reroutes every matching
     /// turn. Env `LLMTRIM_SUB_MODE` (`always`/`fallback`) or the file key `sub.mode`.
     pub sub_fallback: bool,

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -668,13 +668,27 @@ fn edit_sub_table_at(path: &std::path::Path, edit: impl FnOnce(&mut toml::Table)
     Ok(())
 }
 
-/// Set the reroute mode: `on_error` = reroute only when Anthropic fails, anything else = always.
+/// Set the reroute mode: `fallback` = reroute only when Anthropic fails, `always` = reroute every
+/// matching turn. No legacy spelling is accepted so the persisted configuration has one clear
+/// vocabulary.
 /// Preserves the active provider and every `[sub.<provider>.tiers]` entry.
-pub fn write_sub_mode(on_error: bool) -> Result<()> {
+pub fn write_sub_mode(fallback: bool) -> Result<()> {
     let path = config_path().ok_or_else(|| anyhow::anyhow!("no config path (HOME/XDG unset)"))?;
-    let mode = if on_error { "on_error" } else { "always" };
+    let mode = if fallback { "fallback" } else { "always" };
     edit_sub_table_at(&path, |t| {
         t.insert("mode".to_string(), toml::Value::String(mode.to_string()));
+    })
+}
+
+/// Persist the ordered provider chain used by `sub mode fallback`.
+pub fn write_sub_chain(providers: &[String]) -> Result<()> {
+    let path = config_path().ok_or_else(|| anyhow::anyhow!("no config path (HOME/XDG unset)"))?;
+    let values = providers
+        .iter()
+        .map(|p| toml::Value::String(p.trim().to_ascii_lowercase()))
+        .collect();
+    edit_sub_table_at(&path, |t| {
+        t.insert("chain".to_string(), toml::Value::Array(values));
     })
 }
 
@@ -816,12 +830,14 @@ pub struct RuntimeConfig {
     /// request. Env `LLMTRIM_CODEX_EFFORT` or file `sub.codex.effort`. Ignored by Kimi (single
     /// model, no reasoning knob).
     pub sub_effort: Option<String>,
-    /// Reroute only when Anthropic itself fails (usage limit / overload). When `true`, the proxy
-    /// forwards to Anthropic as usual and only replays the turn to the `sub` provider if Anthropic
-    /// answers with a quota/overload status (402/403/429/529); when `false` (default), a set `sub`
-    /// reroutes every matching turn. Env `LLMTRIM_SUB_MODE` (`always`/`on_error`) or the file key
-    /// `sub.mode`.
-    pub sub_on_error: bool,
+    /// Reroute only when Anthropic fails. When `true`, the proxy forwards to Anthropic as usual
+    /// and tries the ordered [`sub_chain`] providers on a quota, overload, transport, or
+    /// retryable upstream failure; when `false` (default), a set `sub` reroutes every matching
+    /// turn. Env `LLMTRIM_SUB_MODE` (`always`/`fallback`) or the file key `sub.mode`.
+    pub sub_fallback: bool,
+    /// Ordered subscription providers to try in fallback mode. Env `LLMTRIM_SUB_CHAIN` or
+    /// `[sub] chain = ["codex", "kimi"]`; when omitted, the active `sub` provider is used.
+    pub sub_chain: Vec<String>,
     /// Whether to enable server-side continuation for Codex reroutes (`previous_response_id` +
     /// delta-only `input` on follow-up turns). This keeps the upstream conversation state warm and
     /// improves real prompt-cache / token reuse (the mechanism behind good `♻ % cached` numbers).
@@ -911,7 +927,8 @@ impl RuntimeConfig {
                 active.filter(|s| s != "off" && !s.is_empty())
             },
             sub_tiers: resolve_sub_tiers(&env, file),
-            sub_on_error: resolve_sub_on_error(&env, file),
+            sub_fallback: resolve_sub_fallback(&env, file),
+            sub_chain: resolve_sub_chain(&env, file),
             sub_effort: resolve_sub_effort(&env, file),
             sub_codex_previous_response_id: resolve_sub_codex_continuation(&env, file),
         }
@@ -985,23 +1002,56 @@ fn resolve_sub_effort(
         .and_then(clean)
 }
 
-/// Whether reroute runs in `on_error` mode: env `LLMTRIM_SUB_MODE` (`on_error`/`on-error` → true,
+/// Whether reroute runs in `fallback` mode: env `LLMTRIM_SUB_MODE` (`fallback` → true,
 /// `always` → false) wins, else the `sub.mode` table key. Default `false` (reroute always).
-fn resolve_sub_on_error(env: &impl Fn(&str) -> Option<String>, file: Option<&toml::Value>) -> bool {
-    let is_on_error = |s: &str| {
-        matches!(
-            s.trim().to_ascii_lowercase().as_str(),
-            "on_error" | "on-error" | "onerror"
-        )
-    };
+fn resolve_sub_fallback(env: &impl Fn(&str) -> Option<String>, file: Option<&toml::Value>) -> bool {
+    let is_fallback = |s: &str| s.trim().eq_ignore_ascii_case("fallback");
     if let Some(v) = env("LLMTRIM_SUB_MODE").filter(|s| !s.is_empty()) {
-        return is_on_error(&v);
+        return is_fallback(&v);
     }
     file.and_then(|v| v.get("sub"))
         .and_then(|v| v.get("mode"))
         .and_then(toml::Value::as_str)
-        .map(is_on_error)
+        .map(is_fallback)
         .unwrap_or(false)
+}
+
+/// Ordered fallback providers from env or `[sub] chain`. Unknown entries are retained so the
+/// serve layer can report them clearly; an empty/missing chain falls back to the active provider.
+fn resolve_sub_chain(
+    env: &impl Fn(&str) -> Option<String>,
+    file: Option<&toml::Value>,
+) -> Vec<String> {
+    let parse = |raw: &str| {
+        raw.split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_ascii_lowercase())
+            .collect::<Vec<_>>()
+    };
+    if let Some(v) = env("LLMTRIM_SUB_CHAIN").filter(|s| !s.is_empty()) {
+        return parse(&v);
+    }
+    let sub = file.and_then(|v| v.get("sub"));
+    let mut chain = sub
+        .and_then(|v| v.get("chain"))
+        .map(|v| match v {
+            toml::Value::Array(values) => values
+                .iter()
+                .filter_map(toml::Value::as_str)
+                .flat_map(parse)
+                .collect(),
+            toml::Value::String(s) => parse(s),
+            _ => Vec::new(),
+        })
+        .unwrap_or_default();
+    if chain.is_empty()
+        && let Some(active) = resolve_sub_provider(env, file)
+        && active != "off"
+    {
+        chain.push(active);
+    }
+    chain
 }
 
 /// Codex continuation (previous_response_id deltas) enabled? Env `LLMTRIM_CODEX_PREVIOUS_RESPONSE_ID`
@@ -1345,19 +1395,40 @@ mod tests {
     }
 
     #[test]
-    fn sub_on_error_env_wins_over_file_mode() {
+    fn sub_fallback_env_wins_over_file_mode() {
         let file: toml::Value =
-            toml::from_str("[sub]\nactive = \"codex\"\nmode = \"on_error\"\n").unwrap();
+            toml::from_str("[sub]\nactive = \"codex\"\nmode = \"fallback\"\n").unwrap();
         let no_env = |_: &str| None;
-        assert!(resolve_sub_on_error(&no_env, Some(&file)));
+        assert!(resolve_sub_fallback(&no_env, Some(&file)));
         // Default is always (false) when no mode key.
         let plain: toml::Value = toml::from_str("sub = \"codex\"").unwrap();
-        assert!(!resolve_sub_on_error(&no_env, Some(&plain)));
+        assert!(!resolve_sub_fallback(&no_env, Some(&plain)));
         // Env overrides the file both ways.
         let env_always = |k: &str| (k == "LLMTRIM_SUB_MODE").then(|| "always".to_string());
-        assert!(!resolve_sub_on_error(&env_always, Some(&file)));
-        let env_err = |k: &str| (k == "LLMTRIM_SUB_MODE").then(|| "on-error".to_string());
-        assert!(resolve_sub_on_error(&env_err, Some(&plain)));
+        assert!(!resolve_sub_fallback(&env_always, Some(&file)));
+        let env_fallback = |k: &str| (k == "LLMTRIM_SUB_MODE").then(|| "fallback".to_string());
+        assert!(resolve_sub_fallback(&env_fallback, Some(&plain)));
+        let env_removed = |k: &str| (k == "LLMTRIM_SUB_MODE").then(|| "legacy".to_string());
+        assert!(!resolve_sub_fallback(&env_removed, Some(&plain)));
+    }
+
+    #[test]
+    fn sub_chain_reads_order_and_falls_back_to_active() {
+        let file: toml::Value =
+            toml::from_str("[sub]\nactive = \"codex\"\nchain = [\"kimi\", \"codex\"]\n").unwrap();
+        let no_env = |_: &str| None;
+        assert_eq!(
+            resolve_sub_chain(&no_env, Some(&file)),
+            vec!["kimi".to_string(), "codex".to_string()]
+        );
+        let plain: toml::Value = toml::from_str("sub = \"kimi\"").unwrap();
+        assert_eq!(resolve_sub_chain(&no_env, Some(&plain)), vec!["kimi"]);
+        let env =
+            |key: &str| (key == "LLMTRIM_SUB_CHAIN").then(|| "codex, kimi, codex".to_string());
+        assert_eq!(
+            resolve_sub_chain(&env, Some(&file)),
+            vec!["codex".to_string(), "kimi".to_string(), "codex".to_string()]
+        );
     }
 
     #[test]
@@ -1365,14 +1436,14 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("llmtrim-sub-edit-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("config.toml");
-        // Seed a full mapping + on-error mode.
+        // Seed a full mapping + fallback mode.
         let mut tiers = std::collections::BTreeMap::new();
         tiers.insert("opus".to_string(), "gpt-5.5".to_string());
         write_sub_mapping_at(&path, "codex", &tiers).unwrap();
         edit_sub_table_at(&path, |t| {
             t.insert(
                 "mode".to_string(),
-                toml::Value::String("on_error".to_string()),
+                toml::Value::String("fallback".to_string()),
             );
         })
         .unwrap();
@@ -1404,7 +1475,7 @@ mod tests {
             resolve_sub_provider(&no_env, Some(&file)).as_deref(),
             Some("codex")
         );
-        assert!(resolve_sub_on_error(&no_env, Some(&file)));
+        assert!(resolve_sub_fallback(&no_env, Some(&file)));
         let read = resolve_sub_tiers(&no_env, Some(&file));
         assert_eq!(read.get("opus").map(String::as_str), Some("gpt-5.5"));
         assert_eq!(
@@ -1434,7 +1505,7 @@ mod tests {
         .unwrap();
         let back: toml::Value = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert!(
-            resolve_sub_on_error(&no_env, Some(&back)),
+            resolve_sub_fallback(&no_env, Some(&back)),
             "mode survived off/on"
         );
         let restored = resolve_sub_tiers(&no_env, Some(&back));


### PR DESCRIPTION
## Summary

Implements ordered subscription fallback chains and fixes Claude Code rerouting through the Codex ChatGPT backend.

- Add `always` / `fallback` subscription modes and ordered `codex,kimi` fallback chains.
- Retry transient, quota, overload, auth, translation, transport, and embedded stream failures with bounded backoff.
- Keep Claude Sonnet mapped to `gpt-5.6-luna` and send GPT-5.6 requests using the standard Responses shape with the official Codex originator and user-agent identity.
- Preserve Codex encrypted thinking signatures across the Anthropic SSE boundary so Claude Code follow-up turns remain valid.
- Update CLI, monitor, statusline, configuration, documentation, changelog, and tests.

## Verification

- `cargo test -p llmtrim --lib` — 432 passed, 1 ignored
- `cargo build -p llmtrim --release`
- Isolated end-to-end Claude Code smoke test: Sonnet → `gpt-5.6-luna` → `OK`
- `git diff --check`

Related to #156.