### PR TITLE
fix(sub): stop Codex reroute from cold-starting the prompt cache every turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ All notable changes to this project are documented here. The format follows
   is now reported in the shape the client is reading (an SSE `error` frame on a streaming call, a
   retryable `overloaded_error` otherwise), and the underlying cause is named on stderr, so
   `llmtrim serve` in the foreground shows what actually broke.
+
+- **Subscription reroute: the Codex prompt cache no longer goes cold every turn.** Claude Code
+  prepends a billing-header system block whose hash changes on every turn, and the Codex translator
+  forwarded it at the head of the Responses `instructions` — the very front of the cached prefix —
+  so each turn re-sent a different prefix and paid a full cold cache. The block is now dropped for
+  both Codex and Kimi. On a 4-turn session, cached input read back rose from 4.6k to 34.3k tokens.
+
+- **Subscription reroute: the status line shows trim again.** Rerouted turns never recorded their
+  Claude Code session, so the trim segment sat at `✂ –` even though compression was running
+  normally. It now reports the session's real savings (`✂ 39.8%` on the run above).
+
 - **GPT-5.6 Codex reroutes.** Claude model requests keep the standard Responses shape and use the
   official Codex originator and user-agent identity required by the backend.
 

--- a/crates/llmtrim-cli/src/reroute/codex.rs
+++ b/crates/llmtrim-cli/src/reroute/codex.rs
@@ -42,10 +42,9 @@ pub fn build_request_body(
     let mut body = Map::new();
     body.insert("model".into(), json!(model));
 
-    // instructions = flattened system text (skip when empty).
-    if let Some(instr) = anthropic.get("system").map(flatten_text)
-        && !instr.is_empty()
-    {
+    // instructions = flattened system text, minus Claude Code's billing-header block (its `cch=`
+    // rotates every turn, and `instructions` heads the cached prefix).
+    if let Some(instr) = crate::reroute::flatten_system_text(anthropic.get("system")) {
         body.insert("instructions".into(), json!(instr));
     }
 
@@ -1000,7 +999,42 @@ mod tests {
             None,
         )
         .expect("build");
-        assert_eq!(body["instructions"], "Line 1\nLine 2");
+        assert_eq!(body["instructions"], "Line 1\n\nLine 2");
+    }
+
+    /// Claude Code prepends a billing-header system block whose `cch=` hash changes every turn.
+    /// It heads the Responses cached prefix, so forwarding it would cold-start the prompt cache
+    /// on every turn.
+    #[test]
+    fn instructions_drop_the_billing_header_block() {
+        let body = build_request_body(
+            &json!({
+                "system": [
+                    { "type": "text", "text": "x-anthropic-billing-header: cc_version=1; cch=ff3a6;" },
+                    { "type": "text", "text": "Be concise." }
+                ],
+                "messages": []
+            }),
+            "gpt-5.6-luna",
+            None,
+        )
+        .expect("build");
+        assert_eq!(body["instructions"], "Be concise.");
+    }
+
+    /// A system that is *only* the billing header leaves no instructions at all.
+    #[test]
+    fn billing_header_only_system_yields_no_instructions() {
+        let body = build_request_body(
+            &json!({
+                "system": [{ "type": "text", "text": "x-anthropic-billing-header: cch=ff3a6;" }],
+                "messages": []
+            }),
+            "gpt-5.6-luna",
+            None,
+        )
+        .expect("build");
+        assert!(body.get("instructions").is_none());
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/kimi.rs
+++ b/crates/llmtrim-cli/src/reroute/kimi.rs
@@ -21,10 +21,6 @@ pub const PATH: &str = "/coding/v1/chat/completions";
 const WIRE_MODEL: &str = "kimi-for-coding";
 /// Kimi caps `max_tokens` for the coding endpoint at 32k.
 const MAX_TOKENS_CAP: i64 = 32_000;
-/// System text blocks that begin with this marker are llmtrim/Claude-Code billing metadata and must
-/// not be forwarded upstream.
-const BILLING_HEADER_PREFIX: &str = "x-anthropic-billing-header:";
-
 /// Device id advertised in the `X-Msh-Device-Id` header.
 ///
 /// `LLMTRIM_KIMI_DEVICE_ID` overrides for tests/debugging; otherwise the persistent per-install id
@@ -157,28 +153,7 @@ fn reasoning_effort(anthropic: &Value) -> String {
 /// Flatten the Anthropic `system` (string or block array) into a single string, dropping any text
 /// block whose text starts with the billing-header marker. Returns `None` when nothing survives.
 fn build_system(system: Option<&Value>) -> Option<String> {
-    match system {
-        Some(Value::String(s)) => {
-            if s.starts_with(BILLING_HEADER_PREFIX) || s.is_empty() {
-                None
-            } else {
-                Some(s.clone())
-            }
-        }
-        Some(Value::Array(blocks)) => {
-            let parts: Vec<&str> = blocks
-                .iter()
-                .filter_map(|b| b.get("text").and_then(Value::as_str))
-                .filter(|t| !t.starts_with(BILLING_HEADER_PREFIX))
-                .collect();
-            if parts.is_empty() {
-                None
-            } else {
-                Some(parts.join("\n\n"))
-            }
-        }
-        _ => None,
-    }
+    crate::reroute::flatten_system_text(system)
 }
 
 /// Anthropic `tools` -> Kimi function tools, stripping the hosted `web_search_20250305` tool.

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -298,6 +298,34 @@ pub fn resolve_model(
         .unwrap_or_else(|| default_codex_tier_model(Tier::Sonnet).to_string())
 }
 
+/// System text blocks beginning with this marker are Claude Code billing metadata smuggled as a
+/// system block, not prompt content. Its `cch=` field changes every turn, so forwarding it poisons
+/// the head of the provider's cached prefix and every turn pays a cold prompt cache.
+pub const BILLING_HEADER_PREFIX: &str = "x-anthropic-billing-header:";
+
+/// Flatten an Anthropic `system` (string or block array) into one string for providers that take a
+/// single system/instructions field, dropping [`BILLING_HEADER_PREFIX`] blocks. `None` when nothing
+/// survives.
+pub fn flatten_system_text(system: Option<&Value>) -> Option<String> {
+    let texts: Vec<&str> = match system? {
+        Value::String(s) => vec![s.as_str()],
+        Value::Array(blocks) => blocks
+            .iter()
+            .filter_map(|b| b.get("text").and_then(Value::as_str))
+            .collect(),
+        _ => return None,
+    };
+    let kept: Vec<&str> = texts
+        .into_iter()
+        .filter(|t| !t.starts_with(BILLING_HEADER_PREFIX) && !t.is_empty())
+        .collect();
+    if kept.is_empty() {
+        None
+    } else {
+        Some(kept.join("\n\n"))
+    }
+}
+
 /// The Codex models the ChatGPT backend actually accepts. A model outside this set 400s upstream;
 /// the caller can still send it (forward-compat) but the mapping editor picks from this list.
 pub const CODEX_MODELS: [&str; 9] = [

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1457,6 +1457,12 @@ mod imp {
             .await
             .ok()
             .flatten();
+            // The breakdown carries `cc_session_id` — the key the status line scopes trim to — so
+            // it has to ride along on the reroute pending too, or a `sub` session records no
+            // session row and the status line renders an idle `✂ –` for every turn.
+            let breakdown = compressed
+                .as_ref()
+                .and_then(|(_, pending)| pending.breakdown.clone());
             let (mut translate_value, input_before, input_after, tokenizer, exact) =
                 match &compressed {
                     Some((json, pending)) => (
@@ -1545,7 +1551,7 @@ mod imp {
                 original: None,
                 output_shaped: false,
                 frozen_input_tokens: None,
-                breakdown: None,
+                breakdown,
                 reroute: Some(RerouteInfo {
                     provider: sub,
                     model: rewrite.model.clone(),


### PR DESCRIPTION
## Symptoms

Running Claude Code through `llmtrim` in `sub = codex` mode with `--model sonnet` (→ `gpt-5.6-luna`):

1. The prompt cache was erased on every turn.
2. The trim segment never appeared in the status line.

Two independent root causes.

## 1. Prompt cache: the billing header poisoned the prefix

Claude Code prepends a system block:

```
x-anthropic-billing-header: cc_version=2.1.207.d48; cc_entrypoint=sdk-cli; cch=ff3a6;
```

Its `cch=` hash **changes on every turn**. Anthropic ignores it for cache purposes, but `codex.rs` flattened the entire `system` array straight into the Responses `instructions` field — which sits at the very front of OpenAI's cached prefix. Every turn therefore presented a different prefix and cold-started the cache.

The translated `input` array was verified stable across all four turns (identical leading items every time); only `instructions` differed.

`kimi.rs` already stripped this block and `codex.rs` never did. The sibling `claude-code-proxy` handles it with a shared `flatten_system_text` used by all providers, so this PR hoists the same helper into `reroute/mod.rs` and points Codex and Kimi at it.

## 2. Missing trim: a dropped `breakdown`

`reroute_messages` built its `Pending` with `breakdown: None`, but `cc_session_id` — the key the status line scopes trim to — only reaches the ledger via that breakdown payload. A `sub` session recorded no session row, so the status line fell through to the idle `✂ –`. Compression was working the whole time (41% trim); it just wasn't being reported.

## Verification

Live Codex sub session, identical 4-turn agent loop, same ~62.5k compressed input, isolated proxy + ledger:

| | before | after |
|---|---|---|
| `cache_read_tokens` | 4,608 | 34,304 |
| status line | `✂ –` | `✂ 39.8%` |

454 tests pass; clippy clean with `--all-targets`. Two regression tests added on the Codex instructions path. `system_array_is_flattened`'s expectation changed because the shared helper joins blocks with `\n\n` (matching Kimi and the sibling proxy) rather than `\n`.