### PR TITLE
fix(statusline): show the backend that actually served the turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Status line claimed a reroute that never happened in `sub` fallback mode.** The reroute arrow
+  and the context gauge were derived from config: if `sub` was set, the line rendered
+  `◆ Opus→gpt-5.6-terra` on every turn. But in `fallback` mode Anthropic serves the turn and the
+  chain fires only when Anthropic *fails* — so the arrow named a backend that hadn't answered, and
+  the gauge rescaled to that backend's context window, under-reporting how full the real (Claude)
+  window was. The serving backend is now recorded per turn in the ledger (new `sub_provider`
+  column, added to existing ledgers on open) and the status line reads *that*: the arrow appears
+  only on a turn a backend genuinely served, and shows the model it ran. In `always` mode, where
+  every turn reroutes, config still seeds the arrow before the first turn lands, so nothing
+  changes there.
+
 ### Added
 
 - **Ordered subscription fallback chains.** `llmtrim sub mode fallback` now tries a list of

--- a/README.md
+++ b/README.md
@@ -296,9 +296,11 @@ The printed block is the standard MCP config; for a client you edit by hand it l
 ```
 
 **Status line for Claude Code.** `llmtrim statusline` renders a single line for Claude Code's
-[custom status line](https://code.claude.com/docs/en/statusline): the model, the subscription
-actually serving the turn when you reroute (e.g. `→gpt-5.6-terra` or `→kimi`), a context-health gauge, and how
-much llmtrim is trimming, plus rate-limit and prompt-cache reuse when Claude Code reports them.
+[custom status line](https://code.claude.com/docs/en/statusline): the model, the backend that
+actually served the turn when you reroute (e.g. `→gpt-5.6-terra` or `→kimi`), a context-health
+gauge, and how much llmtrim is trimming, plus rate-limit and prompt-cache reuse when Claude Code
+reports them. The arrow reflects what answered, not what's configured — so in `sub` fallback mode
+it stays off while Anthropic is serving, and appears on the turns the chain actually fires.
 
 ```bash
 llmtrim statusline install          # wire it into ~/.claude/settings.json

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -2399,6 +2399,8 @@ mod tests {
             input_before: 1000,
             input_after: 600,
             last_ts: "2026-06-19T00:00:00+00:00".to_string(),
+            last_sub_provider: None,
+            last_model: None,
         }
     }
 
