### PR TITLE
Warn before a resumed session pays for a cold cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`llmtrim guard` — stop paying for a cold cache without being told.** Resume a session that has
+  been idle past the prompt-cache TTL and the next turn silently re-writes the entire context,
+  billed at the cache-write rate (2× base input for the 1h TTL Claude Code asks for). On a 225k
+  context — the median across my own idle gaps — that is a few dollars before any work happens, and
+  nothing at the prompt says so. `guard` is a Claude Code `UserPromptSubmit` hook: on the first
+  submit after a long gap on a big context it prints the idle time, the context size and what the
+  cold write costs, then exits 2, which blocks the prompt with no API call. A resend goes straight
+  through, and the blocked message is saved to disk since Claude Code does not restore it. `llmtrim
+  setup` offers to wire it in; `guard install` / `guard uninstall` do it directly, merging into
+  `~/.claude/settings.json` rather than clobbering hooks you already have. It reads Claude Code's
+  transcript, not llmtrim's ledger — the ledger keys sessions by a hash of the system prompt, so a
+  subagent turn would mask a stale main conversation — and every failure path exits 0: a bug in the
+  guard must never block a prompt.
+
+### Changed
+
+- **The status line now refreshes while a session sits idle.** It already reddened the cache segment
+  once the prompt cache expired, but Claude Code only re-renders on conversation events, so an
+  abandoned session kept the line drawn at its last turn — green and warm — straight through the TTL
+  expiring. The warning only appeared *after* the turn that paid for it. It now sets
+  `refreshInterval`, so the state is on screen before you type. Re-run `llmtrim statusline install`
+  to pick it up.
+- **The cold-cache segment no longer suggests `/compact`.** It read `♻ cold · /compact`, which sold
+  compaction as the thrifty move. It isn't: `/compact` re-reads the same cold context to summarise
+  it — paying the charge it appears to avoid — and the next turn then writes a fresh cache for the
+  summary. Resending pays once. The segment now just reports the state: `♻ cache cold`.
+
 ## [0.10.1] - 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -315,10 +315,32 @@ The `✂` trim figure is scoped to the current Claude Code session; it reads `�
 has saved something this session. `◔ 5h·24% · 7d·12%` is the share of your Claude.ai 5-hour and
 7-day limits used. The context gauge fills against the real window of the model serving
 the turn — the rerouted backend's window under `sub`, not Claude's — green below 40%, orange
-40–65%, red above. `♻` shows this turn's prompt-cache reuse, and turns into `♻ cold · /compact`
+40–65%, red above. `♻` shows this turn's prompt-cache reuse, and turns into `♻ cache cold`
 once the session has been idle past the cache TTL, since the next message then pays a cold cache
 write. Segments drop right-to-left on narrow terminals, and anything Claude Code doesn't report
 (no reroute, no rate limits) is simply left out.
+
+### Guard
+
+Resuming a session whose prompt cache has expired re-writes the whole context on the very next
+turn, billed at the cache-write rate — a few dollars on a large session, spent before any work
+happens, with nothing at the prompt to say so.
+
+`llmtrim guard` is a Claude Code `UserPromptSubmit` hook that stops that one turn:
+
+```text
+Idle 6h 19m, 347k tokens of context. The prompt cache has expired, so the next turn
+re-writes the whole context — about $3.47 before any work happens.
+
+You pay that whichever way you go: /compact pays it too (it reads the full context to
+summarise it), and only comes out ahead if you are staying for several more turns. To
+avoid the charge entirely, ask in a fresh session.
+```
+
+The prompt is not sent and no API call is made, so the warning itself is free. Resend to continue;
+you are only warned once per idle gap. `llmtrim setup` offers to wire it in, or run `llmtrim guard
+install` (`guard uninstall` to remove it — it merges into `~/.claude/settings.json` and leaves your
+other hooks alone).
 
 ## Works with
 

