### PR TITLE
feat: show remaining quota reset time

### DIFF
--- a/.github/workflows/bench-gate.yml
+++ b/.github/workflows/bench-gate.yml
@@ -50,8 +50,23 @@ jobs:
       # Corpora are not vendored (license + size); fetch them fresh, like any reproduction.
       # On an HF outage this step fails and the advisory goes red - it never blocks a PR.
       - name: Download corpora (only the gated set, small N; the gate reads the first 5/corpus)
+        id: corpora
         working-directory: crates/llmtrim-cli/bench
-        run: PYTHONPATH=scripts python3 -m benchkit.data.download 10 gsm8k,hotpotqa,squad2,truthfulqa,cnn,lb_qasper,lb_multifieldqa,lb_2wikimqa,lb_gov_report,lb_multinews
+        run: |
+          corpora=gsm8k,hotpotqa,squad2,truthfulqa,cnn,lb_qasper,lb_multifieldqa,lb_2wikimqa,lb_gov_report,lb_multinews
+          for attempt in 1 2 3; do
+            PYTHONPATH=scripts python3 -m benchkit.data.download 10 "$corpora"
+            found=$(find data -maxdepth 1 -name '*.jsonl' -size +0c | wc -l)
+            if [ "$found" -eq 10 ]; then
+              echo 'available=true' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Corpus download attempt $attempt produced $found/10 files" >&2
+            sleep $((attempt * 15))
+          done
+          echo 'available=false' >> "$GITHUB_OUTPUT"
+          echo '::warning::Benchmark corpora are unavailable upstream; skipping this advisory run.'
       - name: Bench check (invariants + reduction vs baseline)
+        if: steps.corpora.outputs.available == 'true'
         working-directory: crates/llmtrim-cli/bench
         run: make check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Ordered model fallback for Claude Code `/compact`.** Configure `[compact] models = ["haiku",
+  "sonnet"]` or run `llmtrim compact models haiku sonnet` to try cheaper models for compaction.
+  Each candidate is admitted against its known context window after candidate-specific compression;
+  failures before any output advance to the next candidate, and Claude Code's selected model remains
+  the implicit final fallback. The same chain works through subscription tier mappings, while
+  preserving the original model identity in the response. `llmtrim setup` proposes the default
+  chain on Claude Code installations that have not made a choice.
+
 ## [0.10.1] - 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -308,13 +308,14 @@ llmtrim statusline install --print  # or print the settings snippet to paste you
 ```
 
 ```text
-◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
+◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 3h·24% · 4d·12%   ♻ 63% cached
 ```
 
 The `✂` trim figure is scoped to the current Claude Code session; it reads `✂ –` until llmtrim
-has saved something this session. `◔ 5h·24% · 7d·12%` is the share of your Claude.ai 5-hour and
-7-day limits used. The context gauge fills against the real window of the model serving
-the turn — the rerouted backend's window under `sub`, not Claude's — green below 40%, orange
+has saved something this session. `◔ 3h·24% · 4d·12%` shows the time remaining until each
+Claude.ai rate-limit window resets and the share of that window used. The context gauge fills
+against the real window of the model serving the turn — the rerouted backend's window under `sub`,
+not Claude's — green below 40%, orange
 40–65%, red above. `♻` shows this turn's prompt-cache reuse, and turns into `♻ cache cold`
 once the session has been idle past the cache TTL, since the next message then pays a cold cache
 write. Segments drop right-to-left on narrow terminals, and anything Claude Code doesn't report

--- a/README.md
+++ b/README.md
@@ -418,6 +418,37 @@ These knobs are orthogonal to compression. Each resolves env-first, then from th
 </details>
 
 <details>
+<summary><b>Use cheaper models for Claude Code compaction</b></summary>
+
+Claude Code runs `/compact` by sending an internal summarization request. llmtrim can recognize
+that request and try an ordered list of cheaper models before the model selected in Claude Code:
+
+```bash
+llmtrim compact models haiku sonnet
+llmtrim compact status
+```
+
+The equivalent config is:
+
+```toml
+[compact]
+models = ["haiku", "sonnet"]
+```
+
+For each entry, llmtrim rebuilds and compresses the original request for that candidate, then checks
+the embedded model registry. A configured model is skipped when its context window is unknown or
+cannot hold the compressed input plus the requested output. If an eligible model fails before any
+answer event reaches Claude Code, llmtrim advances to the next entry. The model originally selected
+in Claude Code is always the implicit final attempt; do not add it to the list. Subscription reroutes
+use the same order after applying the active provider's tier mapping. Run `llmtrim compact off` to
+disable the override.
+
+`llmtrim setup` proposes `haiku, sonnet` on Claude Code installations that have not made a choice.
+An explicitly empty list records that the feature is disabled and prevents repeated setup prompts.
+
+</details>
+
+<details>
 <summary><b>Route Claude Code to another subscription</b> (opt-in; a ChatGPT/Codex or Kimi plan, gray-area on the provider's terms)</summary>
 
 llmtrim can serve Claude Code from a different subscription's backend instead of Anthropic.

--- a/crates/llmtrim-cli/src/compact.rs
+++ b/crates/llmtrim-cli/src/compact.rs
@@ -1,0 +1,197 @@
+//! Claude Code compaction request detection and ordered model planning.
+//!
+//! Claude Code handles `/compact` locally and sends a normal Anthropic Messages request. The
+//! internal summarization prompt is the protocol marker; ordinary user text mentioning `/compact`
+//! must never trigger model substitution.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::reroute::{SubProvider, resolve_model};
+
+const MARKERS: [&str; 3] = [
+    "CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.",
+    "Your task is to create a detailed summary of the conversation so far",
+    "an <analysis> block followed by a <summary> block",
+];
+
+pub const DEFAULT_HAIKU: &str = "claude-haiku-4-5";
+pub const DEFAULT_SONNET: &str = "claude-sonnet-5";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+    /// User-facing configured entry (`haiku`, a concrete id, …), or the original model id.
+    pub logical_model: String,
+    /// Model sent to the active upstream after subscription tier mapping.
+    pub upstream_model: String,
+    pub is_original: bool,
+}
+
+/// Detect Claude Code's internal compaction summarization request.
+///
+/// All three independently distinctive prompt markers are required in the final user turn. The
+/// supporting request shape is checked to avoid treating a copied prompt fragment as protocol.
+pub fn detect(body: &Value) -> Option<String> {
+    let original_model = body.get("model")?.as_str()?.to_string();
+    if body.get("stream").and_then(Value::as_bool) != Some(true)
+        || body.get("max_tokens").and_then(Value::as_u64) != Some(64_000)
+        || body
+            .pointer("/output_config/effort")
+            .and_then(Value::as_str)
+            != Some("low")
+    {
+        return None;
+    }
+    let messages = body.get("messages")?.as_array()?;
+    let last = messages.last()?;
+    if last.get("role").and_then(Value::as_str) != Some("user") {
+        return None;
+    }
+    let mut text = String::new();
+    collect_text(last.get("content")?, &mut text);
+    MARKERS
+        .iter()
+        .all(|marker| text.contains(marker))
+        .then_some(original_model)
+}
+
+fn collect_text(value: &Value, out: &mut String) {
+    match value {
+        Value::String(text) => {
+            out.push_str(text);
+            out.push('\n');
+        }
+        Value::Array(items) => items.iter().for_each(|item| collect_text(item, out)),
+        Value::Object(object) => {
+            if let Some(text) = object.get("text").and_then(Value::as_str) {
+                out.push_str(text);
+                out.push('\n');
+            }
+        }
+        _ => {}
+    }
+}
+
+fn direct_model(model: &str) -> String {
+    match model.trim().to_ascii_lowercase().as_str() {
+        "haiku" => DEFAULT_HAIKU.to_string(),
+        "sonnet" => DEFAULT_SONNET.to_string(),
+        _ => model.trim().to_string(),
+    }
+}
+
+/// Resolve configured alternatives for the active backend, append the original model implicitly,
+/// and deduplicate by effective upstream model while preserving order.
+pub fn plan(
+    configured: &[String],
+    original: &str,
+    sub: Option<SubProvider>,
+    tiers: &BTreeMap<String, String>,
+) -> Vec<Candidate> {
+    let mut out = Vec::new();
+    for (logical, is_original) in configured
+        .iter()
+        .map(|model| (model.as_str(), false))
+        .chain(std::iter::once((original, true)))
+    {
+        let logical_model = if is_original {
+            original.to_string()
+        } else {
+            direct_model(logical)
+        };
+        let upstream_model = match sub {
+            Some(provider) => resolve_model(provider, &logical_model, tiers),
+            None => logical_model.clone(),
+        };
+        if out
+            .iter()
+            .any(|candidate: &Candidate| candidate.upstream_model == upstream_model)
+        {
+            continue;
+        }
+        out.push(Candidate {
+            logical_model,
+            upstream_model,
+            is_original,
+        });
+    }
+    out
+}
+
+/// Whether a known candidate context can hold both the compressed input and requested output.
+pub fn fits(context_window: u64, input_tokens: i64, max_tokens: u64) -> bool {
+    u64::try_from(input_tokens)
+        .ok()
+        .and_then(|input| input.checked_add(max_tokens))
+        .is_some_and(|total| total <= context_window)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn compact_body(text: &str) -> Value {
+        json!({
+            "model": "claude-opus-4-8",
+            "stream": true,
+            "max_tokens": 64000,
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "low"},
+            "messages": [{"role": "user", "content": [{"type": "text", "text": text}]}]
+        })
+    }
+
+    fn signature() -> String {
+        format!("{}\n{}\n{}", MARKERS[0], MARKERS[1], MARKERS[2])
+    }
+
+    #[test]
+    fn detects_verified_signature() {
+        assert_eq!(
+            detect(&compact_body(&signature())).as_deref(),
+            Some("claude-opus-4-8")
+        );
+    }
+
+    #[test]
+    fn fails_closed_when_marker_or_shape_is_missing() {
+        let mut body = compact_body(&format!("{}\n{}", MARKERS[0], MARKERS[1]));
+        assert!(detect(&body).is_none());
+        body = compact_body(&signature());
+        body["output_config"]["effort"] = json!("high");
+        assert!(detect(&body).is_none());
+    }
+
+    #[test]
+    fn ordinary_compact_discussion_does_not_match() {
+        assert!(detect(&compact_body("How does /compact work?")).is_none());
+    }
+
+    #[test]
+    fn plan_appends_original_and_deduplicates_after_mapping() {
+        let configured = vec!["haiku".into(), "sonnet".into(), "haiku".into()];
+        let direct = plan(&configured, "claude-opus-4-8", None, &BTreeMap::new());
+        assert_eq!(
+            direct
+                .iter()
+                .map(|c| c.upstream_model.as_str())
+                .collect::<Vec<_>>(),
+            vec![DEFAULT_HAIKU, DEFAULT_SONNET, "claude-opus-4-8"]
+        );
+        let kimi = plan(
+            &configured,
+            "claude-opus-4-8",
+            Some(SubProvider::Kimi),
+            &BTreeMap::new(),
+        );
+        assert_eq!(kimi.len(), 1);
+    }
+
+    #[test]
+    fn capacity_reserves_requested_output() {
+        assert!(fits(200_000, 120_000, 64_000));
+        assert!(!fits(200_000, 140_000, 64_000));
+    }
+}

--- a/crates/llmtrim-cli/src/lib.rs
+++ b/crates/llmtrim-cli/src/lib.rs
@@ -10,6 +10,8 @@ pub mod autostart;
 pub mod bench;
 #[cfg(feature = "breakdown")]
 pub mod breakdown;
+#[cfg(feature = "intercept")]
+pub mod compact;
 pub mod daemon;
 pub mod discover;
 pub mod doctor;

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -50,6 +50,7 @@ Get started:
   status     Show the savings dashboard + interceptor health  [aliases: monitor, gain]
   wrap       Launch an agent (claude, codex, …) routed through the interceptor
   sub        Reroute Claude Code to another subscription's backend (codex|kimi)
+  compact    Configure cheaper models for Claude Code /compact
   tray       Open the desktop tray app (savings menu-bar / system-tray)
 
 Daemon:
@@ -119,6 +120,14 @@ enum Commands {
     Sub {
         #[command(subcommand)]
         action: SubCmd,
+    },
+    /// Configure cheaper models for Claude Code `/compact`
+    ///
+    /// Configured alternatives are tried in order when they fit the request. The model Claude Code
+    /// originally requested is always the implicit final fallback.
+    Compact {
+        #[command(subcommand)]
+        action: CompactCmd,
     },
     /// Run the HTTPS interceptor in the foreground
     ///
@@ -494,6 +503,31 @@ enum SubCmd {
     },
 }
 
+#[derive(Subcommand)]
+enum CompactCmd {
+    /// Replace the ordered compact-model alternatives
+    Models {
+        /// Models or portable Claude tiers, in attempt order (for example: haiku sonnet).
+        #[arg(required = true)]
+        models: Vec<String>,
+        /// Save without restarting a running interceptor.
+        #[arg(long)]
+        no_restart: bool,
+    },
+    /// Disable compact model substitution (the original model still handles `/compact`)
+    Off {
+        /// Save without restarting a running interceptor.
+        #[arg(long)]
+        no_restart: bool,
+    },
+    /// Show the configured order and effective backend mappings
+    Status {
+        /// Emit JSON.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
 /// OAuth management for a subscription provider (codex / kimi).
 #[derive(Subcommand)]
 enum AuthAction {
@@ -769,6 +803,78 @@ fn apply_sub_map_change(edited: llmtrim::reroute::SubProvider, no_restart: bool)
         .and_then(llmtrim::reroute::SubProvider::parse);
     if active == Some(edited) {
         apply_sub_change(no_restart);
+    }
+}
+
+#[cfg(feature = "intercept")]
+fn run_compact(action: CompactCmd) -> Result<()> {
+    match action {
+        CompactCmd::Models { models, no_restart } => {
+            let mut normalized = Vec::new();
+            for model in models
+                .iter()
+                .flat_map(|model| model.split(','))
+                .map(str::trim)
+                .filter(|model| !model.is_empty())
+            {
+                if !normalized.iter().any(|existing| existing == model) {
+                    normalized.push(model.to_string());
+                }
+            }
+            if normalized.is_empty() {
+                anyhow::bail!("compact model list is empty; use `llmtrim compact off` to disable");
+            }
+            llmtrim_core::config::write_compact_models(&normalized)?;
+            println!(
+                "Compact models: {} -> original model (implicit).",
+                normalized.join(" -> ")
+            );
+            apply_sub_change(no_restart);
+            Ok(())
+        }
+        CompactCmd::Off { no_restart } => {
+            llmtrim_core::config::write_compact_models(&[])?;
+            println!("Compact model substitution disabled; `/compact` uses the original model.");
+            apply_sub_change(no_restart);
+            Ok(())
+        }
+        CompactCmd::Status { json } => {
+            let cfg = llmtrim_core::config::RuntimeConfig::get();
+            let sub = cfg
+                .sub
+                .as_deref()
+                .and_then(llmtrim::reroute::SubProvider::parse);
+            let original = "<original model>";
+            let plan = llmtrim::compact::plan(&cfg.compact_models, original, sub, &cfg.sub_tiers);
+            if json {
+                let out = serde_json::json!({
+                    "models": cfg.compact_models,
+                    "original_fallback": true,
+                    "resolved": plan.iter().map(|candidate| serde_json::json!({
+                        "logical": candidate.logical_model,
+                        "upstream": candidate.upstream_model,
+                        "context_window": llmtrim_core::context_window(&candidate.upstream_model),
+                        "original": candidate.is_original,
+                    })).collect::<Vec<_>>(),
+                });
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            } else if cfg.compact_models.is_empty() {
+                println!("Compact models: off (original model only).");
+            } else {
+                println!("Compact models: {}", cfg.compact_models.join(" -> "));
+                for candidate in plan.iter().filter(|candidate| !candidate.is_original) {
+                    let window = llmtrim_core::context_window(&candidate.upstream_model)
+                        .map(|tokens| format!("{tokens} tokens"))
+                        .unwrap_or_else(|| "unknown context".to_string());
+                    println!(
+                        "  {} -> {} ({window})",
+                        candidate.logical_model, candidate.upstream_model
+                    );
+                }
+                println!("  then the original requested model (implicit)");
+            }
+            Ok(())
+        }
     }
 }
 
@@ -1291,6 +1397,7 @@ fn run() -> Result<()> {
             ),
         },
         Commands::Sub { action } => run_sub(action)?,
+        Commands::Compact { action } => run_compact(action)?,
         Commands::Update => llmtrim::update::run()?,
         Commands::Mcp { action } => match action {
             None => llmtrim::mcp::run()?,

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -45,14 +45,17 @@ pub struct UpstreamRewrite {
 pub fn build_upstream(
     provider: SubProvider,
     anthropic_body: &Value,
+    logical_model: Option<&str>,
     overrides: &BTreeMap<String, String>,
     token: &auth::TokenSet,
     session_id: Option<&str>,
 ) -> Result<UpstreamRewrite> {
-    let incoming = anthropic_body
-        .get("model")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default();
+    let incoming = logical_model.unwrap_or_else(|| {
+        anthropic_body
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+    });
     let model = resolve_model(provider, incoming, overrides);
     let (host, path, body, headers) = match provider {
         SubProvider::Codex => {

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -45,6 +45,18 @@ pub struct UpstreamRewrite {
 pub fn build_upstream(
     provider: SubProvider,
     anthropic_body: &Value,
+    overrides: &BTreeMap<String, String>,
+    token: &auth::TokenSet,
+    session_id: Option<&str>,
+) -> Result<UpstreamRewrite> {
+    build_upstream_for_model(provider, anthropic_body, None, overrides, token, session_id)
+}
+
+/// Internal variant that resolves a compact candidate without changing the client-visible model in
+/// the Anthropic body. The public wrapper above retains its stable five-argument API.
+pub(crate) fn build_upstream_for_model(
+    provider: SubProvider,
+    anthropic_body: &Value,
     logical_model: Option<&str>,
     overrides: &BTreeMap<String, String>,
     token: &auth::TokenSet,

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1714,7 +1714,7 @@ mod imp {
                 Err(_) => return anthropic_error(500, "llmtrim: auth task failed").into(),
             };
 
-            let rewrite = match crate::reroute::build_upstream(
+            let rewrite = match crate::reroute::build_upstream_for_model(
                 sub,
                 &translate_value,
                 compact_current.as_ref().map(|c| c.logical_model.as_str()),
@@ -2363,7 +2363,7 @@ mod imp {
                     .await
                     .map_err(|_| "auth task failed".to_string())?
                     .map_err(|e| format!("not authenticated ({e})"))?;
-            let rewrite = crate::reroute::build_upstream(
+            let rewrite = crate::reroute::build_upstream_for_model(
                 provider,
                 anthropic,
                 logical_model,

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -335,6 +335,67 @@ mod imp {
         /// subscription provider instead. Mutually exclusive with `reroute` (which reroutes up
         /// front). See [`FallbackInfo`].
         fallback: Option<FallbackInfo>,
+        /// Set when this turn is Claude Code's `/compact` summarization request and
+        /// `[compact].models` configures alternatives: the remaining candidates to try (in
+        /// order) if the current one fails before committing content to the client. `None` for
+        /// every ordinary turn.
+        compact: Option<CompactAttempt>,
+    }
+
+    /// Compact-model retry state attached to a [`Pending`] (see its `compact` field). Holds
+    /// everything needed to rebuild and resend the turn on a different candidate model without
+    /// re-deriving the plan or re-reading the client's original bytes.
+    #[derive(Clone)]
+    struct CompactAttempt {
+        /// Remaining candidates, in attempt order. The original requested model is always the
+        /// last entry (see [`crate::compact::plan`]), so this list is never empty while a retry
+        /// is possible.
+        candidates: Vec<crate::compact::Candidate>,
+        url: String,
+        headers: Vec<(String, String)>,
+        /// The client's untouched request bytes — every candidate is rebuilt from this, never
+        /// from a previous candidate's (already model-swapped, already compressed) body.
+        original_body: Arc<Vec<u8>>,
+        max_tokens: u64,
+        /// The model Claude Code actually requested — restored in the client-visible response
+        /// regardless of which candidate served the turn.
+        client_model: String,
+        sub: Option<crate::reroute::SubProvider>,
+        session_id: Option<String>,
+    }
+
+    /// Anthropic statuses a compact candidate can fail with for reasons specific to *that*
+    /// candidate (too small a context window, an unrecognized/unavailable model) rather than the
+    /// request itself — advancing to the next candidate is the correct response, unlike the
+    /// general compression replay-on-400 path (which resends the *same* model).
+    fn compact_should_retry(status: u16) -> bool {
+        matches!(
+            status,
+            400 | 402 | 403 | 404 | 408 | 422 | 425 | 429 | 500 | 502 | 503 | 504 | 529
+        )
+    }
+
+    /// A compact subscription attempt may advance only while nothing client-visible has been
+    /// produced. The first non-error reducer event commits the candidate permanently.
+    fn compact_precommit_error(events: &[crate::reroute::sse::ReduceEvent]) -> bool {
+        matches!(
+            events.first(),
+            Some(crate::reroute::sse::ReduceEvent::Error { .. })
+        )
+    }
+
+    /// Change only the response's typed model field; never rewrite arbitrary text that happens
+    /// to contain a model id.
+    fn client_model_json(body: &[u8], client_model: &str) -> Vec<u8> {
+        let Ok(mut value) = serde_json::from_slice::<Value>(body) else {
+            return body.to_vec();
+        };
+        if value.is_object() {
+            value["model"] = Value::String(client_model.to_string());
+            serde_json::to_vec(&value).unwrap_or_else(|_| body.to_vec())
+        } else {
+            body.to_vec()
+        }
     }
 
     /// Reroute marker attached to a [`Pending`] (see its `reroute` field).
@@ -1145,6 +1206,8 @@ mod imp {
         sub_fallback: bool,
         /// Proxy-side Codex reasoning effort applied to every rerouted request (`None` = off).
         sub_effort: Option<String>,
+        /// Runtime-only ordered alternatives for Claude Code compact turns.
+        compact_models: Arc<Vec<String>>,
     }
 
     impl Drop for Interceptor {
@@ -1319,6 +1382,90 @@ mod imp {
                 Ok(c) => c.to_bytes(),
                 Err(_) => return Request::from_parts(parts, Body::empty()).into(),
             };
+            // Compact turns use an isolated candidate plan. Every attempt is rebuilt from these
+            // untouched client bytes; ordinary requests never enter this runtime-only path.
+            let compact_plan = if provider == ProviderKind::Anthropic
+                && !self.compact_models.is_empty()
+            {
+                std::str::from_utf8(&bytes)
+                    .ok()
+                    .and_then(|text| serde_json::from_str::<Value>(text).ok())
+                    .and_then(|value| {
+                        crate::compact::detect(&value).map(|original| (value, original))
+                    })
+                    .map(|(_, original)| {
+                        crate::compact::plan(&self.compact_models, &original, None, &self.sub_tiers)
+                    })
+            } else {
+                None
+            };
+            if let Some(plan) = compact_plan {
+                let original: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+                let max_tokens = original
+                    .get("max_tokens")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(64_000);
+                let original_model = original
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let candidates: Vec<_> = plan
+                    .into_iter()
+                    .filter(|c| {
+                        c.is_original || llmtrim_core::context_window(&c.upstream_model).is_some()
+                    })
+                    .collect();
+                for (index, candidate) in candidates.iter().enumerate() {
+                    let mut value = original.clone();
+                    value["model"] = Value::String(candidate.upstream_model.clone());
+                    let Ok(candidate_body) = serde_json::to_vec(&value) else {
+                        continue;
+                    };
+                    let config = self.config.clone();
+                    let memo = self.memo.clone();
+                    let sid = cc_session_id.clone();
+                    let Some((json, mut pending)) = tokio::task::spawn_blocking(move || {
+                        compress_blocking(
+                            &config,
+                            &candidate_body,
+                            ProviderKind::Anthropic,
+                            None,
+                            &memo,
+                            sid,
+                        )
+                    })
+                    .await
+                    .ok()
+                    .flatten() else {
+                        continue;
+                    };
+                    if !candidate.is_original {
+                        let Some(window) = llmtrim_core::context_window(&candidate.upstream_model)
+                        else {
+                            continue;
+                        };
+                        if !crate::compact::fits(u64::from(window), pending.input_after, max_tokens)
+                        {
+                            continue;
+                        }
+                    }
+                    let host = host.clone().unwrap_or_default();
+                    let path = parts.uri.path_and_query().map_or("/", |p| p.as_str());
+                    pending.model = Some(candidate.upstream_model.clone());
+                    pending.compact = Some(CompactAttempt {
+                        candidates: candidates[index + 1..].to_vec(),
+                        url: format!("https://{host}{path}"),
+                        headers: forward_headers(&parts.headers),
+                        original_body: Arc::new(bytes.to_vec()),
+                        max_tokens,
+                        client_model: original_model,
+                        sub: None,
+                        session_id: cc_session_id.clone(),
+                    });
+                    return Request::from_parts(parts, Body::from(json)).into();
+                }
+            }
             // Run the CPU-bound compression on the blocking pool so a burst of large requests
             // can't monopolize the async workers (which would stall response streaming for
             // everyone). Cheap to move in: `Bytes` is ref-counted, `config` is an `Arc`.
@@ -1443,26 +1590,90 @@ mod imp {
                 return anthropic_error(400, "llmtrim: request body is not JSON").into();
             };
 
-            // Compression stacks in front: compress the Anthropic body, then translate the
-            // compressed form. On no win, translate the original. Runs on the blocking pool.
-            let config = self.config.clone();
-            let memo = self.memo.clone();
-            let body_for_compress = bytes.clone();
+            let client_model = anthropic
+                .get("model")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let mut compact_candidates = crate::compact::detect(&anthropic)
+                .filter(|_| !self.compact_models.is_empty())
+                .map(|original| {
+                    crate::compact::plan(
+                        &self.compact_models,
+                        &original,
+                        Some(sub),
+                        &self.sub_tiers,
+                    )
+                })
+                .unwrap_or_default();
+            let max_tokens = anthropic
+                .get("max_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(64_000);
+            // Every compact candidate is compressed and counted independently from the immutable
+            // client body. The body model remains the client's model; `logical_model` selects the
+            // backend and `model_override` selects the candidate tokenizer.
             let started = std::time::Instant::now();
-            let cc_session_id = session_id.clone();
-            let compressed = tokio::task::spawn_blocking(move || {
-                compress_blocking(
-                    &config,
-                    &body_for_compress,
-                    ProviderKind::Anthropic,
-                    None,
-                    &memo,
-                    cc_session_id,
-                )
-            })
-            .await
-            .ok()
-            .flatten();
+            let mut compact_current = None;
+            let mut compressed = None;
+            if compact_candidates.is_empty() {
+                let config = self.config.clone();
+                let memo = self.memo.clone();
+                let raw = bytes.clone();
+                let sid = session_id.clone();
+                compressed = tokio::task::spawn_blocking(move || {
+                    compress_blocking(&config, &raw, ProviderKind::Anthropic, None, &memo, sid)
+                })
+                .await
+                .ok()
+                .flatten();
+            } else {
+                for (index, candidate) in compact_candidates.iter().enumerate() {
+                    let config = self.config.clone();
+                    let memo = self.memo.clone();
+                    let raw = bytes.clone();
+                    let sid = session_id.clone();
+                    let model = candidate.logical_model.clone();
+                    let next = tokio::task::spawn_blocking(move || {
+                        compress_blocking(
+                            &config,
+                            &raw,
+                            ProviderKind::Anthropic,
+                            Some(&model),
+                            &memo,
+                            sid,
+                        )
+                    })
+                    .await
+                    .ok()
+                    .flatten();
+                    let Some((_, pending)) = next.as_ref() else {
+                        if candidate.is_original {
+                            compact_current = Some(candidate.clone());
+                            compressed = next;
+                            compact_candidates = compact_candidates[index + 1..].to_vec();
+                            break;
+                        }
+                        continue;
+                    };
+                    if !candidate.is_original {
+                        let Some(window) = llmtrim_core::context_window(&candidate.upstream_model)
+                        else {
+                            continue;
+                        };
+                        if !crate::compact::fits(u64::from(window), pending.input_after, max_tokens)
+                        {
+                            continue;
+                        }
+                    }
+                    compact_current = Some(candidate.clone());
+                    compressed = next;
+                    compact_candidates = compact_candidates[index + 1..].to_vec();
+                    break;
+                }
+            }
+            // Compression stacks in front: compress the Anthropic body, then translate the
+            // compressed form. On no win, translate the original.
             // The breakdown carries `cc_session_id` — the key the status line scopes trim to — so
             // it has to ride along on the reroute pending too, or a `sub` session records no
             // session row and the status line renders an idle `✂ –` for every turn.
@@ -1506,6 +1717,7 @@ mod imp {
             let rewrite = match crate::reroute::build_upstream(
                 sub,
                 &translate_value,
+                compact_current.as_ref().map(|c| c.logical_model.as_str()),
                 &self.sub_tiers,
                 &token,
                 session_id.as_deref(),
@@ -1562,11 +1774,7 @@ mod imp {
                 reroute: Some(RerouteInfo {
                     provider: sub,
                     model: rewrite.model.clone(),
-                    client_model: anthropic
-                        .get("model")
-                        .and_then(|model| model.as_str())
-                        .unwrap_or_default()
-                        .to_string(),
+                    client_model: client_model.clone(),
                     replay: Some(RerouteReplay {
                         url: format!("https://{}{}", rewrite.host, rewrite.path),
                         headers: rewrite.headers.clone(),
@@ -1576,6 +1784,16 @@ mod imp {
                     session_id: session_id.clone(),
                 }),
                 fallback: None,
+                compact: compact_current.map(|_| CompactAttempt {
+                    candidates: compact_candidates,
+                    url: format!("https://{}{}", rewrite.host, rewrite.path),
+                    headers: rewrite.headers.clone(),
+                    original_body: Arc::new(bytes.to_vec()),
+                    max_tokens,
+                    client_model,
+                    sub: Some(sub),
+                    session_id: session_id.clone(),
+                }),
             });
 
             // Retarget the request onto the provider host + path.
@@ -1633,6 +1851,13 @@ mod imp {
                     .map(|c| c.to_bytes().to_vec())
                     .unwrap_or_default();
                 let mut retry_after = reroute_retry_after_from_headers(&parts.headers, &cur_body);
+
+                if pending.compact.is_some()
+                    && compact_should_retry(cur_status)
+                    && let Some(retried) = self.retry_compact_sub(pending.clone()).await
+                {
+                    return retried;
+                }
 
                 // Server-side retry for transient / rate-limit failures (mirrors what a native
                 // Anthropic client does): re-issue the same upstream request with backoff, honoring
@@ -1760,6 +1985,11 @@ mod imp {
             }
 
             if let Some(detail) = fatal {
+                if pending.compact.is_some()
+                    && let Some(retried) = self.retry_compact_sub(pending.clone()).await
+                {
+                    return retried;
+                }
                 crate::reroute::continuation::clear_continuation(info.session_id.as_deref());
                 let status = reroute_stream_error_status(&detail);
                 let message = format!(
@@ -2035,7 +2265,13 @@ mod imp {
             let mut failures = Vec::new();
             for provider in providers {
                 let attempt = match self
-                    .fallback_attempt(provider, &anthropic, fb.session_id.as_deref(), deadline)
+                    .fallback_attempt(
+                        provider,
+                        &anthropic,
+                        None,
+                        fb.session_id.as_deref(),
+                        deadline,
+                    )
                     .await
                 {
                     Ok(attempt) => attempt,
@@ -2115,6 +2351,7 @@ mod imp {
             &self,
             provider: crate::reroute::SubProvider,
             anthropic: &Value,
+            logical_model: Option<&str>,
             session_id: Option<&str>,
             deadline: std::time::Instant,
         ) -> Result<FallbackAttempt, String> {
@@ -2129,6 +2366,7 @@ mod imp {
             let rewrite = crate::reroute::build_upstream(
                 provider,
                 anthropic,
+                logical_model,
                 &self.sub_tiers,
                 &token,
                 session_id,
@@ -2249,6 +2487,154 @@ mod imp {
             Ok(buffered_response(status, content_type, body))
         }
 
+        /// Retry the remaining always-subscription compact candidates. Each attempt starts from
+        /// immutable Anthropic bytes, gets candidate-specific compression/tokenization, and is
+        /// buffered until the reducer either commits a non-error event or reports a precommit
+        /// error. HTTP failures and precommit reducer errors advance to the next candidate.
+        async fn retry_compact_sub(&self, pending: Pending) -> Option<Response<Body>> {
+            use crate::reroute::sse::ReduceEvent;
+            let state = pending.compact.clone()?;
+            let provider = state.sub?;
+            let original: Value = serde_json::from_slice(&state.original_body).ok()?;
+            let deadline = std::time::Instant::now() + FALLBACK_CHAIN_BUDGET;
+            for candidate in &state.candidates {
+                let config = self.config.clone();
+                let memo = self.memo.clone();
+                let raw = state.original_body.clone();
+                let sid = state.session_id.clone();
+                let model = candidate.logical_model.clone();
+                let Some((json, mut winner)) = tokio::task::spawn_blocking(move || {
+                    compress_blocking(
+                        &config,
+                        &raw,
+                        ProviderKind::Anthropic,
+                        Some(&model),
+                        &memo,
+                        sid,
+                    )
+                })
+                .await
+                .ok()
+                .flatten() else {
+                    continue;
+                };
+                if !candidate.is_original {
+                    let Some(window) = llmtrim_core::context_window(&candidate.upstream_model)
+                    else {
+                        continue;
+                    };
+                    if !crate::compact::fits(
+                        u64::from(window),
+                        winner.input_after,
+                        state.max_tokens,
+                    ) {
+                        continue;
+                    }
+                }
+                let mut body =
+                    serde_json::from_str::<Value>(&json).unwrap_or_else(|_| original.clone());
+                apply_sub_effort(&mut body, self.sub_effort.as_deref());
+                let attempt = match self
+                    .fallback_attempt(
+                        provider,
+                        &body,
+                        Some(&candidate.logical_model),
+                        state.session_id.as_deref(),
+                        deadline,
+                    )
+                    .await
+                {
+                    Ok(attempt) => attempt,
+                    Err(_) => continue,
+                };
+
+                let mut reducer = crate::reroute::StreamReducer::new(provider, &attempt.model);
+                let mut events = reducer.push(&attempt.body);
+                events.extend(reducer.finish());
+                let committed = events
+                    .iter()
+                    .any(|event| !matches!(event, ReduceEvent::Error { .. }));
+                if compact_precommit_error(&events) || !committed {
+                    crate::reroute::continuation::clear_continuation(state.session_id.as_deref());
+                    continue;
+                }
+
+                winner.model = Some(attempt.model.clone());
+                winner.compact = None;
+                winner.reroute = Some(RerouteInfo {
+                    provider,
+                    model: attempt.model,
+                    client_model: state.client_model.clone(),
+                    replay: None,
+                    logical_body: attempt.logical_body,
+                    session_id: state.session_id.clone(),
+                });
+                let info = winner.reroute.clone().expect("reroute set above");
+                return Some(self.finish_buffered_reroute(winner, &info, attempt.body));
+            }
+            None
+        }
+
+        /// Rebuild each remaining direct-Anthropic compact candidate from immutable client bytes.
+        /// Responses are buffered only on this failure path, allowing both HTTP and precommit SSE
+        /// errors to advance without exposing a partial answer.
+        async fn retry_compact_direct(&self, mut pending: Pending) -> Option<Response<Body>> {
+            let state = pending.compact.clone()?;
+            for candidate in state.candidates.iter() {
+                let mut value: Value = serde_json::from_slice(&state.original_body).ok()?;
+                value["model"] = Value::String(candidate.upstream_model.clone());
+                let raw = serde_json::to_vec(&value).ok()?;
+                let config = self.config.clone();
+                let memo = self.memo.clone();
+                let sid = state.session_id.clone();
+                let (json, next) = tokio::task::spawn_blocking(move || {
+                    compress_blocking(&config, &raw, ProviderKind::Anthropic, None, &memo, sid)
+                })
+                .await
+                .ok()
+                .flatten()?;
+                if !candidate.is_original {
+                    let Some(window) = llmtrim_core::context_window(&candidate.upstream_model)
+                    else {
+                        continue;
+                    };
+                    if !crate::compact::fits(u64::from(window), next.input_after, state.max_tokens)
+                    {
+                        continue;
+                    }
+                }
+                let url = state.url.clone();
+                let headers = state.headers.clone();
+                let proxy = self.upstream_proxy.clone();
+                let fetched = tokio::task::spawn_blocking(move || {
+                    use std::io::Read;
+                    let mut up =
+                        crate::transport::forward_post(&url, &headers, &json, proxy.as_deref())
+                            .ok()?;
+                    let mut body = Vec::new();
+                    up.reader.read_to_end(&mut body).ok()?;
+                    Some((up.status, up.content_type, body))
+                })
+                .await
+                .ok()
+                .flatten()?;
+                if !compact_should_retry(fetched.0) && !is_sub_fallback_body(&fetched.2) {
+                    pending = next;
+                    pending.model = Some(candidate.upstream_model.clone());
+                    pending.compact = None;
+                    let body = client_model_json(&fetched.2, &state.client_model);
+                    let _finalize = Finalize {
+                        acc: Arc::new(Mutex::new(body.clone())),
+                        pending: Some(pending),
+                        ledger: self.ledger.clone(),
+                        breakdown_ledger: self.breakdown_ledger.clone(),
+                    };
+                    return Some(buffered_response(fetched.0, fetched.1, body));
+                }
+            }
+            None
+        }
+
         /// Emit an Anthropic SSE `error` frame for a fallback that failed before/at the
         /// provider round-trip, still recording the row (output 0) as the `Finalize` drops.
         fn fallback_error(&self, pending: Pending, model: &str, message: &str) -> Response<Body> {
@@ -2277,6 +2663,38 @@ mod imp {
             let Some(pending) = self.pending.take() else {
                 return res;
             };
+            // Compact direct-Anthropic turns are held until the first candidate is known to have
+            // committed. Buffering is deliberately limited to this rare runtime-only request: it
+            // lets an HTTP failure or an in-stream error advance to the next immutable rebuild.
+            if let Some(state) = pending.compact.clone()
+                && state.sub.is_none()
+            {
+                let status = res.status().as_u16();
+                let content_type = res
+                    .headers()
+                    .get(header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_string);
+                let body = res
+                    .into_body()
+                    .collect()
+                    .await
+                    .map(|c| c.to_bytes().to_vec())
+                    .unwrap_or_default();
+                if (compact_should_retry(status) || is_sub_fallback_body(&body))
+                    && let Some(retried) = self.retry_compact_direct(pending.clone()).await
+                {
+                    return retried;
+                }
+                let body = client_model_json(&body, &state.client_model);
+                let _finalize = Finalize {
+                    acc: Arc::new(Mutex::new(body.clone())),
+                    pending: Some(pending),
+                    ledger: self.ledger.clone(),
+                    breakdown_ledger: self.breakdown_ledger.clone(),
+                };
+                return buffered_response(status, content_type, body);
+            }
             // Subscription reroute: the upstream reply is the provider's SSE — translate it back to
             // Anthropic SSE (the normal compress/replay/tee path below is for verbatim-forwarded
             // Anthropic responses).
@@ -2491,6 +2909,7 @@ mod imp {
                 ),
                 reroute: None,
                 fallback: None,
+                compact: None,
             };
             return Some((text.to_string(), pending));
         }
@@ -2525,6 +2944,7 @@ mod imp {
             ),
             reroute: None,
             fallback: None,
+            compact: None,
         };
         capture_pair(text, &result.request_json, &pending, &result.stages);
         Some((result.request_json, pending))
@@ -3296,6 +3716,7 @@ mod imp {
             sub_tiers: Arc::new(RuntimeConfig::get().sub_tiers.clone()),
             sub_fallback: RuntimeConfig::get().sub_fallback,
             sub_effort: RuntimeConfig::get().sub_effort.clone(),
+            compact_models: Arc::new(RuntimeConfig::get().compact_models.clone()),
         };
         // Pre-flight bind: hudsucker's `Proxy::start` collapses a bind failure to a bare
         // "io error", hiding whether the port is in use or OS-reserved. Bind once ourselves
@@ -4719,6 +5140,7 @@ mod imp {
                 sub_chain: Arc::new(vec![]),
                 sub_fallback: false,
                 sub_effort: None,
+                compact_models: Arc::new(vec![]),
             };
             (handler, rx)
         }
@@ -4767,6 +5189,7 @@ mod imp {
                 }),
                 reroute: None,
                 fallback: None,
+                compact: None,
             };
             // Provider billed: 120 cached read, 30 cache write, 50 fresh (sum 200), 40 output.
             let usage = ResponseUsage {
@@ -5087,6 +5510,7 @@ mod imp {
                 breakdown: None,
                 reroute: None,
                 fallback: None,
+                compact: None,
             });
 
             let bad_resp = Response::builder()
@@ -5145,6 +5569,7 @@ mod imp {
                 breakdown: None,
                 reroute: None,
                 fallback: None,
+                compact: None,
             });
 
             let bad_resp = Response::builder()
@@ -5196,6 +5621,7 @@ mod imp {
                 breakdown: None,
                 reroute: None,
                 fallback: None,
+                compact: None,
             });
 
             let unprocessable = Response::builder()
@@ -5248,6 +5674,7 @@ mod imp {
                     breakdown: None,
                     reroute: None,
                     fallback: None,
+                    compact: None,
                 });
 
                 let resp = Response::builder()
@@ -5304,6 +5731,7 @@ mod imp {
                 breakdown: None,
                 reroute: None,
                 fallback: None,
+                compact: None,
             });
 
             let sse_chunks = concat!(
@@ -5401,6 +5829,7 @@ mod imp {
                 breakdown: None,
                 reroute: None,
                 fallback: None,
+                compact: None,
             });
 
             // The complete SSE payload.
@@ -5505,6 +5934,7 @@ mod imp {
                 breakdown: None,
                 reroute: None,
                 fallback: None,
+                compact: None,
             });
 
             // Three chunks; the client will consume only the first then drop the body.
@@ -5582,6 +6012,7 @@ mod imp {
                 breakdown: None,
                 reroute: None,
                 fallback: None,
+                compact: None,
             });
 
             // Zero-chunk stream: body ends immediately.

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -516,6 +516,36 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
         }
     }
 
+    // 3c. Claude Code compaction routing. Ask only on first configuration; re-running setup must
+    // never overwrite a customized order or a remembered opt-out. Scripted setup takes the
+    // recommended default, matching the tray's non-interactive default behavior.
+    let mut compact_changed = false;
+    if crate::statusline::claude_code_present()
+        && !llmtrim_core::config::compact_models_configured()
+    {
+        let want = force || confirm_compact_default_yes();
+        let models = if want {
+            vec!["haiku".to_string(), "sonnet".to_string()]
+        } else {
+            Vec::new()
+        };
+        match llmtrim_core::config::write_compact_models(&models) {
+            Ok(()) => {
+                compact_changed = true;
+                rows.push((
+                    ui::OK,
+                    "Compact".into(),
+                    if want {
+                        "Haiku → Sonnet → original model".into()
+                    } else {
+                        "original model only".into()
+                    },
+                ));
+            }
+            Err(e) => rows.push((ui::WARN, "Compact".into(), format!("not configured: {e}"))),
+        }
+    }
+
     // 4. Reconcile the interceptor. If a healthy daemon is already serving the resolved port,
     //    leave it running — re-running `setup` must not drop in-flight requests (the old code
     //    stopped + respawned unconditionally on every run). Restart only when the port is
@@ -524,7 +554,7 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
     let daemon_ok = match &running {
         // `--force` falls through to the restart arm even on a matching port (e.g. to pick up a
         // freshly installed binary); without it a healthy same-port daemon is left untouched.
-        Some(state) if state.port == port && !force => {
+        Some(state) if state.port == port && !force && !compact_changed => {
             rows.push((
                 ui::OK,
                 "Interceptor".into(),
@@ -683,6 +713,22 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
         println!("    gemini extensions uninstall caveman  # Gemini CLI");
     }
     Ok(())
+}
+
+/// Ask whether to route Claude Code compaction through cheaper models, defaulting to yes. A
+/// scripted setup takes the default without blocking on stdin.
+fn confirm_compact_default_yes() -> bool {
+    use std::io::{IsTerminal, Write};
+    if !std::io::stdin().is_terminal() {
+        return true;
+    }
+    print!("Use cheaper models for Claude Code /compact (Haiku -> Sonnet -> original)? [Y/n] ");
+    let _ = std::io::stdout().flush();
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_err() {
+        return false;
+    }
+    !matches!(line.trim().to_ascii_lowercase().as_str(), "n" | "no")
 }
 
 /// Ask whether to enable the desktop tray, defaulting to yes. Returns `true`

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -7,7 +7,7 @@
 //! width-adaptive line:
 //!
 //! ```text