@@ -2899,6 +2901,7 @@ mod tests {
             session_name: Some(name.into()),
             provider: "anthropic".into(),
             model: Some("claude-opus-4-8".into()),
+            sub_provider: None,
             window: 200_000,
             fresh_input: 6_000,
             cache_read: 22_000,

--- a/crates/llmtrim-cli/src/breakdown/export.rs
+++ b/crates/llmtrim-cli/src/breakdown/export.rs
@@ -148,6 +148,8 @@ mod tests {
             input_before: 1000,
             input_after: 600,
             last_ts: "2026-06-19T00:00:00+00:00".to_string(),
+            last_sub_provider: None,
+            last_model: None,
         }
     }
 

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -976,6 +976,10 @@ mod imp {
             session_name: None,
             provider: provider.to_string(),
             model: p.model.clone(),
+            // Who actually answered. `reroute` is set up front in `always` mode, and in
+            // `fallback` mode only once an attempt has *succeeded* — so it is true per turn,
+            // which config alone can never be (a fallback fires only when Anthropic fails).
+            sub_provider: p.reroute.as_ref().map(|r| r.provider.as_str().to_string()),
             // The window heuristic (`window_for`) can under-shoot — it can't tell a 1M-context
             // beta from the model id — which would make occupancy exceed 100%. The window must
             // be at least the prompt actually sent, so clamp it to the real input size.

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -18,8 +18,12 @@
 //! gone cold, where the cache segment becomes `♻ cold · /compact`. Segments whose data is
 //! absent — no reroute, an API-key user with no rate limits — simply don't render.
 //!
-//! Under `sub` the arrow shows the concrete model actually serving the turn (e.g. `→gpt-5.6-terra`)
-//! for Codex reroutes; Kimi shows the provider shortname (`→kimi`) since all tiers collapse.
+//! Under `sub` the arrow shows the concrete model that served the last turn (e.g.
+//! `→gpt-5.6-terra`) for Codex reroutes; Kimi shows the provider shortname (`→kimi`), since all
+//! its tiers collapse to one internal wire id. The arrow is read from the ledger — what actually
+//! answered — not from config, because in `fallback` mode config predicts nothing: Anthropic
+//! serves the turn and the chain fires only if it fails. So there the arrow appears only on turns
+//! a backend really served, and the gauge keeps Claude's window until one does.
 //!
 //! `install` wires it into `~/.claude/settings.json`; rendering itself never touches the
 //! network or API tokens.
@@ -221,13 +225,7 @@ fn proxy_health() -> Health {
 
 fn ledger_snapshot(cc: &CcInput) -> Led {
     let cfg = llmtrim_core::config::RuntimeConfig::get();
-    let reroute = cfg.sub.clone().filter(|s| !s.is_empty() && s != "off");
-    let reroute_window = reroute
-        .as_deref()
-        .and_then(|p| reroute_real_window(p, &cc.model_id, &cfg.sub_tiers));
-    let resolved_model = reroute
-        .as_deref()
-        .and_then(|p| reroute_resolved_model(p, &cc.model_id, &cfg.sub_tiers));
+    let configured = cfg.sub.clone().filter(|s| !s.is_empty() && s != "off");
     let health = proxy_health();
 
     // One session-row read serves both trim and cache-cold. Match on `cc_session_id` — the real
@@ -248,6 +246,25 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
     let ledger_cold = row.as_ref().is_some_and(|r| cache_cold(&r.last_ts));
     let cache_cold = effective_cache_cold(cc, ledger_cold);
 
+    let (reroute, reroute_window, resolved_model) =
+        match arrow_source(configured.as_deref(), cfg.sub_fallback, row.as_ref()) {
+            // Truth: the backend that answered the last turn, and the model recorded on it.
+            ArrowSource::Served { provider, model } => {
+                let window = model.as_deref().and_then(upstream_window);
+                // Kimi collapses every tier to one internal wire id, which tells the user nothing
+                // the provider shortname doesn't — so the arrow keeps the shortname there.
+                let shown = model.filter(|_| provider != "kimi");
+                (Some(provider), window, shown)
+            }
+            // Prediction (always mode, no turn yet): resolve from the configured tier mapping.
+            ArrowSource::Predicted(provider) => (
+                Some(provider.clone()),
+                reroute_real_window(&provider, &cc.model_id, &cfg.sub_tiers),
+                reroute_resolved_model(&provider, &cc.model_id, &cfg.sub_tiers),
+            ),
+            ArrowSource::None => (None, None, None),
+        };
+
     Led {
         health,
         trim_pct,
@@ -258,12 +275,62 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
     }
 }
 
+/// Where the reroute arrow's content comes from.
+enum ArrowSource {
+    /// The ledger recorded this backend serving the session's last turn. Ground truth.
+    Served {
+        provider: String,
+        model: Option<String>,
+    },
+    /// No turn recorded yet, but `always` mode reroutes every turn — so config predicts it.
+    Predicted(String),
+    /// Anthropic is serving (or nothing is configured): no arrow.
+    None,
+}
+
+/// Decide what the reroute arrow may claim.
+///
+/// The ledger wins whenever it has a turn for this session, because only it knows who actually
+/// answered. Config is consulted solely to bridge the gap before the first turn lands, and only in
+/// `always` mode — where every turn reroutes, so the prediction is sound and the arrow doesn't have
+/// to blink in late on a fresh session.
+///
+/// In `fallback` mode config predicts nothing: the chain fires only when Anthropic actually fails.
+/// Claiming a reroute there would be a lie on every healthy turn (and would rescale the context
+/// gauge to the wrong backend's window), so the arrow stays off until the ledger shows a turn a
+/// backend really served.
+fn arrow_source(
+    configured: Option<&str>,
+    fallback_mode: bool,
+    row: Option<&SessionLedgerRow>,
+) -> ArrowSource {
+    match row {
+        Some(r) => match &r.last_sub_provider {
+            Some(provider) => ArrowSource::Served {
+                provider: provider.clone(),
+                model: r.last_model.clone(),
+            },
+            // A recorded turn that no backend served: Anthropic answered it.
+            None => ArrowSource::None,
+        },
+        None => match configured {
+            Some(p) if !fallback_mode => ArrowSource::Predicted(p.to_string()),
+            _ => ArrowSource::None,
+        },
+    }
+}
+
 /// The ledger fields the status line needs from a session's row: its summed savings and the
 /// timestamp of its last turn (for the cold-cache check).
 struct SessionLedgerRow {
     input_before: i64,
     input_after: i64,
     last_ts: String,
+    /// The `sub` backend that served this session's most recent turn, and that turn's model id.
+    /// The ground truth behind the reroute arrow: in fallback mode a reroute happens only when
+    /// Anthropic actually failed, which config cannot predict.
+    last_sub_provider: Option<String>,
+    last_model: Option<String>,
 }
 
 /// This Claude Code session's aggregated ledger row, matched on the real `cc_session_id`. Behind
@@ -282,6 +349,8 @@ fn session_row(sid: &str) -> Option<SessionLedgerRow> {
             input_before: r.input_before,
             input_after: r.input_after,
             last_ts: r.last_ts,
+            last_sub_provider: r.last_sub_provider,
+            last_model: r.last_model,
         })
 }
 
