### PR TITLE
fix(compact): reconcile thinking on model swap + fix candidate fall-through

### DIFF
--- a/crates/llmtrim-cli/src/compact.rs
+++ b/crates/llmtrim-cli/src/compact.rs
@@ -6,11 +6,11 @@
 
 use std::collections::BTreeMap;
 
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::reroute::{SubProvider, resolve_model};
 
-const MARKERS: [&str; 3] = [
+pub(crate) const MARKERS: [&str; 3] = [
     "CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.",
     "Your task is to create a detailed summary of the conversation so far",
     "an <analysis> block followed by a <summary> block",
@@ -136,6 +136,41 @@ pub fn fits(context_window: u64, input_tokens: i64, max_tokens: u64) -> bool {
         .is_some_and(|total| total <= context_window)
 }
 
+/// Thinking budget (tokens) substituted for `adaptive` when a compact candidate can't take the
+/// adaptive mode. Ample for a summarization turn's reasoning; clamped below the request's
+/// `max_tokens` (and above Anthropic's 1024 floor) so it's valid on every model.
+const COMPACT_THINKING_BUDGET: u64 = 8_192;
+
+/// Reconcile a compact candidate's `thinking` block with the swapped-in model. Claude Code's
+/// `/compact` uses `thinking.type = "adaptive"`, which only some models accept — the Haiku family
+/// rejects it ("adaptive thinking is not supported on this model") even though it *is*
+/// reasoning-capable. So:
+///
+/// - a reasoning-capable model keeps thinking, with `adaptive` downgraded to an explicit
+///   `enabled` budget (universally accepted);
+/// - a non-reasoning model has the block stripped entirely.
+///
+/// Only this isolated compact request is edited — the client's ordinary turns keep their thinking,
+/// so it resumes after compaction. Reasoning capability comes from the embedded models.dev flag
+/// ([`llmtrim_core::model_is_reasoning_capable`]), not a hardcoded model list. Returns `true` when
+/// the body was modified.
+pub fn normalize_compact_thinking(body: &mut Value, model: &str, max_tokens: u64) -> bool {
+    if body.pointer("/thinking/type").and_then(Value::as_str) != Some("adaptive") {
+        return false;
+    }
+    if llmtrim_core::model_is_reasoning_capable(model) {
+        // Keep thinking, but as an explicit budget every model accepts. Stay under `max_tokens`
+        // (Anthropic requires `budget_tokens < max_tokens`) and above the 1024 floor.
+        let budget = COMPACT_THINKING_BUDGET
+            .min(max_tokens.saturating_sub(1))
+            .max(1_024);
+        body["thinking"] = json!({ "type": "enabled", "budget_tokens": budget });
+    } else if let Some(obj) = body.as_object_mut() {
+        obj.remove("thinking");
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,6 +189,61 @@ mod tests {
 
     fn signature() -> String {
         format!("{}\n{}\n{}", MARKERS[0], MARKERS[1], MARKERS[2])
+    }
+
+    #[test]
+    fn adaptive_thinking_downgrades_to_a_budget_when_the_model_can_reason() {
+        // A reasoning-capable model keeps thinking, with `adaptive` swapped for an explicit budget
+        // (clamped below max_tokens, above the 1024 floor). The decision is the models.dev flag, not
+        // the id — this fixture just needs one model the registry marks reasoning-capable.
+        assert!(llmtrim_core::model_is_reasoning_capable("claude-haiku-4-5"));
+        let mut body = compact_body("x");
+        assert!(normalize_compact_thinking(
+            &mut body,
+            "claude-haiku-4-5",
+            64_000
+        ));
+        assert_eq!(body["thinking"]["type"], "enabled");
+        let budget = body["thinking"]["budget_tokens"].as_u64().unwrap();
+        assert!((1_024..64_000).contains(&budget), "{budget}");
+    }
+
+    #[test]
+    fn adaptive_thinking_is_stripped_when_the_model_cannot_reason() {
+        // A model the registry marks non-reasoning can't take any thinking block: strip it.
+        assert!(!llmtrim_core::model_is_reasoning_capable("gpt-4o-mini"));
+        let mut body = compact_body("x");
+        assert!(normalize_compact_thinking(&mut body, "gpt-4o-mini", 64_000));
+        assert!(body.get("thinking").is_none());
+    }
+
+    #[test]
+    fn non_adaptive_thinking_is_left_untouched() {
+        // Only `adaptive` needs reconciling; an explicit budget is already universal.
+        let mut body = json!({
+            "model": "claude-haiku-4-5",
+            "max_tokens": 64000,
+            "thinking": {"type": "enabled", "budget_tokens": 8000},
+        });
+        assert!(!normalize_compact_thinking(
+            &mut body,
+            "claude-haiku-4-5",
+            64_000
+        ));
+        assert_eq!(body["thinking"]["budget_tokens"], 8000);
+    }
+
+    #[test]
+    fn budget_is_clamped_below_a_small_max_tokens() {
+        // Defensive: if the request cap were ever tiny, the budget must stay strictly under it.
+        let mut body = compact_body("x");
+        body["max_tokens"] = json!(1500);
+        assert!(normalize_compact_thinking(
+            &mut body,
+            "claude-haiku-4-5",
+            1500
+        ));
+        assert!(body["thinking"]["budget_tokens"].as_u64().unwrap() < 1500);
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1435,6 +1435,11 @@ mod imp {
                 for (index, candidate) in candidates.iter().enumerate() {
                     let mut value = original.clone();
                     value["model"] = Value::String(candidate.upstream_model.clone());
+                    crate::compact::normalize_compact_thinking(
+                        &mut value,
+                        &candidate.upstream_model,
+                        max_tokens,
+                    );
                     let Ok(candidate_body) = serde_json::to_vec(&value) else {
                         continue;
                     };
@@ -1479,6 +1484,10 @@ mod imp {
                         sub: None,
                         session_id: cc_session_id.clone(),
                     });
+                    // Store the compact state so the response handler can advance to the next
+                    // candidate when this one fails (e.g. a candidate that rejects the request);
+                    // without it the raw first-candidate error is passed straight to the client.
+                    self.pending = Some(pending);
                     return Request::from_parts(parts, Body::from(json)).into();
                 }
             }
@@ -2599,6 +2608,11 @@ mod imp {
             for candidate in state.candidates.iter() {
                 let mut value: Value = serde_json::from_slice(&state.original_body).ok()?;
                 value["model"] = Value::String(candidate.upstream_model.clone());
+                crate::compact::normalize_compact_thinking(
+                    &mut value,
+                    &candidate.upstream_model,
+                    state.max_tokens,
+                );
                 let raw = serde_json::to_vec(&value).ok()?;
                 let config = self.config.clone();
                 let memo = self.memo.clone();
@@ -5376,6 +5390,60 @@ mod imp {
                 rx.try_recv().is_err(),
                 "no ledger record must be emitted from handle_request_inner alone"
             );
+        }
+
+        /// A direct-Anthropic `/compact` turn must store `pending` with its compact state (so the
+        /// response handler can advance past a failing candidate) and forward the first candidate
+        /// with the swapped-in model and its thinking reconciled — here `adaptive` downgraded to an
+        /// `enabled` budget because Haiku is reasoning-capable but rejects `adaptive`.
+        #[tokio::test]
+        async fn compact_request_sets_pending_and_reconciles_candidate_thinking() {
+            let (mut handler, _rx) = make_interceptor();
+            handler.compact_models = Arc::new(vec!["haiku".to_string()]);
+
+            let marker_text = crate::compact::MARKERS.join("\n");
+            let input_json = serde_json::json!({
+                "model": "claude-opus-4-8",
+                "stream": true,
+                "max_tokens": 64000,
+                "thinking": {"type": "adaptive"},
+                "output_config": {"effort": "low"},
+                "messages": [{"role": "user", "content": [{"type": "text", "text": marker_text}]}]
+            })
+            .to_string();
+
+            let req = post_request("https://api.anthropic.com/v1/messages", &input_json);
+            let result = handler.handle_request_inner(req).await;
+
+            let RequestOrResponse::Request(out_req) = result else {
+                panic!("compact request must be forwarded, not short-circuited");
+            };
+
+            // The fall-through fix: pending is stored with the remaining-candidate state.
+            let pending = handler
+                .pending
+                .as_ref()
+                .expect("compact request must set self.pending for candidate fall-through");
+            let compact = pending
+                .compact
+                .as_ref()
+                .expect("pending must carry compact state");
+            assert!(compact.sub.is_none(), "direct-Anthropic compact has no sub");
+            // The original model is the implicit last candidate to fall through to.
+            assert!(
+                compact
+                    .candidates
+                    .iter()
+                    .any(|c| c.upstream_model == "claude-opus-4-8"),
+                "original model must remain as a fall-through candidate"
+            );
+
+            // The forwarded body targets the swapped model with adaptive thinking downgraded.
+            let out_body = drain_body(out_req.into_body()).await;
+            let body: serde_json::Value = serde_json::from_slice(&out_body).expect("valid JSON");
+            assert_eq!(body["model"], "claude-haiku-4-5");
+            assert_eq!(body["thinking"]["type"], "enabled");
+            assert!(body["thinking"]["budget_tokens"].as_u64().unwrap() < 64_000);
         }
 
         // Test 1b: WebSocket refusal ──────────────────────────────────────────

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -217,6 +217,13 @@ pub fn latest_model_for_family(family: &str) -> Option<String> {
     capability::latest_model_for_family(family)
 }
 
+/// Whether a model has a reasoning/thinking mode, per the embedded models.dev `reasoning` flag
+/// (refreshed by `tools/refresh_reasoning.py`). Opt-in: an unlisted model returns `false`. Used by
+/// the CLI's compaction reroute to decide whether a swapped-in model can keep a `thinking` block.
+pub fn model_is_reasoning_capable(model_id: &str) -> bool {
+    capability::model_is_reasoning_capable(model_id)
+}
+
 /// Pick the workload preset for a request from its structure alone (no model): tool
 /// calls → `agent`; fenced code → `code`; a long context segment alongside a question
 /// (≥2 messages) → `rag` (sentence pruning, not blanket-`aggressive`, which misfires on


### PR DESCRIPTION
## Symptom

With `[compact].models` configured (e.g. `llmtrim compact models haiku sonnet`), `/compact` fails with a bare:

```
Error during compaction: API Error: 400 Bad Request
```

## Root cause (two bugs)

**1. Adaptive thinking incompatibility.** Claude Code's `/compact` request sets `thinking.type = "adaptive"`. Verified against the live Anthropic API (identical params, only the model differs):

| model | `max_tokens: 64000` + adaptive thinking |
|---|---|
| `claude-haiku-4-5` | **400** — `adaptive thinking is not supported on this model` |
| `claude-sonnet-5` | 200 |
| `claude-opus-4-8` | 200 |

Haiku *is* reasoning-capable (it accepts `{type:enabled,budget_tokens}` → 200), it just rejects the `adaptive` type. So swapping Haiku in as a compact candidate 400s.

**2. Missing `self.pending` → no fall-through.** The direct-Anthropic compact branch forwarded the first candidate but never stored `self.pending`, so `handle_response_inner`'s `take()` got `None` and returned the raw candidate error to the client. `retry_compact_direct` (which already treats 400 as retryable) never ran, so the request never advanced haiku→sonnet.

## Fix

- **`normalize_compact_thinking(body, model, max_tokens)`**: for a compact candidate, if the swapped-in model is reasoning-capable, downgrade `adaptive` → `{type:enabled, budget_tokens:N}` (N clamped to `[1024, max_tokens-1]`, default 8192); if it has no reasoning mode, strip the block. The reason/no-reason decision comes from the embedded models.dev flag (`llmtrim_core::model_is_reasoning_capable`) — **no hardcoded model list**. Only the isolated compact request is edited, so ordinary turns keep their thinking and it resumes after compaction.
- **Store `self.pending`** before forwarding the first compact candidate, so a failing candidate advances to the next (and ultimately the original model).

## Why downgrade rather than strip for Haiku

Haiku is reasoning-capable; keeping thinking (as a budget) preserves compaction quality while still letting the cheapest model serve `/compact`. `budget_tokens` 4096/8192 both return 200 on haiku, sonnet, and opus.

## Tests

- `normalize_compact_thinking`: downgrade when reasoning-capable, strip when not, budget clamp below a small `max_tokens`, and non-adaptive thinking left untouched.
- End-to-end serve test: a direct `/compact` turn sets `pending` with fall-through candidate state and forwards the swapped model with reconciled thinking.
- `cargo test -p llmtrim --lib` (compact + serve) and `-p llmtrim-core` green; clippy `--all-targets` clean.