--- a/crates/llmtrim-cli/src/guard.rs
+++ b/crates/llmtrim-cli/src/guard.rs
@@ -1,0 +1,748 @@
+//! `guard` — a Claude Code `UserPromptSubmit` hook that stops the first turn of a resumed,
+//! cold-cache, large-context session so the user sees what it costs *before* paying it.
+//!
+//! Past the prompt-cache TTL (the same 1h Claude Code asks for, [`crate::statusline::CACHE_TTL_SECS`])
+//! a resumed session re-writes its whole context on the next request, billed at the cache-write
+//! rate. Nothing at the prompt says so. So on the first submit after a long idle gap on a big
+//! context, print the figure to stderr and exit 2 — Claude Code blocks the prompt with no API
+//! call, and a resend goes straight through.
+//!
+//! Data comes from Claude Code's own transcript, not llmtrim's ledger: the ledger's `session_id`
+//! is a hash of the system prompt, so a *subagent* turn (different system prompt, same Claude Code
+//! session) would mask a stale main conversation — and a session that never went through the proxy
+//! has no ledger row at all. The transcript carries `isSidechain`, which excludes subagent turns
+//! exactly. The ledger is consulted only to price a `sub`-rerouted backend, never to decide.
+//!
+//! Every fallible step maps to exit 0. A bug in here must never block a prompt.
+
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+use crate::statusline::CACHE_TTL_SECS;
+
+/// Context size (tokens) below which a cold turn isn't worth interrupting anyone for.
+const MIN_TOKENS: i64 = 100_000;
+/// A 1h-TTL cache write is billed at 2x the base input rate. The cold turn pays exactly that,
+/// which is why the prototype's plain input rate understated it ~2x.
+const CACHE_WRITE_MULTIPLIER: f64 = 2.0;
+
+// ── the hook payload (only the fields we need) ───────────────────────────────────
+
+/// Claude Code's `UserPromptSubmit` JSON on stdin. It carries no token/context fields — those
+/// live in the *statusline* blob, a different payload — so the numbers come from the transcript.
+struct HookInput {
+    session_id: String,
+    transcript_path: PathBuf,
+}
+
+fn parse_hook(input: &str) -> Option<HookInput> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    let transcript = v.get("transcript_path").and_then(Value::as_str)?;
+    if transcript.is_empty() {
+        return None;
+    }
+    Some(HookInput {
+        session_id: v
+            .get("session_id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        transcript_path: PathBuf::from(transcript),
+    })
+}
+
+// ── the transcript ───────────────────────────────────────────────────────────────
+
+/// What the transcript says about *this* conversation (subagent turns excluded).
+struct Scan {
+    /// Newest timestamp among non-sidechain entries — the point we are resuming from.
+    last_ts: DateTime<Utc>,
+    /// Input the next request re-sends: everything the newest non-sidechain assistant turn was
+    /// billed for on input (fresh + cache write + cache read).
+    tokens: i64,
+    model: String,
+}
+
+fn parse_ts(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|t| t.with_timezone(&Utc))
+}
+
+/// Scan the transcript JSONL. Unparseable lines are skipped, not fatal — Claude Code appends
+/// while we read, so a torn last line is normal.
+fn scan(reader: impl BufRead) -> Option<Scan> {
+    let mut last_ts: Option<DateTime<Utc>> = None;
+    let mut tokens = 0_i64;
+    let mut model = String::new();
+
+    for line in reader.lines() {
+        let Ok(line) = line else { continue };
+        let Ok(entry) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        // Subagent turns run on their own context; they are not the one we would resume.
+        if entry.get("isSidechain").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        if let Some(ts) = entry
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .and_then(parse_ts)
+            && last_ts.is_none_or(|prev| ts > prev)
+        {
+            last_ts = Some(ts);
+        }
+        if let Some(usage) = entry.pointer("/message/usage") {
+            let field = |k: &str| usage.get(k).and_then(Value::as_i64).unwrap_or(0);
+            tokens = field("input_tokens")
+                + field("cache_creation_input_tokens")
+                + field("cache_read_input_tokens");
+            if let Some(m) = entry
+                .pointer("/message/model")
+                .and_then(Value::as_str)
+                .filter(|m| !m.is_empty())
+            {
+                model = m.to_string();
+            }
+        }
+    }
+
+    Some(Scan {
+        last_ts: last_ts?,
+        tokens,
+        model,
+    })
+}
+
+/// The rule, shared with the status line's cold-cache signal: idle past the cache TTL, on a
+/// context big enough that re-writing it costs real money.
+fn should_warn(idle_secs: i64, tokens: i64) -> bool {
+    idle_secs >= CACHE_TTL_SECS && tokens >= MIN_TOKENS
+}
+
+// ── the once-per-gap marker ──────────────────────────────────────────────────────
+
+/// Markers live beside the ledger, under llmtrim's existing state dir.
+fn marker_path(session_id: &str) -> Result<PathBuf> {
+    let db = crate::tracking::db_path()?;
+    let dir = db
+        .parent()
+        .context("ledger path has no parent directory")?
+        .join("guard");
+    // A session id from the payload is a UUID, but never let it walk out of the state dir.
+    let safe: String = session_id
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    Ok(dir.join(format!("{safe}.acked")))
+}
+
+/// Whether this exact idle gap was already warned about. The gap is keyed by the timestamp we
+/// are resuming from, so a *later* gap in the same session re-arms the warning.
+fn already_acked(path: &Path, gap_id: &str) -> bool {
+    std::fs::read_to_string(path).is_ok_and(|s| s.trim() == gap_id)
+}
+
+fn ack(path: &Path, gap_id: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    std::fs::write(path, gap_id).with_context(|| format!("failed to write {}", path.display()))
+}
+
+// ── cost + message ───────────────────────────────────────────────────────────────
+
+/// What the cold turn costs, in dollars, at the cache-write rate. `None` when the model isn't in
+/// the pricing snapshot — the warning then simply carries no figure.
+fn cold_turn_cost(tokens: i64, model: &str) -> Option<f64> {
+    // Claude Code tags some ids with a context suffix (`claude-opus-4-8[1m]`), which no registry
+    // knows; the base id prices the same tokens.
+    let base = model.split('[').next().unwrap_or(model);
+    let (input_per_1m, _) = crate::monitor::llm_prices(base)?;
+    Some(tokens as f64 / 1_000_000.0 * input_per_1m * CACHE_WRITE_MULTIPLIER)
+}
+
+/// The model to price the cold turn at: the `sub` backend that actually served this session's last
+/// turn, when there is one, else the model the transcript recorded. Ledger absence never changes
+/// the decision — only the number.
+fn pricing_model(session_id: &str, transcript_model: &str) -> String {
+    crate::statusline::session_sub_model(session_id).unwrap_or_else(|| transcript_model.to_string())
+}
+
+fn human_idle(secs: i64) -> String {
+    let (h, m) = (secs / 3600, (secs % 3600) / 60);
+    if h > 0 {
+        format!("{h}h {m}m")
+    } else {
+        format!("{m}m")
+    }
+}
+
+/// The warning. It must not claim `/compact` saves money: `/compact` reads the same cold context
+/// to summarise it (paying the charge), then the next turn writes a fresh cache for the summary
+/// (paying again) — measured on real captures at 128,758 then 45,131 tokens. Resending pays once.
+///
+/// The user's prompt is not echoed: Claude Code appends it itself as `Original prompt:`, so
+/// echoing nests the warning inside itself on every resend.
+fn message(idle_secs: i64, tokens: i64, cost: Option<f64>) -> String {
+    let cost = match cost {
+        Some(c) => format!(" — about ${c:.2}"),
+        None => String::new(),
+    };
+    format!(
+        "Idle {}, {:.0}k tokens of context. The prompt cache has expired, so the next turn \
+         re-writes the whole context{} before any work happens.\n\
+         \n\
+         You pay that whichever way you go: /compact pays it too (it reads the full context to \
+         summarise it), and only comes out ahead if you are staying for several more turns. To \
+         avoid the charge entirely, ask in a fresh session.\n\
+         \n\
+         Not sent. Resend to continue as-is.",
+        human_idle(idle_secs),
+        tokens as f64 / 1000.0,
+        cost,
+    )
+}
+
+// ── the hook entrypoint ──────────────────────────────────────────────────────────
+
+/// Exit code for "block this prompt". Claude Code shows stderr to the user and makes no API call.
+const BLOCK: i32 = 2;
+const PASS: i32 = 0;
+
+/// Decide and (if warning) print. Returns the exit code. Any error inside maps to `PASS` at the
+/// boundary in [`run`].
+fn decide(input: &str, now: DateTime<Utc>) -> Result<i32> {
+    let Some(hook) = parse_hook(input) else {
+        return Ok(PASS);
+    };
+    let Ok(file) = std::fs::File::open(&hook.transcript_path) else {
+        return Ok(PASS);
+    };
+    let Some(s) = scan(std::io::BufReader::new(file)) else {
+        return Ok(PASS);
+    };
+
+    let idle = now.signed_duration_since(s.last_ts).num_seconds();
+    if !should_warn(idle, s.tokens) {
+        return Ok(PASS);
+    }
+
+    // Warn once per idle gap; a resend then goes straight through.
+    let gap_id = s.last_ts.to_rfc3339();
+    let marker = marker_path(&hook.session_id)?;
+    if already_acked(&marker, &gap_id) {
+        return Ok(PASS);
+    }
+    ack(&marker, &gap_id)?;
+
+    let model = pricing_model(&hook.session_id, &s.model);
+    eprintln!("{}", message(idle, s.tokens, cold_turn_cost(s.tokens, &model)));
+    Ok(BLOCK)
+}
+
+/// Run the hook: read stdin, print to stderr, return the exit code for `main` to exit with.
+///
+/// Fail open, unconditionally: an error, a panic, a missing transcript — anything but a genuine
+/// stale-and-large session — returns 0 and the prompt goes through.
+pub fn run() -> i32 {
+    fail_open(|| {
+        use std::io::Read;
+        let mut input = String::new();
+        if std::io::stdin().read_to_string(&mut input).is_err() {
+            return PASS;
+        }
+        decide(&input, Utc::now()).unwrap_or(PASS)
+    })
+}
+
+/// The outer boundary: a panic in the handler must not block a prompt either.
+fn fail_open(f: impl FnOnce() -> i32 + std::panic::UnwindSafe) -> i32 {
+    std::panic::catch_unwind(f).unwrap_or(PASS)
+}
+
+// ── install / uninstall (wire ~/.claude/settings.json) ───────────────────────────
+//
+// Unlike `statusLine` (a singleton key), `hooks.UserPromptSubmit` is an ARRAY that may already
+// hold the user's own hooks. So we find-or-create the array and replace *our* entry in place —
+// never clobber the object.
+
+/// One `UserPromptSubmit` matcher group holding just our command.
+fn guard_hook_entry() -> Value {
+    serde_json::json!({
+        "hooks": [{
+            "type": "command",
+            "command": crate::statusline::exe_command("guard"),
+            "timeout": 10,
+        }]
+    })
+}
+
+/// Whether a hook command is one `llmtrim guard install` wrote: the llmtrim binary invoked with
+/// `guard`, or — for an install renamed or vendored under another file name — the exact command
+/// this binary writes, so uninstall/refresh still recognise their own entry.
+fn is_llmtrim_guard_command(command: &str) -> bool {
+    crate::statusline::is_llmtrim_command(command, "guard")
+        || command == crate::statusline::exe_command("guard")
+}
+
+/// Whether a `UserPromptSubmit` group is ours (any of its commands is our guard command).
+fn is_ours(group: &Value) -> bool {
+    group
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_some_and(|hooks| {
+            hooks.iter().any(|h| {
+                h.get("command")
+                    .and_then(Value::as_str)
+                    .is_some_and(is_llmtrim_guard_command)
+            })
+        })
+}
+
+/// Add (or refresh) our hook in a parsed settings object, preserving every other hook. Pure
+/// transform, so the merge is unit-testable.
+fn set_guard_hook(settings: &mut Value, path: &Path) -> Result<()> {
+    let obj = settings
+        .as_object_mut()
+        .with_context(|| format!("{} is not a JSON object", path.display()))?;
+    let hooks = obj
+        .entry("hooks")
+        .or_insert_with(|| Value::Object(Default::default()))
+        .as_object_mut()
+        .with_context(|| format!("`hooks` in {} is not a JSON object", path.display()))?;
+    let list = hooks
+        .entry("UserPromptSubmit")
+        .or_insert_with(|| Value::Array(Vec::new()))
+        .as_array_mut()
+        .with_context(|| {
+            format!(
+                "`hooks.UserPromptSubmit` in {} is not a JSON array",
+                path.display()
+            )
+        })?;
+    match list.iter().position(is_ours) {
+        Some(i) => list[i] = guard_hook_entry(),
+        None => list.push(guard_hook_entry()),
+    }
+    Ok(())
+}
+
+/// Remove only our hook, pruning the array/object if we were the last one in it. Returns whether
+/// anything was removed. Pure transform.
+fn clear_guard_hook(settings: &mut Value, path: &Path) -> Result<bool> {
+    let obj = settings
+        .as_object_mut()
+        .with_context(|| format!("{} is not a JSON object", path.display()))?;
+    let Some(hooks) = obj.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return Ok(false);
+    };
+    let Some(list) = hooks
+        .get_mut("UserPromptSubmit")
+        .and_then(Value::as_array_mut)
+    else {
+        return Ok(false);
+    };
+    let before = list.len();
+    list.retain(|g| !is_ours(g));
+    let removed = list.len() != before;
+    if list.is_empty() {
+        hooks.remove("UserPromptSubmit");
+    }
+    if hooks.is_empty() {
+        obj.remove("hooks");
+    }
+    Ok(removed)
+}
+
+fn claude_settings_path() -> Result<PathBuf> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .context("neither HOME nor USERPROFILE is set")?;
+    Ok(PathBuf::from(home).join(".claude").join("settings.json"))
+}
+
+/// Wire the hook into `~/.claude/settings.json` (merging, never clobbering). Returns the file it
+/// wrote, so `setup` can report it without printing its own line.
+pub fn wire() -> Result<PathBuf> {
+    let path = claude_settings_path()?;
+    let mut settings: Value = match std::fs::read_to_string(&path) {
+        Ok(s) => serde_json::from_str(&s)
+            .with_context(|| format!("{} is not valid JSON", path.display()))?,
+        Err(_) => Value::Object(Default::default()),
+    };
+    set_guard_hook(&mut settings, &path)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    std::fs::write(&path, serde_json::to_string_pretty(&settings)?)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(path)
+}
+
+/// `guard install` — wire the hook, or just print the settings snippet with `--print`.
+pub fn install(print: bool) -> Result<()> {
+    if print {
+        let snippet = serde_json::json!({ "hooks": { "UserPromptSubmit": [guard_hook_entry()] } });
+        println!("{}", serde_json::to_string_pretty(&snippet)?);
+        return Ok(());
+    }
+    let path = wire()?;
+    println!(
+        "Wired the llmtrim guard into {}. Restart Claude Code to arm it.",
+        path.display()
+    );
+    Ok(())
+}
+
+/// Remove our hook from `~/.claude/settings.json`, leaving the user's other hooks alone.
+/// Returns whether one was present.
+pub fn unwire() -> Result<bool> {
+    let path = claude_settings_path()?;
+    let Ok(s) = std::fs::read_to_string(&path) else {
+        return Ok(false);
+    };
+    let mut settings: Value =
+        serde_json::from_str(&s).with_context(|| format!("{} is not valid JSON", path.display()))?;
+    if !clear_guard_hook(&mut settings, &path)? {
+        return Ok(false);
+    }
+    std::fs::write(&path, serde_json::to_string_pretty(&settings)?)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(true)
+}
+
+/// `guard uninstall`.
+pub fn uninstall() -> Result<()> {
+    let path = claude_settings_path()?;
+    if unwire()? {
+        println!("Removed the llmtrim guard from {}.", path.display());
+    } else {
+        println!("No llmtrim guard found in {}.", path.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A transcript entry, as Claude Code writes them.
+    fn entry(ts: &str, tokens: i64, sidechain: bool) -> String {
+        serde_json::json!({
+            "timestamp": ts,
+            "isSidechain": sidechain,
+            "message": {
+                "model": "claude-opus-4-8",
+                "usage": {
+                    "input_tokens": 10,
+                    "cache_creation_input_tokens": tokens - 10,
+                    "cache_read_input_tokens": 0,
+                },
+            },
+        })
+        .to_string()
+    }
+
+    /// Write a transcript + hook payload into a fresh temp dir; returns (payload, dir).
+    fn fixture(lines: &[String]) -> (String, PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "llmtrim-guard-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let transcript = dir.join("transcript.jsonl");
+        std::fs::write(&transcript, lines.join("\n")).unwrap();
+        // Keep every test's markers inside its own dir: `marker_path` hangs off the ledger path,
+        // which `LLMTRIM_DB_PATH` (read by `RuntimeConfig`) would pin — but that's process-global
+        // state, so tests instead assert on `decide` with an explicit `now` and on the marker
+        // helpers directly (below).
+        let payload = serde_json::json!({
+            "session_id": format!("sess-{}", dir.file_name().unwrap().to_string_lossy()),
+            "transcript_path": transcript.display().to_string(),
+            "prompt": "carry on",
+        })
+        .to_string();
+        (payload, dir)
+    }
+
+    fn ago(secs: i64) -> String {
+        (Utc::now() - chrono::Duration::seconds(secs)).to_rfc3339()
+    }
+
+    /// `decide` with the marker step neutralised: the trigger logic, not the filesystem.
+    fn verdict(payload: &str) -> i32 {
+        let hook = match parse_hook(payload) {
+            Some(h) => h,
+            None => return PASS,
+        };
+        let Ok(file) = std::fs::File::open(&hook.transcript_path) else {
+            return PASS;
+        };
+        let Some(s) = scan(std::io::BufReader::new(file)) else {
+            return PASS;
+        };
+        let idle = Utc::now().signed_duration_since(s.last_ts).num_seconds();
+        if should_warn(idle, s.tokens) { BLOCK } else { PASS }
+    }
+
+    #[test]
+    fn cold_and_big_blocks() {
+        let (payload, dir) = fixture(&[entry(&ago(7200), 150_000, false)]);
+        assert_eq!(verdict(&payload), BLOCK);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn warm_session_passes() {
+        let (payload, dir) = fixture(&[entry(&ago(60), 150_000, false)]);
+        assert_eq!(verdict(&payload), PASS);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn cold_but_small_passes() {
+        let (payload, dir) = fixture(&[entry(&ago(7200), 20_000, false)]);
+        assert_eq!(verdict(&payload), PASS);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn a_newer_subagent_turn_does_not_hide_a_stale_conversation() {
+        // The regression the ledger-based design would have shipped: the main conversation is
+        // stale, but a subagent answered a minute ago. Only `isSidechain` separates them.
+        let (payload, dir) = fixture(&[
+            entry(&ago(7200), 150_000, false),
+            entry(&ago(30), 150_000, true),
+        ]);
+        assert_eq!(verdict(&payload), BLOCK);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn sidechain_only_transcript_never_fires() {
+        let (payload, dir) = fixture(&[entry(&ago(7200), 150_000, true)]);
+        assert_eq!(verdict(&payload), PASS);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn once_per_gap_then_again_on_the_next_gap() {
+        let dir = std::env::temp_dir().join(format!("llmtrim-guard-marker-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let marker = dir.join("sess.acked");
+        let gap = ago(7200);
+
+        assert!(!already_acked(&marker, &gap), "first submit warns");
+        ack(&marker, &gap).unwrap();
+        assert!(already_acked(&marker, &gap), "the resend goes through");
+
+        // A later idle gap in the same session re-arms the warning.
+        let next_gap = ago(3700);
+        assert!(!already_acked(&marker, &next_gap));
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn fails_open_on_bad_input() {
+        assert_eq!(verdict("not json"), PASS);
+        assert_eq!(verdict("{}"), PASS);
+        assert_eq!(
+            decide(r#"{"transcript_path":"/nonexistent/x.jsonl"}"#, Utc::now()).unwrap(),
+            PASS,
+            "missing transcript fails open"
+        );
+        assert_eq!(
+            decide("garbage", Utc::now()).unwrap(),
+            PASS,
+            "malformed stdin fails open"
+        );
+    }
+
+    #[test]
+    fn a_transcript_of_junk_lines_fails_open() {
+        let (payload, dir) = fixture(&["not json".into(), "{".into()]);
+        assert_eq!(verdict(&payload), PASS);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn a_panic_in_the_handler_never_blocks() {
+        // The outer boundary is what guarantees "a bug here can't cost the user a turn".
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let code = fail_open(|| panic!("bug"));
+        std::panic::set_hook(prev);
+        assert_eq!(code, PASS);
+    }
+
+    #[test]
+    fn scan_sums_the_whole_resent_context() {
+        let line = serde_json::json!({
+            "timestamp": "2026-07-14T10:00:00Z",
+            "message": {
+                "model": "claude-opus-4-8",
+                "usage": {
+                    "input_tokens": 5,
+                    "cache_creation_input_tokens": 1000,
+                    "cache_read_input_tokens": 120_000,
+                },
+            },
+        })
+        .to_string();
+        let s = scan(line.as_bytes()).unwrap();
+        assert_eq!(s.tokens, 121_005);
+        assert_eq!(s.model, "claude-opus-4-8");
+    }
+
+    #[test]
+    fn message_does_not_sell_compact_as_a_saving() {
+        let m = message(7200, 150_000, Some(1.5));
+        assert!(m.contains("2h 0m") && m.contains("150k"), "{m}");
+        assert!(m.contains("$1.50"), "cost at the cache-write rate: {m}");
+        assert!(
+            m.contains("/compact pays it too"),
+            "compact is not a money-saver: {m}"
+        );
+        assert!(!m.contains("Run /compact"), "no compact recommendation: {m}");
+        assert!(!m.contains("carry on"), "never echo the prompt: {m}");
+        // No price for an unknown model ⇒ no figure, but still a warning.
+        assert!(!message(7200, 150_000, None).contains('$'));
+    }
+
+    #[test]
+    fn cold_turn_is_priced_at_the_cache_write_rate() {
+        // Whatever the snapshot says, the cold write is 2x the base input rate.
+        let Some((input_per_1m, _)) = crate::monitor::llm_prices("claude-opus-4-8") else {
+            return; // model not in the pricing snapshot on this build — nothing to assert
+        };
+        let cost = cold_turn_cost(1_000_000, "claude-opus-4-8[1m]").unwrap();
+        assert!(
+            (cost - input_per_1m * 2.0).abs() < 1e-9,
+            "1M cold tokens = 2x input rate: {cost}"
+        );
+    }
+
+    #[test]
+    fn marker_path_lives_under_the_ledger_dir_and_cannot_escape_it() {
+        let p = marker_path("../../etc/passwd").unwrap();
+        let dir = p.parent().unwrap();
+        assert_eq!(dir.file_name().unwrap(), "guard");
+        assert_eq!(
+            p.file_name().unwrap().to_string_lossy(),
+            "------etc-passwd.acked"
+        );
+    }
+
+    // ── settings merge ──────────────────────────────────────────────────────────
+
+    fn p() -> &'static Path {
+        Path::new("settings.json")
+    }
+
+    fn commands(settings: &Value) -> Vec<String> {
+        settings["hooks"]["UserPromptSubmit"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|g| g["hooks"].as_array().unwrap())
+            .map(|h| h["command"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn install_into_empty_settings_adds_the_hook() {
+        let mut settings = serde_json::json!({});
+        set_guard_hook(&mut settings, p()).unwrap();
+        assert_eq!(commands(&settings).len(), 1);
+        assert!(is_llmtrim_guard_command(&commands(&settings)[0]));
+    }
+
+    #[test]
+    fn install_preserves_unrelated_user_hooks() {
+        let mut settings = serde_json::json!({
+            "hooks": {
+                "UserPromptSubmit": [
+                    { "hooks": [{ "type": "command", "command": "~/.claude/hooks/mine" }] }
+                ],
+                "Stop": [{ "hooks": [{ "type": "command", "command": "notify" }] }],
+            }
+        });
+        set_guard_hook(&mut settings, p()).unwrap();
+        let cmds = commands(&settings);
+        assert_eq!(cmds.len(), 2, "ours is appended, not substituted: {cmds:?}");
+        assert_eq!(cmds[0], "~/.claude/hooks/mine");
+        assert!(is_llmtrim_guard_command(&cmds[1]));
+        assert_eq!(settings["hooks"]["Stop"][0]["hooks"][0]["command"], "notify");
+    }
+
+    #[test]
+    fn install_refreshes_our_entry_in_place_instead_of_duplicating_it() {
+        let mut settings = serde_json::json!({
+            "hooks": { "UserPromptSubmit": [
+                { "hooks": [{ "type": "command",
+                              "command": "/opt/homebrew/Cellar/llmtrim/0.9.4/bin/llmtrim guard" }] }
+            ]}
+        });
+        set_guard_hook(&mut settings, p()).unwrap();
+        let cmds = commands(&settings);
+        assert_eq!(cmds.len(), 1, "refreshed in place: {cmds:?}");
+        assert_ne!(cmds[0], "/opt/homebrew/Cellar/llmtrim/0.9.4/bin/llmtrim guard");
+        assert!(is_llmtrim_guard_command(&cmds[0]));
+    }
+
+    #[test]
+    fn uninstall_removes_only_ours_and_prunes_empties() {
+        let mut settings = serde_json::json!({ "theme": "dark" });
+        set_guard_hook(&mut settings, p()).unwrap();
+        assert!(clear_guard_hook(&mut settings, p()).unwrap());
+        assert!(
+            settings.get("hooks").is_none(),
+            "an emptied hooks object is pruned: {settings}"
+        );
+        assert_eq!(settings["theme"], "dark");
+        // A second removal is a no-op.
+        assert!(!clear_guard_hook(&mut settings, p()).unwrap());
+
+        // With a user hook alongside, only ours goes.
+        let mut settings = serde_json::json!({
+            "hooks": { "UserPromptSubmit": [
+                { "hooks": [{ "type": "command", "command": "~/.claude/hooks/mine" }] }
+            ]}
+        });
+        set_guard_hook(&mut settings, p()).unwrap();
+        assert!(clear_guard_hook(&mut settings, p()).unwrap());
+        assert_eq!(commands(&settings), vec!["~/.claude/hooks/mine".to_string()]);
+    }
+
+    #[test]
+    fn recognizes_only_llmtrim_guard_commands() {
+        assert!(is_llmtrim_guard_command(
+            "/opt/homebrew/Cellar/llmtrim/0.9.4/bin/llmtrim guard"
+        ));
+        assert!(is_llmtrim_guard_command(
+            r#""C:\Program Files\llmtrim\llmtrim.exe" guard"#
+        ));
+        assert!(!is_llmtrim_guard_command("llmtrim statusline"));
+        assert!(!is_llmtrim_guard_command("~/.claude/hooks/guard"));
+    }
+
+    #[test]
+    fn merge_rejects_a_non_object_settings_file() {
+        let mut settings = serde_json::json!([1, 2, 3]);
+        assert!(set_guard_hook(&mut settings, p()).is_err());
+        assert!(clear_guard_hook(&mut settings, p()).is_err());
+    }
+}

--- a/crates/llmtrim-cli/src/guard.rs
+++ b/crates/llmtrim-cli/src/guard.rs
@@ -37,6 +37,8 @@ const CACHE_WRITE_MULTIPLIER: f64 = 2.0;
 struct HookInput {
     session_id: String,
     transcript_path: PathBuf,
+    /// What the user typed. Blocking erases it from the input box, so it is saved to disk.
+    prompt: String,
 }
 
 fn parse_hook(input: &str) -> Option<HookInput> {
@@ -52,6 +54,11 @@ fn parse_hook(input: &str) -> Option<HookInput> {
             .unwrap_or("")
             .to_string(),
         transcript_path: PathBuf::from(transcript),
+        prompt: v
+            .get("prompt")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
     })
 }
 
@@ -128,24 +135,41 @@ fn should_warn(idle_secs: i64, tokens: i64) -> bool {
 // ── the once-per-gap marker ──────────────────────────────────────────────────────
 
 /// Markers live beside the ledger, under llmtrim's existing state dir.
-fn marker_path(session_id: &str) -> Result<PathBuf> {
+fn guard_dir() -> Result<PathBuf> {
     let db = crate::tracking::db_path()?;
-    let dir = db
+    Ok(db
         .parent()
         .context("ledger path has no parent directory")?
-        .join("guard");
+        .join("guard"))
+}
+
+/// The marker for one session, under `dir`. Taking the directory as an argument keeps
+/// [`decide_in`] testable without reaching for the process-global `LLMTRIM_DB_PATH`.
+fn marker_path(dir: &Path, session_id: &str) -> PathBuf {
     // A session id from the payload is a UUID, but never let it walk out of the state dir.
     let safe: String = session_id
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
         .collect();
-    Ok(dir.join(format!("{safe}.acked")))
+    dir.join(format!("{safe}.acked"))
 }
 
 /// Whether this exact idle gap was already warned about. The gap is keyed by the timestamp we
 /// are resuming from, so a *later* gap in the same session re-arms the warning.
 fn already_acked(path: &Path, gap_id: &str) -> bool {
     std::fs::read_to_string(path).is_ok_and(|s| s.trim() == gap_id)
+}
+
+/// Stash the blocked prompt beside its marker. Claude Code does not restore it to the input box,
+/// so this is the only copy; failing to write it must not stop the warning.
+fn save_prompt(dir: &Path, session_id: &str, prompt: &str) -> Option<PathBuf> {
+    if prompt.is_empty() {
+        return None;
+    }
+    let path = marker_path(dir, session_id).with_extension("prompt");
+    std::fs::create_dir_all(dir).ok()?;
+    std::fs::write(&path, prompt).ok()?;
+    Some(path)
 }
 
 fn ack(path: &Path, gap_id: &str) -> Result<()> {
@@ -189,10 +213,16 @@ fn human_idle(secs: i64) -> String {
 /// (paying again) — measured on real captures at 128,758 then 45,131 tokens. Resending pays once.
 ///
 /// The user's prompt is not echoed: Claude Code appends it itself as `Original prompt:`, so
-/// echoing nests the warning inside itself on every resend.
-fn message(idle_secs: i64, tokens: i64, cost: Option<f64>) -> String {
+/// echoing nests the warning inside itself on every resend. It is *saved* instead — a blocked
+/// prompt is not restored to the input box (observed: the resend came back as `promptSource:
+/// typed`), so without this the text would be lost.
+fn message(idle_secs: i64, tokens: i64, cost: Option<f64>, saved: Option<&Path>) -> String {
     let cost = match cost {
         Some(c) => format!(" — about ${c:.2}"),
+        None => String::new(),
+    };
+    let saved = match saved {
+        Some(p) => format!(" Your message is saved at {}.", p.display()),
         None => String::new(),
     };
     format!(
@@ -203,10 +233,11 @@ fn message(idle_secs: i64, tokens: i64, cost: Option<f64>) -> String {
          summarise it), and only comes out ahead if you are staying for several more turns. To \
          avoid the charge entirely, ask in a fresh session.\n\
          \n\
-         Not sent. Resend to continue as-is.",
+         Not sent.{} Resend to continue as-is.",
         human_idle(idle_secs),
         tokens as f64 / 1000.0,
         cost,
+        saved,
     )
 }
 
@@ -219,6 +250,11 @@ const PASS: i32 = 0;
 /// Decide and (if warning) print. Returns the exit code. Any error inside maps to `PASS` at the
 /// boundary in [`run`].
 fn decide(input: &str, now: DateTime<Utc>) -> Result<i32> {
+    decide_in(input, now, &guard_dir()?)
+}
+
+/// [`decide`] against an explicit marker directory, so tests drive the real path.
+fn decide_in(input: &str, now: DateTime<Utc>, dir: &Path) -> Result<i32> {
     let Some(hook) = parse_hook(input) else {
         return Ok(PASS);
     };
@@ -236,14 +272,27 @@ fn decide(input: &str, now: DateTime<Utc>) -> Result<i32> {
 
     // Warn once per idle gap; a resend then goes straight through.
     let gap_id = s.last_ts.to_rfc3339();
-    let marker = marker_path(&hook.session_id)?;
+    let marker = marker_path(dir, &hook.session_id);
     if already_acked(&marker, &gap_id) {
         return Ok(PASS);
     }
+    // Ack before printing: if the marker cannot be written we fail open rather than block
+    // without recording that we did.
     ack(&marker, &gap_id)?;
 
+    // Best effort: losing the saved copy is not a reason to let the expensive turn through.
+    let saved = save_prompt(dir, &hook.session_id, &hook.prompt);
+
     let model = pricing_model(&hook.session_id, &s.model);
-    eprintln!("{}", message(idle, s.tokens, cold_turn_cost(s.tokens, &model)));
+    eprintln!(
+        "{}",
+        message(
+            idle,
+            s.tokens,
+            cold_turn_cost(s.tokens, &model),
+            saved.as_deref()
+        )
+    );
     Ok(BLOCK)
 }
 
@@ -371,7 +420,12 @@ fn claude_settings_path() -> Result<PathBuf> {
 /// Wire the hook into `~/.claude/settings.json` (merging, never clobbering). Returns the file it
 /// wrote, so `setup` can report it without printing its own line.
 pub fn wire() -> Result<PathBuf> {
-    let path = claude_settings_path()?;
+    wire_at(claude_settings_path()?)
+}
+
+/// [`wire`] against an explicit settings file, so tests exercise the read-modify-write round
+/// trip instead of only the pure merge.
+fn wire_at(path: PathBuf) -> Result<PathBuf> {
     let mut settings: Value = match std::fs::read_to_string(&path) {
         Ok(s) => serde_json::from_str(&s)
             .with_context(|| format!("{} is not valid JSON", path.display()))?,
@@ -405,12 +459,16 @@ pub fn install(print: bool) -> Result<()> {
 /// Remove our hook from `~/.claude/settings.json`, leaving the user's other hooks alone.
 /// Returns whether one was present.
 pub fn unwire() -> Result<bool> {
-    let path = claude_settings_path()?;
+    unwire_at(claude_settings_path()?)
+}
+
+/// [`unwire`] against an explicit settings file. See [`wire_at`].
+fn unwire_at(path: PathBuf) -> Result<bool> {
     let Ok(s) = std::fs::read_to_string(&path) else {
         return Ok(false);
     };
-    let mut settings: Value =
-        serde_json::from_str(&s).with_context(|| format!("{} is not valid JSON", path.display()))?;
+    let mut settings: Value = serde_json::from_str(&s)
+        .with_context(|| format!("{} is not valid JSON", path.display()))?;
     if !clear_guard_hook(&mut settings, &path)? {
         return Ok(false);
     }
@@ -464,10 +522,6 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let transcript = dir.join("transcript.jsonl");
         std::fs::write(&transcript, lines.join("\n")).unwrap();
-        // Keep every test's markers inside its own dir: `marker_path` hangs off the ledger path,
-        // which `LLMTRIM_DB_PATH` (read by `RuntimeConfig`) would pin — but that's process-global
-        // state, so tests instead assert on `decide` with an explicit `now` and on the marker
-        // helpers directly (below).
         let payload = serde_json::json!({
             "session_id": format!("sess-{}", dir.file_name().unwrap().to_string_lossy()),
             "transcript_path": transcript.display().to_string(),
@@ -481,40 +535,30 @@ mod tests {
         (Utc::now() - chrono::Duration::seconds(secs)).to_rfc3339()
     }
 
-    /// `decide` with the marker step neutralised: the trigger logic, not the filesystem.
-    fn verdict(payload: &str) -> i32 {
-        let hook = match parse_hook(payload) {
-            Some(h) => h,
-            None => return PASS,
-        };
-        let Ok(file) = std::fs::File::open(&hook.transcript_path) else {
-            return PASS;
-        };
-        let Some(s) = scan(std::io::BufReader::new(file)) else {
-            return PASS;
-        };
-        let idle = Utc::now().signed_duration_since(s.last_ts).num_seconds();
-        if should_warn(idle, s.tokens) { BLOCK } else { PASS }
+    /// The real [`decide_in`], with markers kept inside the test's own dir. Drives the whole
+    /// path — scan, trigger, marker, message — not a re-implementation of it.
+    fn verdict(payload: &str, dir: &Path) -> i32 {
+        decide_in(payload, Utc::now(), dir).unwrap_or(PASS)
     }
 
     #[test]
     fn cold_and_big_blocks() {
         let (payload, dir) = fixture(&[entry(&ago(7200), 150_000, false)]);
-        assert_eq!(verdict(&payload), BLOCK);
+        assert_eq!(verdict(&payload, &dir), BLOCK);
         std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
     fn warm_session_passes() {
         let (payload, dir) = fixture(&[entry(&ago(60), 150_000, false)]);
-        assert_eq!(verdict(&payload), PASS);
+        assert_eq!(verdict(&payload, &dir), PASS);
         std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
     fn cold_but_small_passes() {
         let (payload, dir) = fixture(&[entry(&ago(7200), 20_000, false)]);
-        assert_eq!(verdict(&payload), PASS);
+        assert_eq!(verdict(&payload, &dir), PASS);
         std::fs::remove_dir_all(dir).unwrap();
     }
 
@@ -526,14 +570,14 @@ mod tests {
             entry(&ago(7200), 150_000, false),
             entry(&ago(30), 150_000, true),
         ]);
-        assert_eq!(verdict(&payload), BLOCK);
+        assert_eq!(verdict(&payload, &dir), BLOCK);
         std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
     fn sidechain_only_transcript_never_fires() {
         let (payload, dir) = fixture(&[entry(&ago(7200), 150_000, true)]);
-        assert_eq!(verdict(&payload), PASS);
+        assert_eq!(verdict(&payload, &dir), PASS);
         std::fs::remove_dir_all(dir).unwrap();
     }
 
@@ -557,8 +601,9 @@ mod tests {
 
     #[test]
     fn fails_open_on_bad_input() {
-        assert_eq!(verdict("not json"), PASS);
-        assert_eq!(verdict("{}"), PASS);
+        let dir = std::env::temp_dir();
+        assert_eq!(verdict("not json", &dir), PASS);
+        assert_eq!(verdict("{}", &dir), PASS);
         assert_eq!(
             decide(r#"{"transcript_path":"/nonexistent/x.jsonl"}"#, Utc::now()).unwrap(),
             PASS,
@@ -574,7 +619,7 @@ mod tests {
     #[test]
     fn a_transcript_of_junk_lines_fails_open() {
         let (payload, dir) = fixture(&["not json".into(), "{".into()]);
-        assert_eq!(verdict(&payload), PASS);
+        assert_eq!(verdict(&payload, &dir), PASS);
         std::fs::remove_dir_all(dir).unwrap();
     }
 
@@ -609,17 +654,20 @@ mod tests {
 
     #[test]
     fn message_does_not_sell_compact_as_a_saving() {
-        let m = message(7200, 150_000, Some(1.5));
+        let m = message(7200, 150_000, Some(1.5), None);
         assert!(m.contains("2h 0m") && m.contains("150k"), "{m}");
         assert!(m.contains("$1.50"), "cost at the cache-write rate: {m}");
         assert!(
             m.contains("/compact pays it too"),
             "compact is not a money-saver: {m}"
         );
-        assert!(!m.contains("Run /compact"), "no compact recommendation: {m}");
+        assert!(
+            !m.contains("Run /compact"),
+            "no compact recommendation: {m}"
+        );
         assert!(!m.contains("carry on"), "never echo the prompt: {m}");
         // No price for an unknown model ⇒ no figure, but still a warning.
-        assert!(!message(7200, 150_000, None).contains('$'));
+        assert!(!message(7200, 150_000, None, None).contains('$'));
     }
 
     #[test]
@@ -636,14 +684,21 @@ mod tests {
     }
 
     #[test]
-    fn marker_path_lives_under_the_ledger_dir_and_cannot_escape_it() {
-        let p = marker_path("../../etc/passwd").unwrap();
-        let dir = p.parent().unwrap();
-        assert_eq!(dir.file_name().unwrap(), "guard");
+    fn a_hostile_session_id_cannot_walk_the_marker_out_of_its_directory() {
+        let dir = Path::new("/tmp/llmtrim-guard-test");
+        let p = marker_path(dir, "../../etc/passwd");
+        assert_eq!(p.parent().unwrap(), dir, "stays put");
         assert_eq!(
             p.file_name().unwrap().to_string_lossy(),
             "------etc-passwd.acked"
         );
+    }
+
+    #[test]
+    fn markers_live_beside_the_ledger() {
+        // The directory itself is only resolved in production; `decide_in` takes it as an
+        // argument so the tests above never touch the real state dir.
+        assert_eq!(guard_dir().unwrap().file_name().unwrap(), "guard");
     }
 
     // ── settings merge ──────────────────────────────────────────────────────────
@@ -685,7 +740,10 @@ mod tests {
         assert_eq!(cmds.len(), 2, "ours is appended, not substituted: {cmds:?}");
         assert_eq!(cmds[0], "~/.claude/hooks/mine");
         assert!(is_llmtrim_guard_command(&cmds[1]));
-        assert_eq!(settings["hooks"]["Stop"][0]["hooks"][0]["command"], "notify");
+        assert_eq!(
+            settings["hooks"]["Stop"][0]["hooks"][0]["command"],
+            "notify"
+        );
     }
 
     #[test]
@@ -699,7 +757,10 @@ mod tests {
         set_guard_hook(&mut settings, p()).unwrap();
         let cmds = commands(&settings);
         assert_eq!(cmds.len(), 1, "refreshed in place: {cmds:?}");
-        assert_ne!(cmds[0], "/opt/homebrew/Cellar/llmtrim/0.9.4/bin/llmtrim guard");
+        assert_ne!(
+            cmds[0],
+            "/opt/homebrew/Cellar/llmtrim/0.9.4/bin/llmtrim guard"
+        );
         assert!(is_llmtrim_guard_command(&cmds[0]));
     }
 
@@ -724,7 +785,10 @@ mod tests {
         });
         set_guard_hook(&mut settings, p()).unwrap();
         assert!(clear_guard_hook(&mut settings, p()).unwrap());
-        assert_eq!(commands(&settings), vec!["~/.claude/hooks/mine".to_string()]);
+        assert_eq!(
+            commands(&settings),
+            vec!["~/.claude/hooks/mine".to_string()]
+        );
     }
 
     #[test]
@@ -744,5 +808,72 @@ mod tests {
         let mut settings = serde_json::json!([1, 2, 3]);
         assert!(set_guard_hook(&mut settings, p()).is_err());
         assert!(clear_guard_hook(&mut settings, p()).is_err());
+    }
+
+    // ── the real file round trip ────────────────────────────────────────────────
+
+    #[test]
+    fn wire_creates_then_unwire_removes_a_settings_file_on_disk() {
+        let (_, dir) = fixture(&[]);
+        let settings = dir.join("settings.json");
+
+        // A settings file that does not exist yet is created, not an error.
+        wire_at(settings.clone()).unwrap();
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings).unwrap()).unwrap();
+        assert!(is_ours(&written["hooks"]["UserPromptSubmit"][0]));
+
+        // Wiring twice must not duplicate the entry.
+        wire_at(settings.clone()).unwrap();
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(
+            written["hooks"]["UserPromptSubmit"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+
+        assert!(unwire_at(settings.clone()).unwrap(), "ours was removed");
+        assert!(
+            !unwire_at(settings.clone()).unwrap(),
+            "nothing left to remove"
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn unwire_on_a_missing_settings_file_is_not_an_error() {
+        assert!(!unwire_at(PathBuf::from("/nonexistent/settings.json")).unwrap());
+    }
+
+    #[test]
+    fn a_blocked_prompt_is_saved_because_claude_code_does_not_restore_it() {
+        let (payload, dir) = fixture(&[entry(&ago(7200), 150_000, false)]);
+        assert_eq!(verdict(&payload, &dir), BLOCK);
+
+        let saved: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "prompt"))
+            .collect();
+        assert_eq!(saved.len(), 1, "the blocked prompt is stashed");
+        assert_eq!(
+            std::fs::read_to_string(saved[0].path()).unwrap(),
+            "carry on"
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn blocking_then_resending_the_same_gap_goes_through() {
+        // The whole production path, not a re-implementation of its trigger rule.
+        let (payload, dir) = fixture(&[entry(&ago(7200), 150_000, false)]);
+        assert_eq!(verdict(&payload, &dir), BLOCK, "first submit is stopped");
+        assert_eq!(verdict(&payload, &dir), PASS, "the resend goes through");
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/crates/llmtrim-cli/src/guard.rs
+++ b/crates/llmtrim-cli/src/guard.rs
@@ -1,7 +1,7 @@
 //! `guard` — a Claude Code `UserPromptSubmit` hook that stops the first turn of a resumed,
 //! cold-cache, large-context session so the user sees what it costs *before* paying it.
 //!
-//! Past the prompt-cache TTL (the same 1h Claude Code asks for, [`crate::statusline::CACHE_TTL_SECS`])
+//! Past the prompt-cache TTL (the same 1h Claude Code asks for and the status line uses)
 //! a resumed session re-writes its whole context on the next request, billed at the cache-write
 //! rate. Nothing at the prompt says so. So on the first submit after a long idle gap on a big
 //! context, print the figure to stderr and exit 2 — Claude Code blocks the prompt with no API

--- a/crates/llmtrim-cli/src/lib.rs
+++ b/crates/llmtrim-cli/src/lib.rs
@@ -13,6 +13,7 @@ pub mod breakdown;
 pub mod daemon;
 pub mod discover;
 pub mod doctor;
+pub mod guard;
 pub mod mcp;
 pub mod monitor;
 pub mod quality;

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -273,6 +273,17 @@ enum Commands {
         #[command(subcommand)]
         action: Option<StatuslineCmd>,
     },
+    /// Warn before the first turn of a resumed, cold-cache session (or `guard install` to wire it up)
+    ///
+    /// With no subcommand, acts as Claude Code's `UserPromptSubmit` hook: reads the hook JSON on
+    /// stdin and, when the session has been idle past the prompt-cache TTL with a large context,
+    /// blocks that one prompt and prints what re-writing the context will cost. Resend to go ahead.
+    /// `install` wires it into `~/.claude/settings.json` (merging with your other hooks);
+    /// `install --print` just prints the settings snippet.
+    Guard {
+        #[command(subcommand)]
+        action: Option<GuardCmd>,
+    },
     /// Check the install end-to-end and explain anything broken
     ///
     /// Read-only diagnosis: binary, daemon, port, env wiring (persisted + this shell),
@@ -536,6 +547,18 @@ enum StatuslineCmd {
         print: bool,
     },
     /// Remove the status line from `~/.claude/settings.json`
+    Uninstall,
+}
+
+#[derive(Subcommand)]
+enum GuardCmd {
+    /// Wire the guard hook into `~/.claude/settings.json`
+    Install {
+        /// Print the settings snippet instead of editing the file.
+        #[arg(long)]
+        print: bool,
+    },
+    /// Remove the guard hook from `~/.claude/settings.json`
     Uninstall,
 }
 
@@ -1300,6 +1323,13 @@ fn run() -> Result<()> {
             None => llmtrim::statusline::run()?,
             Some(StatuslineCmd::Install { print }) => llmtrim::statusline::install(print)?,
             Some(StatuslineCmd::Uninstall) => llmtrim::statusline::uninstall()?,
+        },
+        Commands::Guard { action } => match action {
+            // The hook path: Claude Code reads the exit code, so return it rather than a Result —
+            // 2 blocks the prompt, anything else lets it through.
+            None => std::process::exit(llmtrim::guard::run()),
+            Some(GuardCmd::Install { print }) => llmtrim::guard::install(print)?,
+            Some(GuardCmd::Uninstall) => llmtrim::guard::uninstall()?,
         },
         Commands::Monitor {
             // Deprecated no-op (see the field docs): accepted, then ignored.

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -1189,7 +1189,7 @@ pub fn overview_data(
 /// matched across every provider (the ledger records the wire-shape provider, not the
 /// upstream brand), then the embedded models.dev snapshot for models the registry hasn't
 /// shipped yet (e.g. day-one releases like claude-fable-5 on 0.14.3).
-fn llm_prices(model_id: &str) -> Option<(f64, f64)> {
+pub(crate) fn llm_prices(model_id: &str) -> Option<(f64, f64)> {
     #[cfg(feature = "intercept")]
     for &provider_id in llm_providers::get_providers_data().keys() {
         if let Some(model) = llm_providers::get_model_ref(provider_id, model_id) {

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -516,6 +516,28 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
         }
     }
 
+    // 3c. Claude Code's cold-cache guard. Offered only to Claude Code users (setup stays
+    //     client-agnostic otherwise), default on; `--force` / a non-interactive setup take that
+    //     default without asking. Merges into `hooks.UserPromptSubmit` — other hooks are kept.
+    if crate::statusline::claude_code_present() {
+        if force || confirm_guard_default_yes() {
+            match crate::guard::wire() {
+                Ok(path) => rows.push((
+                    ui::OK,
+                    "Guard".into(),
+                    format!("warns before a cold resumed turn · {}", path.display()),
+                )),
+                Err(e) => rows.push((ui::WARN, "Guard".into(), format!("not wired: {e}"))),
+            }
+        } else {
+            rows.push((
+                ui::OK,
+                "Guard".into(),
+                "left off · enable later with `llmtrim guard install`".into(),
+            ));
+        }
+    }
+
     // 4. Reconcile the interceptor. If a healthy daemon is already serving the resolved port,
     //    leave it running — re-running `setup` must not drop in-flight requests (the old code
     //    stopped + respawned unconditionally on every run). Restart only when the port is
@@ -704,6 +726,22 @@ fn confirm_tray_default_yes() -> bool {
     !matches!(line.trim().to_ascii_lowercase().as_str(), "n" | "no")
 }
 
+/// Ask whether to arm the cold-cache guard, defaulting to yes. Same contract as
+/// [`confirm_tray_default_yes`]: a scripted `setup` stays non-interactive and takes the default.
+fn confirm_guard_default_yes() -> bool {
+    use std::io::{IsTerminal, Write};
+    if !std::io::stdin().is_terminal() {
+        return true;
+    }
+    print!("Warn before the first turn of a resumed session whose cache went cold? [Y/n] ");
+    let _ = std::io::stdout().flush();
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_err() {
+        return false;
+    }
+    !matches!(line.trim().to_ascii_lowercase().as_str(), "n" | "no")
+}
+
 /// Best-effort caveman detection: the flag file its session hook writes, its standalone
 /// hook files, or a Claude Code plugin-cache entry. Read-only probes; any I/O failure
 /// reads as "not installed" — setup must never fail because of someone else's tool.
@@ -791,6 +829,17 @@ pub fn uninstall(purge: bool, keep_binary: bool) -> Result<()> {
             "Tray autostart".into(),
             format!("not changed: {e}"),
         )),
+    }
+
+    // 2c. Unwire the Claude Code guard hook, leaving the user's other hooks in place.
+    match crate::guard::unwire() {
+        Ok(true) => rows.push((
+            ui::OK,
+            "Guard".into(),
+            "removed from Claude Code settings".into(),
+        )),
+        Ok(false) => rows.push((ui::NOTE, "Guard".into(), "no hook to remove".into())),
+        Err(e) => rows.push((ui::WARN, "Guard".into(), format!("not removed: {e}"))),
     }
 
     // 3. Remove the interceptor env. Windows: the `HKCU\Environment` values (plus any legacy

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -15,7 +15,7 @@
 //! as the terminal narrows (`COLUMNS`). The context gauge fills and colours against the *real*
 //! window of the model serving the turn — the rerouted backend's window under `sub`, not
 //! Claude's — green below 40%, orange 40–65%, red above; and red whenever the prompt cache has
-//! gone cold, where the cache segment becomes `♻ cold · /compact`. Segments whose data is
+//! gone cold, where the cache segment becomes `♻ cache cold`. Segments whose data is
 //! absent — no reroute, an API-key user with no rate limits — simply don't render.
 //!
 //! Under `sub` the arrow shows the concrete model that served the last turn (e.g.
@@ -55,7 +55,7 @@ const CTX_AMBER_PCT: i64 = 65;
 pub(crate) const CACHE_TTL_SECS: i64 = 3600;
 /// How often Claude Code re-runs the status line while a session sits idle. Without it Claude
 /// Code only re-renders on conversation events, so an abandoned session keeps the line drawn at
-/// its last turn — green and warm — straight through the cache expiring, and `♻ cold · /compact`
+/// its last turn — green and warm — straight through the cache expiring, and `♻ cache cold`
 /// only appears *after* the turn that pays for it. Rendering is local (no network, no tokens),
 /// so a refresh costs one short process; 5 minutes is far finer than the 1h TTL it watches, and
 /// 25× cheaper than polling every 10s would be.
@@ -658,9 +658,10 @@ fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
         (None, None) => {}
     }
     if led.cache_cold {
-        // Cache expired: the next turn pays a cold write, so `/compact` (re-baselines the prompt)
-        // pays off here. `cold` communicates the state faster than a stale `0% cached`.
-        out.push(paint(color, RED, "♻ cold · /compact"));
+        // Cache expired: the next turn pays a cold write. State only, no `/compact` nudge —
+        // compacting re-reads the same cold context to summarise it, so it pays that charge too
+        // rather than avoiding it (see `crate::guard::message`).
+        out.push(paint(color, RED, "♻ cache cold"));
     } else if let Some(c) = cache_pct_for(cc.cache_pct, led.last_cache_pct) {
         // Floor, not round: only a genuine 100% cache shows `100%` (99.9 stays `99%`).
         out.push(paint(
@@ -1064,7 +1065,7 @@ mod tests {
         let mut l = led(Health::Healthy);
         l.cache_cold = true;
         let out = render_line(&cc(48_000), &l, 0, false);
-        assert!(out.contains("♻ cold · /compact"), "cold hint shown: {out}");
+        assert!(out.contains("♻ cache cold"), "cold hint shown: {out}");
         assert!(!out.contains("cached"), "no stale % when cold: {out}");
     }
 

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -53,6 +53,13 @@ const CTX_AMBER_PCT: i64 = 65;
 /// "cached %" would lie about the next turn paying a cold write — show it cold instead.
 /// Shared with [`crate::guard`], so the hook and the status line agree on when a cache is cold.
 pub(crate) const CACHE_TTL_SECS: i64 = 3600;
+/// How often Claude Code re-runs the status line while a session sits idle. Without it Claude
+/// Code only re-renders on conversation events, so an abandoned session keeps the line drawn at
+/// its last turn — green and warm — straight through the cache expiring, and `♻ cold · /compact`
+/// only appears *after* the turn that pays for it. Rendering is local (no network, no tokens),
+/// so a refresh costs one short process; 5 minutes is far finer than the 1h TTL it watches, and
+/// 25× cheaper than polling every 10s would be.
+const REFRESH_INTERVAL_SECS: i64 = 300;
 
 // ── ANSI palette ────────────────────────────────────────────────────────────────
 // The status line is captured by Claude Code (never a TTY), but Claude Code renders ANSI,
@@ -786,7 +793,12 @@ pub(crate) fn exe_command(subcommand: &str) -> String {
 
 /// The `statusLine` object we write.
 fn statusline_config() -> Value {
-    serde_json::json!({ "type": "command", "command": exe_command("statusline"), "padding": 0 })
+    serde_json::json!({
+        "type": "command",
+        "command": exe_command("statusline"),
+        "padding": 0,
+        "refreshInterval": REFRESH_INTERVAL_SECS,
+    })
 }
 
 /// Whether a Claude statusline command is one that `llmtrim statusline install` created.
@@ -1428,6 +1440,16 @@ mod tests {
     fn refresh_is_a_no_op_when_the_command_already_points_at_this_binary() {
         let mut settings = serde_json::json!({ "statusLine": statusline_config() });
         assert!(!refresh_statusline_config(&mut settings).unwrap());
+    }
+
+    #[test]
+    fn statusline_config_asks_claude_code_to_refresh_while_idle() {
+        // Claude Code otherwise re-renders only on conversation events, so the cold-cache
+        // warning would land after the expensive turn instead of before it.
+        assert_eq!(
+            statusline_config()["refreshInterval"],
+            serde_json::json!(300)
+        );
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -51,7 +51,8 @@ const CTX_AMBER_PCT: i64 = 65;
 /// (verified from the capture corpus: 3333×1h vs 288×5m), and the cache stays warm up to the
 /// TTL since the last intercepted request. Past this idle gap the cache is cold, so a stale
 /// "cached %" would lie about the next turn paying a cold write — show it cold instead.
-const CACHE_TTL_SECS: i64 = 3600;
+/// Shared with [`crate::guard`], so the hook and the status line agree on when a cache is cold.
+pub(crate) const CACHE_TTL_SECS: i64 = 3600;
 
 // ── ANSI palette ────────────────────────────────────────────────────────────────
 // The status line is captured by Claude Code (never a TTY), but Claude Code renders ANSI,
@@ -397,6 +398,15 @@ fn session_row(sid: &str) -> Option<SessionLedgerRow> {
 #[cfg(not(feature = "breakdown"))]
 fn session_row(_sid: &str) -> Option<SessionLedgerRow> {
     None
+}
+
+/// The concrete model a `sub` backend served this session's last turn with, if any — the only
+/// thing [`crate::guard`] takes from the ledger, and only to price a rerouted turn correctly.
+/// `None` (no row, no reroute, or no `breakdown` feature) never changes the guard's decision.
+pub(crate) fn session_sub_model(session_id: &str) -> Option<String> {
+    let row = session_row(session_id)?;
+    row.last_sub_provider.as_ref()?;
+    row.last_model
 }
 
 /// Decide the trim figure: this session's own savings when we have its row; idle (`None`) for a
@@ -758,26 +768,36 @@ fn stable_executable_path(current_exe: &Path, path: Option<&OsStr>) -> PathBuf {
     current_exe.to_path_buf()
 }
 
-/// The `statusLine` object we write. `command` is an absolute path or a stable PATH alias plus
-/// the subcommand, so it works even when a package manager replaces a versioned executable.
-fn statusline_config() -> Value {
+/// The command string Claude Code should run for one of our subcommands: an absolute path or a
+/// stable PATH alias, so it survives a package manager replacing a versioned executable. Shared
+/// with [`crate::guard`], which writes a hook command the same way.
+pub(crate) fn exe_command(subcommand: &str) -> String {
     let exe = std::env::current_exe()
         .ok()
         .map(|p| stable_executable_path(&p, std::env::var_os("PATH").as_deref()))
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "llmtrim".to_string());
-    let command = if exe.contains(' ') {
-        format!("\"{exe}\" statusline")
+    if exe.contains(' ') {
+        format!("\"{exe}\" {subcommand}")
     } else {
-        format!("{exe} statusline")
-    };
-    serde_json::json!({ "type": "command", "command": command, "padding": 0 })
+        format!("{exe} {subcommand}")
+    }
+}
+
+/// The `statusLine` object we write.
+fn statusline_config() -> Value {
+    serde_json::json!({ "type": "command", "command": exe_command("statusline"), "padding": 0 })
 }
 
 /// Whether a Claude statusline command is one that `llmtrim statusline install` created.
-/// Recognize both POSIX and Windows separators because settings can be moved between systems.
 fn is_llmtrim_statusline_command(command: &str) -> bool {
-    let Some(executable) = command.strip_suffix(" statusline") else {
+    is_llmtrim_command(command, "statusline")
+}
+
+/// Whether `command` is the llmtrim binary invoked with exactly `subcommand`. Recognize both
+/// POSIX and Windows separators because settings can be moved between systems.
+pub(crate) fn is_llmtrim_command(command: &str, subcommand: &str) -> bool {
+    let Some(executable) = command.strip_suffix(&format!(" {subcommand}")) else {
         return false;
     };
     let executable = executable.trim();


### PR DESCRIPTION
## Why

Resume a Claude Code session that has been idle past the prompt-cache TTL and the next turn silently re-writes the whole context, billed at the **cache-write** rate — 2× base input for the 1h TTL Claude Code asks for. Nothing at the prompt says so.

I replayed my own transcripts to size the problem: **204 real idle gaps over an hour**, median context at a gap **225k tokens**, median **~$2.29** per gap, **$647** across the corpus. That charge lands before any work happens, and the first I ever knew of it was the bill.

## What

**`llmtrim guard`** — a `UserPromptSubmit` hook. On the first submit after a long gap on a big context it prints the idle time, the context size, and what the cold write costs, then exits 2. Claude Code blocks the prompt and makes **no API call**, so the warning itself is free. A resend goes straight through; you are warned once per idle gap.

```text
Idle 314h 7m, 151k tokens of context. The prompt cache has expired, so the next turn
re-writes the whole context — about $1.51 before any work happens.

You pay that whichever way you go: /compact pays it too (it reads the full context to
summarise it), and only comes out ahead if you are staying for several more turns. To
avoid the charge entirely, ask in a fresh session.
```

**Status line refresh.** It already reddened the cache segment when the cache went cold — but Claude Code only re-renders on conversation events, so an idle session kept the line drawn at its last turn, green and warm, straight through the TTL expiring. The warning only appeared *after* the turn that paid for it. It now sets `refreshInterval`, so the state is on screen before you type. (Re-run `llmtrim statusline install` to pick it up.)

## Two things worth knowing

**`/compact` is not the thrifty option, and the status line used to say it was.** The segment read `♻ cold · /compact`. But compaction re-reads the same cold context to summarise it — paying the exact charge it appears to avoid — and the next turn then writes a fresh cache for the summary. Measured on captures: 128,758 tokens to compact, then 45,131. Resending pays once. So the segment now just reports state (`♻ cache cold`) and the guard's message says plainly that you pay either way, and that a fresh session is the only way to avoid it.

**The guard reads Claude Code's transcript, not llmtrim's ledger.** The ledger keys sessions by a hash of the system prompt, so a subagent turn (different system prompt, same Claude Code session) lands in a different group and would mask a stale main conversation — and a session that never went through the proxy has no ledger row at all. The transcript's `isSidechain` flag excludes subagent turns exactly. There is a regression test for precisely this: a stale conversation with a *newer* sidechain entry still fires. The ledger is consulted only to price a `sub`-rerouted backend, never to decide.

## Safety

The guard can block a prompt, so fail-open is absolute: bad stdin, missing/unreadable/torn transcript, unparseable timestamps, unwritable marker dir, or a panic all exit 0. The marker is written *before* the message, so a marker failure fails open rather than blocking without recording it. A hostile `session_id` cannot walk the marker out of its directory. The transcript is streamed, so a huge one cannot OOM the hook. Blocked prompts are saved to disk — Claude Code does not restore them to the input box.

Settings wiring merges into `~/.claude/settings.json`: your existing hooks are preserved, re-installing refreshes our entry in place rather than duplicating it, and uninstall removes only ours.

## Verification

- `cargo nextest run` — **1057 passed**, 1 skipped
- `cargo clippy --all-targets`, `cargo fmt --check` — clean
- builds with `--no-default-features`
- driven live against a real 314h-idle / 151k-token transcript: blocks with exit 2, resend passes, garbage input exits 0

Reviewed by three agents before opening; their findings (untested production path, the missing prompt save, the `/compact` contradiction) are folded into `12f394a`.