### PR TITLE
feat(sub): add window-scoped Claude Code controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,22 @@ automatically. `llmtrim sub setup codex` opens an interactive editor to change w
 each Claude tier (opus / sonnet / haiku / fable) maps to; `llmtrim sub status` shows the
 current mapping; `llmtrim sub off` disables rerouting and sends traffic back to Anthropic.
 
+`llmtrim setup` also installs a user-wide Claude Code command for changing only the current
+Claude Code window:
+
+```text
+/sub on
+/sub off
+/sub status
+```
+
+The window override includes its subagents and survives `/clear` and compaction. It does not affect
+other open windows or newly started Claude Code processes. A resumed or forked conversation starts
+with a fresh window policy; `/exit` removes the override, while an uncleanly terminated window
+expires after 30 minutes. `/sub off` forces Anthropic with compression for that window, even when
+the global reroute policy uses `always` or `fallback`. Run `llmtrim window-sub install` or
+`llmtrim window-sub uninstall` explicitly to manage the Claude Code integration.
+
 By default a set provider reroutes every turn. To use subscriptions only as a backup, switch to
 fallback mode: `llmtrim sub mode fallback` forwards to Anthropic as usual and tries the configured
 provider chain when Anthropic hits a quota, overload, transient server error, or transport failure.

--- a/crates/llmtrim-cli/src/lib.rs
+++ b/crates/llmtrim-cli/src/lib.rs
@@ -29,4 +29,5 @@ pub mod transport;
 pub mod tray;
 pub mod ui;
 pub mod update;
+pub mod window_sub;
 pub mod wrap;

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -9,7 +9,7 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use llmtrim::bench::{self, BenchCase};
 use llmtrim::monitor;
