### PR TITLE
fix(compact): strip history thinking blocks for swapped candidates

### DIFF
--- a/crates/llmtrim-cli/src/compact.rs
+++ b/crates/llmtrim-cli/src/compact.rs
@@ -171,6 +171,47 @@ pub fn normalize_compact_thinking(body: &mut Value, model: &str, max_tokens: u64
     true
 }
 
+/// Drop assistant `thinking`/`redacted_thinking` blocks from the conversation history. Anthropic
+/// binds a thinking block's `signature` to the model (tier) that produced it, so a swapped-in
+/// compact candidate can't validate the original model's signatures ("Invalid signature in thinking
+/// block") and rejects the whole request. Compaction summarizes the text/tool content, so dropping
+/// the history's reasoning is safe; a turn left with no content blocks is removed so the request
+/// stays well-formed. Only this isolated compact request is edited. Returns `true` when the body
+/// was modified.
+pub fn strip_history_thinking(body: &mut Value) -> bool {
+    let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
+        return false;
+    };
+    let mut changed = false;
+    for message in messages.iter_mut() {
+        if message.get("role").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+        let Some(content) = message.get_mut("content").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        let before = content.len();
+        content.retain(|block| {
+            !matches!(
+                block.get("type").and_then(Value::as_str),
+                Some("thinking") | Some("redacted_thinking")
+            )
+        });
+        changed |= content.len() != before;
+    }
+    // An assistant turn stripped down to nothing would be an empty-content error: drop it whole.
+    if changed && let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) {
+        messages.retain(|message| {
+            message
+                .get("content")
+                .and_then(Value::as_array)
+                .map(|blocks| blocks.is_empty())
+                != Some(true)
+        });
+    }
+    changed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,6 +256,57 @@ mod tests {
         let mut body = compact_body("x");
         assert!(normalize_compact_thinking(&mut body, "gpt-4o-mini", 64_000));
         assert!(body.get("thinking").is_none());
+    }
+
+    #[test]
+    fn history_thinking_blocks_are_stripped_but_other_content_kept() {
+        let mut body = json!({
+            "model": "claude-haiku-4-5",
+            "messages": [
+                {"role": "user", "content": "start"},
+                {"role": "assistant", "content": [
+                    {"type": "thinking", "thinking": "hmm", "signature": "opus-sig"},
+                    {"type": "text", "text": "answer"}
+                ]},
+                {"role": "user", "content": "go"}
+            ]
+        });
+        assert!(strip_history_thinking(&mut body));
+        let assistant = &body["messages"][1]["content"];
+        assert_eq!(assistant.as_array().unwrap().len(), 1);
+        assert_eq!(assistant[0]["type"], "text");
+        // User turns and a string-content turn are untouched.
+        assert_eq!(body["messages"][0]["content"], "start");
+    }
+
+    #[test]
+    fn assistant_turn_reduced_to_nothing_is_dropped() {
+        let mut body = json!({
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": [
+                    {"type": "thinking", "thinking": "only reasoning", "signature": "s"}
+                ]},
+                {"role": "user", "content": "summarize"}
+            ]
+        });
+        assert!(strip_history_thinking(&mut body));
+        // The pure-thinking assistant turn is removed so no empty-content block is sent.
+        let roles: Vec<&str> = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m["role"].as_str().unwrap())
+            .collect();
+        assert_eq!(roles, vec!["user", "user"]);
+    }
+
+    #[test]
+    fn strip_history_thinking_is_a_noop_without_thinking() {
+        let mut body = json!({
+            "messages": [{"role": "assistant", "content": [{"type": "text", "text": "hi"}]}]
+        });
+        assert!(!strip_history_thinking(&mut body));
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1440,6 +1440,11 @@ mod imp {
                         &candidate.upstream_model,
                         max_tokens,
                     );
+                    // A swapped-in model can't validate the original model's history thinking
+                    // signatures; the original keeps them (they're its own).
+                    if !candidate.is_original {
+                        crate::compact::strip_history_thinking(&mut value);
+                    }
                     let Ok(candidate_body) = serde_json::to_vec(&value) else {
                         continue;
                     };
@@ -2613,6 +2618,9 @@ mod imp {
                     &candidate.upstream_model,
                     state.max_tokens,
                 );
+                if !candidate.is_original {
+                    crate::compact::strip_history_thinking(&mut value);
+                }
                 let raw = serde_json::to_vec(&value).ok()?;
                 let config = self.config.clone();
                 let memo = self.memo.clone();
@@ -5408,7 +5416,13 @@ mod imp {
                 "max_tokens": 64000,
                 "thinking": {"type": "adaptive"},
                 "output_config": {"effort": "low"},
-                "messages": [{"role": "user", "content": [{"type": "text", "text": marker_text}]}]
+                "messages": [
+                    {"role": "assistant", "content": [
+                        {"type": "thinking", "thinking": "prior", "signature": "opus-sig"},
+                        {"type": "text", "text": "earlier answer"}
+                    ]},
+                    {"role": "user", "content": [{"type": "text", "text": marker_text}]}
+                ]
             })
             .to_string();
 