@@ -327,14 +396,24 @@ fn reroute_real_window(
         "kimi" => SubProvider::Kimi,
         _ => return None,
     };
-    let resolved = crate::reroute::resolve_model(sp, incoming_model_id, tiers);
-    // `kimi-for-coding` is an internal routing id, not a models.dev key — map to the public one.
-    let lookup = if resolved == crate::reroute::KIMI_MODEL {
+    upstream_window(&crate::reroute::resolve_model(sp, incoming_model_id, tiers))
+}
+
+/// Registry window of a concrete upstream model id. `kimi-for-coding` is an internal routing id,
+/// not a models.dev key — map it to the public one.
+#[cfg(feature = "intercept")]
+fn upstream_window(model: &str) -> Option<i64> {
+    let lookup = if model == crate::reroute::KIMI_MODEL {
         "moonshotai/kimi-k2"
     } else {
-        resolved.as_str()
+        model
     };
     llmtrim_core::context_window(lookup).map(|w| w as i64)
+}
+
+#[cfg(not(feature = "intercept"))]
+fn upstream_window(_model: &str) -> Option<i64> {
+    None
 }
 
 #[cfg(not(feature = "intercept"))]
@@ -1030,6 +1109,63 @@ mod tests {
             !out.contains("kimi-for-coding"),
             "no internal wire id on the line: {out}"
         );
