### PR TITLE
fix: list GPT-5.6 Codex models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,7 +500,6 @@ jobs:
       - uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           package: llmtrim-core, llmtrim
-          release-type: major
 
   # Unused-dependency check. Dead deps inflate the binary and slow the build/startup that
   # this CLI optimizes for. cargo-machete is fast (manifest scan, no compile).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Ordered subscription fallback chains.** `llmtrim sub mode fallback` now tries a list of
+  providers in order instead of a single one: `llmtrim sub chain codex,kimi` (or
+  `LLMTRIM_SUB_CHAIN=codex,kimi`, or `[sub] chain = ["codex", "kimi"]`). When Anthropic cannot
+  serve a turn — quota, payment, throttling, overload, or a transient server failure — Anthropic is
+  retried once, and if it still fails each provider in the chain is tried in turn (with bounded
+  backoff, honoring `Retry-After`) until one answers. A failure reported *inside* an HTTP 200
+  stream counts as a failure too, and is caught before any of it reaches the client. With no chain
+  configured, the active `sub` provider is the chain, so existing setups behave as before.
+
+### Changed
+
+- **Breaking (config): `sub mode on-error` is now `sub mode fallback`.** The old name still works —
+  `llmtrim sub mode on-error`, `LLMTRIM_SUB_MODE=on_error`, and `[sub] mode = "on_error"` all keep
+  meaning fallback, and print a one-line notice — but the new spelling is what gets persisted.
+- **Breaking (library): `llmtrim-core`'s `RuntimeConfig::sub_on_error` is now `sub_fallback`**, and
+  `RuntimeConfig` gained a `sub_chain` field. Hence the 0.10 minor bump.
+
 ### Fixed
 
 - **GPT-5.6 Codex reroutes.** Claude model requests keep the standard Responses shape and use the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim"