@@ -5444,6 +5458,14 @@ mod imp {
             assert_eq!(body["model"], "claude-haiku-4-5");
             assert_eq!(body["thinking"]["type"], "enabled");
             assert!(body["thinking"]["budget_tokens"].as_u64().unwrap() < 64_000);
+            // The swapped model can't validate opus's history thinking signatures, so they're gone.
+            let has_thinking = serde_json::to_string(&body["messages"])
+                .unwrap()
+                .contains("\"thinking\"");
+            assert!(
+                !has_thinking,
+                "history thinking must be stripped for a swapped model"
+            );
         }
 
         // Test 1b: WebSocket refusal ──────────────────────────────────────────


### PR DESCRIPTION
## Symptom

After #176 reconciled the top-level `adaptive` thinking, `/compact` with `[compact].models` still fell through to the original model instead of the cheaper configured one (e.g. `haiku`). The swapped model 400s:

```
invalid_request_error: messages.N.content.0: Invalid signature in thinking block
```

So haiku is tried, rejected, and the turn is served by Sonnet — confirmed from the ledger (compact turn recorded as `claude-sonnet-5`, only tiny incidental `claude-haiku-4-5` rows).

## Cause

Claude Code's `/compact` request replays the whole conversation, whose assistant turns carry `thinking` blocks. Anthropic binds a thinking block's `signature` to the model/tier that produced it, so a swapped-in compact candidate can't validate the original model's signatures.

Verified live — a thinking block with a non-matching signature 400s on **haiku, sonnet, and opus**, and stripping the history thinking blocks returns **200 on all three**:

```
haiku:  WITH foreign-sig thinking: 400  | stripped: 200
sonnet: WITH foreign-sig thinking: 400  | stripped: 200
opus:   WITH foreign-sig thinking: 400  | stripped: 200
```

## Fix

`strip_history_thinking`: drop assistant `thinking`/`redacted_thinking` blocks from the conversation history for a **non-original** compact candidate (the original model keeps them — they're its own valid signatures). An assistant turn reduced to no content is removed so the body stays well-formed. Only the isolated compact request is edited; compaction summarizes the text/tool content, so the history's reasoning is safe to omit.

Same class of fix as the codex foreign-signature guard (#175), here for Anthropic's own thinking signatures on the direct compact path. Combined with #176, the cheapest configured model (haiku) can now actually serve `/compact` instead of falling through to Sonnet.

## Tests

- `strip_history_thinking`: keeps non-thinking content, drops emptied assistant turns, no-ops without thinking.
- Extended the end-to-end compact serve test to assert the swapped candidate's history thinking is stripped (and it still sets pending + downgrades the top-level thinking).
- `cargo test -p llmtrim --lib` (compact + serve, 71 serve tests) green; clippy `--all-targets` clean.