@@ -381,6 +381,12 @@ enum Commands {
     /// head-to-head comparators (Headroom, caveman).
     #[command(subcommand)]
     Bench(BenchCmd),
+    /// Internal Claude Code window-local subscription integration.
+    #[command(hide = true)]
+    WindowSub {
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
 }
 
 /// Benchmark suite — a single dispatcher over every measurement axis.
@@ -733,6 +739,121 @@ fn read_stdin() -> Result<String> {
         .read_to_string(&mut buf)
         .context("failed to read stdin")?;
     Ok(buf)
+}
+
+#[cfg(feature = "intercept")]
+fn window_sub_provider() -> Result<String> {
+    let configured = llmtrim_core::config::RuntimeConfig::get()
+        .sub
+        .clone()
+        .or_else(llmtrim_core::config::sub_reenable_provider)
+        .context("no provider to re-enable — run `llmtrim sub on codex` (or kimi) first")?;
+    let provider = llmtrim::reroute::SubProvider::parse(&configured)
+        .context("configured subscription provider is invalid")?;
+    let logged_in = llmtrim::reroute::auth::auth_status_json(provider)
+        .get("logged_in")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if !logged_in {
+        bail!(
+            "{} is not signed in — run `llmtrim sub auth {} login` first",
+            provider.as_str(),
+            provider.as_str()
+        );
+    }
+    Ok(provider.as_str().to_string())
+}
+
+#[cfg(not(feature = "intercept"))]
+fn window_sub_provider() -> Result<String> {
+    bail!("window-scoped rerouting needs the `intercept` feature")
+}
+
+fn run_window_sub(args: Vec<String>) -> Result<()> {
+    let action = args.first().map(String::as_str).unwrap_or("status");
+    let session_from_env = || {
+        std::env::var("CLAUDE_CODE_SESSION_ID")
+            .ok()
+            .or_else(|| std::env::var("CLAUDE_SESSION_ID").ok())
+    };
+    match action {
+        "install" => {
+            llmtrim::window_sub::install(&std::env::current_exe()?.display().to_string())?;
+            println!("Claude Code /sub integration installed.");
+        }
+        "uninstall" => {
+            llmtrim::window_sub::uninstall()?;
+            println!("Claude Code /sub integration removed.");
+        }
+        "hook-start" => {
+            let mut raw = String::new();
+            std::io::stdin().read_to_string(&mut raw)?;
+            let value: serde_json::Value = serde_json::from_str(&raw)?;
+            let session = value
+                .get("session_id")
+                .and_then(serde_json::Value::as_str)
+                .context("SessionStart missing session_id")?;
+            let source = value
+                .get("source")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("startup");
+            let existing = std::env::var("LLMTRIM_CLAUDE_WINDOW_TOKEN").ok();
+            let token = llmtrim::window_sub::session_start(session, source, existing.as_deref())?;
+            if let Ok(file) = std::env::var("CLAUDE_ENV_FILE") {
+                let mut f = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(file)?;
+                writeln!(f, "export LLMTRIM_CLAUDE_WINDOW_TOKEN={token}")?;
+            }
+        }
+        "hook-end" => {
+            let mut raw = String::new();
+            std::io::stdin().read_to_string(&mut raw)?;
+            let v: serde_json::Value = serde_json::from_str(&raw)?;
+            if let Some(s) = v.get("session_id").and_then(serde_json::Value::as_str) {
+                let reason = v
+                    .get("reason")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                let _ = llmtrim::window_sub::session_end(s, reason);
+            }
+        }
+        "slash" => {
+            let command = args.get(1).map(String::as_str).unwrap_or("status");
+            let session = args
+                .get(2)
+                .filter(|x| !x.is_empty())
+                .cloned()
+                .or_else(session_from_env)
+                .context("Claude Code session unavailable")?;
+            match command.trim() {
+                "on" => {
+                    let provider = window_sub_provider()?;
+                    llmtrim::window_sub::set(&session, true, Some(&provider))?;
+                    println!("Subscription rerouting enabled for this window ({provider}).");
+                }
+                "off" => {
+                    llmtrim::window_sub::set(&session, false, None)?;
+                    println!(
+                        "Subscription rerouting disabled for this window; Anthropic compression remains active."
+                    );
+                }
+                "status" | "" => match llmtrim::window_sub::status(&session)? {
+                    Some(llmtrim::window_sub::Intent::Enabled { provider }) => {
+                        println!("This window: subscription rerouting enabled ({provider}).")
+                    }
+                    Some(llmtrim::window_sub::Intent::Disabled) => {
+                        println!("This window: subscription rerouting disabled.")
+                    }
+                    None => println!("This window follows the global subscription policy."),
+                },
+                _ => bail!("usage: /sub on|off|status"),
+            }
+        }
+        _ => bail!("unknown window-sub action"),
+    };
+    Ok(())
 }
 
 fn main() {
@@ -1421,6 +1542,16 @@ fn run() -> Result<()> {
         },
         Commands::Sub { action } => run_sub(action)?,
         Commands::Compact { action } => run_compact(action)?,
+        Commands::WindowSub { args } => {
+            let hook = args.first().is_some_and(|arg| arg.starts_with("hook-"));
+            if let Err(error) = run_window_sub(args) {
+                if hook {
+                    eprintln!("llmtrim: window /sub hook skipped: {error:#}");
+                } else {
+                    return Err(error);
+                }
+            }
+        }
         Commands::Update => llmtrim::update::run()?,
         Commands::Mcp { action } => match action {
             None => llmtrim::mcp::run()?,

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1323,8 +1323,24 @@ mod imp {
             let mut fallback_arm: Option<(Vec<crate::reroute::SubProvider>, Option<String>)> = None;
             if matches!(provider, Some(ProviderKind::Anthropic)) && req.method() == Method::POST {
                 let path = req.uri().path();
-                if !self.sub_fallback {
-                    if let Some(sub) = self.sub {
+                // The filesystem registry is consulted per request, keyed by Claude Code's
+                // inbound session header.  A local `off` is authoritative and suppresses both
+                // direct reroute and global fallback; an absent/expired record follows global.
+                let window_intent = crate::window_sub::lookup(
+                    req.headers()
+                        .get("x-claude-code-session-id")
+                        .and_then(|v| v.to_str().ok()),
+                );
+                let window_sub = match &window_intent {
+                    Some(crate::window_sub::Intent::Enabled { provider }) => {
+                        crate::reroute::SubProvider::parse(provider)
+                    }
+                    _ => None,
+                };
+                let window_disabled =
+                    matches!(window_intent, Some(crate::window_sub::Intent::Disabled));
+                if !window_disabled && (!self.sub_fallback || window_sub.is_some()) {
+                    if let Some(sub) = window_sub.or(self.sub) {
                         if path.ends_with("/v1/messages/count_tokens") {
                             return self.reroute_count_tokens(req).await;
                         }
@@ -1332,7 +1348,7 @@ mod imp {
                             return self.reroute_messages(req, sub).await;
                         }
                     }
-                } else if path.ends_with("/v1/messages") {
+                } else if !window_disabled && path.ends_with("/v1/messages") {
                     // A chain is enough to arm the fallback: `sub` selects who serves *every* turn
                     // in `always` mode, but in fallback mode the chain is the whole answer, so
                     // `sub = off` + a chain is a valid configuration.

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -567,6 +567,30 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
             ));
         }
     }
+    // Window-local /sub is safe to install automatically: it only adds owned hooks and a skill;
+    // it neither edits global reroute configuration nor restarts the daemon.
+    if crate::statusline::claude_code_present() {
+        match std::env::current_exe()
+            .ok()
+            .map(|p| crate::window_sub::install(&p.display().to_string()))
+        {
+            Some(Ok(())) => rows.push((
+                ui::OK,
+                "Window /sub".into(),
+                "installed Claude Code window-local controls".into(),
+            )),
+            Some(Err(e)) => rows.push((
+                ui::WARN,
+                "Window /sub".into(),
+                format!("not installed: {e}"),
+            )),
+            None => rows.push((
+                ui::WARN,
+                "Window /sub".into(),
+                "could not resolve llmtrim binary".into(),
+            )),
+        }
+    }
 
     // 4. Reconcile the interceptor. If a healthy daemon is already serving the resolved port,
     //    leave it running — re-running `setup` must not drop in-flight requests (the old code
@@ -877,7 +901,17 @@ pub fn uninstall(purge: bool, keep_binary: bool) -> Result<()> {
         )),
     }
 
-    // 2c. Unwire the Claude Code guard hook, leaving the user's other hooks in place.
+    // 2c. Remove only llmtrim-owned Claude window /sub hooks and skill.
+    match crate::window_sub::uninstall() {
+        Ok(()) => rows.push((
+            ui::OK,
+            "Window /sub".into(),
+            "removed owned Claude Code integration".into(),
+        )),
+        Err(e) => rows.push((ui::WARN, "Window /sub".into(), format!("not removed: {e}"))),
+    }
+
+    // 2d. Unwire the Claude Code guard hook, leaving the user's other hooks in place.
     match crate::guard::unwire() {
         Ok(true) => rows.push((
             ui::OK,

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -253,7 +253,13 @@ fn proxy_health() -> Health {
 
 fn ledger_snapshot(cc: &CcInput) -> Led {
     let cfg = llmtrim_core::config::RuntimeConfig::get();
-    let configured = cfg.sub.clone().filter(|s| !s.is_empty() && s != "off");
+    let global = cfg.sub.clone().filter(|s| !s.is_empty() && s != "off");
+    let window_intent = crate::window_sub::lookup(cc.session_id.as_deref());
+    let configured = match &window_intent {
+        Some(crate::window_sub::Intent::Enabled { provider }) => Some(provider.clone()),
+        Some(crate::window_sub::Intent::Disabled) => None,
+        None => global,
+    };
     let health = proxy_health();
 
     // One session-row read serves both trim and cache-cold. Match on `cc_session_id` — the real
@@ -274,24 +280,28 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
     let ledger_cold = row.as_ref().is_some_and(|r| cache_cold(&r.last_ts));
     let cache_cold = effective_cache_cold(cc, ledger_cold);
 
-    let (reroute, reroute_window, resolved_model) =
-        match arrow_source(configured.as_deref(), cfg.sub_fallback, row.as_ref()) {
-            // Truth: the backend that answered the last turn, and the model recorded on it.
-            ArrowSource::Served { provider, model } => {
-                let window = model.as_deref().and_then(upstream_window);
-                // Kimi collapses every tier to one internal wire id, which tells the user nothing
-                // the provider shortname doesn't — so the arrow keeps the shortname there.
-                let shown = model.filter(|_| provider != "kimi");
-                (Some(provider), window, shown)
-            }
-            // Prediction (always mode, no turn yet): resolve from the configured tier mapping.
-            ArrowSource::Predicted(provider) => (
-                Some(provider.clone()),
-                reroute_real_window(&provider, &cc.model_id, &cfg.sub_tiers),
-                reroute_resolved_model(&provider, &cc.model_id, &cfg.sub_tiers),
-            ),
-            ArrowSource::None => (None, None, None),
-        };
+    let arrow = if matches!(window_intent, Some(crate::window_sub::Intent::Disabled)) {
+        ArrowSource::None
+    } else {
+        arrow_source(configured.as_deref(), cfg.sub_fallback, row.as_ref())
+    };
+    let (reroute, reroute_window, resolved_model) = match arrow {
+        // Truth: the backend that answered the last turn, and the model recorded on it.
+        ArrowSource::Served { provider, model } => {
+            let window = model.as_deref().and_then(upstream_window);
+            // Kimi collapses every tier to one internal wire id, which tells the user nothing
+            // the provider shortname doesn't — so the arrow keeps the shortname there.
+            let shown = model.filter(|_| provider != "kimi");
+            (Some(provider), window, shown)
+        }
+        // Prediction (always mode, no turn yet): resolve from the configured tier mapping.
+        ArrowSource::Predicted(provider) => (
+            Some(provider.clone()),
+            reroute_real_window(&provider, &cc.model_id, &cfg.sub_tiers),
+            reroute_resolved_model(&provider, &cc.model_id, &cfg.sub_tiers),
+        ),
+        ArrowSource::None => (None, None, None),
+    };
 
     Led {
         health,

--- a/crates/llmtrim-cli/src/window_sub.rs
+++ b/crates/llmtrim-cli/src/window_sub.rs
@@ -1,0 +1,483 @@
+//! Private, per-Claude-Code-window subscription overrides.
+//!
+//! This deliberately lives outside the global llmtrim config: a slash command must not
+//! restart the proxy or alter another Claude Code window.
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+const TTL: Duration = Duration::from_secs(30 * 60);
+const TOUCH: Duration = Duration::from_secs(60);
+const COMMAND_NAME: &str = "sub";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct Registry {
+    #[serde(default)]
+    windows: BTreeMap<String, Window>,
+    #[serde(default)]
+    sessions: BTreeMap<String, String>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Window {
+    /// `None` follows the global policy; a value is this window's explicit override.
+    intent: Option<Intent>,
+    touched: u64,
+    #[serde(default)]
+    last_provider: Option<String>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Intent {
+    Enabled { provider: String },
+    Disabled,
+}
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+fn valid(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 160
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+        && !value.contains("..")
+}
+fn valid_provider(value: &str) -> bool {
+    matches!(value, "codex" | "kimi")
+}
+
+pub fn registry_path() -> Result<PathBuf> {
+    Ok(crate::daemon::home_dir()?.join("claude-window-sub.json"))
+}
+struct RegistryLock(PathBuf);
+
+impl Drop for RegistryLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+fn lock_registry(path: &Path) -> Result<RegistryLock> {
+    let lock = path.with_extension("lock");
+    if let Some(parent) = lock.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    for _ in 0..200 {
+        match OpenOptions::new().write(true).create_new(true).open(&lock) {
+            Ok(_) => return Ok(RegistryLock(lock)),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                let stale = fs::metadata(&lock)
+                    .and_then(|m| m.modified())
+                    .ok()
+                    .and_then(|t| t.elapsed().ok())
+                    .is_some_and(|age| age > Duration::from_secs(30));
+                if stale {
+                    let _ = fs::remove_file(&lock);
+                } else {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            }
+            Err(e) => return Err(e).context("creating window registry lock"),
+        }
+    }
+    bail!("timed out waiting for window registry lock")
+}
+
+fn load_at(path: &Path) -> Result<Registry> {
+    if !path.exists() {
+        return Ok(Registry::default());
+    }
+    if fs::symlink_metadata(path)?.file_type().is_symlink() {
+        bail!("refusing symlinked window registry");
+    }
+    let mut raw = String::new();
+    fs::File::open(path)?.read_to_string(&mut raw)?;
+    serde_json::from_str(&raw).context("corrupt window registry")
+}
+fn replace_file(tmp: &Path, destination: &Path) -> Result<()> {
+    #[cfg(windows)]
+    if destination.exists() {
+        fs::remove_file(destination)?;
+    }
+    fs::rename(tmp, destination)?;
+    Ok(())
+}
+
+fn save_at(path: &Path, registry: &Registry) -> Result<()> {
+    let parent = path.parent().context("registry has no parent")?;
+    fs::create_dir_all(parent)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o700))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    if tmp.exists() && fs::symlink_metadata(&tmp)?.file_type().is_symlink() {
+        bail!("refusing symlinked registry temp file");
+    }
+    let bytes = serde_json::to_vec_pretty(registry)?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&tmp)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    replace_file(&tmp, path)?;
+    Ok(())
+}
+fn prune(registry: &mut Registry, current: u64) {
+    registry
+        .windows
+        .retain(|_, w| current.saturating_sub(w.touched) <= TTL.as_secs());
+    registry
+        .sessions
+        .retain(|_, t| registry.windows.contains_key(t));
+}
+fn token() -> String {
+    let mut b = [0u8; 24];
+    if let Ok(mut f) = fs::File::open("/dev/urandom") {
+        let _ = f.read_exact(&mut b);
+    }
+    if b.iter().all(|x| *x == 0) {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let seed = nanos
+            ^ ((std::process::id() as u128) << 64)
+            ^ COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
+        for (i, x) in b.iter_mut().enumerate() {
+            *x = seed.rotate_left((i * 7 % 128) as u32) as u8 ^ (i as u8).wrapping_mul(29);
+        }
+    }
+    b.iter().map(|x| format!("{x:02x}")).collect()
+}
+/// Register a fresh startup/resume window, or retain its token across clear/compact.
+pub fn session_start(session: &str, source: &str, existing: Option<&str>) -> Result<String> {
+    if !valid(session) {
+        bail!("invalid Claude session id");
+    }
+    let path = registry_path()?;
+    let _lock = lock_registry(&path)?;
+    let mut r = load_at(&path)?;
+    let t = now();
+    prune(&mut r, t);
+    let token = if matches!(source, "clear" | "compact") {
+        existing
+            .filter(|x| valid(x) && r.windows.contains_key(*x))
+            .map(str::to_owned)
+            .unwrap_or_else(token)
+    } else {
+        token()
+    };
+    r.windows
+        .entry(token.clone())
+        .or_insert(Window {
+            intent: None,
+            touched: t,
+            last_provider: None,
+        })
+        .touched = t;
+    r.sessions.insert(session.to_owned(), token.clone());
+    save_at(&path, &r)?;
+    Ok(token)
+}
+pub fn session_end(session: &str, reason: &str) -> Result<()> {
+    if !valid(session) {
+        return Ok(());
+    }
+    let path = registry_path()?;
+    let _lock = lock_registry(&path)?;
+    let mut r = load_at(&path)?;
+    if let Some(token) = r.sessions.remove(session)
+        && reason != "clear"
+    {
+        r.windows.remove(&token);
+        r.sessions.retain(|_, mapped| mapped != &token);
+    }
+    prune(&mut r, now());
+    save_at(&path, &r)
+}
+pub fn set(session: &str, enabled: bool, provider: Option<&str>) -> Result<()> {
+    if !valid(session) {
+        bail!("invalid Claude session id");
+    }
+    let path = registry_path()?;
+    let _lock = lock_registry(&path)?;
+    let mut r = load_at(&path)?;
+    prune(&mut r, now());
+    let t = r
+        .sessions
+        .get(session)
+        .cloned()
+        .context("this Claude Code window is not registered; restart or resume it first")?;
+    let w = r
+        .windows
+        .get_mut(&t)
+        .context("window expired; restart or resume it first")?;
+    w.touched = now();
+    if enabled {
+        let p = provider
+            .map(str::to_owned)
+            .or_else(|| w.last_provider.clone())
+            .context(
+                "no configured subscription provider; run llmtrim sub on codex or kimi first",
+            )?;
+        if !valid_provider(&p) {
+            bail!("unsupported subscription provider");
+        }
+        w.last_provider = Some(p.clone());
+        w.intent = Some(Intent::Enabled { provider: p });
+    } else {
+        w.intent = Some(Intent::Disabled);
+    }
+    save_at(&path, &r)
+}
+/// Read intent by inbound Claude session ID. Corruption deliberately falls back to global policy.
+pub fn lookup(session: Option<&str>) -> Option<Intent> {
+    let session = session.filter(|s| valid(s))?;
+    let path = registry_path().ok()?;
+    let _lock = lock_registry(&path).ok()?;
+    let mut r = load_at(&path).ok()?;
+    let token = r.sessions.get(session)?.clone();
+    let window = r.windows.get_mut(&token)?;
+    let current = now();
+    if current.saturating_sub(window.touched) > TTL.as_secs() {
+        r.windows.remove(&token);
+        r.sessions.retain(|_, mapped| mapped != &token);
+        let _ = save_at(&path, &r);
+        return None;
+    }
+    let intent = window.intent.clone();
+    if current.saturating_sub(window.touched) >= TOUCH.as_secs() {
+        window.touched = current;
+        let _ = save_at(&path, &r);
+    }
+    intent
+}
+pub fn status(session: &str) -> Result<Option<Intent>> {
+    Ok(lookup(Some(session)))
+}
+
+#[cfg(unix)]
+fn quoted_exe(exe: &str) -> String {
+    format!("'{}'", exe.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(windows)]
+fn quoted_exe(exe: &str) -> String {
+    format!("\"{}\"", exe.replace('"', "\"\""))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn quoted_exe(exe: &str) -> String {
+    exe.to_string()
+}
+
+pub fn command_markdown(exe: &str) -> String {
+    let exe = quoted_exe(exe);
+    format!(
+        "---\ndescription: Toggle llmtrim subscription rerouting for this Claude Code window only.\ndisable-model-invocation: true\nargument-hint: \"on|off|status\"\n---\n\n<!-- llmtrim-owned-window-sub -->\n!`{exe} window-sub slash \"$ARGUMENTS\" \"$CLAUDE_CODE_SESSION_ID\"`\n"
+    )
+}
+fn settings_path() -> Result<PathBuf> {
+    let h = std::env::var_os("CLAUDE_CONFIG_DIR")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .or_else(|| std::env::var_os("USERPROFILE"))
+                .map(|x| PathBuf::from(x).join(".claude"))
+        })
+        .context("could not determine Claude config directory")?;
+    Ok(h.join("settings.json"))
+}
+const HOOK_MARKER: &str = "# llmtrim-owned-window-sub-hook";
+
+fn owned(v: &serde_json::Value) -> bool {
+    v.get("command")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|command| command.trim_end().ends_with(HOOK_MARKER))
+}
+
+fn remove_owned_hooks(groups: &mut Vec<serde_json::Value>) {
+    for group in groups.iter_mut() {
+        if let Some(hooks) = group
+            .get_mut("hooks")
+            .and_then(serde_json::Value::as_array_mut)
+        {
+            hooks.retain(|hook| !owned(hook));
+        }
+    }
+    groups.retain(|group| {
+        group
+            .get("hooks")
+            .and_then(serde_json::Value::as_array)
+            .is_none_or(|hooks| !hooks.is_empty())
+    });
+}
+pub fn install(exe: &str) -> Result<()> {
+    let hook_exe = quoted_exe(exe);
+    let p = settings_path()?;
+    let skill = p
+        .parent()
+        .context("settings has no parent")?
+        .join("skills")
+        .join(COMMAND_NAME);
+    let skill_file = skill.join("SKILL.md");
+    if skill_file.exists()
+        && !fs::read_to_string(&skill_file)
+            .unwrap_or_default()
+            .contains("llmtrim-owned-window-sub")
+    {
+        bail!(
+            "{} already exists and is not owned by llmtrim",
+            skill_file.display()
+        );
+    }
+    let mut root = if p.exists() {
+        serde_json::from_str(&fs::read_to_string(&p)?)?
+    } else {
+        serde_json::json!({})
+    };
+    let obj = root
+        .as_object_mut()
+        .context("Claude settings root must be an object")?;
+    let hooks = obj
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("Claude hooks must be an object")?;
+    for (event, command) in [
+        (
+            "SessionStart",
+            format!("{hook_exe} window-sub hook-start {HOOK_MARKER}"),
+        ),
+        (
+            "SessionEnd",
+            format!("{hook_exe} window-sub hook-end {HOOK_MARKER}"),
+        ),
+    ] {
+        let arr = hooks
+            .entry(event)
+            .or_insert_with(|| serde_json::json!([]))
+            .as_array_mut()
+            .context("Claude hook event must be an array")?;
+        remove_owned_hooks(arr);
+        arr.push(serde_json::json!({"hooks":[{"type":"command","command":command,"timeout":10}]}));
+    }
+    let dir = p.parent().context("settings has no parent")?;
+    fs::create_dir_all(dir)?;
+    let tmp = p.with_extension("json.tmp");
+    fs::write(&tmp, serde_json::to_vec_pretty(&root)?)?;
+    replace_file(&tmp, &p)?;
+    fs::create_dir_all(&skill)?;
+    fs::write(skill_file, command_markdown(exe))?;
+    Ok(())
+}
+pub fn uninstall() -> Result<()> {
+    let p = settings_path()?;
+    if p.exists() {
+        let mut r: serde_json::Value = serde_json::from_str(&fs::read_to_string(&p)?)?;
+        if let Some(h) = r
+            .get_mut("hooks")
+            .and_then(serde_json::Value::as_object_mut)
+        {
+            for e in ["SessionStart", "SessionEnd"] {
+                if let Some(groups) = h.get_mut(e).and_then(serde_json::Value::as_array_mut) {
+                    remove_owned_hooks(groups);
+                }
+            }
+        }
+        fs::write(&p, serde_json::to_vec_pretty(&r)?)?;
+    }
+    let skill = settings_path()?
+        .parent()
+        .unwrap()
+        .join("skills")
+        .join(COMMAND_NAME);
+    let skill_file = skill.join("SKILL.md");
+    if fs::read_to_string(&skill_file)
+        .unwrap_or_default()
+        .contains("llmtrim-owned-window-sub")
+    {
+        fs::remove_file(skill_file)?;
+        if fs::read_dir(&skill)?.next().is_none() {
+            fs::remove_dir(skill)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_traversal_and_accepts_opaque_ids() {
+        assert!(valid("01abc_DEF-9"));
+        assert!(!valid("../escape"));
+        assert!(!valid("bad/slash"));
+    }
+
+    #[test]
+    fn registry_prunes_expired_window_and_session() {
+        let mut r = Registry::default();
+        r.windows.insert(
+            "token".into(),
+            Window {
+                intent: None,
+                touched: 1,
+                last_provider: None,
+            },
+        );
+        r.sessions.insert("session".into(), "token".into());
+        prune(&mut r, TTL.as_secs() + 2);
+        assert!(r.windows.is_empty());
+        assert!(r.sessions.is_empty());
+    }
+
+    #[test]
+    fn skill_uses_session_environment_without_exposing_it() {
+        let text = command_markdown("llmtrim");
+        assert!(text.contains("CLAUDE_CODE_SESSION_ID"));
+        assert!(!text.contains("LLMTRIM_CLAUDE_WINDOW_TOKEN"));
+    }
+
+    #[test]
+    fn removing_owned_hook_preserves_neighbors_in_the_same_group() {
+        let mut groups = vec![serde_json::json!({
+            "hooks": [
+                {"type": "command", "command": "user-hook"},
+                {"type": "command", "command": format!("llmtrim window-sub hook-start {HOOK_MARKER}")}
+            ]
+        })];
+        remove_owned_hooks(&mut groups);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0]["hooks"].as_array().unwrap().len(), 1);
+        assert_eq!(groups[0]["hooks"][0]["command"], "user-hook");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executable_path_is_single_quote_escaped() {
+        let command = command_markdown("/tmp/a'$(touch nope)/llmtrim");
+        assert!(command.contains("'/tmp/a'\"'\"'$(touch nope)/llmtrim'"));
+    }
+}


### PR DESCRIPTION
## Summary

- add user-wide Claude Code `/sub on`, `/sub off`, and `/sub status` controls
- scope rerouting to the current Claude Code window and its subagents without restarting the shared proxy
- preserve the override across `/clear` and compaction, reset it for fresh/resumed/forked windows, and clean it on exit or after a 30-minute crash lease
- install and remove owned Claude lifecycle hooks safely while preserving unrelated hooks and user files
- make the status line resolve the effective policy for its own window

## Design

I keep global `llmtrim sub` behavior unchanged. Claude window overrides live in a private atomic registry keyed through a stable window token and the changing Claude session IDs. The proxy resolves `x-claude-code-session-id` on each request, so one active window can reroute while every other active or future window continues using its own/global policy.

`/sub off` explicitly forces Anthropic with compression for that window, including when the global configuration uses fallback mode.

## Verification

- `cargo nextest run --profile ci`: 1070 passed, 1 skipped
- `cargo test --doc`: passed
- `cargo clippy -p llmtrim --all-targets -- -D warnings`: passed
- isolated CLI lifecycle drive covered install, two-window isolation, `/clear` handoff, local off/on, exit cleanup, invalid arguments, and ownership-safe uninstall

The verification did not start, stop, or reuse the shared daemon on port 43117.