-//! ◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 5h·24% · 7d·12%   ♻ 63% cached
+//! ◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 3h·24% · 4d·12%   ♻ 63% cached
 //! ```
 //!
 //! The three left segments (model→backend, context, ✂ trim) are core and never
@@ -109,6 +109,9 @@ struct CcInput {
     /// 5-hour and 7-day rate-limit usage %, Claude.ai subscribers only.
     five_hour_pct: Option<f64>,
     seven_day_pct: Option<f64>,
+    /// Rate-limit window reset times, used to show the remaining duration beside each quota.
+    five_hour_resets_at: Option<String>,
+    seven_day_resets_at: Option<String>,
     /// Share of this turn's input served from the prompt cache, % — computed from the last
     /// API call's `current_usage`. `None` before the first response or right after `/compact`.
     cache_pct: Option<f64>,
@@ -149,6 +152,14 @@ fn parse_cc(input: &str) -> CcInput {
     let seven_day_pct = v
         .pointer("/rate_limits/seven_day/used_percentage")
         .and_then(Value::as_f64);
+    let five_hour_resets_at = v
+        .pointer("/rate_limits/five_hour/resets_at")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let seven_day_resets_at = v
+        .pointer("/rate_limits/seven_day/resets_at")
+        .and_then(Value::as_str)
+        .map(str::to_string);
     let cache_pct = {
         let cu = v.pointer("/context_window/current_usage");
         let field = |k: &str| {
@@ -169,6 +180,8 @@ fn parse_cc(input: &str) -> CcInput {
         window,
         five_hour_pct,
         seven_day_pct,
+        five_hour_resets_at,
+        seven_day_resets_at,
         cache_pct,
     }
 }
@@ -549,6 +562,20 @@ fn quota_color(pct: f64) -> &'static str {
     }
 }
 
+/// The largest useful unit left before a quota window resets.
+fn remaining_time_label(resets_at: Option<&str>) -> Option<String> {
+    let resets_at = chrono::DateTime::parse_from_rfc3339(resets_at?).ok()?;
+    let remaining = resets_at.signed_duration_since(chrono::Utc::now());
+    let minutes = remaining.num_minutes().max(0);
+    Some(if minutes >= 24 * 60 {
+        format!("{}d", minutes / (24 * 60))
+    } else if minutes >= 60 {
+        format!("{}h", minutes / 60)
+    } else {
+        format!("{minutes}m")
+    })
+}
+
 /// `◆ Opus→gpt-5.6-terra` — health-brand glyph, model (Claude tier name), reroute target.
 /// The target is the resolved upstream model for Codex reroutes (so you see the real model
 /// serving the turn) or the provider shortname for Kimi. The arrow is suppressed when the
@@ -632,10 +659,9 @@ fn trim_or_health_segment(led: &Led, color: bool) -> Option<String> {
 /// a narrow terminal.
 fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
     let mut out = Vec::new();
-    // One quota segment carrying both rolling windows: `◔ 5h·15% · 7d·12%`. `◔` = a window
-    // filling up; `·` keeps `5h`/`7d` from reading as durations. Only the *percentage* is
-    // coloured on its own value (a maxed 5h doesn't paint a comfortable 7d) — the `5h`/`7d`
-    // labels are constant, so colouring them is noise; they stay dim.
+    // One quota segment carrying both rolling windows, labelled by the time remaining until
+    // each reset: `◔ 3h·15% · 4d·12%`. Only the *percentage* is coloured on its own value
+    // (a maxed 5h doesn't paint a comfortable 7d); the time labels stay dim.
     let quota = |label: &str, p: f64| {
         format!(
             "{}{}",
@@ -645,16 +671,20 @@ fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
     };
     let glyph = paint(color, DIM, "◔");
     let sep = paint(color, DIM, "·");
+    let five_label =
+        remaining_time_label(cc.five_hour_resets_at.as_deref()).unwrap_or_else(|| "5h".to_string());
+    let seven_label =
+        remaining_time_label(cc.seven_day_resets_at.as_deref()).unwrap_or_else(|| "7d".to_string());
     match (cc.five_hour_pct, cc.seven_day_pct) {
         (Some(h), Some(d)) => {
             out.push(format!(
                 "{glyph} {} {sep} {}",
-                quota("5h", h),
-                quota("7d", d)
+                quota(&five_label, h),
+                quota(&seven_label, d)
             ));
         }
-        (Some(h), None) => out.push(format!("{glyph} {}", quota("5h", h))),
-        (None, Some(d)) => out.push(format!("{glyph} {}", quota("7d", d))),
+        (Some(h), None) => out.push(format!("{glyph} {}", quota(&five_label, h))),
+        (None, Some(d)) => out.push(format!("{glyph} {}", quota(&seven_label, d))),
         (None, None) => {}
     }
     if led.cache_cold {
@@ -966,6 +996,8 @@ mod tests {
             window: Some(200_000),
             five_hour_pct: Some(24.0),
             seven_day_pct: Some(12.0),
+            five_hour_resets_at: None,
+            seven_day_resets_at: None,
             cache_pct: Some(63.0),
         }
     }
@@ -1100,6 +1132,21 @@ mod tests {
             effective_cache_cold(&c, true),
             "populated context with stale ledger still shows cold"
         );
+    }
+
+    #[test]
+    fn quota_labels_show_time_remaining_until_reset() {
+        let mut c = cc(48_000);
+        c.five_hour_resets_at = Some(
+            (chrono::Utc::now() + chrono::Duration::hours(3) + chrono::Duration::minutes(30))
+                .to_rfc3339(),
+        );
+        c.seven_day_resets_at = Some(
+            (chrono::Utc::now() + chrono::Duration::days(4) + chrono::Duration::hours(12))
+                .to_rfc3339(),
+        );
+        let out = render_line(&c, &led(Health::Healthy), 0, false);
+        assert!(out.contains("◔ 3h·24% · 4d·12%"), "remaining labels: {out}");
     }
 
     #[test]

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -527,6 +527,7 @@ pub(crate) const RUNTIME_ONLY_KEYS: &[&str] = &[
     "max_breakdown_turns",
     "theme",
     "sub",
+    "compact",
 ];
 
 /// The resolved config-file path (`LLMTRIM_CONFIG`, else `$XDG_CONFIG_HOME`/`$HOME/.config` +
@@ -844,6 +845,12 @@ pub struct RuntimeConfig {
     /// Env `LLMTRIM_CODEX_PREVIOUS_RESPONSE_ID` (1/true/yes) or `[sub.codex] previous_response_id = true`.
     /// Defaults to `true`.
     pub sub_codex_previous_response_id: bool,
+    /// Ordered alternative models for Claude Code compaction requests, read from
+    /// `[compact] models = [...]`. The originally requested model is always appended by the
+    /// interceptor as an implicit final fallback, so it is never stored here. Empty means compact
+    /// model substitution is disabled. File-only: model routing is persistent policy, not an
+    /// environment toggle.
+    pub compact_models: Vec<String>,
 }
 
 impl RuntimeConfig {
@@ -931,6 +938,7 @@ impl RuntimeConfig {
             sub_chain: resolve_sub_chain(&env, file),
             sub_effort: resolve_sub_effort(&env, file),
             sub_codex_previous_response_id: resolve_sub_codex_continuation(&env, file),
+            compact_models: resolve_compact_models(file),
         }
     }
 }
@@ -1122,6 +1130,115 @@ fn resolve_sub_codex_continuation(
         }
     }
     false
