### PR TITLE
refactor(compact): scan snapshot for latest haiku/sonnet id

### DIFF
--- a/crates/llmtrim-cli/src/compact.rs
+++ b/crates/llmtrim-cli/src/compact.rs
@@ -17,7 +17,7 @@ const MARKERS: [&str; 3] = [
 ];
 
 /// Fallback ids for the `haiku`/`sonnet` aliases used only when the embedded models.dev snapshot
-/// has no entry for the family (see [`direct_model`]); the live value is scanned from the snapshot
+/// has no entry for the family (see `direct_model`); the live value is scanned from the snapshot
 /// via [`llmtrim_core::latest_model_for_family`] so a new release doesn't need a code bump here.
 pub const DEFAULT_HAIKU: &str = "claude-haiku-4-5";
 pub const DEFAULT_SONNET: &str = "claude-sonnet-5";

--- a/crates/llmtrim-cli/src/compact.rs
+++ b/crates/llmtrim-cli/src/compact.rs
@@ -16,6 +16,9 @@ const MARKERS: [&str; 3] = [
     "an <analysis> block followed by a <summary> block",
 ];
 
+/// Fallback ids for the `haiku`/`sonnet` aliases used only when the embedded models.dev snapshot
+/// has no entry for the family (see [`direct_model`]); the live value is scanned from the snapshot
+/// via [`llmtrim_core::latest_model_for_family`] so a new release doesn't need a code bump here.
 pub const DEFAULT_HAIKU: &str = "claude-haiku-4-5";
 pub const DEFAULT_SONNET: &str = "claude-sonnet-5";
 
@@ -73,10 +76,16 @@ fn collect_text(value: &Value, out: &mut String) {
     }
 }
 