+    }
+
+    fn ledger_row(sub: Option<&str>, model: Option<&str>) -> SessionLedgerRow {
+        SessionLedgerRow {
+            input_before: 1000,
+            input_after: 940,
+            last_ts: chrono::Utc::now().to_rfc3339(),
+            last_sub_provider: sub.map(str::to_string),
+            last_model: model.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn fallback_mode_shows_no_arrow_until_a_backend_actually_serves() {
+        // Anthropic served the turn: the chain is armed but never fired, so claiming a reroute
+        // would be a lie — and would rescale the gauge to Codex's window.
+        let row = ledger_row(None, Some("claude-opus-4-8"));
+        assert!(matches!(
+            arrow_source(Some("codex"), true, Some(&row)),
+            ArrowSource::None
+        ));
+    }
+
+    #[test]
+    fn fallback_mode_shows_the_backend_once_the_chain_fires() {
+        let row = ledger_row(Some("codex"), Some("gpt-5.6-terra"));
+        let ArrowSource::Served { provider, model } = arrow_source(Some("codex"), true, Some(&row))
+        else {
+            panic!("a fired fallback must surface the backend that served it");
+        };
+        assert_eq!(provider, "codex");
+        assert_eq!(model.as_deref(), Some("gpt-5.6-terra"));
+    }
+
+    #[test]
+    fn fallback_mode_never_predicts_from_config_on_a_fresh_session() {
+        // No turn yet. `always` mode could predict; fallback mode cannot — Anthropic serves the
+        // first turn and the chain only fires if it fails.
+        assert!(matches!(
+            arrow_source(Some("codex"), true, None),
+            ArrowSource::None
+        ));
+        assert!(matches!(
+            arrow_source(Some("codex"), false, None),
+            ArrowSource::Predicted(p) if p == "codex"
+        ));
+    }
+
+    #[test]
+    fn ledger_truth_overrides_a_stale_config_prediction() {
+        // `sub` says kimi, but the last turn was actually served by codex — show what happened.
+        let row = ledger_row(Some("codex"), Some("gpt-5.6-terra"));
+        let ArrowSource::Served { provider, .. } = arrow_source(Some("kimi"), false, Some(&row))
+        else {
+            panic!("the ledger outranks config");
+        };
+        assert_eq!(provider, "codex");
     }
 
     #[test]

--- a/crates/llmtrim-ledger/src/breakdown_db.rs
+++ b/crates/llmtrim-ledger/src/breakdown_db.rs
@@ -30,6 +30,13 @@ pub struct SessionRow {
     pub input_after: i64,
     /// rfc3339 timestamp of the most recent turn, for sorting newest-first.
     pub last_ts: String,
+    /// The `sub` backend that served the session's *most recent* turn (`codex`/`kimi`), or `None`
+    /// when Anthropic served it. Per-turn rather than per-session because in fallback mode the
+    /// backend can change from one turn to the next.
+    pub last_sub_provider: Option<String>,
+    /// The model id of that same most-recent turn — the upstream model (e.g. `gpt-5.6-terra`)
+    /// when `last_sub_provider` is set, else the Claude model.
+    pub last_model: Option<String>,
 }
 
 impl SessionRow {
@@ -101,17 +108,23 @@ impl BreakdownDb {
         let mut stmt = self
             .conn
             .prepare(
-                // One pass: rank each turn within its session (a named row first, then newest)
-                // so the latest `session_name` is `rn = 1`, then aggregate — instead of a
-                // correlated subquery that re-scanned the table once per session group.
+                // One pass, two rankings — instead of correlated subqueries that re-scanned the
+                // table once per session group. `rn` prefers a *named* row (so the session keeps
+                // its latest `session_name`), while `recent` is strictly newest-first: the backend
+                // that served the last turn must come from the newest row, not the newest *named*
+                // one.
                 "WITH ranked AS (
                      SELECT session_id, cc_session_id, agent, project, session_name, ts, id,
                             fresh_input, cache_read, cache_write, output_tok,
-                            bill_micros, input_before, input_after,
+                            bill_micros, input_before, input_after, sub_provider, model,
                             ROW_NUMBER() OVER (
                                 PARTITION BY session_id, agent, project
                                 ORDER BY (session_name IS NOT NULL) DESC, id DESC
-                            ) AS rn
+                            ) AS rn,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY session_id, agent, project
+                                ORDER BY id DESC
+                            ) AS recent
                      FROM breakdown_turns
                  )
                  SELECT session_id, agent, project,
@@ -124,7 +137,9 @@ impl BreakdownDb {
                         COALESCE(SUM(input_before), 0),
                         COALESCE(SUM(input_after), 0),
                         MAX(ts),
-                        MAX(cc_session_id)
+                        MAX(cc_session_id),
+                        MAX(CASE WHEN recent = 1 THEN sub_provider END),
+                        MAX(CASE WHEN recent = 1 THEN model END)
                  FROM ranked
                  GROUP BY session_id, agent, project
                  ORDER BY MAX(ts) DESC",
@@ -151,6 +166,8 @@ impl BreakdownDb {
                     input_after: r.get(10)?,
                     last_ts: r.get(11)?,
                     cc_session_id: r.get(12)?,
+                    last_sub_provider: r.get(13)?,
+                    last_model: r.get(14)?,
                 })
             })
             .context("failed to query sessions")?;
