### PR TITLE
fix(serve): report upstream connection failures instead of swallowing them (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **Upstream connection failures are reported instead of swallowed ([#157](https://github.com/fkiene/llmtrim/issues/157)).**
+  A request that failed *before* the upstream answered (a TLS error, a reset, a dropped
+  keep-alive) fell through to the proxy library's default handler: an empty-bodied `502`, with
+  the cause logged only through a `tracing` subscriber llmtrim never installs. Claude Code could
+  not parse the reply, so the turn died — and nothing anywhere recorded why. A transport failure
+  is now reported in the shape the client is reading (an SSE `error` frame on a streaming call, a
+  retryable `overloaded_error` otherwise), and the underlying cause is named on stderr, so
+  `llmtrim serve` in the foreground shows what actually broke.
 - **GPT-5.6 Codex reroutes.** Claude model requests keep the standard Responses shape and use the
   official Codex originator and user-agent identity required by the backend.
 

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -588,6 +588,43 @@ mod imp {
             .unwrap_or_else(|_| Response::new(Body::empty()))
     }
 
+    /// True if the client asked for a streamed reply (`Accept: text/event-stream`, which the
+    /// Anthropic SDK — and so Claude Code — sets on every `stream: true` call). Read from the
+    /// headers, not the body, so it also works on the passthrough paths that never buffer one.
+    fn wants_event_stream(headers: &header::HeaderMap) -> bool {
+        headers
+            .get(header::ACCEPT)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.contains("text/event-stream"))
+    }
+
+    /// The reply to a *transport* failure against the upstream: the TLS/TCP/HTTP-2 exchange
+    /// never produced a response, so there is no status to relay.
+    ///
+    /// hudsucker's default `handle_error` answers these with a bodiless 502 and logs through
+    /// `tracing`, for which llmtrim installs no subscriber — so the client got an unparseable
+    /// error and the user got no way to see the cause (issue #157). We answer in the shape the
+    /// client is already parsing: an SSE `error` frame for a streaming call, JSON otherwise.
+    ///
+    /// `overloaded_error` (529), not `api_error` (502): a dropped connection is transient and
+    /// this is the class Claude Code retries. A bodiless 502 is a hard failure to the SDK.
+    fn upstream_transport_error(streaming: bool, message: &str) -> Response<Body> {
+        let payload = serde_json::json!({
+            "type": "error",
+            "error": { "type": "overloaded_error", "message": message },
+        });
+        if streaming {
+            // HTTP 200 + an SSE `error` frame: the stream has already been committed to by the
+            // time the client is reading, so the error has to arrive *in* the stream.
+            let mut out = String::new();
+            out.push_str("event: error\ndata: ");
+            out.push_str(&payload.to_string());
+            out.push_str("\n\n");
+            return sse_response(out);
+        }
+        anthropic_error_typed(529, "overloaded_error", message, Some(1))
+    }
+
     /// Anthropic error `type` for an upstream status, so Claude Code renders rate limits and
     /// auth failures as their own error classes instead of a generic `api_error`.
     fn reroute_error_kind(status: u16) -> &'static str {
@@ -1075,6 +1112,10 @@ mod imp {
         memo: Arc<Memo>,
         /// The compressed request awaiting its response (set in `handle_request`).
         pending: Option<Pending>,
+        /// Whether this request asked for a streamed reply (set in `handle_request`, read by
+        /// `handle_error` so a transport failure is reported in the shape the client parses).
+        /// Per-request: the handler is cloned per request, like `pending`.
+        streaming: bool,
         /// Optional upstream proxy URL from `LLMTRIM_UPSTREAM_PROXY`. Used by the replay path
         /// (`forward_post`). The primary MITM interception path honours this setting via the
         /// `ProxyConnector` built at startup (see the `start` function in this module).
@@ -1127,7 +1168,38 @@ mod imp {
             _ctx: &HttpContext,
             req: Request<Body>,
         ) -> RequestOrResponse {
+            self.streaming = wants_event_stream(req.headers());
             self.handle_request_inner(req).await
+        }
+
+        /// A request that never reached the upstream (TLS handshake, TCP reset, HTTP/2 GOAWAY,
+        /// or — the common one on an agent loop — a pooled keep-alive connection the server had
+        /// already closed). hudsucker's default hands the client a bodiless 502 and logs only
+        /// through `tracing`, which llmtrim does not subscribe to: the user sees a dropped
+        /// connection with no cause, and the SDK sees an error it cannot parse (issue #157).
+        ///
+        /// Report it instead: name the cause on stderr (where the rest of llmtrim's proxy
+        /// diagnostics go, so `llmtrim serve` in the foreground shows it) and answer in the
+        /// client's own error shape so it can back off and retry rather than fail the turn.
+        async fn handle_error(
+            &mut self,
+            _ctx: &HttpContext,
+            err: hyper_util::client::legacy::Error,
+        ) -> Response<Body> {
+            // `err` alone prints as "client error (Connect)"; the source chain carries the
+            // underlying cause ("connection closed before message completed", the TLS error, …).
+            let mut cause = err.to_string();
+            let mut src: Option<&(dyn std::error::Error + 'static)> =
+                std::error::Error::source(&err);
+            while let Some(e) = src {
+                cause.push_str(": ");
+                cause.push_str(&e.to_string());
+                src = std::error::Error::source(e);
+            }
+            eprintln!(
+                "llmtrim: upstream request failed ({cause}) — reported to the client as a retryable error"
+            );
+            upstream_transport_error(self.streaming, &format!("upstream request failed: {cause}"))
         }
 
         /// Tee the response: forward it to the client unchanged while accumulating a copy,
@@ -3132,6 +3204,7 @@ mod imp {
             // One process-wide turn-stability memo, shared across the per-request handler clones.
             memo: Arc::new(Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY)),
             pending: None,
+            streaming: false,
             upstream_proxy: upstream_proxy.clone(),
             exclude_providers: Arc::new(exclusions.providers.clone()),
             exclude_hosts: Arc::new(exclusions.hosts.clone()),
@@ -3555,6 +3628,82 @@ mod imp {
                 429
             );
             assert_eq!(reroute_stream_error_status("something else broke"), 502);
+        }
+
+        /// `Accept: text/event-stream` is what the Anthropic SDK (so Claude Code) sends on a
+        /// `stream: true` call, and it is on the headers of *every* request — including the
+        /// passthrough paths that never buffer a body to look for `"stream": true`.
+        #[test]
+        fn wants_event_stream_reads_the_accept_header() {
+            let mut h = header::HeaderMap::new();
+            assert!(!wants_event_stream(&h), "no Accept header: not streaming");
+            h.insert(header::ACCEPT, "application/json".parse().unwrap());
+            assert!(!wants_event_stream(&h));
+            h.insert(header::ACCEPT, "text/event-stream".parse().unwrap());
+            assert!(wants_event_stream(&h));
+        }
+
+        /// A transport failure on a *streaming* call must arrive as an SSE `error` frame: the
+        /// client is parsing an event stream, and hudsucker's default (a bodiless 502) is not
+        /// something it can read — it just drops the connection (issue #157).
+        #[tokio::test]
+        async fn transport_error_on_a_stream_is_an_sse_error_frame() {
+            let res = upstream_transport_error(true, "connection closed before message completed");
+            assert_eq!(
+                res.status(),
+                200,
+                "the stream itself is committed; the error rides in it"
+            );
+            assert_eq!(
+                res.headers().get(header::CONTENT_TYPE).unwrap(),
+                "text/event-stream"
+            );
+            let body =
+                String::from_utf8(res.into_body().collect().await.unwrap().to_bytes().to_vec())
+                    .unwrap();
+            assert!(
+                body.starts_with("event: error\n"),
+                "SSE error frame: {body}"
+            );
+            assert!(body.ends_with("\n\n"), "frame is terminated: {body:?}");
+            let data = body
+                .lines()
+                .find_map(|l| l.strip_prefix("data: "))
+                .expect("data line");
+            let v: serde_json::Value = serde_json::from_str(data).expect("parseable JSON");
+            assert_eq!(v["type"], "error");
+            assert_eq!(v["error"]["type"], "overloaded_error");
+            assert!(
+                v["error"]["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("connection closed"),
+                "names the real cause so the user can report it: {v}"
+            );
+        }
+
+        /// The non-streaming shape: a retryable Anthropic error the SDK backs off on, never the
+        /// bodiless 502 that fails the turn outright.
+        #[tokio::test]
+        async fn transport_error_without_a_stream_is_a_retryable_json_error() {
+            let res = upstream_transport_error(false, "tls handshake eof");
+            assert_eq!(
+                res.status(),
+                529,
+                "overloaded: transient, and Claude Code retries it"
+            );
+            assert_eq!(res.headers().get(header::RETRY_AFTER).unwrap(), "1");
+            let body =
+                String::from_utf8(res.into_body().collect().await.unwrap().to_bytes().to_vec())
+                    .unwrap();
+            let v: serde_json::Value = serde_json::from_str(&body).expect("parseable JSON");
+            assert_eq!(v["error"]["type"], "overloaded_error");
+            assert!(
+                v["error"]["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("tls handshake eof")
+            );
         }
 
         #[test]
@@ -4490,6 +4639,7 @@ mod imp {
                 domains: Arc::new(intercept_domains().into_iter().collect()),
                 memo: Arc::new(Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY)),
                 pending: None,
+                streaming: false,
                 upstream_proxy: None,
                 exclude_hosts: Arc::new(Vec::new()),
                 exclude_providers: Arc::new(Vec::new()),

--- a/crates/llmtrim-core/tests/anthropic_thinking.rs
+++ b/crates/llmtrim-core/tests/anthropic_thinking.rs
@@ -1,0 +1,157 @@
+//! Anthropic extended-thinking invariants across compression (issue #157).
+//!
+//! Anthropic verifies the `signature` on every `thinking` block it is handed back, and rejects
+//! an assistant turn that contains `tool_use` but does not *begin* with its thinking block. A
+//! compression stage that rewrote thinking text, dropped a block, or reordered one would break
+//! Claude Code's thinking outright — so pin the invariants here rather than rely on the stages
+//! happening not to produce a text pointer for those block types.
+
+use serde_json::{Value, json};
+use std::collections::BTreeSet;
+
+fn compress(body: &str) -> Value {
+    let cfg = llmtrim_core::config::DenseConfig::default();
+    let out = llmtrim_core::compress_with_config_model(
+        body,
+        Some(llmtrim_core::ir::ProviderKind::Anthropic),
+        &cfg,
+        None,
+    )
+    .expect("compress");
+    serde_json::from_str(&out.request_json).expect("compressed body is JSON")
+}
+
+/// A Claude Code agent loop: interleaved thinking + tool_use turns, with tool_results big and
+/// repetitive enough that the input-side stages actually fire.
+fn cc_thinking_conversation(turns: usize) -> String {
+    let mut messages = vec![json!({
+        "role": "user",
+        "content": [{"type": "text", "text": "Refactor the proxy and fix the dropped connections."}],
+    })];
+    for i in 0..turns {
+        messages.push(json!({"role": "assistant", "content": [
+            {"type": "thinking",
+             "thinking": format!("Turn {i}: inspect the handler, then reason about the streaming path and the timeout budget. ").repeat(3),
+             "signature": format!("SIG{i}/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==")},
+            {"type": "text", "text": format!("Reading module {i}.")},
+            {"type": "tool_use", "id": format!("toolu_{i:03}"), "name": "Read",
+             "input": {"file_path": format!("src/mod{i}.rs")}},
+        ]}));
+        messages.push(json!({"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": format!("toolu_{i:03}"),
+             "content": [{"type": "text", "text":
+                format!("pub fn handler_{i}() {{\n    let x = compute();\n    log::info!(\"step\");\n    x\n}}\n").repeat(40)}]},
+        ]}));
+    }
+    messages.push(json!({"role": "user",
+        "content": [{"type": "text", "text": "Now summarize the root cause."}]}));
+
+    json!({
+        "model": "claude-sonnet-4-5",
+        "max_tokens": 8192,
+        "thinking": {"type": "enabled", "budget_tokens": 4096},
+        "system": [{"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude."}],
+        "tools": [{"name": "Read", "description": "Read a file.",
+                   "input_schema": {"type": "object", "properties": {"file_path": {"type": "string"}}}}],
+        "messages": messages,
+        "stream": true,
+    })
+    .to_string()
+}
+
+fn blocks_of<'a>(v: &'a Value, ty: &str) -> Vec<&'a Value> {
+    v["messages"]
+        .as_array()
+        .expect("messages")
+        .iter()
+        .filter_map(|m| m["content"].as_array())
+        .flatten()
+        .filter(|b| b["type"].as_str() == Some(ty))
+        .collect()
+}
+
+/// Anthropic verifies the signature over the thinking block it gets back: a single rewritten
+/// byte invalidates the turn.
+#[test]
+fn thinking_blocks_survive_compression_byte_identical() {
+    let body = cc_thinking_conversation(12);
+    let before: Value = serde_json::from_str(&body).unwrap();
+    let after = compress(&body);
+
+    let (b, a) = (
+        blocks_of(&before, "thinking"),
+        blocks_of(&after, "thinking"),
+    );
+    assert_eq!(b.len(), 12, "fixture sanity");
+    assert_eq!(a.len(), b.len(), "compression dropped a thinking block");
+    assert_eq!(
+        a, b,
+        "compression rewrote a thinking block or its signature"
+    );
+}
+
+/// With thinking enabled, an assistant turn carrying `tool_use` must *start* with its thinking
+/// block — Anthropic rejects the request otherwise.
+#[test]
+fn tool_use_turns_still_begin_with_their_thinking_block() {
+    let after = compress(&cc_thinking_conversation(12));
+    for (i, m) in after["messages"].as_array().unwrap().iter().enumerate() {
+        if m["role"].as_str() != Some("assistant") {
+            continue;
+        }
+        let types: Vec<&str> = m["content"]
+            .as_array()
+            .map(|bs| {
+                bs.iter()
+                    .map(|b| b["type"].as_str().unwrap_or("?"))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if types.contains(&"tool_use") {
+            assert_eq!(
+                types.first(),
+                Some(&"thinking"),
+                "messages[{i}] leads with {types:?}, not its thinking block"
+            );
+        }
+    }
+}
+
+/// Dropping one side of a tool_use/tool_result pair is a hard 400 — and with a `thinking` turn
+/// in between it is the easiest way for a retrieval stage to corrupt the transcript.
+#[test]
+fn tool_use_and_tool_result_ids_still_pair_up() {
+    let after = compress(&cc_thinking_conversation(12));
+    let ids = |ty: &str, key: &str| -> BTreeSet<String> {
+        blocks_of(&after, ty)
+            .iter()
+            .filter_map(|b| b[key].as_str().map(str::to_string))
+            .collect()
+    };
+    let uses = ids("tool_use", "id");
+    let results = ids("tool_result", "tool_use_id");
+    assert_eq!(
+        uses,
+        results,
+        "unpaired tool blocks: use-only={:?} result-only={:?}",
+        uses.difference(&results).collect::<Vec<_>>(),
+        results.difference(&uses).collect::<Vec<_>>()
+    );
+}
+
+/// `max_tokens` must stay above `thinking.budget_tokens`, and the thinking config itself must
+/// reach the provider untouched.
+#[test]
+fn thinking_config_and_max_tokens_are_left_alone() {
+    let after = compress(&cc_thinking_conversation(12));
+    assert_eq!(
+        after["thinking"],
+        json!({"type": "enabled", "budget_tokens": 4096})
+    );
+    assert_eq!(after["max_tokens"], json!(8192));
+    assert!(
+        after["max_tokens"].as_i64().unwrap()
+            > after["thinking"]["budget_tokens"].as_i64().unwrap(),
+        "Anthropic rejects max_tokens <= thinking.budget_tokens"
+    );
+}


### PR DESCRIPTION
Scoped deliberately to the part of #157 we can **prove**. It does not claim to fix the reporter's 502s — see "What this does not do".

## The confirmed defect

llmtrim never overrides hudsucker's `handle_error`. Its default ([`hudsucker-0.24.1/src/lib.rs:135-146`](https://docs.rs/hudsucker)) is:

```rust
error!(error = &err as &dyn StdError, "Failed to forward request");
Response::builder().status(StatusCode::BAD_GATEWAY).body(Body::empty())
```

So any request that fails *before* the upstream answers — TLS error, reset, HTTP/2 GOAWAY, a dropped keep-alive — reaches the client as an **empty-bodied 502**, and the cause goes to a `tracing` subscriber **llmtrim never installs**. Two consequences:

1. Claude Code can't parse the reply (worse on a streaming call, where it's reading an event stream and gets a bodiless non-SSE 502), so the turn dies outright rather than being retried.
2. Nothing anywhere records *why*. A user hitting this can only report "frequent 502s" with no cause attached — which is literally all #157 contains.

## The change

Override `handle_error` so a transport failure is:

- **Named on stderr.** The bare error only prints `client error (Connect)`; the source chain carries the real string (`connection closed before message completed`, the TLS error, …), so we walk it. Goes where llmtrim's other proxy diagnostics go, so `llmtrim serve` in the foreground shows it.
- **Answered in the shape the client is reading.** An SSE `error` frame on a streaming call (HTTP 200 — the stream is already committed to, so the error has to ride *in* it), a retryable `overloaded_error` (529 + `Retry-After`) otherwise. `overloaded_error`, not `api_error`: a dropped connection is transient, and that's the class the SDK backs off and retries.

## What this does *not* do

It does not remove the underlying connection failures. **What those actually are is the thing we currently cannot see** — and this is what will show us. Once a reporter runs a patched `serve` in the foreground, one stderr line tells us whether it's stale-pool reuse, a TLS problem, an h2 issue, or Anthropic genuinely returning 502s upstream. I had a candidate fix for the first of those (hyper-util's 90 s idle pool vs. Anthropic's shorter edge close, which extended thinking aggravates because the model idles for tens of seconds between turns) and **deliberately left it out**: it's a plausible story fitted to a symptom, not something I reproduced. It goes in a follow-up if the logs support it.

## Compression is not implicated

Checked, not assumed. I pushed a realistic Claude Code extended-thinking conversation through the real pipeline: thinking blocks come out **byte-identical** (signatures are verified upstream, so a single rewritten byte would invalidate the turn), `tool_use` turns still lead with their thinking block, `tool_use`/`tool_result` ids still pair, `thinking` and `max_tokens` untouched. Those four invariants are now regression tests (`crates/llmtrim-core/tests/anthropic_thinking.rs`) so this can't quietly become a real compression bug later.

Note the reporter is on **0.8.0** (current release 0.9.4), and the sub/Codex reroute they'd need for any of the Codex-path thinking bugs didn't exist until 0.9.0 — so that code was never in their path.

## Verification

967 tests green; `cargo clippy --all-targets` clean; new tests cover the SSE error frame, the JSON error shape, and the `Accept` header detection.