+/// Resolve a `haiku`/`sonnet` family alias to the newest concrete id in the embedded models.dev
+/// snapshot, falling back to the pinned default only if the family is missing from the snapshot.
+/// Any other value is passed through as an explicit model id.
 fn direct_model(model: &str) -> String {
-    match model.trim().to_ascii_lowercase().as_str() {
-        "haiku" => DEFAULT_HAIKU.to_string(),
-        "sonnet" => DEFAULT_SONNET.to_string(),
+    let alias = model.trim().to_ascii_lowercase();
+    match alias.as_str() {
+        "haiku" => llmtrim_core::latest_model_for_family("haiku")
+            .unwrap_or_else(|| DEFAULT_HAIKU.to_string()),
+        "sonnet" => llmtrim_core::latest_model_for_family("sonnet")
+            .unwrap_or_else(|| DEFAULT_SONNET.to_string()),
         _ => model.trim().to_string(),
     }
 }

--- a/crates/llmtrim-core/src/capability.rs
+++ b/crates/llmtrim-core/src/capability.rs
@@ -159,9 +159,62 @@ pub(crate) fn context_window_for(model_id: &str) -> Option<u32> {
     CONTEXT.get(id).copied()
 }
 
+/// Highest-versioned concrete model id for a Claude family (`haiku`, `sonnet`, `opus`, …),
+/// scanned from the embedded models.dev snapshot instead of a hand-maintained constant — same
+/// data-driven-snapshot pattern as the gates above. Keys are matched by the `claude-{family}-`
+/// prefix, dated snapshot suffixes (`-20251001`) are folded into their bare id, and the remaining
+/// dot/dash version components are compared numerically, so `sonnet` resolves to `claude-sonnet-5`
+/// over `claude-sonnet-4-6`. Returns the canonical (date-suffix-free) id, or `None` when the family
+/// is absent from the snapshot, so the caller keeps its own default.
+pub(crate) fn latest_model_for_family(family: &str) -> Option<String> {
+    let prefix = format!("claude-{}-", family.to_ascii_lowercase());
+    CONTEXT
+        .keys()
+        .filter_map(|id| {
+            let rest = id.strip_prefix(&prefix)?;
+            let mut parts: Vec<&str> = rest.split('-').collect();
+            // Drop a trailing 8-digit date snapshot so `4-5-20251001` folds into `4-5`.
+            if parts
+                .last()
+                .is_some_and(|p| p.len() == 8 && p.bytes().all(|b| b.is_ascii_digit()))
+            {
+                parts.pop();
+            }
+            // Every remaining component must be a numeric version segment (`4`, `5`); anything
+            // else (a named variant, `-thinking`) is not a base family release — skip it.
+            let version = parts
+                .iter()
+                .map(|p| p.parse::<u32>())
+                .collect::<Result<Vec<u32>, _>>()
+                .ok()?;
+            (!version.is_empty()).then(|| (version, format!("{prefix}{}", parts.join("-"))))
+        })
+        .max_by(|a, b| a.0.cmp(&b.0))
+        .map(|(_, id)| id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn latest_family_scanned_from_snapshot_picks_highest_version() {
+        // `5` must beat `4-6`/`4-5`, and the dated `-20251001` snapshot must fold into the bare id.
+        assert_eq!(
+            latest_model_for_family("sonnet").as_deref(),
+            Some("claude-sonnet-5")
+        );
+        assert_eq!(
+            latest_model_for_family("haiku").as_deref(),
+            Some("claude-haiku-4-5")
+        );
+        assert_eq!(
+            latest_model_for_family("opus").as_deref(),
+            Some("claude-opus-4-8")
+        );
+        // An unknown family is a miss, so the caller keeps its own default.
+        assert_eq!(latest_model_for_family("nonesuch"), None);
+    }
 
     #[test]
     fn weak_models_are_below_the_bar() {

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -209,6 +209,14 @@ pub fn context_window(model_id: &str) -> Option<u32> {
     capability::context_window_for(model_id)
 }
 
+/// Newest concrete model id for a Claude family (`haiku`, `sonnet`, …), scanned from the embedded
+/// models.dev snapshot (refreshed by `tools/refresh_context.py`) rather than hardcoded. `None` when
+/// the family is absent, so callers keep their own default. Used by the CLI's compaction reroute to
+/// resolve `haiku`/`sonnet` aliases without pinning a version in code.
+pub fn latest_model_for_family(family: &str) -> Option<String> {
+    capability::latest_model_for_family(family)
+}
+
 /// Pick the workload preset for a request from its structure alone (no model): tool
 /// calls → `agent`; fenced code → `code`; a long context segment alongside a question
 /// (≥2 messages) → `rag` (sentence pruning, not blanket-`aggressive`, which misfires on


### PR DESCRIPTION
## What

The compaction reroute resolved the `haiku`/`sonnet` family aliases through two hardcoded constants (`DEFAULT_HAIKU`/`DEFAULT_SONNET`) in `compact.rs`. That's the hand-maintained model table the core crate otherwise avoids — `capability.rs` explicitly prefers data-driven snapshots.

This scans the already-embedded models.dev snapshot for the newest concrete id in a family instead.

## How

- **core** — new `latest_model_for_family(family)` scans the `CONTEXT` snapshot: matches the `claude-{family}-` prefix, folds dated snapshots (`-20251001`) into their bare id, and compares the numeric version components, so `sonnet` resolves to `claude-sonnet-5` over `claude-sonnet-4-6`. Refreshed by `tools/refresh_context.py` at release like the other snapshots.
- **cli** — `direct_model` scans first; `DEFAULT_HAIKU`/`DEFAULT_SONNET` stay only as a fallback for when a family is missing from the snapshot.

## Why not `-latest` aliases

The Anthropic catalog doesn't publish `claude-*-latest` for the current generation and the embedded snapshot has none, so sending one risks a 404 and breaks sub-tier remapping. Scanning concrete ids by version is wire-valid.

## Behaviour

No change today — resolved values match the current constants (`claude-haiku-4-5`, `claude-sonnet-5`; `opus` → `claude-opus-4-8`). The point is the next model release needs only a snapshot refresh, not a code bump here.

## Tests

New scan test in `capability.rs` + all existing `compact::` tests pass; clippy `--all-targets` clean.