@@ -272,6 +289,7 @@ mod tests {
             session_name: Some("my session".to_string()),
             provider: "anthropic".to_string(),
             model: Some("claude-sonnet-4".to_string()),
+            sub_provider: None,
             window: 200_000,
             fresh_input: 50,
             cache_read: 120,
@@ -345,6 +363,109 @@ mod tests {
             rows[0].cc_session_id.as_deref(),
             Some("968ad7ea-6e4a-430e-a708-4eda80c8b858")
         );
+    }
+
+    #[test]
+    fn a_ledger_written_before_sub_provider_existed_still_queries() {
+        // The upgrade path: `sessions()` now SELECTs `sub_provider`, so a ledger created by an
+        // older llmtrim must gain the column on open or every status-line render would error out.
+        let path = std::env::temp_dir().join(format!(
+            "llmtrim-legacy-ledger-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let legacy = Connection::open(&path).unwrap();
+        legacy
+            .execute_batch(
+                "CREATE TABLE breakdown_turns (
+                     id INTEGER PRIMARY KEY, ts TEXT NOT NULL, session_id TEXT NOT NULL,
+                     agent TEXT NOT NULL, project TEXT, session_name TEXT,
+                     provider TEXT NOT NULL, model TEXT, window INTEGER NOT NULL,
+                     fresh_input INTEGER NOT NULL, cache_read INTEGER NOT NULL,
+                     cache_write INTEGER NOT NULL, output_tok INTEGER NOT NULL,
+                     input_rate REAL NOT NULL, output_rate REAL NOT NULL,
+                     cache_read_rate REAL NOT NULL, cache_write_rate REAL NOT NULL,
+                     bill_micros INTEGER NOT NULL
+                 );
+                 INSERT INTO breakdown_turns
+                     (ts, session_id, agent, provider, model, window, fresh_input, cache_read,
+                      cache_write, output_tok, input_rate, output_rate, cache_read_rate,
+                      cache_write_rate, bill_micros)
+                 VALUES ('2026-07-01T00:00:00+00:00', 'sess-old', 'claude-code', 'anthropic',
+                         'claude-sonnet-4', 200000, 10, 0, 0, 5, 3.0, 15.0, 0.3, 3.75, 100);",
+            )
+            .unwrap();
+        drop(legacy);
+
+        let tracker = Tracker::open_reader_at(&path).unwrap();
+        let db = BreakdownDb::from_connection(tracker.into_connection());
+        let rows = db.sessions().unwrap();
+        assert_eq!(rows.len(), 1);
+        // The pre-existing turn has no recorded backend — Anthropic served it, as far as we know.
+        assert_eq!(rows[0].last_sub_provider, None);
+        assert_eq!(rows[0].last_model.as_deref(), Some("claude-sonnet-4"));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn sessions_report_the_backend_that_served_the_newest_turn() {
+        // The `turn()` fixture carries a `session_name`, and the name ranking (`rn`) prefers a
+        // *named* row — so a "latest turn" read off that ranking would answer with whichever named
+        // row sorted first, not the newest one. Anthropic serves turn 1, a fallback to codex fires
+        // on turn 2: the session must report codex, and the model it actually ran.
+        let tracker = Tracker::open_in_memory().unwrap();
+        tracker
+            .record_breakdown(
+                &turn("sess-a"),
+                &[block("Static", "System prompt", None, 50.0, 100.0)],
+            )
+            .unwrap();
+        let mut fired = turn("sess-a");
+        fired.sub_provider = Some("codex".to_string());
+        fired.model = Some("gpt-5.6-terra".to_string());
+        tracker
+            .record_breakdown(
+                &fired,
+                &[block("Static", "System prompt", None, 50.0, 100.0)],
+            )
+            .unwrap();
+
+        let db = BreakdownDb::from_connection(tracker.into_connection());
+        let rows = db.sessions().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].last_sub_provider.as_deref(), Some("codex"));
+        assert_eq!(rows[0].last_model.as_deref(), Some("gpt-5.6-terra"));
+    }
+
+    #[test]
+    fn sessions_report_no_backend_when_anthropic_served_the_newest_turn() {
+        // The reverse order: the fallback fired once, then Anthropic served the latest turn. The
+        // arrow must go away again rather than latch on the older rerouted turn.
+        let tracker = Tracker::open_in_memory().unwrap();
+        let mut fired = turn("sess-a");
+        fired.sub_provider = Some("codex".to_string());
+        fired.model = Some("gpt-5.6-terra".to_string());
+        tracker
+            .record_breakdown(
+                &fired,
+                &[block("Static", "System prompt", None, 50.0, 100.0)],
+            )
+            .unwrap();
+        tracker
+            .record_breakdown(
+                &turn("sess-a"),
+                &[block("Static", "System prompt", None, 50.0, 100.0)],
+            )
+            .unwrap();
+
+        let db = BreakdownDb::from_connection(tracker.into_connection());
+        let rows = db.sessions().unwrap();
+        assert_eq!(rows[0].last_sub_provider, None);
+        assert_eq!(rows[0].last_model.as_deref(), Some("claude-sonnet-4"));
     }
 
     #[test]