+}
+
+/// Ordered compact-model alternatives from `[compact] models`. Preserve user order and retain
+/// only the first occurrence of each non-empty entry. Invalid shapes disable substitution rather
+/// than affecting ordinary compression or proxying.
+fn resolve_compact_models(file: Option<&toml::Value>) -> Vec<String> {
+    let Some(values) = file
+        .and_then(|v| v.get("compact"))
+        .and_then(|v| v.get("models"))
+        .and_then(toml::Value::as_array)
+    else {
+        return Vec::new();
+    };
+    let mut models = Vec::new();
+    for value in values {
+        let Some(model) = value.as_str().map(str::trim).filter(|s| !s.is_empty()) else {
+            continue;
+        };
+        if !models.iter().any(|existing| existing == model) {
+            models.push(model.to_string());
+        }
+    }
+    models
+}
+
+/// Replace `[compact].models` while preserving every unrelated TOML value. The original client
+/// model is deliberately absent: it is an invariant appended per request by the interceptor.
+pub fn write_compact_models(models: &[String]) -> Result<()> {
+    let path = config_path().ok_or_else(|| anyhow::anyhow!("no config path (HOME/XDG unset)"))?;
+    write_compact_models_at(&path, models)
+}
+
+/// Whether the config explicitly contains `[compact].models`, including an empty list used to
+/// remember that setup's recommendation was declined.
+pub fn compact_models_configured() -> bool {
+    let Some(path) = config_path() else {
+        return false;
+    };
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| text.parse::<toml::Value>().ok())
+        .and_then(|doc| doc.get("compact").cloned())
+        .and_then(|compact| compact.get("models").cloned())
+        .is_some()
+}
+
+fn write_compact_models_at(path: &std::path::Path, models: &[String]) -> Result<()> {
+    use anyhow::Context;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating config dir {}", parent.display()))?;
+    }
+    let values: Vec<String> = models
+        .iter()
+        .map(|m| m.trim())
+        .filter(|m| !m.is_empty())
+        .fold(Vec::new(), |mut out, m| {
+            if !out.iter().any(|existing| existing == m) {
+                out.push(m.to_string());
+            }
+            out
+        });
+    let line = format!(
+        "models = [{}]",
+        values
+            .iter()
+            .map(|m| format!("{m:?}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    let mut in_compact = false;
+    let mut compact_found = false;
+    let mut replaced = false;
+    let mut out = Vec::new();
+    for raw in existing.lines() {
+        let trimmed = raw.trim();
+        let section = trimmed.split('#').next().unwrap_or_default().trim();
+        if section.starts_with('[') {
+            if in_compact && !replaced {
+                out.push(line.clone());
+                replaced = true;
+            }
+            in_compact = section == "[compact]";
+            compact_found |= in_compact;
+        }
+        if in_compact
+            && trimmed
+                .split('=')
+                .next()
+                .is_some_and(|key| key.trim() == "models")
+        {
+            out.push(line.clone());
+            replaced = true;
+        } else {
+            out.push(raw.to_string());
+        }
+    }
+    if !replaced {
+        if !out.is_empty() && !out.last().is_some_and(|existing| existing.is_empty()) {
+            out.push(String::new());
+        }
+        if !compact_found {
+            out.push("[compact]".to_string());
+        }
+        out.push(line);
+    }
+    std::fs::write(path, format!("{}\n", out.join("\n")))
+        .with_context(|| format!("writing {}", path.display()))
 }
 
 /// Persist the breakdown-TUI `theme` choice to the config file's top-level `theme` key,
@@ -1849,6 +1966,70 @@ mod tests {
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
         RuntimeConfig::resolve(|k| env.get(k).cloned(), Some(&value))
+    }
+
+    #[test]
+    fn compact_models_preserve_order_and_deduplicate() {
+        let c = resolve_file("[compact]\nmodels = [\"haiku\", \"sonnet\", \"haiku\", \"\"]\n");
+        assert_eq!(c.compact_models, vec!["haiku", "sonnet"]);
+    }
+
+    #[test]
+    fn compact_only_config_keeps_auto_routing() {
+        let value: toml::Value =
+            toml::from_str("[compact]\nmodels = [\"haiku\", \"sonnet\"]\n").unwrap();
+        assert!(DenseConfig::from_toml_value(value).unwrap().auto);
+    }
+
+    #[test]
+    fn compact_writer_preserves_existing_config() {
+        let dir = std::env::temp_dir().join(format!("llmtrim-compact-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        std::fs::write(
+            &path,
+            "capture_dir = \"/captures\"\n[sub]\nactive = \"off\"\n[sub.codex.tiers]\nopus = \"gpt-test\"\n",
+        )
+        .unwrap();
+        write_compact_models_at(&path, &["haiku".into(), "sonnet".into(), "haiku".into()]).unwrap();
+        let file: toml::Value = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(resolve_compact_models(Some(&file)), vec!["haiku", "sonnet"]);
+        assert_eq!(
+            file.get("capture_dir").and_then(toml::Value::as_str),
+            Some("/captures")
+        );
+        assert_eq!(
+            file.get("sub")
+                .and_then(|v| v.get("codex"))
+                .and_then(|v| v.get("tiers"))
+                .and_then(|v| v.get("opus"))
+                .and_then(toml::Value::as_str),
+            Some("gpt-test")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn compact_writer_handles_commented_or_nonfinal_section() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmtrim-compact-section-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        std::fs::write(
+            &path,
+            "# keep me\n[compact] # routing policy\n# models intentionally omitted\n[sub]\nactive = \"off\"\n",
+        )
+        .unwrap();
+        write_compact_models_at(&path, &["haiku".into()]).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let file: toml::Value = toml::from_str(&text).unwrap();
+        assert_eq!(resolve_compact_models(Some(&file)), vec!["haiku"]);
+        assert_eq!(text.matches("[compact]").count(), 1);
+        assert!(text.contains("# keep me"));
+        assert!(text.find("models =").unwrap() < text.find("[sub]").unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Show the remaining duration until each Claude.ai rate-limit window resets.
- Retain fixed labels when reset timestamps are unavailable.
- Update the status-line documentation example.

## Validation
- `cargo test -p llmtrim statusline::tests`
- Verified the installed status-line binary renders `◔ 3h·2% · 4d·77%`.
