### PR TITLE
fix(sub): Codex reroute 400, uncompressible instructions, statusline blink

### DIFF
--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -2401,6 +2401,8 @@ mod tests {
             last_ts: "2026-06-19T00:00:00+00:00".to_string(),
             last_sub_provider: None,
             last_model: None,
+            last_cache_hit: None,
+            last_input_tokens: 0,
         }
     }
 

--- a/crates/llmtrim-cli/src/breakdown/export.rs
+++ b/crates/llmtrim-cli/src/breakdown/export.rs
@@ -150,6 +150,8 @@ mod tests {
             last_ts: "2026-06-19T00:00:00+00:00".to_string(),
             last_sub_provider: None,
             last_model: None,
+            last_cache_hit: None,
+            last_input_tokens: 0,
         }
     }
 

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1542,6 +1542,7 @@ mod imp {
                     sent_body = serialized;
                 }
             }
+            capture_reroute(&sent_body, session_id.as_deref(), sub.as_str());
 
             // Record intent: provider stays Anthropic (we emit Anthropic SSE, which `Finalize`
             // measures); model is the resolved upstream model; `reroute` marks the response path.
@@ -2533,6 +2534,34 @@ mod imp {
     /// in the config file), write the before/after request bodies of each compressed request as
     /// one JSON file so an external reviewer can audit compression quality. Off unless set; any
     /// write failure is logged and swallowed — capture must never break proxying.
+    /// Record the *translated* body actually sent to a reroute backend — the Anthropic-side
+    /// [`capture_pair`] stops at our own pipeline output, so without this the wire payload (the
+    /// thing the upstream prompt cache keys on) is unobservable. Diffing consecutive `input`
+    /// arrays for one session is what locates a prefix-cache divergence.
+    fn capture_reroute(body: &[u8], session_id: Option<&str>, provider: &str) {
+        let Some(dir_path) = RuntimeConfig::get().capture_dir.clone() else {
+            return;
+        };
+        let record = serde_json::json!({
+            "ts": chrono::Utc::now().to_rfc3339(),
+            "kind": "reroute",
+            "provider": provider,
+            "session_id": session_id,
+            "sent": serde_json::from_slice::<Value>(body).unwrap_or(Value::Null),
+        });
+        let name = format!(
+            "{}-{:x}-reroute.json",
+            chrono::Utc::now().timestamp_micros(),
+            std::process::id()
+        );
+        let path = dir_path.join(name);
+        if let Err(e) = std::fs::create_dir_all(&dir_path)
+            .and_then(|_| std::fs::write(&path, record.to_string()))
+        {
+            eprintln!("llmtrim: reroute capture failed ({}): {e}", path.display());
+        }
+    }
+
     fn capture_pair(
         before: &str,
         after: &str,

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -718,11 +718,17 @@ mod imp {
         )
     }
 
+    /// An upstream rejection caused by the `previous_response_id` we attached — a stale/expired
+    /// response id, or a backend that doesn't take the parameter at all (the ChatGPT HTTP
+    /// `/responses` path answers `400 Unsupported parameter: previous_response_id`; it accepts
+    /// continuation only over its WebSocket transport). Either way the cure is the same: drop the
+    /// continuation state and re-issue the full request, which always works.
     fn is_continuation_error(body: &[u8]) -> bool {
         let lower = String::from_utf8_lossy(body).to_lowercase();
         lower.contains("previous_response_not_found")
             || lower.contains("previous response not found")
             || (lower.contains("continuation") && lower.contains("not found"))
+            || (lower.contains("previous_response_id") && lower.contains("unsupported parameter"))
     }
 
     /// Centralized recording for Codex continuation.
@@ -1633,9 +1639,21 @@ mod imp {
                 // at once rather than burning pointless retries.
                 if let Some(replay) = info.replay.as_ref() {
                     let mut attempt = 0;
-                    while attempt < REROUTE_RETRY_MAX && reroute_should_retry(cur_status) {
-                        let Some(wait_ms) = reroute_backoff_ms(attempt, retry_after) else {
-                            break;
+                    // A continuation rejection is retryable regardless of status (it arrives as a
+                    // 400, which is otherwise terminal): the re-issue below drops the continuation
+                    // and sends the full body, so it is a fix, not a blind repeat.
+                    while attempt < REROUTE_RETRY_MAX
+                        && (reroute_should_retry(cur_status) || is_continuation_error(&cur_body))
+                    {
+                        // The upstream isn't struggling, it rejected a parameter — re-issue at once
+                        // rather than making the user wait out a backoff meant for rate limits.
+                        let wait_ms = if is_continuation_error(&cur_body) {
+                            0
+                        } else {
+                            let Some(ms) = reroute_backoff_ms(attempt, retry_after) else {
+                                break;
+                            };
+                            ms
                         };
                         tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
                         attempt += 1;
@@ -3731,6 +3749,24 @@ mod imp {
             for s in [200, 400, 401, 403, 404, 422] {
                 assert!(!reroute_should_retry(s), "{s} should not retry");
             }
+        }
+
+        #[test]
+        fn a_rejected_previous_response_id_is_recognised_as_a_continuation_error() {
+            // The ChatGPT HTTP `/responses` path takes continuation only over its WebSocket
+            // transport; on HTTP it 400s. That 400 is not retryable by status, so it must be
+            // recognised by body — the re-issue drops the continuation and sends the full request.
+            let unsupported = br#"{"detail":"Unsupported parameter: previous_response_id"}"#;
+            assert!(is_continuation_error(unsupported));
+            // The stale-id case this already handled keeps working.
+            assert!(is_continuation_error(
+                br#"{"error":{"code":"previous_response_not_found"}}"#
+            ));
+            // An unrelated 400 must NOT be re-issued — re-sending it would just fail again.
+            assert!(!is_continuation_error(
+                br#"{"detail":"Unsupported parameter: temperature"}"#
+            ));
+            assert!(!is_continuation_error(br#"{"error":"rate limited"}"#));
         }
 
         #[test]

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -187,6 +187,13 @@ struct Led {
     /// The prompt cache has gone cold: the session has been idle past the TTL, so the next turn
     /// pays a cold write. Renders the cache segment red with a `/compact` nudge.
     cache_cold: bool,
+    /// Cache-hit rate of this session's last *completed* turn, %, as the proxy measured it on the
+    /// wire. Stands in for the blob's `current_usage` while a turn is in flight — see
+    /// [`cache_pct_for`].
+    last_cache_pct: Option<f64>,
+    /// Input tokens of that same turn — stands in for the blob's `total_input_tokens` while a
+    /// turn is in flight, so the gauge doesn't empty. See [`ctx_tokens_for`].
+    last_ctx_tokens: i64,
 }
 
 /// Minimal [`DaemonView`] for the health check — mirrors `main::daemon_view` but fills only
@@ -272,7 +279,31 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
         reroute_window,
         resolved_model,
         cache_cold,
+        last_cache_pct: row
+            .as_ref()
+            .and_then(|r| r.last_cache_hit)
+            .map(|f| f * 100.0),
+        last_ctx_tokens: row.as_ref().map_or(0, |r| r.last_input_tokens),
     }
+}
+
+/// Resolve the context occupancy the gauge fills against. Claude Code reports
+/// `total_input_tokens` from the *last response*, so like `current_usage` it reads 0 on every
+/// re-render while a turn is in flight — emptying the bar mid-request and refilling it after.
+/// The proxy counted the same input on the wire, so the last completed turn holds the gauge
+/// steady. A genuinely empty context (fresh session, no turn yet) has no ledger row either, so
+/// it still renders empty rather than inventing a fill.
+fn ctx_tokens_for(blob: i64, ledger_last: i64) -> i64 {
+    if blob > 0 { blob } else { ledger_last }
+}
+
+/// Resolve the cache figure the segment shows. Claude Code fills `current_usage` only once a
+/// response's usage has landed, so it is absent from every re-render *during* a turn — trusting
+/// it alone drops the segment mid-request and pops it back afterwards. The proxy measured the
+/// same quantity on the wire for the last completed turn, so it holds the number steady across
+/// the gap instead of blanking it.
+fn cache_pct_for(blob: Option<f64>, ledger_last: Option<f64>) -> Option<f64> {
+    blob.or(ledger_last)
 }
 
 /// Where the reroute arrow's content comes from.
@@ -331,6 +362,13 @@ struct SessionLedgerRow {
     /// Anthropic actually failed, which config cannot predict.
     last_sub_provider: Option<String>,
     last_model: Option<String>,
+    /// Cache-hit fraction of this session's most recent *completed* turn. Claude Code omits
+    /// `current_usage` from the blob while a turn is in flight, so this is what keeps the cache
+    /// segment from blanking out mid-request.
+    last_cache_hit: Option<f64>,
+    /// Input tokens of that same turn — what the context gauge falls back to when the blob
+    /// reports no occupancy mid-request.
+    last_input_tokens: i64,
 }
 
 /// This Claude Code session's aggregated ledger row, matched on the real `cc_session_id`. Behind
@@ -351,6 +389,8 @@ fn session_row(sid: &str) -> Option<SessionLedgerRow> {
             last_ts: r.last_ts,
             last_sub_provider: r.last_sub_provider,
             last_model: r.last_model,
+            last_cache_hit: r.last_cache_hit,
+            last_input_tokens: r.last_input_tokens,
         })
 }
 
@@ -604,7 +644,7 @@ fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
         // Cache expired: the next turn pays a cold write, so `/compact` (re-baselines the prompt)
         // pays off here. `cold` communicates the state faster than a stale `0% cached`.
         out.push(paint(color, RED, "♻ cold · /compact"));
-    } else if let Some(c) = cc.cache_pct {
+    } else if let Some(c) = cache_pct_for(cc.cache_pct, led.last_cache_pct) {
         // Floor, not round: only a genuine 100% cache shows `100%` (99.9 stays `99%`).
         out.push(paint(
             color,
@@ -624,7 +664,7 @@ fn render_line(cc: &CcInput, led: &Led, cols: usize, color: bool) -> String {
     let mut core = vec![
         model_segment(cc, led, color),
         context_segment(
-            cc.ctx_tokens,
+            ctx_tokens_for(cc.ctx_tokens, led.last_ctx_tokens),
             effective_window(cc, led),
             led.cache_cold,
             color,
@@ -878,6 +918,8 @@ mod tests {
             reroute_window: None,
             resolved_model: Some("gpt-5.6-terra".to_string()),
             cache_cold: false,
+            last_cache_pct: None,
+            last_ctx_tokens: 0,
         }
     }
 
@@ -1118,6 +1160,8 @@ mod tests {
             last_ts: chrono::Utc::now().to_rfc3339(),
             last_sub_provider: sub.map(str::to_string),
             last_model: model.map(str::to_string),
+            last_cache_hit: None,
+            last_input_tokens: 0,
         }
     }
 
@@ -1179,6 +1223,49 @@ mod tests {
         assert!((own - 33.333).abs() < 0.01, "per-session figure: {own}");
         // No session id at all (non-Claude-Code client) ⇒ lifetime is the only honest figure.
         assert_eq!(trim_for(None, None, lifetime), Some(6.8));
+    }
+
+    #[test]
+    fn context_gauge_holds_its_fill_while_a_turn_is_in_flight() {
+        // `total_input_tokens` comes from the last *response*, so mid-request the blob reports 0
+        // and the bar empties — the flicker the cache segment had. The last completed turn's
+        // input, measured on the wire, holds it.
+        let mut mid_turn = cc(48_000);
+        mid_turn.ctx_tokens = 0;
+        let mut l = led(Health::Healthy);
+        l.last_ctx_tokens = 48_000;
+        assert_eq!(
+            render_line(&mid_turn, &l, 0, false),
+            render_line(&cc(48_000), &l, 0, false),
+            "mid-turn gauge matches the completed-turn gauge"
+        );
+        // The blob wins whenever it has a figure; a truly fresh session (no turn, no row) still
+        // renders empty rather than inventing a fill.
+        assert_eq!(ctx_tokens_for(142_000, 48_000), 142_000);
+        assert_eq!(ctx_tokens_for(0, 0), 0);
+    }
+
+    #[test]
+    fn cache_segment_holds_its_value_while_a_turn_is_in_flight() {
+        // Claude Code drops `current_usage` from the blob mid-request, so `cc.cache_pct` is None
+        // on every re-render during a turn. Without a fallback the segment vanishes and pops back
+        // when the turn lands — a flicker that reads like the cache collapsing.
+        let mut mid_turn = cc(48_000);
+        mid_turn.cache_pct = None;
+        let mut l = led(Health::Healthy);
+        l.last_cache_pct = Some(98.0);
+        let out = render_line(&mid_turn, &l, 0, false);
+        assert!(out.contains("♻ 98% cached"), "last turn stands in: {out}");
+
+        // The blob still wins the moment it has a figure — the ledger is one turn stale.
+        let out = render_line(&cc(48_000), &l, 0, false);
+        assert!(
+            out.contains("♻ 63% cached"),
+            "blob wins when present: {out}"
+        );
+
+        // Nothing anywhere (fresh session, no turn yet) ⇒ no segment, not a fake 0%.
+        assert_eq!(cache_pct_for(None, None), None);
     }
 
     #[test]

--- a/crates/llmtrim-core/src/cache_zone.rs
+++ b/crates/llmtrim-core/src/cache_zone.rs
@@ -20,9 +20,9 @@ use crate::ir::Request;
 use crate::provider::Provider;
 
 /// Content-text pointers safe to compress: every content pointer minus those inside the
-/// frozen (cached) prefix, and minus the instructions ([`is_instruction`]). The stages iterate
-/// this instead of [`Provider::content_text_pointers`]; the token gate still counts *all*
-/// content.
+/// frozen (cached) prefix, and minus the system/developer instructions — which are never
+/// compressible, cached or not. The stages iterate this instead of
+/// [`Provider::content_text_pointers`]; the token gate still counts *all* content.
 pub fn compressible_pointers(req: &Request, provider: &dyn Provider) -> Vec<String> {
     let frozen = frozen_pointers(req, provider);
     provider

--- a/crates/llmtrim-core/src/cache_zone.rs
+++ b/crates/llmtrim-core/src/cache_zone.rs
@@ -20,15 +20,37 @@ use crate::ir::Request;
 use crate::provider::Provider;
 
 /// Content-text pointers safe to compress: every content pointer minus those inside the
-/// frozen (cached) prefix. The stages iterate this instead of
-/// [`Provider::content_text_pointers`]; the token gate still counts *all* content.
+/// frozen (cached) prefix, and minus the instructions ([`is_instruction`]). The stages iterate
+/// this instead of [`Provider::content_text_pointers`]; the token gate still counts *all*
+/// content.
 pub fn compressible_pointers(req: &Request, provider: &dyn Provider) -> Vec<String> {
     let frozen = frozen_pointers(req, provider);
     provider
         .content_text_pointers(req)
         .into_iter()
-        .filter(|p| !frozen.contains(p))
+        .filter(|p| !frozen.contains(p) && !is_instruction(req, provider, p))
         .collect()
+}
+
+/// Does this pointer address the system/developer instructions?
+///
+/// Instructions are never compressible, cached or not. They are the text the model *conditions
+/// on* rather than reads as data, so a fold that is harmless in a tool result can invert a
+/// directive: n-gram substitution once rewrote Claude Code's title-prompt few-shot examples from
+/// `Good (Korean session): {"title": …}` to `Good (Korean §3 …`, deleting the conditional and
+/// leaving "Korean titles are good, English titles are bad" — so every session title came back in
+/// Korean. Instructions are also small and near-always inside the provider's cached prefix, so
+/// there was never much to win here.
+///
+/// On real Claude Code traffic this changes nothing (593 of 594 captured requests carry
+/// `cache_control` on `system`, so it was already frozen); it closes the gap for the utility
+/// calls that don't — title generation, summarisation, and any non-caching client.
+fn is_instruction(req: &Request, provider: &dyn Provider, pointer: &str) -> bool {
+    // Top-level instruction fields (Anthropic `/system`, Responses `/instructions`, Gemini
+    // `/systemInstruction/...`) have no turn index; otherwise ask the provider for the role.
+    pointer.starts_with("/system")
+        || pointer.starts_with("/instructions")
+        || provider.role_at(req, pointer) == Some(crate::provider::Role::System)
 }
 
 /// Content-text pointers inside the frozen prefix — everything up to and including the
@@ -93,6 +115,45 @@ mod tests {
 
     fn req(v: Value) -> Request {
         Request::from_value(ProviderKind::Anthropic, v)
+    }
+
+    #[test]
+    fn instructions_are_never_compressible_even_uncached() {
+        // Claude Code's title-generation call carries no `cache_control`, so nothing was frozen
+        // and the stages folded n-grams straight through the system prompt's few-shot examples —
+        // inverting them, and turning every session title Korean. Instructions are off-limits.
+        let r = req(json!({
+            "system": [
+                {"type": "text", "text": "Good (Korean session): {\"title\": \"결제 모듈 리팩토링\"}"},
+            ],
+            "messages": [{"role": "user", "content": "summarise this session"}],
+        }));
+        let p = for_kind(ProviderKind::Anthropic);
+        assert!(
+            frozen_pointers(&r, p.as_ref()).is_empty(),
+            "no cache_control ⇒ nothing frozen"
+        );
+        let c = compressible_pointers(&r, p.as_ref());
+        assert!(
+            !c.iter().any(|p| p.starts_with("/system")),
+            "system stays out of reach: {c:?}"
+        );
+        assert!(
+            c.iter().any(|p| p.starts_with("/messages")),
+            "the session content is still compressible: {c:?}"
+        );
+
+        // Same for a string `system`, and for a wire shape that carries instructions as a
+        // system-role message rather than a top-level field.
+        let r = req(json!({
+            "system": "Return JSON with a single \"title\" field.",
+            "messages": [
+                {"role": "system", "content": "never fold me"},
+                {"role": "user", "content": "but fold me"},
+            ],
+        }));
+        let c = compressible_pointers(&r, p.as_ref());
+        assert_eq!(c, vec!["/messages/1/content".to_string()], "got {c:?}");
     }
 
     #[test]

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1083,8 +1083,13 @@ fn resolve_sub_chain(
 }
 
 /// Codex continuation (previous_response_id deltas) enabled? Env `LLMTRIM_CODEX_PREVIOUS_RESPONSE_ID`
-/// (truthy) wins, else `[sub.codex] previous_response_id = true` (or `continuation`). Defaults to
-/// `true` so sub-codex users get the cache/state benefit by default.
+/// (truthy) wins, else `[sub.codex] previous_response_id = true` (or `continuation`).
+///
+/// Defaults to `false`: the ChatGPT backend accepts `previous_response_id` only over its
+/// WebSocket transport, and rejects it on the HTTP `/responses` path we use with
+/// `400 Unsupported parameter`. It is also incoherent with the `store: false` we send — there is
+/// no server-side response to continue from. Left as an opt-in for a future WebSocket transport;
+/// prefix caching via `prompt_cache_key` is what carries the cache today.
 fn resolve_sub_codex_continuation(
     env: &impl Fn(&str) -> Option<String>,
     file: Option<&toml::Value>,
@@ -1116,7 +1121,7 @@ fn resolve_sub_codex_continuation(
             return is_true(s);
         }
     }
-    true
+    false
 }
 
 /// Persist the breakdown-TUI `theme` choice to the config file's top-level `theme` key,
@@ -1420,6 +1425,25 @@ mod tests {
         std::fs::write(&path, "preset = \"auto\"\n").unwrap();
         assert_eq!(sub_reenable_provider_at(&path), None);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn codex_continuation_is_off_unless_asked_for() {
+        let no_env = |_: &str| None;
+        // Off by default: the ChatGPT HTTP `/responses` path rejects `previous_response_id`
+        // outright, so sending it on every follow-up turn 400s the whole session.
+        assert!(!resolve_sub_codex_continuation(&no_env, None));
+        let plain: toml::Value = toml::from_str("sub = \"codex\"").unwrap();
+        assert!(!resolve_sub_codex_continuation(&no_env, Some(&plain)));
+        // Still opt-in-able, for a transport that accepts it.
+        let on: toml::Value = toml::from_str("[sub.codex]\nprevious_response_id = true\n").unwrap();
+        assert!(resolve_sub_codex_continuation(&no_env, Some(&on)));
+        // Env wins both ways.
+        let env_on = |k: &str| (k == "LLMTRIM_CODEX_PREVIOUS_RESPONSE_ID").then(|| "1".to_string());
+        assert!(resolve_sub_codex_continuation(&env_on, None));
+        let env_off =
+            |k: &str| (k == "LLMTRIM_CODEX_PREVIOUS_RESPONSE_ID").then(|| "0".to_string());
+        assert!(!resolve_sub_codex_continuation(&env_off, Some(&on)));
     }
 
     #[test]

--- a/crates/llmtrim-ledger/src/breakdown_db.rs
+++ b/crates/llmtrim-ledger/src/breakdown_db.rs
@@ -23,6 +23,15 @@ pub struct SessionRow {
     pub tokens: i64,
     /// Cache-hit fraction: cache-read over total input (0.0 when no input billed).
     pub cache_hit: f64,
+    /// Cache-hit fraction of the session's *most recent* turn alone, matching the per-turn
+    /// figure Claude Code reports in `current_usage`. `None` when that turn billed no input.
+    /// Distinct from `cache_hit`, which averages the whole session (and so is dragged down by
+    /// the cold first turn) — the status line wants the last turn's rate, not the average.
+    pub last_cache_hit: Option<f64>,
+    /// Input tokens of that same most-recent turn (fresh + cache read + cache write) — the
+    /// context occupancy Claude Code reports as `total_input_tokens`, which it omits from the
+    /// blob mid-turn. `0` when no turn has landed.
+    pub last_input_tokens: i64,
     /// Total bill in micro-USD (frozen per turn, summed).
     pub bill_micros: i64,
     /// Input tokens before / after compression, summed — the session's savings.
@@ -139,7 +148,12 @@ impl BreakdownDb {
                         MAX(ts),
                         MAX(cc_session_id),
                         MAX(CASE WHEN recent = 1 THEN sub_provider END),
-                        MAX(CASE WHEN recent = 1 THEN model END)
+                        MAX(CASE WHEN recent = 1 THEN model END),
+                        COALESCE(MAX(CASE WHEN recent = 1 THEN cache_read END), 0),
+                        COALESCE(
+                            MAX(CASE WHEN recent = 1 THEN fresh_input + cache_read + cache_write END),
+                            0
+                        )
                  FROM ranked
                  GROUP BY session_id, agent, project
                  ORDER BY MAX(ts) DESC",
@@ -149,6 +163,8 @@ impl BreakdownDb {
             .query_map([], |r| {
                 let cache_read: i64 = r.get(6)?;
                 let total_in: i64 = r.get(7)?;
+                let last_read: i64 = r.get(15)?;
+                let last_total_in: i64 = r.get(16)?;
                 Ok(SessionRow {
                     session_id: r.get(0)?,
                     agent: r.get(1)?,
@@ -161,6 +177,9 @@ impl BreakdownDb {
                     } else {
                         0.0
                     },
+                    last_cache_hit: (last_total_in > 0)
+                        .then(|| last_read as f64 / last_total_in as f64),
+                    last_input_tokens: last_total_in,
                     bill_micros: r.get(8)?,
                     input_before: r.get(9)?,
                     input_after: r.get(10)?,


### PR DESCRIPTION
Four fixes found while running Claude Code through a `sub codex` reroute.

## `previous_response_id` 400s every follow-up turn

The ChatGPT backend accepts `previous_response_id` only over its WebSocket transport. On the HTTP `/responses` path it answers `400 Unsupported parameter: previous_response_id`, so with continuation defaulting to on, every turn after the first in a rerouted session failed. It was incoherent with the `store: false` we send anyway — there is no server-side response to continue from.

Default it off (still opt-in for a transport that accepts it), and let a rejected continuation heal itself: the re-issue path now recognises the rejection and re-sends the full body despite the 400, which is otherwise terminal. An unrelated 400 is still surfaced rather than blindly repeated.

## The compressor rewrote the system prompt

With no `cache_control` markers nothing is frozen, so the text-mutating stages were free to rewrite the instructions. On Claude Code's title-generation call — which carries no markers — n-gram substitution folded the few-shot examples from

    Good (Korean session): {"title": "…"}
    Bad (English title for a Korean session): {"title": "…"}

into `Good (Korean §3 "…"}` / `Bad (English title for a Korean §3 "…"}`, deleting the conditional that was the entire point of the pair.

Instructions are what the model conditions on rather than reads as data, so a fold that is harmless in a tool result can invert a directive. `/system`, `/instructions` and system-role messages are now excluded from the compressible set unconditionally.

This costs nothing on real traffic: 593 of 594 captured requests already carried `cache_control` on `system`, and replaying 58 of them produces byte-identical output. It closes the gap for the utility calls that carry no markers.

## The status line blanked out mid-turn

The cache % and context gauge were read only from Claude Code's blob, which fills `current_usage` / `total_input_tokens` from the *last response*. Claude Code re-runs the status line on every render, so mid-request both are absent — the cache segment vanished and the gauge emptied, then both snapped back. It reads like the cache collapsing every turn.

The proxy measured the same quantities on the wire, so the ledger's last completed turn now stands in across the gap. The blob still wins whenever it carries a figure; a fresh session with no recorded turn still renders empty rather than inventing a value.

## Reroute captures

The capture pair stopped at our own pipeline output, leaving the translated payload — the thing the upstream prompt cache keys on — unobservable. Gated behind `capture_dir`, so it is free when capture is off.

---

Verified against the live Codex backend: a warm prefix plus an appended message reads 13,824 cached tokens and bills 130 fresh, so the reported "cache collapse under sub" is a cold cache on a different backend, not a bug. 1025 tests pass.