--- a/crates/llmtrim-ledger/src/dashboard.rs
+++ b/crates/llmtrim-ledger/src/dashboard.rs
@@ -559,6 +559,7 @@ mod tests {
             session_name: Some("my session".to_string()),
             provider: "anthropic".to_string(),
             model: Some("claude-sonnet-4".to_string()),
+            sub_provider: None,
             window: 200_000,
             fresh_input: 50,
             cache_read: 120,

--- a/crates/llmtrim-ledger/src/tracking.rs
+++ b/crates/llmtrim-ledger/src/tracking.rs
@@ -62,6 +62,12 @@ pub struct BreakdownTurn {
     pub session_name: Option<String>,
     pub provider: String,
     pub model: Option<String>,
+    /// The `sub` backend that actually served this turn (`codex`/`kimi`), when one did. `None`
+    /// for a turn Anthropic served — including a fallback-mode turn where Anthropic answered and
+    /// the chain never fired. `provider` above stays the *wire* provider (`anthropic`, the shape
+    /// we parse and reply in), so this is the only record of who really answered; `model` already
+    /// carries the upstream model id on a rerouted turn.
+    pub sub_provider: Option<String>,
     /// Context window of the model, for occupancy %.
     pub window: i64,
     pub fresh_input: i64,
@@ -370,6 +376,7 @@ impl Tracker {
                     session_name  TEXT,
                     provider      TEXT NOT NULL,
                     model         TEXT,
+                    sub_provider  TEXT,
                     window        INTEGER NOT NULL,
                     fresh_input   INTEGER NOT NULL,
                     cache_read    INTEGER NOT NULL,
@@ -440,13 +447,15 @@ impl Tracker {
                 return Err(e).with_context(|| format!("failed to add breakdown column {col}"));
             }
         }
-        // cc_session_id is TEXT, not INTEGER — additive ALTER kept separate from the loop above.
-        if let Err(e) = self.conn.execute(
-            "ALTER TABLE breakdown_turns ADD COLUMN cc_session_id TEXT",
-            [],
-        ) && !is_duplicate_column(&e)
-        {
-            return Err(e).context("failed to add breakdown column cc_session_id");
+        // TEXT columns, not INTEGER — additive ALTERs kept separate from the loop above.
+        for col in ["cc_session_id", "sub_provider"] {
+            if let Err(e) = self.conn.execute(
+                &format!("ALTER TABLE breakdown_turns ADD COLUMN {col} TEXT"),
+                [],
+            ) && !is_duplicate_column(&e)
+            {
+                return Err(e).with_context(|| format!("failed to add breakdown column {col}"));
+            }
         }
         Ok(())
     }
@@ -541,10 +550,10 @@ impl Tracker {
             .execute(
                 "INSERT INTO breakdown_turns
                     (ts, session_id, cc_session_id, agent, project, session_name, provider, model,
-                     window, fresh_input, cache_read, cache_write, output_tok,
+                     sub_provider, window, fresh_input, cache_read, cache_write, output_tok,
                      input_rate, output_rate, cache_read_rate, cache_write_rate, bill_micros,
                      input_before, input_after)
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)",
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21)",
                 params![
                     ts,
                     turn.session_id,
@@ -554,6 +563,7 @@ impl Tracker {
                     turn.session_name,
                     turn.provider,
                     turn.model,
+                    turn.sub_provider,
                     turn.window,
                     turn.fresh_input,
                     turn.cache_read,
@@ -657,10 +667,10 @@ impl Tracker {
             .execute(
                 "INSERT INTO breakdown_turns
                     (ts, session_id, cc_session_id, agent, project, session_name, provider, model,
-                     window, fresh_input, cache_read, cache_write, output_tok,
+                     sub_provider, window, fresh_input, cache_read, cache_write, output_tok,
                      input_rate, output_rate, cache_read_rate, cache_write_rate, bill_micros,
                      input_before, input_after)
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)",
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21)",
                 params![
                     ts,
                     turn.session_id,
@@ -670,6 +680,7 @@ impl Tracker {
                     turn.session_name,
                     turn.provider,
                     turn.model,
+                    turn.sub_provider,
                     turn.window,
                     turn.fresh_input,
                     turn.cache_read,
@@ -986,6 +997,7 @@ mod tests {
             session_name: None,
             provider: "anthropic".to_string(),
             model: Some("claude-sonnet-4".to_string()),
+            sub_provider: None,
             window: 200_000,
             fresh_input: 1000,
             cache_read: 500,


### PR DESCRIPTION
Follow-up to #153 (merged). Started as a small cleanup, turned up a real bug once I checked how it interacts with the fallback chains from #160/#161.

## The bug

`statusline.rs` never reads `sub_fallback` (grep: zero hits). It derived both the reroute arrow and the context gauge from `cfg.sub` alone.

But in **fallback mode** the request goes down the normal compress-and-forward path to **Anthropic** — the chain only fires *after* Anthropic fails. So with `sub = codex` + `mode = fallback`, on every healthy turn:

1. **The arrow lied**: `◆ Opus→gpt-5.6-terra` while Anthropic actually served. #153 made this worse, upgrading a vague provider hint (`→codex`) into a concrete claim about "the *real* model serving the turn".
2. **The gauge was miscalibrated** (the worse half): `reroute_window` swapped the denominator to Codex's window, so a context near Claude's real 200k limit rendered as a comfortable fraction of a larger window. The context-health gauge under-reported fullness exactly when it should warn.

Whether a backend served a given turn is a **runtime** fact — no config-derived value can answer it.

## The fix

`Pending.reroute` already holds the truth: set up front in `always` mode, and in `fallback` mode only once an attempt has **succeeded** (`serve.rs`, the fallback loop). It just never reached the ledger.

- **Ledger**: new `sub_provider` column on `breakdown_turns`, written from `p.reroute` in `build_breakdown`. Added to existing ledgers via the established additive-ALTER migration. (`model` already carried the upstream model id on a rerouted turn, so no second column is needed.)
- **Query**: `sessions()` surfaces the *newest* turn's backend + model. Note the existing `rn` ranking prefers a **named** row, so it is not "latest" — added a separate strictly-newest `recent` ranking rather than reusing it.
- **Status line**: `arrow_source()` — the ledger wins whenever it has a turn; config seeds the arrow only before the first turn lands, and only in `always` mode (where every turn reroutes, so the prediction is sound and the arrow doesn't blink in late). In fallback mode the arrow appears only on turns a backend really served, and the gauge keeps Claude's window until one does.

Also folds in the original cleanup: Kimi resolves to `None` at the source instead of resolving a model and filtering the literal `"kimi-for-coding"` back out at render time.

## Prior art

Checked `raine/claude-code-proxy`. It has no Anthropic-primary failover (its only `fallback` is an axum 404 handler), so config == truth there and the case never arises. It does keep a per-session `affinity_provider`, which validates tracking the backend per session — but it records at *request* time (wrong for fallback: the request goes to Anthropic) and lives in-memory (unreachable from our status line, which Claude Code spawns as a separate short-lived process per render). Hence the durable ledger column.

## Tests

507 passing in `llmtrim` + `llmtrim-ledger`; clippy + fmt clean.

New:
- `fallback_mode_shows_no_arrow_until_a_backend_actually_serves` / `..._shows_the_backend_once_the_chain_fires` / `..._never_predicts_from_config_on_a_fresh_session`
- `ledger_truth_overrides_a_stale_config_prediction`
- `sessions_report_the_backend_that_served_the_newest_turn` — guards the named-vs-newest ranking trap
- `sessions_report_no_backend_when_anthropic_served_the_newest_turn` — the arrow goes away again
- `a_ledger_written_before_sub_provider_existed_still_queries` — upgrade path. Verified it actually fails without the migration, with the real production error (`no such column: sub_provider`)