-version = "0.9.5-dev"
+version = "0.10.0-dev"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-core"
-version = "0.9.5-dev"
+version = "0.10.0-dev"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-ledger"
-version = "0.9.5-dev"
+version = "0.10.0-dev"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-tray"
-version = "0.9.5-dev"
+version = "0.10.0-dev"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-uniffi"
-version = "0.9.5-dev"
+version = "0.10.0-dev"
 dependencies = [
  "llmtrim-core",
  "serde_json",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-wasm"
-version = "0.9.5-dev"
+version = "0.10.0-dev"
 dependencies = [
  "llmtrim-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = [
 
 # Shared package metadata — inherited by each member via `field.workspace = true`.
 [workspace.package]
-version = "0.9.5-dev"
+version = "0.10.0-dev"
 edition = "2024"
 rust-version = "1.88"
 repository = "https://github.com/fkiene/llmtrim"

--- a/README.md
+++ b/README.md
@@ -444,6 +444,9 @@ By default a set provider reroutes every turn. To use subscriptions only as a ba
 fallback mode: `llmtrim sub mode fallback` forwards to Anthropic as usual and tries the configured
 provider chain when Anthropic hits a quota, overload, transient server error, or transport failure.
 Set the order with `llmtrim sub chain codex,kimi`; `llmtrim sub mode always` restores the default.
+A transient failure (429/5xx) gets one bounded retry against Anthropic before the chain takes over,
+so a blip doesn't move the turn — and its spend — to another provider. (`on-error`, the pre-0.10
+name for this mode, still works.)
 
 The mapping is not limited to the four Claude tiers. `llmtrim sub map codex <from> <to>` remaps
 one model, where `from` is a tier name or an exact incoming model id, so any Anthropic-speaking

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -37,10 +37,10 @@ path = "src/main.rs"
 [dependencies]
 # `version` is required for `cargo publish` (path alone isn't publishable) and is kept in
 # lockstep with llmtrim-core by cargo-release's shared-version on every bump.
-llmtrim-core = { path = "../llmtrim-core", version = "0.9.5-dev" }
+llmtrim-core = { path = "../llmtrim-core", version = "0.10.0-dev" }
 # Published alongside core (see release.yml publish order). `version` is required
 # for `cargo publish` and is kept in lockstep by cargo-release's shared-version.
-llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.9.5-dev" }
+llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.10.0-dev" }
 anyhow.workspace = true
 chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive"] }

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -838,7 +838,9 @@ fn run_sub(action: SubCmd) -> Result<()> {
         }
         SubCmd::Mode { mode, no_restart } => {
             let fallback = match mode.trim().to_ascii_lowercase().as_str() {
-                "fallback" => true,
+                // The old names for the same mode: accepted so an existing muscle-memory command
+                // (or script) keeps working, but persisted under the new spelling.
+                "fallback" | "on-error" | "on_error" | "onerror" => true,
                 "always" => false,
                 other => anyhow::bail!("unknown mode '{other}' (always|fallback)"),
             };

--- a/crates/llmtrim-cli/src/reroute/codex.rs
+++ b/crates/llmtrim-cli/src/reroute/codex.rs
@@ -412,6 +412,15 @@ fn reasoning_encrypted_content(item: &Value) -> Option<String> {
 
 /// Build a Codex `reasoning` input item from an Anthropic thinking block (signature round-trips
 /// as `encrypted_content`). Returns `None` when the block carries nothing Codex can replay.
+fn reasoning_item(encrypted: &str, summary_text: &str) -> Value {
+    let summary = if summary_text.is_empty() {
+        json!([])
+    } else {
+        json!([{"type": "summary_text", "text": summary_text}])
+    };
+    json!({ "type": "reasoning", "encrypted_content": encrypted, "summary": summary })
+}
+
 fn thinking_input_item(block: &Value) -> Option<Value> {
     let thinking = block
         .get("thinking")
@@ -424,15 +433,7 @@ fn thinking_input_item(block: &Value) -> Option<Value> {
     if signature.is_empty() {
         return None;
     }
-    let mut item = json!({
-        "type": "reasoning",
-        "encrypted_content": signature,
-        "summary": [],
-    });
-    if !thinking.is_empty() {
-        item["summary"] = json!([{"type": "summary_text", "text": thinking}]);
-    }
-    Some(item)
+    Some(reasoning_item(signature, thinking))
 }
 
 /// Build the Responses `text.format` from an Anthropic `output_config.format`.
@@ -551,6 +552,9 @@ pub struct Reducer {
     deferred_text_deltas: Vec<String>,
     // Accumulation for continuation transcript (assistant outputs in codex input item shape)
     current_assistant_text: String,
+    /// Thinking text emitted downstream this block; replayed as the reasoning item's `summary` so
+    /// the transcript matches what `build_input` rebuilds from the echoed thinking block.
+    current_thinking: String,
     output_items: Vec<Value>,
 }
 
@@ -571,6 +575,7 @@ impl Reducer {
             last_signature: None,
             deferred_text_deltas: Vec::new(),
             current_assistant_text: String::new(),
+            current_thinking: String::new(),
             output_items: Vec::new(),
         }
     }
@@ -585,8 +590,14 @@ impl Reducer {
             && self.last_signature.as_deref() != Some(sig.as_str())
         {
             out.push(ReduceEvent::ThinkingSignatureDelta(sig.clone()));
+            // Continuation compares the stored transcript positionally against the input rebuilt
+            // next turn, where the echoed thinking block becomes a reasoning item ahead of the
+            // assistant message. Record the same item here or the prefix never matches again.
+            self.output_items
+                .push(reasoning_item(&sig, &self.current_thinking));
             self.last_signature = Some(sig);
         }
+        self.current_thinking.clear();
         out.push(ReduceEvent::ThinkingStop);
         self.open = Open::None;
         self.flush_deferred_text(out);
@@ -786,6 +797,7 @@ impl Reducer {
             }
             "response.reasoning_summary_part.added" => {
                 if self.open == Open::Thinking {
+                    self.current_thinking.push_str("\n\n");
                     out.push(ReduceEvent::ThinkingDelta("\n\n".to_string()));
                 }
             }
@@ -800,6 +812,7 @@ impl Reducer {
                     out.push(ReduceEvent::ThinkingStart);
                     self.open = Open::Thinking;
                 }
+                self.current_thinking.push_str(delta);
                 out.push(ReduceEvent::ThinkingDelta(delta.to_string()));
             }
             "response.output_text.delta" => {
@@ -1542,6 +1555,41 @@ mod tests {
                 .any(|i| i["content"][0]["text"] == "the answer"),
             "deferred text must also reach the continuation transcript"
         );
+    }
+
+    #[test]
+    fn reasoning_item_reaches_the_continuation_transcript() {
+        let sse = concat!(
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"pondering\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"enc1\"}}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"m\"}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"hi\"}\n\n",
+        );
+        let (_events, mut r) = reduce(sse);
+        let items = r.take_output_items();
+        // Continuation matches the stored transcript positionally against the input rebuilt next
+        // turn, where the echoed thinking block becomes a reasoning item ahead of the message.
+        assert_eq!(items[0]["type"], "reasoning");
+        assert_eq!(items[0]["encrypted_content"], "enc1");
+        assert_eq!(items[0]["summary"][0]["text"], "pondering");
+        assert_eq!(items[1]["type"], "message");
+
+        // ...and it must be byte-identical to what `build_input` reconstructs from that block.
+        let rebuilt = build_request_body(
+            &json!({
+                "messages": [{
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "pondering", "signature": "enc1"},
+                        {"type": "text", "text": "hi"}
+                    ]
+                }]
+            }),
+            "gpt-5.6-luna",
+            None,
+        )
+        .expect("build");
+        assert_eq!(rebuilt["input"][0], items[0]);
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -300,7 +300,10 @@ pub fn resolve_model(
 
 /// The Codex models the ChatGPT backend actually accepts. A model outside this set 400s upstream;
 /// the caller can still send it (forward-compat) but the mapping editor picks from this list.
-pub const CODEX_MODELS: [&str; 6] = [
+pub const CODEX_MODELS: [&str; 9] = [
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.6-sol",
     "gpt-5.2",
     "gpt-5.3-codex",
     "gpt-5.3-codex-spark",

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -2033,12 +2033,29 @@ mod imp {
                 session_id,
             )
             .map_err(|e| format!("translation failed: {e}"))?;
-            let logical_body = (provider == crate::reroute::SubProvider::Codex)
-                .then(|| serde_json::from_slice(&rewrite.body).ok())
-                .flatten();
+            // Same Codex continuation handling as the single-provider path: `logical_body` is the
+            // full pre-delta request kept for the transcript, while the request actually sent may
+            // carry `previous_response_id` plus only the new input. Without this the
+            // `record_codex_continuation` call on this path would store state nothing ever reads.
+            let mut sent_body = rewrite.body.clone();
+            let mut logical_body = None;
+            if provider == crate::reroute::SubProvider::Codex
+                && let Ok(mut bval) = serde_json::from_slice::<Value>(&rewrite.body)
+            {
+                logical_body = Some(bval.clone());
+                let enabled =
+                    llmtrim_core::config::RuntimeConfig::get().sub_codex_previous_response_id;
+                let cand = crate::reroute::continuation::continuation_candidate(
+                    session_id, &bval, enabled,
+                );
+                crate::reroute::continuation::apply_codex_continuation(&mut bval, &cand);
+                if let Ok(serialized) = serde_json::to_vec(&bval) {
+                    sent_body = serialized;
+                }
+            }
             let url = format!("https://{}{}", rewrite.host, rewrite.path);
             let headers = rewrite.headers.clone();
-            let body = String::from_utf8_lossy(&rewrite.body).into_owned();
+            let body = String::from_utf8_lossy(&sent_body).into_owned();
             let proxy = self.upstream_proxy.clone();
             let mut attempt = 0;
             loop {

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -375,8 +375,7 @@ mod imp {
     /// provider's session header).
     #[derive(Clone)]
     struct FallbackInfo {
-        /// First provider retained for the single-provider compatibility helper below.
-        provider: crate::reroute::SubProvider,
+        /// Providers to try, in order. Never empty (the arming site drops the fallback otherwise).
         providers: Vec<crate::reroute::SubProvider>,
         anthropic_body: Vec<u8>,
         session_id: Option<String>,
@@ -400,22 +399,39 @@ mod imp {
         )
     }
 
-    /// Some upstreams report a failed turn inside an HTTP 200 SSE response. In fallback mode the
-    /// Anthropic response is buffered before it is exposed to the client, so this path can still
-    /// fail over without emitting a malformed partial stream.
+    /// Some upstreams report a failed turn *inside* an HTTP 200 response: an `error` frame in the
+    /// SSE stream, or an error object in a non-streamed JSON reply. Only a top-level `{"type":
+    /// "error"}` counts — an assistant message that merely *mentions* that shape parses as its own
+    /// frame type (`content_block_delta`, …) and is not treated as a failure.
     fn is_sub_fallback_body(body: &[u8]) -> bool {
-        let text = String::from_utf8_lossy(body).to_ascii_lowercase();
+        let text = String::from_utf8_lossy(body);
         text.lines().any(|line| {
             let data = line
                 .strip_prefix("data:")
                 .map(str::trim)
                 .unwrap_or(line.trim());
-            if let Ok(value) = serde_json::from_str::<Value>(data) {
-                let kind = value.get("type").and_then(Value::as_str);
-                return kind == Some("error")
-                    || (kind == Some("message_stop") && value.get("error").is_some());
-            }
-            data.contains("\"type\":\"error\"") || data.contains("\"type\": \"error\"")
+            serde_json::from_str::<Value>(data)
+                .is_ok_and(|value| value.get("type").and_then(Value::as_str) == Some("error"))
+        })
+    }
+
+    /// Whether the SSE seen so far has already committed content to the client — the first
+    /// `message_start`/`content_block_*` frame. Past that point the turn cannot be failed over
+    /// (the client has the beginning of an answer), so the fallback probe stops peeking and
+    /// streams the rest through untouched.
+    fn sse_committed_content(body: &[u8]) -> bool {
+        let text = String::from_utf8_lossy(body);
+        text.lines().any(|line| {
+            let data = line
+                .strip_prefix("data:")
+                .map(str::trim)
+                .unwrap_or(line.trim());
+            serde_json::from_str::<Value>(data).is_ok_and(|value| {
+                matches!(
+                    value.get("type").and_then(Value::as_str),
+                    Some("message_start" | "content_block_start" | "content_block_delta")
+                )
+            })
         })
     }
 
@@ -447,21 +463,79 @@ mod imp {
         matches!(status, 400 | 422)
     }
 
-    /// Replay the original (uncompressed) request to the upstream — direct, all statuses
-    /// relayed — and build a response for the client. `None` if the replay itself fails (in
-    /// which case the caller keeps the compressed response's error).
-    fn replay_original(orig: &OriginalRequest, proxy_url: Option<&str>) -> Option<Response<Body>> {
+    /// Send the original (uncompressed) request to the upstream and buffer the reply. `None` if
+    /// the round-trip itself fails.
+    fn fetch_original(
+        orig: &OriginalRequest,
+        proxy_url: Option<&str>,
+    ) -> Option<(u16, Option<String>, Vec<u8>)> {
         use std::io::Read;
         let body = std::str::from_utf8(&orig.body).ok()?;
         let mut up =
             crate::transport::forward_post(&orig.url, &orig.headers, body, proxy_url).ok()?;
         let mut buf = Vec::new();
         up.reader.read_to_end(&mut buf).ok()?;
-        let mut builder = Response::builder().status(up.status);
-        if let Some(ct) = up.content_type {
+        Some((up.status, up.content_type, buf))
+    }
+
+    /// Build a client response from a buffered upstream reply.
+    fn buffered_response(
+        status: u16,
+        content_type: Option<String>,
+        body: Vec<u8>,
+    ) -> Response<Body> {
+        let mut builder = Response::builder().status(status);
+        if let Some(ct) = content_type {
             builder = builder.header(header::CONTENT_TYPE, ct);
         }
-        builder.body(Body::from(Full::new(Bytes::from(buf)))).ok()
+        builder
+            .body(Body::from(Full::new(Bytes::from(body))))
+            .unwrap_or_else(|_| Response::new(Body::empty()))
+    }
+
+    /// Replay the original (uncompressed) request to the upstream — direct, all statuses
+    /// relayed — and build a response for the client. `None` if the replay itself fails (in
+    /// which case the caller keeps the compressed response's error).
+    fn replay_original(orig: &OriginalRequest, proxy_url: Option<&str>) -> Option<Response<Body>> {
+        let (status, content_type, body) = fetch_original(orig, proxy_url)?;
+        Some(buffered_response(status, content_type, body))
+    }
+
+    /// Peek the head of an Anthropic SSE stream in fallback mode. Stops at the first frame that
+    /// either reports an error (`Err`: the turn has committed nothing to the client, so it can
+    /// still be failed over) or commits content (`message_start`/`content_block_*` — from there on
+    /// the client owns a partial answer and the rest streams through untouched). A transport
+    /// failure before any content is treated as a failed turn too: a dropped Anthropic connection
+    /// is exactly what the chain exists for.
+    async fn probe_sse_head(body: Body) -> Result<Body, ()> {
+        use hudsucker::futures::StreamExt;
+        let mut stream = BodyStream::new(body);
+        let mut head: Vec<Bytes> = Vec::new();
+        let mut seen = Vec::<u8>::new();
+        while let Some(frame) = stream.next().await {
+            let Ok(frame) = frame else {
+                return Err(());
+            };
+            let Ok(bytes) = frame.into_data() else {
+                continue;
+            };
+            seen.extend_from_slice(&bytes);
+            head.push(bytes);
+            if is_sub_fallback_body(&seen) {
+                return Err(());
+            }
+            if sse_committed_content(&seen) {
+                break;
+            }
+        }
+        let head = hudsucker::futures::stream::iter(head.into_iter().map(Ok));
+        let rest = stream.filter_map(|frame| {
+            hudsucker::futures::future::ready(match frame {
+                Ok(frame) => frame.into_data().ok().map(Ok),
+                Err(e) => Some(Err(e)),
+            })
+        });
+        Ok(Body::from_stream(head.chain(rest)))
     }
 
     /// A JSON body response (used for the local `count_tokens` answer on the reroute path).
@@ -549,6 +623,9 @@ mod imp {
     }
 
     const REROUTE_RETRY_MAX: u32 = 3;
+    /// Wall-clock budget for a whole fallback chain (all providers, all their retries). Bounds the
+    /// worst case a client waits after Anthropic already failed.
+    const FALLBACK_CHAIN_BUDGET: std::time::Duration = std::time::Duration::from_secs(90);
     const REROUTE_RETRY_BASE_MS: u64 = 1_000;
     const REROUTE_RETRY_CAP_MS: u64 = 20_000;
 
@@ -1099,30 +1176,33 @@ mod imp {
             // Anthropic normally, and only replays to the sub provider if Anthropic fails (handled
             // in the response phase). Captured here so we can read the session header and body.
             let mut fallback_arm: Option<(Vec<crate::reroute::SubProvider>, Option<String>)> = None;
-            if let Some(sub) = self.sub
-                && matches!(provider, Some(ProviderKind::Anthropic))
-                && req.method() == Method::POST
-            {
+            if matches!(provider, Some(ProviderKind::Anthropic)) && req.method() == Method::POST {
                 let path = req.uri().path();
                 if !self.sub_fallback {
-                    if path.ends_with("/v1/messages/count_tokens") {
-                        return self.reroute_count_tokens(req).await;
-                    }
-                    if path.ends_with("/v1/messages") {
-                        return self.reroute_messages(req, sub).await;
+                    if let Some(sub) = self.sub {
+                        if path.ends_with("/v1/messages/count_tokens") {
+                            return self.reroute_count_tokens(req).await;
+                        }
+                        if path.ends_with("/v1/messages") {
+                            return self.reroute_messages(req, sub).await;
+                        }
                     }
                 } else if path.ends_with("/v1/messages") {
-                    let session_id = req
-                        .headers()
-                        .get("x-claude-code-session-id")
-                        .and_then(|v| v.to_str().ok())
-                        .map(str::to_string);
-                    let providers = if self.sub_chain.is_empty() {
-                        vec![sub]
-                    } else {
-                        self.sub_chain.as_ref().clone()
-                    };
-                    fallback_arm = Some((providers, session_id));
+                    // A chain is enough to arm the fallback: `sub` selects who serves *every* turn
+                    // in `always` mode, but in fallback mode the chain is the whole answer, so
+                    // `sub = off` + a chain is a valid configuration.
+                    let mut providers = self.sub_chain.as_ref().clone();
+                    if providers.is_empty() {
+                        providers.extend(self.sub);
+                    }
+                    if !providers.is_empty() {
+                        let session_id = req
+                            .headers()
+                            .get("x-claude-code-session-id")
+                            .and_then(|v| v.to_str().ok())
+                            .map(str::to_string);
+                        fallback_arm = Some((providers, session_id));
+                    }
                 }
             }
             // Only compress POST bodies to a known provider; pass everything else through.
@@ -1216,12 +1296,7 @@ mod imp {
                 && let Some(body) = fallback_body
                 && let Some(pending) = self.pending.as_mut()
             {
-                let provider = providers
-                    .first()
-                    .copied()
-                    .unwrap_or(crate::reroute::SubProvider::Codex);
                 pending.fallback = Some(FallbackInfo {
-                    provider,
                     providers,
                     anthropic_body: body,
                     session_id,
@@ -1847,15 +1922,19 @@ mod imp {
             apply_sub_effort(&mut anthropic, self.sub_effort.as_deref());
 
             let mut providers = Vec::new();
-            for provider in fb.providers.iter().copied().chain([fb.provider]) {
+            for provider in fb.providers.iter().copied() {
                 if !providers.contains(&provider) {
                     providers.push(provider);
                 }
             }
+            // One wall-clock budget for the whole chain: per-provider backoff × N providers can
+            // otherwise outlast the client's own timeout, and a client that has already given up
+            // makes every further attempt pure waste (and pure spend).
+            let deadline = std::time::Instant::now() + FALLBACK_CHAIN_BUDGET;
             let mut failures = Vec::new();
             for provider in providers {
                 let attempt = match self
-                    .fallback_attempt(provider, &anthropic, fb.session_id.as_deref())
+                    .fallback_attempt(provider, &anthropic, fb.session_id.as_deref(), deadline)
                     .await
                 {
                     Ok(attempt) => attempt,
@@ -1936,7 +2015,11 @@ mod imp {
             provider: crate::reroute::SubProvider,
             anthropic: &Value,
             session_id: Option<&str>,
+            deadline: std::time::Instant,
         ) -> Result<FallbackAttempt, String> {
+            if std::time::Instant::now() >= deadline {
+                return Err("fallback budget exhausted".to_string());
+            }
             let token =
                 tokio::task::spawn_blocking(move || crate::reroute::auth::get_token(provider))
                     .await
@@ -1994,9 +2077,58 @@ mod imp {
                 let Some(wait_ms) = reroute_backoff_ms(attempt, retry_after) else {
                     return Err(format!("HTTP {status}: retry window exceeds budget"));
                 };
-                tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+                // Don't burn the chain's whole budget waiting on one provider: if this backoff
+                // would eat into the deadline, give the next provider its turn instead.
+                let wait = std::time::Duration::from_millis(wait_ms);
+                if std::time::Instant::now() + wait >= deadline {
+                    return Err(format!(
+                        "HTTP {status}: retry window exceeds fallback budget"
+                    ));
+                }
+                tokio::time::sleep(wait).await;
                 attempt += 1;
             }
+        }
+
+        /// One bounded retry of the turn against Anthropic before the chain takes over. A 503 or a
+        /// short 429 is usually a blip, and a blip should not move a turn (and its spend) to a
+        /// different provider. Returns the `Pending` back when no retry was possible or the retry
+        /// failed, so the caller falls through to the chain. The retry sends the *original*
+        /// (uncompressed) request — the compressed body isn't retained past the forward — so the
+        /// row is recorded honestly as a no-savings turn.
+        async fn retry_anthropic_once(
+            &self,
+            mut pending: Pending,
+            retry_after_secs: Option<u64>,
+        ) -> Result<Response<Body>, Pending> {
+            let Some(original) = pending.original.clone() else {
+                return Err(pending);
+            };
+            // A reset hint beyond the backoff cap (a usage limit hours away) means "don't wait" —
+            // go straight to the chain, which is the whole point of fallback mode.
+            let Some(wait_ms) = reroute_backoff_ms(0, retry_after_secs) else {
+                return Err(pending);
+            };
+            tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+            let proxy = self.upstream_proxy.clone();
+            let fetched =
+                tokio::task::spawn_blocking(move || fetch_original(&original, proxy.as_deref()))
+                    .await;
+            let Ok(Some((status, content_type, body))) = fetched else {
+                return Err(pending);
+            };
+            if !(200..300).contains(&status) || is_sub_fallback_body(&body) {
+                return Err(pending);
+            }
+            pending.input_after = pending.input_before;
+            pending.output_shaped = false;
+            let _finalize = Finalize {
+                acc: Arc::new(Mutex::new(body.clone())),
+                pending: Some(pending),
+                ledger: self.ledger.clone(),
+                breakdown_ledger: self.breakdown_ledger.clone(),
+            };
+            Ok(buffered_response(status, content_type, body))
         }
 
         /// Emit an Anthropic SSE `error` frame for a fallback that failed before/at the
@@ -2033,36 +2165,61 @@ mod imp {
             if let Some(info) = pending.reroute.clone() {
                 return self.reroute_response(res, pending, info).await;
             }
-            // Fallback reroute: Anthropic answered with a capacity/transient status, so replay the turn
-            // to the subscription provider instead of handing the client Anthropic's error.
+            // Fallback reroute: Anthropic could not serve the turn. On a *transient* status
+            // (429/5xx) Anthropic gets one bounded retry first — a blip should not hand the turn,
+            // and its spend, to another provider — and only then does the chain take over.
             if let Some(fb) = pending.fallback.clone()
                 && is_sub_fallback_status(res.status().as_u16())
             {
+                let status = res.status().as_u16();
+                let (parts, body) = res.into_parts();
+                let bytes = body
+                    .collect()
+                    .await
+                    .map(|c| c.to_bytes().to_vec())
+                    .unwrap_or_default();
+                let mut pending = pending;
+                if reroute_should_retry(status) {
+                    let hint = reroute_retry_after_from_headers(&parts.headers, &bytes);
+                    match self.retry_anthropic_once(pending, hint).await {
+                        Ok(response) => return response,
+                        Err(returned) => pending = returned,
+                    }
+                }
                 return self.fallback_to_chain(pending, fb).await;
             }
-            // Some providers encode an error as a successful SSE/JSON response. Buffer only in
-            // fallback mode so a failed stream can still advance to the next provider without
-            // exposing a partial response to Claude Code.
+            // An upstream can also report a failed turn inside an HTTP 200 body. In fallback mode
+            // we peek the *head* of the stream — up to the first error frame or the first frame
+            // that commits content to the client — and then forward the rest untouched. Buffering
+            // the whole response here would cost every fallback-mode user their streaming.
             let mut res = res;
-            if pending.fallback.is_some() && (200..300).contains(&res.status().as_u16()) {
-                let is_stream = res
+            if let Some(fb) = pending.fallback.clone()
+                && (200..300).contains(&res.status().as_u16())
+            {
+                let content_type = res
                     .headers()
                     .get(header::CONTENT_TYPE)
                     .and_then(|v| v.to_str().ok())
-                    .is_some_and(|v| v.contains("event-stream") || v.contains("json"));
-                if is_stream {
+                    .unwrap_or_default()
+                    .to_string();
+                if content_type.contains("event-stream") {
+                    let (parts, body) = res.into_parts();
+                    match probe_sse_head(body).await {
+                        Ok(body) => res = Response::from_parts(parts, body),
+                        Err(()) => return self.fallback_to_chain(pending, fb).await,
+                    }
+                } else if content_type.contains("json") {
+                    // Non-streamed JSON is a single small object: buffering it costs nothing.
                     let (parts, body) = res.into_parts();
                     let bytes = body
                         .collect()
                         .await
                         .map(|c| c.to_bytes().to_vec())
                         .unwrap_or_default();
-                    if is_sub_fallback_body(&bytes)
-                        && let Some(fb) = pending.fallback.clone()
-                    {
+                    if is_sub_fallback_body(&bytes) {
                         return self.fallback_to_chain(pending, fb).await;
                     }
-                    res = Response::from_parts(parts, Body::from(bytes));
+                    res = Response::from_parts(parts, Body::from(Full::new(Bytes::from(bytes))));
                 }
             }
             // Safety net: if the upstream rejected our compressed request with a *validation*
@@ -2976,7 +3133,17 @@ mod imp {
                 RuntimeConfig::get()
                     .sub_chain
                     .iter()
-                    .filter_map(|p| crate::reroute::SubProvider::parse(p))
+                    .filter_map(|p| {
+                        let parsed = crate::reroute::SubProvider::parse(p);
+                        if parsed.is_none() {
+                            // Silently dropping it would leave a typo'd chain quietly shorter than
+                            // the user configured — and the fallback they think they have missing.
+                            eprintln!(
+                                "llmtrim: unknown provider '{p}' in the sub fallback chain — ignored (expected codex|kimi)"
+                            );
+                        }
+                        parsed
+                    })
                     .collect(),
             ),
             sub_tiers: Arc::new(RuntimeConfig::get().sub_tiers.clone()),
@@ -4137,16 +4304,68 @@ mod imp {
 
 "#
             ));
+            // A non-streamed JSON error body.
             assert!(is_sub_fallback_body(
-                br#"data: {"type": "message_stop", "error": {"type":"api_error"}}
-
-"#
+                br#"{"type":"error","error":{"type":"overloaded_error"}}"#
             ));
             assert!(!is_sub_fallback_body(
                 br#"data: {"type":"message_stop","stop_reason":"end_turn"}
 
 "#
             ));
+            // An assistant message that merely *quotes* an error frame is not a failed turn.
+            assert!(!is_sub_fallback_body(
+                br#"data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"{\"type\":\"error\"}"}}
+
+"#
+            ));
+        }
+
+        #[test]
+        fn sse_committed_content_marks_the_point_of_no_failover() {
+            assert!(sse_committed_content(
+                br#"data: {"type":"message_start","message":{"id":"m"}}
+
+"#
+            ));
+            assert!(sse_committed_content(
+                br#"data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}
+
+"#
+            ));
+            // A ping alone commits nothing: the turn can still be failed over.
+            assert!(!sse_committed_content(
+                br#"data: {"type":"ping"}
+
+"#
+            ));
+        }
+
+        #[tokio::test]
+        async fn probe_sse_head_streams_a_good_response_through_unbuffered() {
+            let body = Body::from(Full::new(Bytes::from(
+                "event: message_start\ndata: {\"type\":\"message_start\"}\n\n\
+                 data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n\
+                 data: {\"type\":\"message_stop\"}\n\n",
+            )));
+            let out = probe_sse_head(body)
+                .await
+                .expect("a good stream must not fail over");
+            let bytes = out.collect().await.unwrap().to_bytes();
+            let text = String::from_utf8_lossy(&bytes);
+            assert!(text.contains("message_start"), "head is replayed");
+            assert!(text.contains("message_stop"), "tail still streams");
+        }
+
+        #[tokio::test]
+        async fn probe_sse_head_fails_over_on_an_error_frame() {
+            let body = Body::from(Full::new(Bytes::from(
+                "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\"}}\n\n",
+            )));
+            assert!(
+                probe_sse_head(body).await.is_err(),
+                "an error frame before any content must fail over"
+            );
         }
 
         #[test]

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1004,15 +1004,43 @@ fn resolve_sub_effort(
 
 /// Whether reroute runs in `fallback` mode: env `LLMTRIM_SUB_MODE` (`fallback` → true,
 /// `always` → false) wins, else the `sub.mode` table key. Default `false` (reroute always).
+///
+/// The pre-0.10 spellings (`on_error`/`on-error`/`onerror`) still resolve to `fallback` — they
+/// mean the same thing, and silently reading them as `always` would flip an existing config into
+/// rerouting *every* turn to the subscription provider. An unrecognized value is reported and
+/// treated as `always` (the default), never as fallback.
+fn parse_sub_mode(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "always" => Some(false),
+        "fallback" => Some(true),
+        "on_error" | "on-error" | "onerror" => {
+            eprintln!(
+                "llmtrim: sub mode '{}' is the old name for 'fallback' — run `llmtrim sub mode fallback` to update the config",
+                raw.trim()
+            );
+            Some(true)
+        }
+        _ => None,
+    }
+}
+
 fn resolve_sub_fallback(env: &impl Fn(&str) -> Option<String>, file: Option<&toml::Value>) -> bool {
-    let is_fallback = |s: &str| s.trim().eq_ignore_ascii_case("fallback");
+    let resolve = |raw: &str, source: &str| {
+        parse_sub_mode(raw).unwrap_or_else(|| {
+            eprintln!(
+                "llmtrim: unknown sub mode '{}' in {source} — using 'always' (expected always|fallback)",
+                raw.trim()
+            );
+            false
+        })
+    };
     if let Some(v) = env("LLMTRIM_SUB_MODE").filter(|s| !s.is_empty()) {
-        return is_fallback(&v);
+        return resolve(&v, "LLMTRIM_SUB_MODE");
     }
     file.and_then(|v| v.get("sub"))
         .and_then(|v| v.get("mode"))
         .and_then(toml::Value::as_str)
-        .map(is_fallback)
+        .map(|v| resolve(v, "[sub] mode"))
         .unwrap_or(false)
 }
 
@@ -1408,8 +1436,23 @@ mod tests {
         assert!(!resolve_sub_fallback(&env_always, Some(&file)));
         let env_fallback = |k: &str| (k == "LLMTRIM_SUB_MODE").then(|| "fallback".to_string());
         assert!(resolve_sub_fallback(&env_fallback, Some(&plain)));
-        let env_removed = |k: &str| (k == "LLMTRIM_SUB_MODE").then(|| "legacy".to_string());
-        assert!(!resolve_sub_fallback(&env_removed, Some(&plain)));
+        // An unknown value is not fallback (defaults to always, the documented default).
+        let env_unknown = |k: &str| (k == "LLMTRIM_SUB_MODE").then(|| "wat".to_string());
+        assert!(!resolve_sub_fallback(&env_unknown, Some(&plain)));
+    }
+
+    #[test]
+    fn sub_mode_legacy_on_error_still_means_fallback() {
+        // A pre-0.10 config must not silently flip to rerouting every turn.
+        let no_env = |_: &str| None;
+        for legacy in ["on_error", "on-error", "onerror"] {
+            let file: toml::Value =
+                toml::from_str(&format!("[sub]\nactive = \"codex\"\nmode = \"{legacy}\"\n"))
+                    .unwrap();
+            assert!(resolve_sub_fallback(&no_env, Some(&file)), "{legacy}");
+        }
+        let env = |k: &str| (k == "LLMTRIM_SUB_MODE").then(|| "on-error".to_string());
+        assert!(resolve_sub_fallback(&env, None));
     }
 
     #[test]

--- a/crates/llmtrim-ledger/Cargo.toml
+++ b/crates/llmtrim-ledger/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["llm", "sqlite", "tokens", "compression", "tracking"]
 categories = ["database", "development-tools"]
 
 [dependencies]
-llmtrim-core = { path = "../llmtrim-core", version = "0.9.5-dev" }
+llmtrim-core = { path = "../llmtrim-core", version = "0.10.0-dev" }
 anyhow.workspace = true
 chrono = "0.4.45"
 rusqlite = { version = "0.39", features = ["bundled"] }

--- a/crates/llmtrim-tray/Cargo.toml
+++ b/crates/llmtrim-tray/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.9.5-dev" }
+llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.10.0-dev" }
 # image-png: required for Image::from_bytes to decode the embedded PNG tray icon.
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }


### PR DESCRIPTION
## Summary
- add GPT-5.6 Terra, Luna, and Sol to the curated Codex model catalog
- make them selectable in the subscription mapping/status UI

## Testing
- cargo test -p llmtrim reroute::catalog::tests::codex_returns_exactly_curated_ids --lib