### PR TITLE
fix(compact): drop output_config for swapped candidates

### DIFF
--- a/crates/llmtrim-cli/src/compact.rs
+++ b/crates/llmtrim-cli/src/compact.rs
@@ -212,6 +212,16 @@ pub fn strip_history_thinking(body: &mut Value) -> bool {
     changed
 }
 
+/// Drop `output_config` from a compact candidate's body. Claude Code's `/compact` sets
+/// `output_config.effort` (the field [`detect`] keys on), which some models reject ("This model
+/// does not support the effort parameter." — e.g. the Haiku family). Effort steering is
+/// inessential to a summarization turn, so a swapped-in candidate simply drops it. The original
+/// model — which Claude Code chose the effort for — keeps it. Returns `true` when removed.
+pub fn strip_output_config(body: &mut Value) -> bool {
+    body.as_object_mut()
+        .is_some_and(|obj| obj.remove("output_config").is_some())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -299,6 +309,17 @@ mod tests {
             .map(|m| m["role"].as_str().unwrap())
             .collect();
         assert_eq!(roles, vec!["user", "user"]);
+    }
+
+    #[test]
+    fn output_config_is_dropped() {
+        // `output_config.effort` 400s models that don't support the effort parameter (e.g. haiku).
+        let mut body = compact_body("x");
+        assert!(body.get("output_config").is_some());
+        assert!(strip_output_config(&mut body));
+        assert!(body.get("output_config").is_none());
+        // No-op when already absent.
+        assert!(!strip_output_config(&mut body));
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1441,9 +1441,11 @@ mod imp {
                         max_tokens,
                     );
                     // A swapped-in model can't validate the original model's history thinking
-                    // signatures; the original keeps them (they're its own).
+                    // signatures, and may reject `output_config.effort`; the original keeps both
+                    // (they're valid for / chosen for it).
                     if !candidate.is_original {
                         crate::compact::strip_history_thinking(&mut value);
+                        crate::compact::strip_output_config(&mut value);
                     }
                     let Ok(candidate_body) = serde_json::to_vec(&value) else {
                         continue;
@@ -2620,6 +2622,7 @@ mod imp {
                 );
                 if !candidate.is_original {
                     crate::compact::strip_history_thinking(&mut value);
+                    crate::compact::strip_output_config(&mut value);
                 }
                 let raw = serde_json::to_vec(&value).ok()?;
                 let config = self.config.clone();
@@ -5465,6 +5468,11 @@ mod imp {
             assert!(
                 !has_thinking,
                 "history thinking must be stripped for a swapped model"
+            );
+            // ...and `output_config.effort`, which haiku rejects, is dropped.
+            assert!(
+                body.get("output_config").is_none(),
+                "output_config must be dropped for a swapped model"
             );
         }
 


### PR DESCRIPTION
## Symptom

Even after #176 (adaptive thinking) and #177 (history thinking signatures), `/compact` with `[compact].models = haiku sonnet` still fell through to Sonnet — the ledger showed the compact-sized turn served by `claude-sonnet-5`, never `claude-haiku-4-5`.

## Cause

Claude Code's `/compact` request sets `output_config: {effort: "low"}` — the field `detect` keys on, so it's always present. Some models reject it:

```
400 invalid_request_error: This model does not support the effort parameter.
```

Verified live by reconstructing an actual `/compact` request from a session transcript and replaying it:

| haiku request | result |
|---|---|
| real compact shape (adaptive thinking + `output_config` + history thinking) | **400** |
| fully normalized (thinking→enabled budget, history thinking stripped, `output_config` dropped) | **200** |

haiku accepts `output_config`-free requests; sonnet/opus accept `output_config`, which is why it fell through to Sonnet.

## Fix

`strip_output_config`: drop `output_config` for a **non-original** compact candidate (the original model keeps it — Claude Code chose the effort for it). Effort steering is inessential to a summarization turn. Same swapped-candidate-only pattern as the history-thinking strip in #177.

With #176 + #177 + this, a compact candidate swap sheds every field the swapped model can't take (adaptive thinking, foreign history thinking signatures, `output_config`), so the cheapest configured model actually serves `/compact`.

## Tests

- `strip_output_config`: drops the field, no-ops when absent.
- End-to-end serve test now also asserts `output_config` is dropped for the swapped haiku candidate.
- `cargo test -p llmtrim --lib` (compact + serve) green; clippy `--all-targets` clean.