### PR TITLE
feat: ensure integrations stay current across install and update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`llmtrim ensure`:** bring this machine to the recommended state. Installs or refreshes owned
+  Claude Code integrations (statusline, cold-cache guard, window-local `/sub`, default compact
+  model chain), tray login when the GUI binary is present, and restarts a version-skewed daemon.
+  Opt-outs live in `~/.llmtrim/integrations.json` so ensure does not re-enable after an explicit no.
+- **`llmtrim doctor --fix`** and status **`f`** run the same ensure path.
+- **Quiet auto-heal on `start` and status open** when the binary version advanced or owned pieces
+  look stale (no prompts; no network tray download; no first-time installs).
+- **Linux desktop tray one-shot download** during interactive ensure when the tray binary is
+  missing (optional; default off when non-interactive).
+- **One-time subscription onboarding in the status TUI** (`s` for login steps, `n` to dismiss)
+  when Claude Code is present and `sub` is not configured.
+
+### Changed
+
+- **`setup` and binary-channel `update` call ensure.** First install wires
+  statusline/guard/`/sub`/compact. Binary `update` restarts the daemon and runs `ensure -q` on the
+  new binary (never in-process after a self-replace). Package-manager channels print the package
+  command then a single `llmtrim ensure` follow-up.
+- **Owned Claude Code hooks and statusline rewrite in place** when the binary path or payload
+  (e.g. `refreshInterval`) changes. Quiet auto-heal only refreshes stale owned pieces and daemon
+  skew; it never first-installs integrations or enables tray login.
+- **Top-level help** leads with `setup` / `update` / `ensure` / `doctor`. Power-user
+  `statusline` / `guard` / `compact` stay available but are hidden from the main command list.
+- **Opt-outs stick:** `statusline` / `guard` / `window-sub` / `compact off` write
+  `integrations.json` opt-outs; corrupt state refuses auto-apply instead of resetting them.
+- **Safer hooks and tray install:** shell-quoted hook paths, atomic `settings.json` writes,
+  shared `CLAUDE_CONFIG_DIR`, arch-aware tray download via path-filtered tar into a temp dir,
+  then promote.
+
 ## [0.10.2] - 2026-07-15
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,149 +1,169 @@
 # Installing llmtrim
 
-## Quick install (Linux / macOS)
+| You want | Run |
+|---|---|
+| First install | install the binary, then `llmtrim setup` |
+| New version | `llmtrim update` (then `llmtrim ensure` on package-manager channels) |
+| Something broken | `llmtrim ensure` · or `llmtrim doctor --fix` |
+
+Most installs only need **Get the binary** and **Bootstrap**.
+
+---
+
+## Get the binary
+
+### npm (recommended)
+
+```bash
+npm install -g @llmtrim/cli@latest && llmtrim setup
+```
+
+Prebuilt binary for your platform; no Rust. Prefer the global install over `npx` for
+`setup`: the daemon and autostart need a path that survives `npm cache clean`.
+
+### curl (Linux / macOS)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/fkiene/llmtrim/main/install.sh | sh
 ```
 
-Downloads the latest release binary for your platform into `~/.local/bin`. Override with:
+Installs into `~/.local/bin` and runs `setup`. Optional overrides (omit either to keep the default):
 
 ```bash
-LLMTRIM_INSTALL_DIR=/usr/local/bin LLMTRIM_VERSION=v0.1.0 \
+# pin a release tag from https://github.com/fkiene/llmtrim/releases  (e.g. v0.10.2)
+# and/or install outside ~/.local/bin
+LLMTRIM_INSTALL_DIR=/usr/local/bin LLMTRIM_VERSION=vX.Y.Z \
   curl -fsSL https://raw.githubusercontent.com/fkiene/llmtrim/main/install.sh | sh
 ```
 
-If `~/.local/bin` isn't on your `PATH`:
+If `~/.local/bin` is not on your `PATH`:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"   # add to ~/.bashrc or ~/.zshrc
 ```
 
-## Quick install (Windows)
+### PowerShell (Windows)
 
 ```powershell
 irm https://raw.githubusercontent.com/fkiene/llmtrim/main/install.ps1 | iex
 ```
 
-Downloads the latest release binary into `%LOCALAPPDATA%\llmtrim\bin` and adds it to your
-user `PATH`. Override with:
+Binary lands in `%LOCALAPPDATA%\llmtrim\bin` (user `PATH` updated). Overrides:
 
 ```powershell
-$env:LLMTRIM_VERSION = "v0.1.0"    # pin a release
-$env:LLMTRIM_NO_SETUP = "1"        # install the binary only, skip `setup`
+$env:LLMTRIM_VERSION = "vX.Y.Z"    # pin a release tag (see GitHub Releases)
+$env:LLMTRIM_NO_SETUP = "1"        # binary only; run setup yourself later
 irm https://raw.githubusercontent.com/fkiene/llmtrim/main/install.ps1 | iex
 ```
 
-Open a new PowerShell window afterward so the `PATH` and profile env apply. Prebuilt binaries
-ship for both x64 and ARM64. WSL users: use the Linux line above.
+Open a new PowerShell window so `PATH` and env apply. x64 and ARM64 ship; WSL uses the Linux line.
 
-## Homebrew (macOS / Linux)
+### Other channels
 
 ```bash
 brew install fkiene/tap/llmtrim
-# or, from this repo's formula:
-brew install --build-from-source ./Formula/llmtrim.rb
+cargo binstall llmtrim                 # or: cargo install --locked llmtrim
+scoop bucket add llmtrim https://github.com/fkiene/scoop-bucket && scoop install llmtrim
 ```
 
-## With npm
+Homebrew from this repo: `brew install --build-from-source ./Formula/llmtrim.rb`.
 
-```bash
-npm install -g @llmtrim/cli@latest && llmtrim setup   # prebuilt binary for your platform (no Rust needed)
-```
-
-`npx @llmtrim/cli compress < req.json` works for trying it without installing, but use the
-global install for `setup`: the daemon and autostart need a binary that survives
-`npm cache clean`, which the npx cache does not.
-
-## With Cargo
-
-```bash
-cargo binstall llmtrim     # prebuilt binary (needs cargo-binstall; seconds)
-cargo install --locked llmtrim   # or compile from crates.io
-```
-
-## Scoop (Windows)
-
-```powershell
-scoop bucket add llmtrim https://github.com/fkiene/scoop-bucket
-scoop install llmtrim
-```
-
-## Docker
-
-For containers and CI: runs the proxy with the state on a volume:
+### Docker
 
 ```bash
 docker run -d --name llmtrim -p 43117:43117 -v llmtrim-state:/data ghcr.io/fkiene/llmtrim
-# wire your shell to it (CA comes out of the container, no manual file hunting):
 docker run --rm -v llmtrim-state:/data ghcr.io/fkiene/llmtrim ca --pem > ~/.llmtrim-ca.pem
 export HTTPS_PROXY=http://localhost:43117 NODE_EXTRA_CA_CERTS=~/.llmtrim-ca.pem
 ```
 
-The image binds `0.0.0.0` inside the container (set `LLMTRIM_BIND` to change). The two
-`export`s are the whole client side; put them in your shell profile or your CI job env.
+Image binds `0.0.0.0` inside the container (`LLMTRIM_BIND` to change). Put the two
+`export`s in the job or shell that should route through the proxy.
 
-## From source
+### From source
 
 ```bash
 git clone https://github.com/fkiene/llmtrim
 cd llmtrim
-cargo build --release
-# binary at target/release/llmtrim
+cargo build --release                  # target/release/llmtrim
 cargo install --path . --locked
 ```
 
-Requires Rust 1.88+ (edition 2024). `rusqlite` is bundled (no system SQLite needed) and pinned at 0.39: 0.40+ pulls `libsqlite3-sys` 0.38, whose build script needs the still-unstable `cfg_select` ([rust#115585](https://github.com/rust-lang/rust/issues/115585)) and won't build on stable.
+Rust 1.88+ (edition 2024). `rusqlite` is bundled (no system SQLite) and pinned at 0.39:
+0.40+ pulls `libsqlite3-sys` 0.38, which needs unstable `cfg_select`
+([rust#115585](https://github.com/rust-lang/rust/issues/115585)) and will not build on stable.
 
-## Verify
+---
+
+## Bootstrap (after the binary is on PATH)
+
+curl and the npm one-liner above run this for you. After Cargo, Homebrew, Scoop, source, or
+`LLMTRIM_NO_SETUP=1`, run it yourself:
+
+```bash
+llmtrim setup      # CA + shell env + autostart + Claude Code integrations + daemon
+llmtrim status     # live savings dashboard
+```
+
+Open a new terminal so tools inherit `HTTPS_PROXY`. Re-running `setup` is safe (idempotent).
+
+When Claude Code is present (`~/.claude`), `setup` also enables:
+
+- status line
+- cold-cache guard
+- window-local `/sub`
+- cheaper `/compact` model chain
+
+No separate install steps for those. Later upgrades refresh them via `update` / `ensure`.
+
+llmtrim is a local MITM proxy (plus optional Claude Code hooks).
+`llmtrim uninstall` reverses it. How traffic reaches tools: [README](README.md#what-it-does).
+
+### Verify
 
 ```bash
 llmtrim --version
 llmtrim --help
+llmtrim doctor          # diagnose; doctor --fix applies repairs
 ```
 
-## Next: bootstrap the interceptor
-
-The `curl | sh` installer runs this for you. If you built from source or skipped it
-(`LLMTRIM_NO_SETUP=1`), run it yourself:
-
-```bash
-llmtrim setup     # CA + HTTPS_PROXY/NODE_EXTRA_CA_CERTS in your shell profile + autostart + start
-llmtrim status    # live savings dashboard
-```
-
-llmtrim is purely a MITM proxy; it configures your **environment** (no IDE settings).
-See [the README](README.md#how-it-reaches-your-tools) for how it reaches your tools.
+---
 
 ## Update
 
-One command, channel-aware: it detects how llmtrim was installed and **restarts the daemon
-onto the new binary** (a binary swap alone leaves the old version running):
+One command when possible: new binary, daemon restart, integration refresh.
 
 ```bash
 llmtrim update
 ```
 
-- **Binary** (`curl | sh`): re-runs the installer to fetch the latest release, then restarts.
-- **Cargo / Homebrew**: prints the right command (`cargo install --locked llmtrim --force` /
-  `brew upgrade fkiene/tap/llmtrim`), then run `llmtrim start --force` to restart the daemon on it.
+| Channel | What happens |
+|---|---|
+| Binary (`curl \| sh`) | Re-runs the installer, restarts the daemon, runs `ensure` |
+| npm / Homebrew / Cargo / Scoop | Prints the package command; then run `llmtrim ensure` (or press **`f`** in `status`) |
 
-`status` shows a one-line notice when a newer release exists (checked at most once a day,
-cached; set `LLMTRIM_NO_UPDATE_CHECK=1` to disable, and it's skipped offline). Pin a version
-in production and update promptly; security fixes land on the latest release (see SECURITY.md).
+`status` shows a one-line notice when a newer release exists (cached at most once/day;
+`LLMTRIM_NO_UPDATE_CHECK=1` to disable; skipped offline). Pin versions in production;
+security fixes land on the latest release ([SECURITY.md](SECURITY.md)).
+
+After an incomplete upgrade:
+
+```bash
+llmtrim ensure
+llmtrim doctor --fix
+```
+
+---
 
 ## Uninstall
 
-One command, fully transparent: the exact inverse of `setup`:
+Inverse of `setup`:
 
 ```bash
-llmtrim uninstall            # stop daemon, disable autostart, strip env block, remove CA + state + binary
-llmtrim uninstall --purge    # also delete the savings ledger
+llmtrim uninstall              # stop daemon, disable autostart, strip env, remove CA + state + binary
+llmtrim uninstall --purge      # also delete the savings ledger
 llmtrim uninstall --keep-binary
 ```
 
-Installed via a package manager? Run `llmtrim uninstall` **first** (it undoes `setup`;
-removing the package alone leaves `HTTPS_PROXY` pointing at a dead proxy and breaks your
-LLM tools), then remove the binary with your manager. `uninstall` detects the channel
-and prints the exact command (`npm uninstall -g @llmtrim/cli` / `cargo uninstall llmtrim` /
-`brew uninstall llmtrim`).
+Package managers: run `llmtrim uninstall` first. Removing only the package leaves
+`HTTPS_PROXY` pointing at a dead proxy. `uninstall` detects the channel and prints the
+follow-up (`npm uninstall -g @llmtrim/cli` / `cargo uninstall llmtrim` / `brew uninstall llmtrim`).

--- a/README.md
+++ b/README.md
@@ -5,20 +5,18 @@
 <h1 align="center">llmtrim</h1>
 
 <p align="center">
-  <strong>llmtrim is a local proxy that compresses your LLM API requests so you pay less, with no change to the answers.</strong><br>
-  It sits between your AI tools and the provider, strips the wasted tokens out of every request, and forwards it on. You get the same answers for a smaller bill.
+  <strong>Local proxy that compresses LLM API traffic so you pay less. Same answers, smaller bill.</strong>
 </p>
 
 <p align="center">
-  <sub><b>−31% input and −74% output tokens</b>, measured live across 112 A/B cases, with no change in answer quality.</sub>
+  <sub>
+    <b>−31% input · −74% output · −66% round-trip cost</b>
+    · 112 live A/B cases · ~5&nbsp;ms/call · no model to load
+  </sub>
 </p>
 
 <p align="center">
-  <sub>One static binary. <b>~5 ms per call</b>, no model to load.</sub>
-</p>
-
-<p align="center">
-  <sub>Use it as a <b>proxy</b>, a <b>CLI</b>, an <b>MCP server</b>, or a <b>library</b> (Python · Ruby · Swift · Kotlin · JS · TS · WASM).</sub>
+  <sub>Proxy · CLI · MCP · library (Python · Ruby · Swift · Kotlin · JS/WASM)</sub>
 </p>
 
 <p align="center">
@@ -38,24 +36,116 @@
 </p>
 
 <p align="center">
-  <a href="#what-it-actually-does">What it does</a> &bull;
-  <a href="#see-it-on-real-output">In action</a> &bull;
-  <a href="#get-started">Get started</a> &bull;
-  <a href="#use-it-as-a-cli-mcp-or-library">CLI &amp; library</a> &bull;
+  <a href="#get-started">Install</a> &bull;
+  <a href="#day-to-day">Day to day</a> &bull;
+  <a href="#what-it-does">How it works</a> &bull;
   <a href="#works-with">Works with</a> &bull;
+  <a href="#claude-code">Claude Code</a> &bull;
   <a href="#the-numbers">Numbers</a> &bull;
-  <a href="#how-it-compares">How it compares</a>
+  <a href="#configuration">Config</a> &bull;
+  <a href="#use-it-as-a-cli-mcp-or-library">CLI &amp; library</a>
 </p>
 
 ---
 
-## What it actually does
+## Get started
 
-You run Claude Code, Codex, Cursor, or your own app. Every time it talks to an LLM, it sends a big blob of text: your system prompt, the tool definitions, the whole conversation history, and the raw output of every command it ran. You pay for every one of those tokens, on every single turn.
+```bash
+npm install -g @llmtrim/cli@latest && llmtrim setup
+# open a new terminal, then keep working
+llmtrim status
+```
 
-**A lot of that text is waste.** A 200-line build log where only 2 lines are errors. A tool schema resent identically 50 times. A JSON array with 500 near-identical rows. The model doesn't need the bulk of it to answer well, but you're billed for all of it.
+That's it. `setup` starts a local proxy, wires your shell, and (when Claude Code is present) turns on the status line, cold-cache guard, `/sub`, and cheaper `/compact`. You do not run a separate install for each of those.
 
-**llmtrim removes the waste before it's sent.** It installs as a local proxy that sits between your tool and the LLM provider. Requests pass through it, get compressed, and continue to the provider. The reply comes back unchanged. Your tool doesn't know it's there; you just get a smaller bill.
+| You want | Run |
+|---|---|
+| First install | `llmtrim setup` |
+| New version | `llmtrim update` (then `llmtrim ensure` after npm/brew/cargo) |
+| Something broken | `llmtrim ensure` · `llmtrim doctor --fix` · or **`f`** in `status` |
+
+> Any tool that honors `HTTPS_PROXY` works (Claude Code, Codex, Cursor, Aider, your SDK). GitHub Copilot does not (certificate pinning). [Full list →](#works-with)
+
+<details>
+<summary><b>Other installers</b> (Homebrew, curl, Scoop, Cargo, Docker)</summary>
+
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/fkiene/llmtrim/main/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/fkiene/llmtrim/main/install.ps1 | iex
+
+# Package managers
+brew install fkiene/tap/llmtrim
+cargo binstall llmtrim
+scoop install llmtrim
+docker run -d -p 43117:43117 -v llmtrim-state:/data ghcr.io/fkiene/llmtrim
+```
+
+Full options: [INSTALL.md](INSTALL.md).
+
+</details>
+
+<details>
+<summary><b>Desktop tray</b> (menu bar / system tray)</summary>
+
+Menu-bar / system-tray popover with the same savings numbers. Bundled in Homebrew, Scoop, and npm; `setup` can enable open-at-login. Open with `llmtrim tray`. On Linux desktops, interactive `ensure` can fetch the tray binary from the [latest release](https://github.com/fkiene/llmtrim/releases) (needs `libwebkit2gtk-4.1` and `libayatana-appindicator3`).
+
+<p align="center"><img src="crates/llmtrim-tray/docs/popover.svg" alt="llmtrim tray popover" width="320"></p>
+
+</details>
+
+<details>
+<summary><b>Is this safe?</b></summary>
+
+Same technique as [mitmproxy](https://mitmproxy.org), scoped to LLM API hosts only. `setup` changes three things; `llmtrim uninstall` reverses all three:
+
+1. Private CA in `~/.llmtrim/` (name-constrained; cannot intercept your bank or email)
+2. Shell env: `HTTPS_PROXY` + CA trust
+3. Login service: daemon at login
+
+No API keys stored (your tool's auth is forwarded). Prompts never touch disk; only anonymous token counts. Full threat model: [SECURITY.md](SECURITY.md).
+
+```bash
+llmtrim ca
+openssl x509 -in ~/.llmtrim/ca.pem -noout -text | grep -A3 "Name Constraints"
+```
+
+</details>
+
+---
+
+## Day to day
+
+```bash
+llmtrim status     # savings + health  (aliases: monitor, gain)
+llmtrim update     # new release, restart daemon, refresh integrations
+llmtrim ensure     # match the recommended install state on this machine
+```
+
+| Situation | Command |
+|---|---|
+| Watch savings | `llmtrim status` |
+| After `npm` / `brew` / `cargo` upgrade | `llmtrim ensure` (or **`f`** in status) |
+| Diagnose | `llmtrim doctor` · repair with `doctor --fix` |
+| Pause / resume proxy | `llmtrim stop` · `llmtrim start` |
+| Force one session through llmtrim | `llmtrim wrap claude` |
+| Remove everything | `llmtrim uninstall` |
+
+After `setup`, `update`, or `ensure`, owned Claude Code pieces (status line, guard, `/sub`, compact defaults) stay in sync with the binary. You should not need `statusline install` or similar after an upgrade.
+
+Time series: `llmtrim status --daily` · `--weekly` · `--monthly` · `--json` · `--csv`.
+
+---
+
+## What it does
+
+You run Claude Code, Codex, Cursor, or your own app. Each request carries a large blob: system prompt, tools, history, and raw tool output. You pay for that on every turn.
+
+A lot of it is noise. A 200-line build log with two errors. Tool schemas resent fifty times. JSON with hundreds of near-identical rows. The model does not need the bulk to answer well.
+
+llmtrim strips that noise on your machine before the request hits the provider. Your tool stays the same, the reply stays the same, the bill shrinks.
 
 ```
   before:  your tool ───── full request ─────▶  OpenAI / Anthropic / …
@@ -67,30 +157,26 @@ You run Claude Code, Codex, Cursor, or your own app. Every time it talks to an L
 ```
 
 > [!IMPORTANT]
-> **It can never make your bill bigger or break a request.** Every compression step is re-measured with the provider's real tokenizer; if a step doesn't actually save tokens, it's reverted. If the provider rejects the compressed request, the original is resent verbatim. Worst case is zero savings, never a worse outcome.
+> Compression cannot raise your bill or break a request. Each step is re-measured with the provider's real tokenizer and undone if it does not save tokens. If the provider rejects the compressed body, the original is resent. Worst case is zero savings.
 
-Everything runs locally. Nothing is ever sent to us.
+Everything runs locally. Nothing is sent to us.
 
-## See it on real output
+### In action
 
-Here's one real thing llmtrim does, end to end. An AI agent ran a build, and the `bash` tool returned a 58-line log. Only two lines matter (the errors), but all 58 get sent to the model and billed.
+Real agent build log: 58 lines, two of them errors. Keep the errors, drop the rest.
 
-**Before**, what the model would receive (58 lines, 4,662 chars):
+Before (4,662 chars) → after (978 chars, −79%):
 
 ```text
+# before (noise + signal)
 [2026-06-13T10:02:00Z] INFO  compiling module core::worker::task_0 (incremental)
-[2026-06-13T10:02:01Z] INFO  compiling module core::worker::task_1 (incremental)
-[2026-06-13T10:02:02Z] INFO  compiling module core::worker::task_2 (incremental)
-... 27 more near-identical INFO lines ...
+… 28 more near-identical INFO lines …
 [2026-06-13T10:02:31Z] ERROR src/worker/pool.rs:214: mismatched types: expected `usize`, found `i64`
-... 25 more INFO lines ...
+… 25 more INFO lines …
 [2026-06-13T10:03:01Z] ERROR src/net/conn.rs:88: cannot borrow `buf` as mutable more than once
 [2026-06-13T10:03:02Z] INFO  build failed, 2 errors
-```
 
-**After**, what llmtrim sends instead (5 lines, 978 chars, **−79%**):
-
-```text
+# after (errors verbatim; INFO folded losslessly)
 [{}] INFO compiling module core::worker::task_{} (incremental) [×30: (10:02:00Z..10:02:29Z step 1s; 0..29)]
 [2026-06-13T10:02:31Z] ERROR src/worker/pool.rs:214: mismatched types: expected `usize`, found `i64`
 [{}] INFO compiling module core::net::conn_{} (incremental) [×25: 10:02:32Z..10:02:56Z; 0..24]
@@ -98,36 +184,23 @@ Here's one real thing llmtrim does, end to end. An AI agent ran a build, and the
 [2026-06-13T10:03:02Z] INFO  build failed, 2 errors
 ```
 
-Both errors and the summary survive **verbatim**. The repetitive INFO lines fold into a template plus their values, losslessly, because the range is regular (`task_0..task_29`). The model still sees exactly what happened; it just costs a fifth as much.
-
-> If that's useful to you, a ⭐ helps other people find it.
-
-Try it yourself on any request body:
+Try any request body:
 
 ```bash
 echo '{"model":"gpt-4o","messages":[...]}' | llmtrim compress --provider openai
 ```
 
-Log-folding is just one of ten compressors. A different one re-encodes bulky JSON arrays into a compact table, with the same data in a third of the tokens:
-
-```text
-before:  [{"id":1,"city":"Paris","ok":true},{"id":2,"city":"Lyon","ok":false}, … 200 rows]
-after:   [200]{id,city,ok}: 1,Paris,true; 2,Lyon,false; …          (TOON encoding, lossless)
-```
-
-Each compressor fires only where it pays:
-
-| Where the waste is | What llmtrim does |
+| Waste | What happens |
 |---|---|
-| **Tool output** (build logs, diffs, grep dumps, big JSON) | Keep the signal (errors, changes, matches), fold the noise |
-| **Long context** (pasted docs, history) | Rank and keep the chunks relevant to the question; drop the rest |
-| **Source code** | Keep the bodies of relevant functions, reduce the rest to signatures |
-| **Tool schemas** (resent every turn) | Trim descriptions, drop unused tools, keep the cache prefix stable |
-| **JSON / record arrays** | Re-encode to a compact table format, sample huge arrays |
-| **The model's reply** | Ask for terser output where it won't hurt the answer |
+| Build logs, diffs, grep dumps | Keep errors / changes / matches; fold the rest |
+| Long pasted context | Keep chunks relevant to the question |
+| Source code | Keep useful bodies; rest → signatures |
+| Tool schemas every turn | Trim + keep the cache prefix stable |
+| Huge JSON arrays | Compact table (TOON) or sample |
+| Verbose model replies | Ask for terser output where safe |
 
 <details>
-<summary><b>Full stage reference (all 10 compressors)</b></summary>
+<summary><b>All 10 compressors</b></summary>
 
 Stages run in savings order. Nothing under a `cache_control` marker is ever rewritten.
 
@@ -144,148 +217,155 @@ Stages run in savings order. Nothing under a `cache_control` marker is ever rewr
 | **tool layer** | Static tool selection + description trimming | tools |
 | **multimodal** | Downscale images to the provider's resolution cap | images |
 
-Default `auto` switches each stage on only where it pays. `safe` runs the lossless stages only. [Full config →](#configuration)
+Default `auto` enables each stage only where it pays. `safe` is lossless-only. [Config →](#configuration)
 
 </details>
 
-## Get started
+---
 
-> [!NOTE]
-> Works with any tool that routes through `HTTPS_PROXY`: Claude Code, Codex, Cursor, Aider, your own app. GitHub Copilot pins its certificates and can't be intercepted ([full list](#works-with)).
+## Claude Code
 
-```bash
-# 1. Install (any OS, prebuilt binary, no Rust needed)
-npm install -g @llmtrim/cli@latest && llmtrim setup
+When `~/.claude` exists, `setup`, `update`, and `ensure` wire these. No separate install commands.
 
-# 2. Open a new shell. Your AI tools now route through llmtrim automatically.
+| Feature | What you get |
+|---|---|
+| Status line | Model, context gauge, trim %, rate limits, cache warm/cold |
+| Guard | Blocks one turn if a cold-cache resume would rewrite a huge context (and bill for it) |
+| `/compact` models | Prefer Haiku → Sonnet before your selected model |
+| `/sub` | Per-window: `/sub on` · `/sub off` · `/sub status` |
 
-# 3. Watch the savings add up as you work
-llmtrim status
+```text
+◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 3h·24% · 4d·12%   ♻ 63% cached
 ```
-
-Prefer a GUI? The desktop tray app puts per-agent savings in your menu bar (macOS),
-system tray (Windows), or AppIndicator (Linux). `setup` offers to install it, or run
-`llmtrim tray` yourself. It ships in the Homebrew, Scoop, and npm packages; on Linux
-download `llmtrim-tray` from the [latest release](https://github.com/fkiene/llmtrim/releases)
-(needs `libwebkit2gtk-4.1` and `libayatana-appindicator3`).
-
-<p align="center"><img src="crates/llmtrim-tray/docs/popover.svg" alt="llmtrim tray popover" width="320"></p>
-
-**No Node?** Use an installer instead:
-
-```bash
-# Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/fkiene/llmtrim/main/install.sh | sh
-
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/fkiene/llmtrim/main/install.ps1 | iex
-```
-
-Or your own package manager, same binary everywhere: `brew install fkiene/tap/llmtrim` · `cargo binstall llmtrim` · `scoop install llmtrim` · `docker run ghcr.io/fkiene/llmtrim`. Full options in [INSTALL.md](INSTALL.md).
-
-### Is this safe to install?
-
-`setup` is a local HTTPS proxy, the same technique as [mitmproxy](https://mitmproxy.org), scoped to LLM APIs. It changes exactly three things (a CA certificate in `~/.llmtrim/`, a proxy setting in your shell profile, a login service), and `llmtrim uninstall` reverses all three. No API keys are stored (it forwards your tool's own auth), and your prompts never touch disk; only an anonymous count of tokens saved is kept. Full threat model: [SECURITY.md](SECURITY.md).
 
 <details>
-<summary><b>What gets installed, and how to verify the cert is harmless</b></summary>
+<summary><b>Status line details</b></summary>
 
-1. **A private certificate** in `~/.llmtrim/`, cryptographically constrained to LLM API domains. It *cannot* read your bank, email, or any other traffic, even if the key were stolen. Check that yourself:
-   ```bash
-   llmtrim ca   # prints the cert path
-   openssl x509 -in ~/.llmtrim/ca.pem -noout -text | grep -A3 "Name Constraints"
-   # those domains are the only ones it can ever touch
-   ```
-2. **A proxy setting** in your shell profile (`HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS`).
-3. **A background service** that starts at login.
+Claude Code [custom status line](https://code.claude.com/docs/en/statusline). The arrow is the backend that answered the last turn (not merely what is configured). In `sub` fallback mode it stays off while Anthropic serves and shows up when a chain provider does.
 
-If the service stops, your tools fail fast with a connection error rather than silently bypassing it.
+- `✂`: trim for this session (`✂ –` until something is saved)
+- `◔`: Claude.ai rate-limit windows (time left · % used)
+- Context gauge: fill of the serving model's real window (green under 40%, orange 40-65%, red above)
+- `♻`: prompt-cache reuse; becomes `♻ cache cold` after the cache TTL
+
+Owned settings rewrite themselves when the binary path or payload changes. To opt out, leave your own status line in place, or uninstall ours (`llmtrim statusline uninstall`).
 
 </details>
 
 <details>
-<summary><b>Day-to-day commands</b></summary>
+<summary><b>Cold-cache guard</b></summary>
 
-```bash
-llmtrim status              # health + savings dashboard (aliases: monitor, gain)
-llmtrim statusline install  # add a live status line to Claude Code
-llmtrim doctor              # something off? end-to-end diagnosis; each check names its fix
-llmtrim start               # start the background proxy
-llmtrim stop                # stop it
-llmtrim serve               # run in the foreground instead (Ctrl-C to quit)
-llmtrim wrap claude         # run an agent, guaranteeing this session routes through llmtrim (fails fast if it can't)
-llmtrim update              # update to the latest release + restart
-llmtrim uninstall           # exact inverse of setup: removes all three changes
+Resuming a large session after the prompt-cache TTL rewrites the whole context at cache-write rates (often a few dollars) with no warning at the prompt.
+
+Guard is a free `UserPromptSubmit` hook. It blocks one turn, prints idle time, context size, and estimated cost, then lets a resend through. `/compact` pays that cold write too, because it has to read the full context to summarize.
+
+Opt out: `llmtrim guard uninstall`. `ensure` remembers that choice.
+
+```text
+Idle 6h 19m, 347k tokens of context. The prompt cache has expired, so the next turn
+rewrites the whole context (about $3.47 before any work happens).
 ```
 
-`llmtrim status --daily` (or `--weekly` / `--monthly`) gives a time-series report; add `--json` or `--csv` to export.
+</details>
+
+<details>
+<summary><b>Cheaper `/compact`</b></summary>
+
+```bash
+llmtrim compact models haiku sonnet   # setup already sets this by default
+llmtrim compact status
+llmtrim compact off
+```
+
+```toml
+[compact]
+models = ["haiku", "sonnet"]
+```
+
+Candidates run in order when they fit the compressed request. Claude's selected model is always the last fallback (do not put it in the list). Empty `models = []` records opt-out.
 
 </details>
+
+<details>
+<summary><b>Subscription reroute (`sub`)</b> (opt-in; may conflict with provider ToS)</summary>
+
+Serve Claude Code from a ChatGPT/Codex or Kimi plan instead of Anthropic, or as fallback when Anthropic fails. Login prints a warning; decide for yourself.
+
+```bash
+llmtrim sub auth codex login    # or: kimi
+llmtrim sub on codex
+llmtrim sub status
+llmtrim sub mode fallback       # only when Anthropic fails
+llmtrim sub chain codex,kimi
+llmtrim sub off
+```
+
+This window only (installed with ensure; includes subagents; survives `/clear`):
+
+```text
+/sub on
+/sub off
+/sub status
+```
+
+Tokens: `~/.llmtrim/<provider>/auth.json` (mode 0600). Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_SUB_CHAIN`.
+
+</details>
+
+---
 
 ## Use it as a CLI, MCP, or library
 
-The same compression runs with no proxy and no setup, as a one-shot CLI, an embeddable Rust crate, native bindings for **Python, Ruby, Swift and Kotlin**, or a **WebAssembly** module for JavaScript (browser, Node, Cloudflare Worker). No extra model calls, no network: the deterministic engine runs in your process.
+Same engine, no proxy required. No extra model calls; compress runs in-process.
 
 | Language | Install |
 |---|---|
 | Rust | `cargo add llmtrim-core` |
 | Python | `pip install llmtrim` |
 | Ruby | `gem install llmtrim` |
-| Kotlin | `implementation("io.github.fkiene:llmtrim:0.10.2")` (Maven Central) |
-| Swift | `.package(url: "https://github.com/fkiene/llmtrim-swift", from: "0.1.8")` (SwiftPM) |
+| Kotlin | `implementation("io.github.fkiene:llmtrim:0.10.2")` |
+| Swift | SwiftPM `fkiene/llmtrim-swift` ≥ 0.1.8 |
+| JS / TS | `@llmtrim/js` (WASM) |
 
-**CLI.** Pipe a request in, get a compressed one out:
+<details>
+<summary><b>CLI pipe</b></summary>
 
 ```bash
 echo '{"model":"gpt-4o","messages":[...]}' | llmtrim compress --provider openai > out.json
-echo '{"model":"gpt-4o","messages":[...]}' | llmtrim send     --provider openai   # compress, call, print
+echo '{"model":"gpt-4o","messages":[...]}' | llmtrim send --provider openai
 ```
 
-**Rust.** The engine is the [`llmtrim-core`](https://crates.io/crates/llmtrim-core) crate (no `tokio`, no network in its dependency tree):
+</details>
+
+<details>
+<summary><b>Rust · Python · JS</b></summary>
 
 ```rust
-use llmtrim_core::{compress, compress_with_config, config::DenseConfig, ir::ProviderKind};
-
-// None auto-detects the provider from the request shape.
+use llmtrim_core::{compress, ir::ProviderKind};
 let out = compress(request_json, Some(ProviderKind::OpenAi))?;
-println!("{} -> {} input tokens", out.input_tokens_before, out.input_tokens_after);
-
-// …or pass an explicit preset/config:
-let out = compress_with_config(request_json, Some(ProviderKind::OpenAi), &DenseConfig::preset("agent").unwrap())?;
 ```
-
-**Python / Ruby / Swift / Kotlin.** One flat `compress(input, provider, preset)` call, generated from the same Rust engine via [UniFFI](https://mozilla.github.io/uniffi-rs/). The compiled engine is bundled in each package, so there's no Rust toolchain to install:
 
 ```python
 import llmtrim
-
 out = llmtrim.compress(request_json, llmtrim.Provider.OPEN_AI, "aggressive")
-print(out.input_tokens_before, "->", out.input_tokens_after)
 ```
-
-> [!NOTE]
-> Every binding returns the compressed `request_json` plus the before/after token counts, and maps errors to native exceptions. Per-language install and usage live in [`crates/llmtrim-uniffi`](crates/llmtrim-uniffi).
-
-**JavaScript / TypeScript (WebAssembly).** The same `compress(input, provider, preset)` call, compiled to WebAssembly, runs in the browser, Node, Bun, Deno, or a Cloudflare Worker with no network or filesystem access. The output type is fully typed in TypeScript:
 
 ```ts
-import { compress } from "@llmtrim/js"; // @llmtrim/wasm is an alias for the same package
-
+import { compress } from "@llmtrim/js";
 const out = compress(requestJson, "openai", "aggressive");
-console.log(out.input_tokens_before, "->", out.input_tokens_after);
 ```
 
-> [!NOTE]
-> To stay small, the WASM build uses the estimate tokenizer: the absolute token counts are approximate, but the savings percentage is unaffected. Build and usage live in [`crates/llmtrim-wasm`](crates/llmtrim-wasm).
+Bindings and WASM notes: [`crates/llmtrim-uniffi`](crates/llmtrim-uniffi) · [`crates/llmtrim-wasm`](crates/llmtrim-wasm).
 
-**MCP server.** `llmtrim mcp` speaks the [Model Context Protocol](https://modelcontextprotocol.io) over stdin/stdout, so any MCP client can compress payloads and read your savings without the proxy. It exposes three tools: `llmtrim_compress` (compress a full request body, honoring your `~/.llmtrim` config like the proxy), `llmtrim_compress_text` (shrink one text blob, lossless), and `llmtrim_stats` (your savings ledger). Every call records to the same ledger, so MCP traffic shows up in `llmtrim status`.
+</details>
+
+<details>
+<summary><b>MCP server</b></summary>
 
 ```bash
-llmtrim mcp install          # register with Claude Code (one command)
-llmtrim mcp install --print  # or print the config to paste into any other client
+llmtrim mcp install          # Claude Code
+llmtrim mcp install --print  # paste into any client
 ```
-
-The printed block is the standard MCP config; for a client you edit by hand it looks like:
 
 ```json
 {
@@ -295,57 +375,13 @@ The printed block is the standard MCP config; for a client you edit by hand it l
 }
 ```
 
-**Status line for Claude Code.** `llmtrim statusline` renders a single line for Claude Code's
-[custom status line](https://code.claude.com/docs/en/statusline): the model, the backend that
-actually served the turn when you reroute (e.g. `→gpt-5.6-terra` or `→kimi`), a context-health
-gauge, and how much llmtrim is trimming, plus rate-limit and prompt-cache reuse when Claude Code
-reports them. The arrow reflects what answered, not what's configured — so in `sub` fallback mode
-it stays off while Anthropic is serving, and appears on the turns the chain actually fires.
+Tools: `llmtrim_compress`, `llmtrim_compress_text`, `llmtrim_stats` (same ledger as `status`).
 
-```bash
-llmtrim statusline install          # wire it into ~/.claude/settings.json
-llmtrim statusline install --print  # or print the settings snippet to paste yourself
-```
-
-```text
-◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 3h·24% · 4d·12%   ♻ 63% cached
-```
-
-The `✂` trim figure is scoped to the current Claude Code session; it reads `✂ –` until llmtrim
-has saved something this session. `◔ 3h·24% · 4d·12%` shows the time remaining until each
-Claude.ai rate-limit window resets and the share of that window used. The context gauge fills
-against the real window of the model serving the turn — the rerouted backend's window under `sub`,
-not Claude's — green below 40%, orange
-40–65%, red above. `♻` shows this turn's prompt-cache reuse, and turns into `♻ cache cold`
-once the session has been idle past the cache TTL, since the next message then pays a cold cache
-write. Segments drop right-to-left on narrow terminals, and anything Claude Code doesn't report
-(no reroute, no rate limits) is simply left out.
-
-### Guard
-
-Resuming a session whose prompt cache has expired re-writes the whole context on the very next
-turn, billed at the cache-write rate — a few dollars on a large session, spent before any work
-happens, with nothing at the prompt to say so.
-
-`llmtrim guard` is a Claude Code `UserPromptSubmit` hook that stops that one turn:
-
-```text
-Idle 6h 19m, 347k tokens of context. The prompt cache has expired, so the next turn
-re-writes the whole context — about $3.47 before any work happens.
-
-You pay that whichever way you go: /compact pays it too (it reads the full context to
-summarise it), and only comes out ahead if you are staying for several more turns. To
-avoid the charge entirely, ask in a fresh session.
-```
-
-The prompt is not sent and no API call is made, so the warning itself is free. Resend to continue;
-you are only warned once per idle gap. `llmtrim setup` offers to wire it in, or run `llmtrim guard
-install` (`guard uninstall` to remove it — it merges into `~/.claude/settings.json` and leaves your
-other hooks alone).
+</details>
 
 ## Works with
 
-Any tool that honors `HTTPS_PROXY` and an env-provided CA. That covers all 18 agents below plus any HTTPS_PROXY-aware CLI or SDK you build yourself:
+Any tool that honors `HTTPS_PROXY` and an env-provided CA:
 
 | Tool | Works | Notes |
 |---|:---:|---|
@@ -362,21 +398,21 @@ Any tool that honors `HTTPS_PROXY` and an env-provided CA. That covers all 18 ag
 | Warp, Devin | ❌ | Provider call is server-side; a local proxy never sees it |
 | Cursor Agent, Kiro | ❌ | Routes through a vendor gateway, not a standard provider host |
 
-Prefer no proxy? Any MCP client (Claude Code, Cursor, custom agents) can call llmtrim directly as tools instead: run `llmtrim mcp install`, or see [CLI, MCP, or library](#use-it-as-a-cli-mcp-or-library).
+No proxy: any MCP client can call llmtrim as tools (`llmtrim mcp install`), or use the [CLI / library](#use-it-as-a-cli-mcp-or-library).
 
-Providers come from the [`llm_providers`](https://crates.io/crates/llm_providers) registry (OpenAI, Anthropic, Google, DeepSeek, Mistral, xAI, Moonshot, Zhipu, Qwen, OpenRouter, …) and update with it. Every non-LLM connection passes through untouched.
+Providers come from the [`llm_providers`](https://crates.io/crates/llm_providers) registry (OpenAI, Anthropic, Google, DeepSeek, Mistral, xAI, Moonshot, Zhipu, Qwen, OpenRouter, …) and update with it. Non-LLM connections pass through untouched.
 
 ## Configuration
 
-**Zero config needed.** The default (`auto`) inspects each request and picks the right compressors for its shape: tool-heavy → `agent`, code → `code`, long context with a question → `rag`, otherwise → `aggressive`.
+Default is fine for most traffic. `auto` inspects each request and picks compressors by shape (tools → `agent`, code → `code`, long Q&A → `rag`, else `aggressive`).
 
-Three tiers cover almost everyone. To force one, set `LLMTRIM_PRESET=<name>` or `preset = "<name>"` in `$XDG_CONFIG_HOME/llmtrim/config.toml`:
+Override with `LLMTRIM_PRESET=<name>` or `preset = "<name>"` in `$XDG_CONFIG_HOME/llmtrim/config.toml`:
 
-| preset | for |
+| preset | When to use |
 | --- | --- |
-| **`auto`** *(default)* | routes each request to the right compressors; right for almost everyone |
-| **`safe`** | lossless input only: byte-faithful round-trip, no lossy stages |
-| **`aggressive`** | squeeze everything, accept lossy cuts (quality-gated) |
+| **`auto`** *(default)* | Let llmtrim choose per request |
+| **`safe`** | Lossless input only |
+| **`aggressive`** | Max squeeze, quality-gated |
 
 <details>
 <summary><b>Advanced presets</b></summary>
@@ -425,7 +461,7 @@ These knobs are orthogonal to compression. Each resolves env-first, then from th
 | env var | config key | meaning |
 | --- | --- | --- |
 | `LLMTRIM_EXTRA_HOSTS` | `extra_hosts` | extra exact LLM-API hosts to intercept (comma-separated env / array in file), e.g. a self-hosted OpenAI-compatible endpoint |
-| `LLMTRIM_EXCLUDE_PROVIDERS` | `exclude_providers` | wire shapes to skip compressing — `openai` / `anthropic` / `google` (e.g. `anthropic` to leave Claude Code untouched); coarse, covers every host of that shape |
+| `LLMTRIM_EXCLUDE_PROVIDERS` | `exclude_providers` | wire shapes to skip compressing: `openai` / `anthropic` / `google` (e.g. `anthropic` to leave Claude Code untouched); coarse, covers every host of that shape |
 | `LLMTRIM_EXCLUDE_HOSTS` | `exclude_hosts` | exact hostnames to skip compressing (e.g. `openrouter.ai`); precise, leaves other hosts of the same shape compressed |
 | `LLMTRIM_UPSTREAM_PROXY` | `upstream_proxy` | route egress through another proxy (see below) |
 | `LLMTRIM_DB_PATH` | `db_path` | ledger location |
@@ -440,121 +476,25 @@ These knobs are orthogonal to compression. Each resolves env-first, then from th
 
 </details>
 
-<details>
-<summary><b>Use cheaper models for Claude Code compaction</b></summary>
-
-Claude Code runs `/compact` by sending an internal summarization request. llmtrim can recognize
-that request and try an ordered list of cheaper models before the model selected in Claude Code:
-
-```bash
-llmtrim compact models haiku sonnet
-llmtrim compact status
-```
-
-The equivalent config is:
-
-```toml
-[compact]
-models = ["haiku", "sonnet"]
-```
-
-For each entry, llmtrim rebuilds and compresses the original request for that candidate, then checks
-the embedded model registry. A configured model is skipped when its context window is unknown or
-cannot hold the compressed input plus the requested output. If an eligible model fails before any
-answer event reaches Claude Code, llmtrim advances to the next entry. The model originally selected
-in Claude Code is always the implicit final attempt; do not add it to the list. Subscription reroutes
-use the same order after applying the active provider's tier mapping. Run `llmtrim compact off` to
-disable the override.
-
-`llmtrim setup` proposes `haiku, sonnet` on Claude Code installations that have not made a choice.
-An explicitly empty list records that the feature is disabled and prevents repeated setup prompts.
-
-</details>
+Claude Code options (compact models, subscription reroute) are under
+[Claude Code](#claude-code).
 
 <details>
-<summary><b>Route Claude Code to another subscription</b> (opt-in; a ChatGPT/Codex or Kimi plan, gray-area on the provider's terms)</summary>
-
-llmtrim can serve Claude Code from a different subscription's backend instead of Anthropic.
-It intercepts the Anthropic `/v1/messages` call, rewrites it to the provider's wire format,
-streams the reply back as Anthropic SSE, and maps the Claude model tiers to provider models.
-Two providers are supported: a ChatGPT plan through the Codex Responses API, and a Kimi
-coding plan.
-
-> **Warning:** using a subscription this way may violate the provider's terms of service. The
-> login command prints this warning before it stores a token. Decide for yourself whether your
-> plan permits it.
-
-Sign in once, then turn it on:
+<summary><b>Upstream proxy</b> (corporate egress or chaining local tools)</summary>
 
 ```bash
-llmtrim sub auth codex login   # or: llmtrim sub auth kimi login
-llmtrim sub use codex         # apply the built-in tier mapping
+export LLMTRIM_UPSTREAM_PROXY=http://host:port
+# or with auth: http://user:pass@host:port  (redacted in logs)
 ```
 
-Tokens are stored under `~/.llmtrim/<provider>/auth.json` (mode 0600) and refreshed
-automatically. `llmtrim sub setup codex` opens an interactive editor to change which provider model
-each Claude tier (opus / sonnet / haiku / fable) maps to; `llmtrim sub status` shows the
-current mapping; `llmtrim sub off` disables rerouting and sends traffic back to Anthropic.
+Outbound calls use `CONNECT` + verifying TLS; the upstream only sees the encrypted stream.
+Looping to llmtrim's own listen address is rejected. Put the variable in the **daemon's**
+launch environment (launchd / systemd), not only your interactive shell. Profile secrets
+sit in plaintext.
 
-`llmtrim setup` also installs a user-wide Claude Code command for changing only the current
-Claude Code window:
-
-```text
-/sub on
-/sub off
-/sub status
-```
-
-The window override includes its subagents and survives `/clear` and compaction. It does not affect
-other open windows or newly started Claude Code processes. A resumed or forked conversation starts
-with a fresh window policy; `/exit` removes the override, while an uncleanly terminated window
-expires after 30 minutes. `/sub off` forces Anthropic with compression for that window, even when
-the global reroute policy uses `always` or `fallback`. Run `llmtrim window-sub install` or
-`llmtrim window-sub uninstall` explicitly to manage the Claude Code integration.
-
-By default a set provider reroutes every turn. To use subscriptions only as a backup, switch to
-fallback mode: `llmtrim sub mode fallback` forwards to Anthropic as usual and tries the configured
-provider chain when Anthropic hits a quota, overload, transient server error, or transport failure.
-Set the order with `llmtrim sub chain codex,kimi`; `llmtrim sub mode always` restores the default.
-A transient failure (429/5xx) gets one bounded retry against Anthropic before the chain takes over,
-so a blip doesn't move the turn — and its spend — to another provider. (`on-error`, the pre-0.10
-name for this mode, still works.)
-
-The mapping is not limited to the four Claude tiers. `llmtrim sub map codex <from> <to>` remaps
-one model, where `from` is a tier name or an exact incoming model id, so any Anthropic-speaking
-tool can be routed model by model; `llmtrim sub unmap` removes an entry, and `llmtrim sub models
-codex` lists the candidate provider models. `llmtrim sub status --json` and `llmtrim sub auth
-<codex|kimi> status --json` expose the state for scripts and the tray.
-
-| env var | config key | meaning |
-| --- | --- | --- |
-| `LLMTRIM_SUB` | `sub` | active reroute provider (`codex`, `kimi`, or `off`) |
-| `LLMTRIM_SUB_MODE` | `sub.mode` | `always` (default) or `fallback` |
-| `LLMTRIM_SUB_CHAIN` | `sub.chain` | ordered fallback providers, e.g. `codex,kimi` |
-
-Codex reasoning is adaptive by default; `llmtrim sub effort <none|low|medium|high|xhigh>` (env
-`LLMTRIM_CODEX_EFFORT`) pins one effort on every rerouted turn instead.
+Companion tools on another port (e.g. [headroom](https://github.com/chopratejas/headroom)) are fine.
 
 </details>
-
-### Chaining through an upstream proxy
-
-Set `LLMTRIM_UPSTREAM_PROXY=http://host:port` to make llmtrim send its outbound
-calls through another proxy instead of dialing the API directly. This covers two
-cases: a corporate or auth proxy that all egress must pass through, and running
-llmtrim alongside a second local tool such as [headroom](https://github.com/chopratejas/headroom)
-on a different port.
-
-The connection to the API is tunneled through the upstream with `CONNECT` and stays
-under verifying TLS, so the upstream sees only the encrypted stream. An upstream that
-points at llmtrim's own listen address (any spelling of localhost on the same port) is
-rejected, because it would loop traffic back into the daemon; a companion proxy on a
-different port is allowed. `http://user:pass@host:port` works for proxy auth, and those
-credentials are redacted from logs.
-
-Put the variable in the daemon's own launch environment (the launchd plist or systemd
-unit), not only your shell profile. Credentials written into a shell profile are stored
-there in plaintext.
 
 ## The numbers
 
@@ -691,7 +631,16 @@ Built on [`tiktoken-rs`](https://crates.io/crates/tiktoken-rs), [`tree-sitter`](
 
 ## Found a problem?
 
-Run `llmtrim doctor` for an end-to-end diagnosis; each failing check names its fix. Found a request it mangled? Set `LLMTRIM_CAPTURE_DIR` and [open an issue](https://github.com/fkiene/llmtrim/issues) with the before/after capture, since a repro is a fix. And if it saved you money, a ⭐ helps others find it.
+```bash
+llmtrim doctor          # diagnose
+llmtrim doctor --fix     # diagnose + apply repairs
+llmtrim ensure          # same repair path
+```
+
+Each failing check names its fix. If a request was mangled, set `LLMTRIM_CAPTURE_DIR` and
+[open an issue](https://github.com/fkiene/llmtrim/issues) with the before/after pair.
+
+If llmtrim saved you money, a ⭐ helps others find it.
 
 ## Star history
 

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -181,7 +181,7 @@ pub fn run(
     // the UI thread never runs a query for Detail.
     let detail_db = BreakdownDb::open().context("failed to open breakdown ledger")?;
     enable_raw_mode().context("failed to enter raw mode")?;
-    let _guard = TerminalGuard;
+    let guard = TerminalGuard;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen).context("failed to enter alternate screen")?;
     // Buffer the backend so each frame is one write/flush instead of many small syscalls.
@@ -325,26 +325,39 @@ pub fn run(
     if let Err(e) = detail_worker.join() {
         eprintln!("llmtrim: breakdown detail thread panicked: {e:?}");
     }
-    Ok(app.action)
+    let action = app.action;
+    let pending_ensure = app.pending_ensure;
+    let pending_sub_login = app.pending_sub_login;
+    // Leave alt-screen before any normal stdout work (ensure / sub hints).
+    drop(terminal);
+    drop(guard);
+    if pending_ensure {
+        crate::ensure::run_cli(false)?;
+    }
+    if pending_sub_login {
+        let _ = crate::ensure::mark_sub_nudge_shown();
+        println!("Subscription setup: pick a provider, then log in.");
+        println!("  llmtrim sub auth codex login   # ChatGPT / Codex plan");
+        println!("  llmtrim sub auth kimi login    # Kimi coding plan");
+        println!("  llmtrim sub on codex           # enable after login");
+    }
+    Ok(action)
 }
 
 /// What the caller should do after the TUI exits — set by a key, run on the normal screen.
+///
+/// Keep the public variant set stable (semver): new TUI actions that only need work inside
+/// this crate are handled before returning (see `f` / sub-nudge keys).
 #[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
 pub enum PostAction {
     #[default]
     None,
     /// `d` — run `llmtrim doctor` (repair check).
     Doctor,
-    /// `f` — run `llmtrim ensure` (apply recommended integration fixes).
-    Fix,
     /// `u` — run `llmtrim update` (a newer release is available).
     Update,
     /// `u` on a stale daemon — restart it (`llmtrim start --force`) to load the new binary.
     Restart,
-    /// One-time sub onboarding: print login instructions.
-    SubLogin,
-    /// Dismiss the one-time sub onboarding nudge permanently.
-    SubDismiss,
 }
 
 struct App {
@@ -380,6 +393,10 @@ struct App {
     needs_ensure: bool,
     /// One-time subscription onboarding on the Overview tab.
     show_sub_nudge: bool,
+    /// Run `ensure` after the TUI tears down (alt-screen left). Keeps `PostAction` stable.
+    pending_ensure: bool,
+    /// Print sub login steps after the TUI tears down.
+    pending_sub_login: bool,
 }
 
 impl App {
@@ -403,6 +420,8 @@ impl App {
             tray_available: crate::tray::tray_binary().is_some(),
             needs_ensure: crate::ensure::needs_attention(),
             show_sub_nudge: crate::ensure::should_show_sub_nudge(),
+            pending_ensure: false,
+            pending_sub_login: false,
         }
     }
 
@@ -457,7 +476,8 @@ impl App {
                 return true;
             }
             KeyCode::Char('f') if self.needs_ensure => {
-                self.action = PostAction::Fix;
+                // Run ensure after alt-screen exit so `PostAction` stays semver-stable.
+                self.pending_ensure = true;
                 return true;
             }
             KeyCode::Char('u') => {
@@ -474,16 +494,16 @@ impl App {
                 };
                 return true;
             }
-            // One-time sub onboarding: `s` = show login steps, `n` = never again.
+            // One-time sub onboarding: `s` = show login steps (after exit), `n` = never again.
             KeyCode::Char('s') if self.show_sub_nudge && self.tab == Tab::Overview => {
-                self.action = PostAction::SubLogin;
                 self.show_sub_nudge = false;
+                self.pending_sub_login = true;
                 return true;
             }
             KeyCode::Char('n') if self.show_sub_nudge && self.tab == Tab::Overview => {
-                self.action = PostAction::SubDismiss;
                 self.show_sub_nudge = false;
-                return true;
+                let _ = crate::ensure::dismiss_sub_nudge();
+                return false;
             }
             // `c` flips the Overview gauge between "% of new content" and "% of the whole prompt"
             // — the one figure with two honest framings. It's a no-op on the other tabs, which

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -335,10 +335,16 @@ pub enum PostAction {
     None,
     /// `d` — run `llmtrim doctor` (repair check).
     Doctor,
+    /// `f` — run `llmtrim ensure` (apply recommended integration fixes).
+    Fix,
     /// `u` — run `llmtrim update` (a newer release is available).
     Update,
     /// `u` on a stale daemon — restart it (`llmtrim start --force`) to load the new binary.
     Restart,
+    /// One-time sub onboarding: print login instructions.
+    SubLogin,
+    /// Dismiss the one-time sub onboarding nudge permanently.
+    SubDismiss,
 }
 
 struct App {
@@ -370,6 +376,10 @@ struct App {
     /// Whether the tray GUI is installed next to the CLI — gates the `y tray` action so the
     /// hint never offers something that can't run. Resolved once at construction.
     tray_available: bool,
+    /// Integrations need attention (statusline/guard/daemon skew…) — gates `f` fix.
+    needs_ensure: bool,
+    /// One-time subscription onboarding on the Overview tab.
+    show_sub_nudge: bool,
 }
 
 impl App {
@@ -391,6 +401,8 @@ impl App {
             detail_req: None,
             action: PostAction::None,
             tray_available: crate::tray::tray_binary().is_some(),
+            needs_ensure: crate::ensure::needs_attention(),
+            show_sub_nudge: crate::ensure::should_show_sub_nudge(),
         }
     }
 
@@ -438,10 +450,14 @@ impl App {
                 palette::cycle();
                 let _ = llmtrim_core::config::save_theme(palette::ident());
             }
-            // `d`/`u` queue a command and quit, so it runs on the normal screen (not inside the
-            // alt-screen): `d` = repair check (doctor), `u` = update.
+            // `d`/`f`/`u` queue a command and quit, so it runs on the normal screen (not inside
+            // the alt-screen): `d` = doctor, `f` = ensure/fix integrations, `u` = update.
             KeyCode::Char('d') => {
                 self.action = PostAction::Doctor;
+                return true;
+            }
+            KeyCode::Char('f') if self.needs_ensure => {
+                self.action = PostAction::Fix;
                 return true;
             }
             KeyCode::Char('u') => {
@@ -456,6 +472,17 @@ impl App {
                 } else {
                     PostAction::Update
                 };
+                return true;
+            }
+            // One-time sub onboarding: `s` = show login steps, `n` = never again.
+            KeyCode::Char('s') if self.show_sub_nudge && self.tab == Tab::Overview => {
+                self.action = PostAction::SubLogin;
+                self.show_sub_nudge = false;
+                return true;
+            }
+            KeyCode::Char('n') if self.show_sub_nudge && self.tab == Tab::Overview => {
+                self.action = PostAction::SubDismiss;
+                self.show_sub_nudge = false;
                 return true;
             }
             // `c` flips the Overview gauge between "% of new content" and "% of the whole prompt"
@@ -704,6 +731,15 @@ impl App {
                     .add_modifier(Modifier::BOLD),
             ));
         }
+        // Integrations stale / missing — `f` fixes without reading the changelog.
+        if self.needs_ensure {
+            meta.push(Span::styled(
+                "  ⚠ fix",
+                Style::default()
+                    .fg(palette::warn())
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
         meta.push(Span::styled(
             format!(
                 " │ {h12}:{m:02}:{s:02} {ampm} │ ↻ {}s",
@@ -835,13 +871,19 @@ impl App {
             Tab::Detail => String::from(" Tab tabs · ⇧Tab pane · ↑↓ move · →/← expand"),
         };
         if problem {
-            keys.push_str(" · d repair");
+            keys.push_str(" · d doctor");
+        }
+        if self.needs_ensure {
+            keys.push_str(" · f fix");
         }
         if update {
             keys.push_str(" · u update");
         }
         if self.tray_available {
             keys.push_str(" · y tray");
+        }
+        if self.show_sub_nudge && self.tab == Tab::Overview {
+            keys.push_str(" · s sub · n dismiss");
         }
         keys.push_str(match self.tab {
             Tab::Overview => " · t theme · ? help · q quit",
@@ -898,6 +940,10 @@ fn render_help_overlay(f: &mut Frame, tray: bool) {
         lines.push(Line::from("  y                  open the desktop tray"));
     }
     lines.extend([
+        Line::from("  f                  fix integrations (ensure)"),
+        Line::from("  d                  doctor (diagnose)"),
+        Line::from("  u                  update / restart stale daemon"),
+        Line::from("  s / n              sub setup / dismiss (when shown)"),
         Line::from(""),
         Line::from("  \"would have cost\" = the price at your provider's"),
         Line::from("   normal rate; \"you paid\" is after llmtrim trimmed it."),

--- a/crates/llmtrim-cli/src/doctor.rs
+++ b/crates/llmtrim-cli/src/doctor.rs
@@ -38,8 +38,6 @@ pub struct State {
     pub log_path: Option<String>,
     /// Newer released version, if the (cached) update check knows one.
     pub update_available: Option<String>,
-    /// Integration gaps from [`crate::ensure::probe`] (label, detail).
-    pub integration_gaps: Vec<(String, String)>,
 }
 
 /// The finished diagnosis: checklist rows + how many are real problems (`⚠` rows;
@@ -100,12 +98,18 @@ pub fn gather() -> Report {
             .ok()
             .map(|p| p.display().to_string()),
         update_available: crate::update::check(false),
-        integration_gaps: crate::ensure::probe()
-            .into_iter()
-            .map(|g| (g.label, g.detail))
-            .collect(),
     };
-    build(&state)
+    let mut report = build(&state);
+    // Gaps are not part of the public `State` shape (semver); append after pure `build`.
+    for gap in crate::ensure::probe() {
+        report.rows.push((
+            ui::WARN,
+            gap.label.to_ascii_lowercase(),
+            format!("{} — fix: llmtrim ensure", gap.detail),
+        ));
+        report.problems += 1;
+    }
+    report
 }
 
 /// Turn probed state into checklist rows. Pure — the testable core of doctor.
@@ -286,15 +290,6 @@ pub fn build(s: &State) -> Report {
         ));
     }
 
-    // Claude Code integrations — gaps are WARN so doctor --fix / ensure is the remedy.
-    for (label, detail) in &s.integration_gaps {
-        rows.push((
-            ui::WARN,
-            label.to_ascii_lowercase(),
-            format!("{detail} — fix: llmtrim ensure"),
-        ));
-    }
-
     let problems = rows.iter().filter(|(g, _, _)| *g == ui::WARN).count();
     Report { rows, problems }
 }
@@ -347,7 +342,6 @@ mod tests {
             last_request: Some("4s ago".into()),
             log_path: Some("/home/u/.llmtrim/serve.log".into()),
             update_available: None,
-            integration_gaps: Vec::new(),
         }
     }
 

--- a/crates/llmtrim-cli/src/doctor.rs
+++ b/crates/llmtrim-cli/src/doctor.rs
@@ -1,9 +1,10 @@
-//! `llmtrim doctor` — read-only, end-to-end install diagnosis.
+//! `llmtrim doctor` — end-to-end install diagnosis (optionally repairs with `--fix`).
 //!
 //! One pass/fail row per link in the chain (binary → daemon → port → env → CA →
-//! autostart → ledger), each failing row naming its fix. `status` shows the same chain
-//! compressed to a header; doctor is the long form for "it doesn't work, why?".
-//! Gathering is separated from rendering so the row logic is unit-testable.
+//! autostart → ledger → integrations), each failing row naming its fix. `status` shows
+//! the same chain compressed to a header; doctor is the long form for "it doesn't work,
+//! why?". Pass `--fix` to run [`crate::ensure`] first. Gathering is separated from
+//! rendering so the row logic is unit-testable.
 
 use crate::ui;
 
@@ -37,6 +38,8 @@ pub struct State {
     pub log_path: Option<String>,
     /// Newer released version, if the (cached) update check knows one.
     pub update_available: Option<String>,
+    /// Integration gaps from [`crate::ensure::probe`] (label, detail).
+    pub integration_gaps: Vec<(String, String)>,
 }
 
 /// The finished diagnosis: checklist rows + how many are real problems (`⚠` rows;
@@ -97,6 +100,10 @@ pub fn gather() -> Report {
             .ok()
             .map(|p| p.display().to_string()),
         update_available: crate::update::check(false),
+        integration_gaps: crate::ensure::probe()
+            .into_iter()
+            .map(|g| (g.label, g.detail))
+            .collect(),
     };
     build(&state)
 }
@@ -279,6 +286,15 @@ pub fn build(s: &State) -> Report {
         ));
     }
 
+    // Claude Code integrations — gaps are WARN so doctor --fix / ensure is the remedy.
+    for (label, detail) in &s.integration_gaps {
+        rows.push((
+            ui::WARN,
+            label.to_ascii_lowercase(),
+            format!("{detail} — fix: llmtrim ensure"),
+        ));
+    }
+
     let problems = rows.iter().filter(|(g, _, _)| *g == ui::WARN).count();
     Report { rows, problems }
 }
@@ -331,6 +347,7 @@ mod tests {
             last_request: Some("4s ago".into()),
             log_path: Some("/home/u/.llmtrim/serve.log".into()),
             update_available: None,
+            integration_gaps: Vec::new(),
         }
     }
 

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -202,16 +202,15 @@ fn probe_with(state: &State) -> Vec<Gap> {
     }
 
     // Version skew: daemon older than this binary.
-    if let Some(d) = crate::daemon::running() {
-        if let Some(v) = d.version.as_deref() {
-            if v != CURRENT {
-                gaps.push(Gap {
-                    id: "daemon",
-                    label: "Daemon".into(),
-                    detail: format!("running v{v}, binary is v{CURRENT}"),
-                });
-            }
-        }
+    if let Some(d) = crate::daemon::running()
+        && let Some(v) = d.version.as_deref()
+        && v != CURRENT
+    {
+        gaps.push(Gap {
+            id: "daemon",
+            label: "Daemon".into(),
+            detail: format!("running v{v}, binary is v{CURRENT}"),
+        });
     }
 
     // Tray binary appeared but login entry never enabled (and user did not opt out).
@@ -496,25 +495,22 @@ pub fn apply(opts: Options) -> Result<Report> {
     }
 
     // Daemon version skew.
-    if opts.restart_daemon {
-        if let Some(d) = crate::daemon::running() {
-            if d.version.as_deref().is_some_and(|v| v != CURRENT) {
-                match crate::update::restart_daemon_silent() {
-                    Ok(()) => {
-                        report.applied.push("daemon");
-                        report.rows.push((
-                            ui::OK,
-                            "Daemon".into(),
-                            format!("restarted on v{CURRENT}"),
-                        ));
-                    }
-                    Err(e) => report.rows.push((
-                        ui::WARN,
-                        "Daemon".into(),
-                        format!("restart failed: {e:#} — try `llmtrim start --force`"),
-                    )),
-                }
+    if opts.restart_daemon
+        && let Some(d) = crate::daemon::running()
+        && d.version.as_deref().is_some_and(|v| v != CURRENT)
+    {
+        match crate::update::restart_daemon_silent() {
+            Ok(()) => {
+                report.applied.push("daemon");
+                report
+                    .rows
+                    .push((ui::OK, "Daemon".into(), format!("restarted on v{CURRENT}")));
             }
+            Err(e) => report.rows.push((
+                ui::WARN,
+                "Daemon".into(),
+                format!("restart failed: {e:#} — try `llmtrim start --force`"),
+            )),
         }
     }
 

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -61,8 +61,7 @@ fn load_at(path: &Path) -> Result<State> {
     if !path.exists() {
         return Ok(State::default());
     }
-    let s = std::fs::read_to_string(path)
-        .with_context(|| format!("read {}", path.display()))?;
+    let s = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     serde_json::from_str(&s).with_context(|| {
         format!(
             "{} is corrupt or invalid JSON — fix or delete it before running ensure              (deleting resets opt-outs)",
@@ -73,8 +72,7 @@ fn load_at(path: &Path) -> Result<State> {
 
 fn save_at(path: &Path, state: &State) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("create {}", parent.display()))?;
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
     let tmp = path.with_extension("json.tmp");
     std::fs::write(&tmp, serde_json::to_vec_pretty(state)?)
@@ -195,10 +193,7 @@ fn probe_with(state: &State) -> Vec<Gap> {
         }
     }
 
-    if claude
-        && !state.opt_out.compact
-        && !llmtrim_core::config::compact_models_configured()
-    {
+    if claude && !state.opt_out.compact && !llmtrim_core::config::compact_models_configured() {
         gaps.push(Gap {
             id: "compact",
             label: "Compact".into(),
@@ -265,8 +260,8 @@ pub fn apply(opts: Options) -> Result<Report> {
 
     if claude && !state.opt_out.statusline {
         let status = crate::statusline::owned_status();
-        let skip_missing = !opts.install_missing
-            && matches!(status, crate::statusline::OwnedStatus::Missing);
+        let skip_missing =
+            !opts.install_missing && matches!(status, crate::statusline::OwnedStatus::Missing);
         if !skip_missing {
             match crate::statusline::sync_owned() {
                 Ok(crate::statusline::SyncOutcome::Installed) => {
@@ -286,7 +281,9 @@ pub fn apply(opts: Options) -> Result<Report> {
                     ));
                 }
                 Ok(crate::statusline::SyncOutcome::AlreadyCurrent) => {
-                    report.rows.push((ui::OK, "Statusline".into(), "current".into()));
+                    report
+                        .rows
+                        .push((ui::OK, "Statusline".into(), "current".into()));
                 }
                 Ok(crate::statusline::SyncOutcome::SkippedForeign) => {
                     report.rows.push((
@@ -295,11 +292,11 @@ pub fn apply(opts: Options) -> Result<Report> {
                         "custom status line left alone".into(),
                     ));
                 }
-                Err(e) => report.rows.push((
-                    ui::WARN,
-                    "Statusline".into(),
-                    format!("not wired: {e:#}"),
-                )),
+                Err(e) => {
+                    report
+                        .rows
+                        .push((ui::WARN, "Statusline".into(), format!("not wired: {e:#}")))
+                }
             }
         }
     } else if claude && state.opt_out.statusline {
@@ -310,8 +307,8 @@ pub fn apply(opts: Options) -> Result<Report> {
 
     if claude && !state.opt_out.guard {
         let gstatus = crate::guard::owned_status();
-        let skip_missing = !opts.install_missing
-            && matches!(gstatus, crate::guard::OwnedStatus::Missing);
+        let skip_missing =
+            !opts.install_missing && matches!(gstatus, crate::guard::OwnedStatus::Missing);
         if !skip_missing {
             match crate::guard::sync_owned() {
                 Ok(true) => {
@@ -338,8 +335,8 @@ pub fn apply(opts: Options) -> Result<Report> {
 
     if claude && !state.opt_out.window_sub {
         let wstatus = crate::window_sub::owned_status();
-        let skip_missing = !opts.install_missing
-            && matches!(wstatus, crate::window_sub::OwnedStatus::Missing);
+        let skip_missing =
+            !opts.install_missing && matches!(wstatus, crate::window_sub::OwnedStatus::Missing);
         if !skip_missing {
             let was_installed = matches!(
                 wstatus,
@@ -362,11 +359,11 @@ pub fn apply(opts: Options) -> Result<Report> {
                         ));
                     }
                 }
-                Err(e) => report.rows.push((
-                    ui::WARN,
-                    "/sub".into(),
-                    format!("not installed: {e:#}"),
-                )),
+                Err(e) => {
+                    report
+                        .rows
+                        .push((ui::WARN, "/sub".into(), format!("not installed: {e:#}")))
+                }
             }
         }
     } else if claude && state.opt_out.window_sub {
@@ -395,11 +392,11 @@ pub fn apply(opts: Options) -> Result<Report> {
                         "Haiku → Sonnet → original model".into(),
                     ));
                 }
-                Err(e) => report.rows.push((
-                    ui::WARN,
-                    "Compact".into(),
-                    format!("not configured: {e:#}"),
-                )),
+                Err(e) => {
+                    report
+                        .rows
+                        .push((ui::WARN, "Compact".into(), format!("not configured: {e:#}")))
+                }
             }
         } else {
             // Remember opt-out as empty models list + flag.
@@ -412,17 +409,13 @@ pub fn apply(opts: Options) -> Result<Report> {
             ));
         }
     } else if claude && llmtrim_core::config::compact_models_configured() {
-        report.rows.push((
-            ui::OK,
-            "Compact".into(),
-            "configured".into(),
-        ));
+        report
+            .rows
+            .push((ui::OK, "Compact".into(), "configured".into()));
     }
 
     // Tray autostart when binary is present (explicit ensure/setup only).
-    if opts.install_missing
-        && crate::tray::tray_binary().is_some()
-        && !state.opt_out.tray_autostart
+    if opts.install_missing && crate::tray::tray_binary().is_some() && !state.opt_out.tray_autostart
     {
         if !crate::autostart::is_tray_enabled() {
             let want = if opts.interactive {
@@ -455,11 +448,9 @@ pub fn apply(opts: Options) -> Result<Report> {
                 ));
             }
         } else {
-            report.rows.push((
-                ui::OK,
-                "Tray".into(),
-                "autostart on".into(),
-            ));
+            report
+                .rows
+                .push((ui::OK, "Tray".into(), "autostart on".into()));
         }
     } else if opts.install_missing
         && crate::tray::tray_binary().is_none()
@@ -488,11 +479,11 @@ pub fn apply(opts: Options) -> Result<Report> {
                         let _ = crate::autostart::configure_tray(true);
                     }
                 }
-                Err(e) => report.rows.push((
-                    ui::WARN,
-                    "Tray".into(),
-                    format!("download failed: {e:#}"),
-                )),
+                Err(e) => {
+                    report
+                        .rows
+                        .push((ui::WARN, "Tray".into(), format!("download failed: {e:#}")))
+                }
             }
         } else if opts.interactive {
             state.opt_out.tray_download = true;
@@ -632,7 +623,9 @@ pub fn should_show_sub_nudge() -> bool {
     }
     // Only nudge when sub is not already configured.
     let cfg = llmtrim_core::config::RuntimeConfig::get();
-    cfg.sub.as_deref().is_none_or(|s| s == "off" || s.is_empty())
+    cfg.sub
+        .as_deref()
+        .is_none_or(|s| s == "off" || s.is_empty())
 }
 
 /// Mark the sub onboarding nudge as shown / dismissed.
@@ -751,8 +744,8 @@ fn download_file(url: &str, dest: &Path) -> Result<()> {
     }
     use std::io::Read;
     let mut reader = resp.body_mut().as_reader();
-    let mut file = std::fs::File::create(dest)
-        .with_context(|| format!("create {}", dest.display()))?;
+    let mut file =
+        std::fs::File::create(dest).with_context(|| format!("create {}", dest.display()))?;
     // Bound size (~64 MiB) so a runaway response cannot fill the disk.
     let mut limited = Read::take(&mut reader, 64 * 1024 * 1024);
     let n = std::io::copy(&mut limited, &mut file).context("write download")?;
@@ -785,12 +778,9 @@ fn extract_tray_tarball_safe(tarball: &Path, tmp_dir: &Path) -> Result<PathBuf> 
         }
         members.push(name.to_string());
     }
-    let has_tray = members.iter().any(|m| {
-        Path::new(m)
-            .file_name()
-            .and_then(|f| f.to_str())
-            == Some("llmtrim-tray")
-    });
+    let has_tray = members
+        .iter()
+        .any(|m| Path::new(m).file_name().and_then(|f| f.to_str()) == Some("llmtrim-tray"));
     if !has_tray {
         anyhow::bail!("tray archive does not contain llmtrim-tray");
     }

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -1,0 +1,859 @@
+//! Bring this install to the recommended current state — one verb for setup, update, and repair.
+//!
+//! Happy path: `llmtrim setup` / `llmtrim update` / `llmtrim doctor --fix` / status `f` all
+//! land here. Power-user install/uninstall commands remain as escape hatches; humans should not
+//! need them after a release. Owned Claude Code hooks and the status line are rewritten in place
+//! when the binary path or feature payload changes so changelogs never say "re-run install".
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::ui;
+
+const CURRENT: &str = env!("CARGO_PKG_VERSION");
+const STATE_FILE: &str = "integrations.json";
+
+/// User opt-outs, remembered forever so ensure never re-prompts after an explicit no.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct OptOut {
+    pub statusline: bool,
+    pub guard: bool,
+    pub window_sub: bool,
+    pub compact: bool,
+    pub tray_autostart: bool,
+    /// User declined the optional Linux tray download.
+    pub tray_download: bool,
+    /// User dismissed the one-time subscription onboarding nudge.
+    pub sub_nudge: bool,
+}
+
+/// Persistent integration state under `~/.llmtrim/integrations.json`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct State {
+    pub last_ensured_version: Option<String>,
+    pub opt_out: OptOut,
+    /// Subscription onboarding already shown in the status TUI.
+    pub sub_nudge_shown: bool,
+}
+
+impl State {
+    /// Load state; missing file → defaults. Corrupt file → error (never reset opt-outs silently).
+    pub fn load() -> Result<Self> {
+        let path = state_path()?;
+        load_at(&path)
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = state_path()?;
+        save_at(&path, self)
+    }
+}
+
+fn state_path() -> Result<PathBuf> {
+    Ok(crate::daemon::home_dir()?.join(STATE_FILE))
+}
+
+fn load_at(path: &Path) -> Result<State> {
+    if !path.exists() {
+        return Ok(State::default());
+    }
+    let s = std::fs::read_to_string(path)
+        .with_context(|| format!("read {}", path.display()))?;
+    serde_json::from_str(&s).with_context(|| {
+        format!(
+            "{} is corrupt or invalid JSON — fix or delete it before running ensure              (deleting resets opt-outs)",
+            path.display()
+        )
+    })
+}
+
+fn save_at(path: &Path, state: &State) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, serde_json::to_vec_pretty(state)?)
+        .with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path).with_context(|| format!("rename onto {}", path.display()))?;
+    Ok(())
+}
+
+/// How ensure was invoked — controls prompting and how loud the report is.
+#[derive(Debug, Clone, Copy)]
+pub struct Options {
+    /// May prompt on a TTY (first-run compact/tray choices). Non-interactive defaults to yes
+    /// for recommended items, no for optional network downloads.
+    pub interactive: bool,
+    /// Skip the success panel (daemon start / quiet migrations).
+    pub quiet: bool,
+    /// Restart the daemon when binary/daemon versions disagree.
+    pub restart_daemon: bool,
+    /// Allow downloading the Linux tray binary when missing (interactive confirm, or forced).
+    pub download_tray: bool,
+    /// When false (quiet auto-heal), only refresh *owned* stale integrations and daemon skew —
+    /// never first-install statusline/guard//sub/compact or enable tray autostart.
+    pub install_missing: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            interactive: std::io::IsTerminal::is_terminal(&std::io::stdin()),
+            quiet: false,
+            restart_daemon: true,
+            download_tray: false,
+            install_missing: true,
+        }
+    }
+}
+
+/// One gap between the desired recommended state and reality.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Gap {
+    pub id: &'static str,
+    pub label: String,
+    pub detail: String,
+}
+
+/// Outcome of [`apply`].
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    pub rows: Vec<(&'static str, String, String)>,
+    /// Integration ids that were changed.
+    pub applied: Vec<&'static str>,
+    pub gaps_before: usize,
+}
+
+impl Report {
+    pub fn changed(&self) -> bool {
+        !self.applied.is_empty()
+    }
+}
+
+/// Probe without writing. Pure enough for the status TUI and doctor rows.
+pub fn probe() -> Vec<Gap> {
+    match State::load() {
+        Ok(s) => probe_with(&s),
+        Err(_) => Vec::new(), // corrupt state: do not invent gaps; ensure/apply will error
+    }
+}
+
+fn probe_with(state: &State) -> Vec<Gap> {
+    let mut gaps = Vec::new();
+    let claude = crate::statusline::claude_code_present();
+
+    if claude && !state.opt_out.statusline {
+        match crate::statusline::owned_status() {
+            crate::statusline::OwnedStatus::Missing => gaps.push(Gap {
+                id: "statusline",
+                label: "Statusline".into(),
+                detail: "not installed — recommended for Claude Code".into(),
+            }),
+            crate::statusline::OwnedStatus::Stale => gaps.push(Gap {
+                id: "statusline",
+                label: "Statusline".into(),
+                detail: "stale (binary path or refresh settings)".into(),
+            }),
+            crate::statusline::OwnedStatus::Current | crate::statusline::OwnedStatus::Foreign => {}
+        }
+    }
+
+    if claude && !state.opt_out.guard {
+        match crate::guard::owned_status() {
+            crate::guard::OwnedStatus::Missing => gaps.push(Gap {
+                id: "guard",
+                label: "Guard".into(),
+                detail: "not installed — warns before cold-cache resumes".into(),
+            }),
+            crate::guard::OwnedStatus::Stale => gaps.push(Gap {
+                id: "guard",
+                label: "Guard".into(),
+                detail: "stale (binary path)".into(),
+            }),
+            crate::guard::OwnedStatus::Current => {}
+        }
+    }
+
+    if claude && !state.opt_out.window_sub {
+        match crate::window_sub::owned_status() {
+            crate::window_sub::OwnedStatus::Missing => gaps.push(Gap {
+                id: "window_sub",
+                label: "/sub".into(),
+                detail: "window-local subscription controls not installed".into(),
+            }),
+            crate::window_sub::OwnedStatus::Stale => gaps.push(Gap {
+                id: "window_sub",
+                label: "/sub".into(),
+                detail: "stale (binary path)".into(),
+            }),
+            crate::window_sub::OwnedStatus::Current => {}
+        }
+    }
+
+    if claude
+        && !state.opt_out.compact
+        && !llmtrim_core::config::compact_models_configured()
+    {
+        gaps.push(Gap {
+            id: "compact",
+            label: "Compact".into(),
+            detail: "cheaper /compact models not configured".into(),
+        });
+    }
+
+    // Version skew: daemon older than this binary.
+    if let Some(d) = crate::daemon::running() {
+        if let Some(v) = d.version.as_deref() {
+            if v != CURRENT {
+                gaps.push(Gap {
+                    id: "daemon",
+                    label: "Daemon".into(),
+                    detail: format!("running v{v}, binary is v{CURRENT}"),
+                });
+            }
+        }
+    }
+
+    // Tray binary appeared but login entry never enabled (and user did not opt out).
+    if crate::tray::tray_binary().is_some()
+        && !state.opt_out.tray_autostart
+        && !crate::autostart::is_tray_enabled()
+    {
+        gaps.push(Gap {
+            id: "tray_autostart",
+            label: "Tray".into(),
+            detail: "installed but not set to open at login".into(),
+        });
+    }
+
+    gaps
+}
+
+/// Whether the status TUI / doctor should offer a one-key fix.
+pub fn needs_attention() -> bool {
+    !probe().is_empty()
+}
+
+/// Short banner line for the status dashboard (None when clean).
+pub fn attention_summary() -> Option<String> {
+    let gaps = probe();
+    if gaps.is_empty() {
+        return None;
+    }
+    let labels: Vec<&str> = gaps.iter().map(|g| g.label.as_str()).collect();
+    Some(format!(
+        "{} need{} attention — press f to fix",
+        labels.join(", "),
+        if gaps.len() == 1 { "s" } else { "" }
+    ))
+}
+
+/// Apply recommended state. Idempotent; honors opt-outs.
+pub fn apply(opts: Options) -> Result<Report> {
+    let mut state = State::load()?;
+    let gaps_before = probe_with(&state).len();
+    let mut report = Report {
+        gaps_before,
+        ..Report::default()
+    };
+    let claude = crate::statusline::claude_code_present();
+
+    if claude && !state.opt_out.statusline {
+        let status = crate::statusline::owned_status();
+        let skip_missing = !opts.install_missing
+            && matches!(status, crate::statusline::OwnedStatus::Missing);
+        if !skip_missing {
+            match crate::statusline::sync_owned() {
+                Ok(crate::statusline::SyncOutcome::Installed) => {
+                    report.applied.push("statusline");
+                    report.rows.push((
+                        ui::OK,
+                        "Statusline".into(),
+                        "installed in ~/.claude/settings.json".into(),
+                    ));
+                }
+                Ok(crate::statusline::SyncOutcome::Refreshed) => {
+                    report.applied.push("statusline");
+                    report.rows.push((
+                        ui::OK,
+                        "Statusline".into(),
+                        "refreshed for this binary".into(),
+                    ));
+                }
+                Ok(crate::statusline::SyncOutcome::AlreadyCurrent) => {
+                    report.rows.push((ui::OK, "Statusline".into(), "current".into()));
+                }
+                Ok(crate::statusline::SyncOutcome::SkippedForeign) => {
+                    report.rows.push((
+                        ui::NOTE,
+                        "Statusline".into(),
+                        "custom status line left alone".into(),
+                    ));
+                }
+                Err(e) => report.rows.push((
+                    ui::WARN,
+                    "Statusline".into(),
+                    format!("not wired: {e:#}"),
+                )),
+            }
+        }
+    } else if claude && state.opt_out.statusline {
+        report
+            .rows
+            .push((ui::NOTE, "Statusline".into(), "opted out".into()));
+    }
+
+    if claude && !state.opt_out.guard {
+        let gstatus = crate::guard::owned_status();
+        let skip_missing = !opts.install_missing
+            && matches!(gstatus, crate::guard::OwnedStatus::Missing);
+        if !skip_missing {
+            match crate::guard::sync_owned() {
+                Ok(true) => {
+                    report.applied.push("guard");
+                    report.rows.push((
+                        ui::OK,
+                        "Guard".into(),
+                        "warns before a cold resumed turn".into(),
+                    ));
+                }
+                Ok(false) => {
+                    report.rows.push((ui::OK, "Guard".into(), "current".into()));
+                }
+                Err(e) => report
+                    .rows
+                    .push((ui::WARN, "Guard".into(), format!("not wired: {e:#}"))),
+            }
+        }
+    } else if claude && state.opt_out.guard {
+        report
+            .rows
+            .push((ui::NOTE, "Guard".into(), "opted out".into()));
+    }
+
+    if claude && !state.opt_out.window_sub {
+        let wstatus = crate::window_sub::owned_status();
+        let skip_missing = !opts.install_missing
+            && matches!(wstatus, crate::window_sub::OwnedStatus::Missing);
+        if !skip_missing {
+            let was_installed = matches!(
+                wstatus,
+                crate::window_sub::OwnedStatus::Current | crate::window_sub::OwnedStatus::Stale
+            );
+            match crate::window_sub::install(&crate::statusline::stable_exe_string()) {
+                Ok(()) => {
+                    if was_installed {
+                        report.rows.push((
+                            ui::OK,
+                            "/sub".into(),
+                            "window-local controls current".into(),
+                        ));
+                    } else {
+                        report.applied.push("window_sub");
+                        report.rows.push((
+                            ui::OK,
+                            "/sub".into(),
+                            "window-local on|off|status installed".into(),
+                        ));
+                    }
+                }
+                Err(e) => report.rows.push((
+                    ui::WARN,
+                    "/sub".into(),
+                    format!("not installed: {e:#}"),
+                )),
+            }
+        }
+    } else if claude && state.opt_out.window_sub {
+        report
+            .rows
+            .push((ui::NOTE, "/sub".into(), "opted out".into()));
+    }
+
+    if claude
+        && opts.install_missing
+        && !state.opt_out.compact
+        && !llmtrim_core::config::compact_models_configured()
+    {
+        let want = if opts.interactive {
+            confirm_default_yes("Use cheaper models for Claude Code /compact (Haiku → Sonnet)?")
+        } else {
+            true
+        };
+        if want {
+            match llmtrim_core::config::write_compact_models(&["haiku".into(), "sonnet".into()]) {
+                Ok(()) => {
+                    report.applied.push("compact");
+                    report.rows.push((
+                        ui::OK,
+                        "Compact".into(),
+                        "Haiku → Sonnet → original model".into(),
+                    ));
+                }
+                Err(e) => report.rows.push((
+                    ui::WARN,
+                    "Compact".into(),
+                    format!("not configured: {e:#}"),
+                )),
+            }
+        } else {
+            // Remember opt-out as empty models list + flag.
+            let _ = llmtrim_core::config::write_compact_models(&[]);
+            state.opt_out.compact = true;
+            report.rows.push((
+                ui::OK,
+                "Compact".into(),
+                "original model only (remembered)".into(),
+            ));
+        }
+    } else if claude && llmtrim_core::config::compact_models_configured() {
+        report.rows.push((
+            ui::OK,
+            "Compact".into(),
+            "configured".into(),
+        ));
+    }
+
+    // Tray autostart when binary is present (explicit ensure/setup only).
+    if opts.install_missing
+        && crate::tray::tray_binary().is_some()
+        && !state.opt_out.tray_autostart
+    {
+        if !crate::autostart::is_tray_enabled() {
+            let want = if opts.interactive {
+                confirm_default_yes("Enable the llmtrim desktop tray (opens at login)?")
+            } else {
+                true
+            };
+            if want {
+                match crate::autostart::configure_tray(true) {
+                    Ok(()) => {
+                        report.applied.push("tray_autostart");
+                        report.rows.push((
+                            ui::OK,
+                            "Tray".into(),
+                            "opens at login · run `llmtrim tray` to open now".into(),
+                        ));
+                    }
+                    Err(e) => report.rows.push((
+                        ui::WARN,
+                        "Tray".into(),
+                        format!("autostart failed: {e:#}"),
+                    )),
+                }
+            } else {
+                state.opt_out.tray_autostart = true;
+                report.rows.push((
+                    ui::NOTE,
+                    "Tray".into(),
+                    "left off · enable later with `llmtrim autostart --tray`".into(),
+                ));
+            }
+        } else {
+            report.rows.push((
+                ui::OK,
+                "Tray".into(),
+                "autostart on".into(),
+            ));
+        }
+    } else if opts.install_missing
+        && crate::tray::tray_binary().is_none()
+        && !state.opt_out.tray_download
+        && cfg!(target_os = "linux")
+        && std::env::var_os("DISPLAY")
+            .or_else(|| std::env::var_os("WAYLAND_DISPLAY"))
+            .is_some()
+    {
+        // Optional one-shot tray download on Linux desktops.
+        let want = opts.download_tray
+            || (opts.interactive
+                && confirm_default_no(
+                    "Desktop tray not installed. Download llmtrim-tray from GitHub releases?",
+                ));
+        if want {
+            match download_linux_tray() {
+                Ok(path) => {
+                    report.applied.push("tray_download");
+                    report.rows.push((
+                        ui::OK,
+                        "Tray".into(),
+                        format!("installed {}", path.display()),
+                    ));
+                    if !state.opt_out.tray_autostart {
+                        let _ = crate::autostart::configure_tray(true);
+                    }
+                }
+                Err(e) => report.rows.push((
+                    ui::WARN,
+                    "Tray".into(),
+                    format!("download failed: {e:#}"),
+                )),
+            }
+        } else if opts.interactive {
+            state.opt_out.tray_download = true;
+            report.rows.push((
+                ui::NOTE,
+                "Tray".into(),
+                "skipped — download later from the GitHub release".into(),
+            ));
+        }
+    }
+
+    // Daemon version skew.
+    if opts.restart_daemon {
+        if let Some(d) = crate::daemon::running() {
+            if d.version.as_deref().is_some_and(|v| v != CURRENT) {
+                match crate::update::restart_daemon_silent() {
+                    Ok(()) => {
+                        report.applied.push("daemon");
+                        report.rows.push((
+                            ui::OK,
+                            "Daemon".into(),
+                            format!("restarted on v{CURRENT}"),
+                        ));
+                    }
+                    Err(e) => report.rows.push((
+                        ui::WARN,
+                        "Daemon".into(),
+                        format!("restart failed: {e:#} — try `llmtrim start --force`"),
+                    )),
+                }
+            }
+        }
+    }
+
+    state.last_ensured_version = Some(CURRENT.to_string());
+    if let Err(e) = state.save() {
+        report.rows.push((
+            ui::WARN,
+            "State".into(),
+            format!("could not save integrations.json: {e:#}"),
+        ));
+    }
+
+    Ok(report)
+}
+
+/// Auto-heal after a version bump (daemon start / first status). Quiet, non-interactive,
+/// never downloads. Returns whether anything changed.
+pub fn maybe_auto() -> Result<bool> {
+    let state = match State::load() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("llmtrim: skip auto-heal ({e:#})");
+            return Ok(false);
+        }
+    };
+    let gaps = probe_with(&state);
+    let version_mismatch = state.last_ensured_version.as_deref() != Some(CURRENT);
+    let needs_refresh = gaps
+        .iter()
+        .any(|g| g.id == "daemon" || g.detail.contains("stale"));
+    // Quiet path never first-installs missing integrations — only refresh owned stale
+    // pieces / daemon skew, or stamp the version after a binary bump.
+    if !version_mismatch && !needs_refresh {
+        return Ok(false);
+    }
+    let report = apply(Options {
+        interactive: false,
+        quiet: true,
+        restart_daemon: true,
+        download_tray: false,
+        install_missing: false,
+    })?;
+    Ok(report.changed())
+}
+
+/// CLI entry for `llmtrim ensure` and `doctor --fix`.
+pub fn run_cli(quiet: bool) -> Result<()> {
+    let color = ui::color_stdout();
+    let report = apply(Options {
+        interactive: std::io::IsTerminal::is_terminal(&std::io::stdin()),
+        quiet,
+        restart_daemon: true,
+        download_tray: false,
+        install_missing: true,
+    })?;
+    if !quiet {
+        print!(
+            "{}",
+            ui::panel(color, "llmtrim ensure", &ui::kv_rows(color, &report.rows))
+        );
+        if report.applied.is_empty() {
+            println!("{}", ui::ok(color, "already at the recommended state."));
+        } else {
+            println!(
+                "{}",
+                ui::ok(
+                    color,
+                    &format!(
+                        "applied {} change{} · you're on v{CURRENT}",
+                        report.applied.len(),
+                        if report.applied.len() == 1 { "" } else { "s" }
+                    )
+                )
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Record an opt-out (e.g. after `guard uninstall`).
+pub fn set_opt_out(id: &str, value: bool) -> Result<()> {
+    let mut state = State::load()?;
+    match id {
+        "statusline" => state.opt_out.statusline = value,
+        "guard" => state.opt_out.guard = value,
+        "window_sub" | "window-sub" | "sub" => state.opt_out.window_sub = value,
+        "compact" => state.opt_out.compact = value,
+        "tray_autostart" | "tray" => state.opt_out.tray_autostart = value,
+        "tray_download" => state.opt_out.tray_download = value,
+        "sub_nudge" => state.opt_out.sub_nudge = value,
+        _ => anyhow::bail!("unknown integration id: {id}"),
+    }
+    state.save()
+}
+
+/// Whether the status TUI should show one-time sub onboarding.
+pub fn should_show_sub_nudge() -> bool {
+    let Ok(state) = State::load() else {
+        return false;
+    };
+    if state.opt_out.sub_nudge || state.sub_nudge_shown {
+        return false;
+    }
+    if !crate::statusline::claude_code_present() {
+        return false;
+    }
+    // Only nudge when sub is not already configured.
+    let cfg = llmtrim_core::config::RuntimeConfig::get();
+    cfg.sub.as_deref().is_none_or(|s| s == "off" || s.is_empty())
+}
+
+/// Mark the sub onboarding nudge as shown / dismissed.
+pub fn mark_sub_nudge_shown() -> Result<()> {
+    let mut state = State::load()?;
+    state.sub_nudge_shown = true;
+    state.save()
+}
+
+pub fn dismiss_sub_nudge() -> Result<()> {
+    let mut state = State::load()?;
+    state.sub_nudge_shown = true;
+    state.opt_out.sub_nudge = true;
+    state.save()
+}
+
+fn confirm_default_yes(prompt: &str) -> bool {
+    if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        return true;
+    }
+    eprint!("{prompt} [Y/n] ");
+    let _ = std::io::Write::flush(&mut std::io::stderr());
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_err() {
+        return false; // do not enable optional bits the user never confirmed
+    }
+    let t = line.trim().to_ascii_lowercase();
+    t.is_empty() || t == "y" || t == "yes"
+}
+
+fn confirm_default_no(prompt: &str) -> bool {
+    if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        return false;
+    }
+    eprint!("{prompt} [y/N] ");
+    let _ = std::io::Write::flush(&mut std::io::stderr());
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_err() {
+        return false;
+    }
+    let t = line.trim().to_ascii_lowercase();
+    t == "y" || t == "yes"
+}
+
+/// Download the Linux gnu tray binary next to the CLI.
+fn download_linux_tray() -> Result<PathBuf> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        anyhow::bail!("tray download is only implemented for Linux");
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let exe = std::env::current_exe()
+            .ok()
+            .filter(|p| p.exists())
+            .context("current_exe")?;
+        let dir = exe.parent().context("exe has no parent")?;
+        let dest = dir.join("llmtrim-tray");
+        let triple = linux_tray_target_triple()?;
+        let tag = format!("v{CURRENT}");
+        let url = format!(
+            "https://github.com/fkiene/llmtrim/releases/download/{tag}/llmtrim-tray-{triple}.tar.gz"
+        );
+        let tmp_dir = tempfile_dir()?;
+        let tarball = tmp_dir.join("tray.tar.gz");
+        download_file(&url, &tarball)?;
+        let extracted = extract_tray_tarball_safe(&tarball, &tmp_dir)?;
+        if let Err(e) = std::fs::rename(&extracted, &dest) {
+            std::fs::copy(&extracted, &dest).with_context(|| {
+                format!("install tray to {} (rename failed: {e})", dest.display())
+            })?;
+            let _ = std::fs::remove_file(&extracted);
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&dest)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&dest, perms)?;
+        }
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        Ok(dest)
+    }
+}
+
+/// Release asset triple for the prebuilt Linux tray, or an error if unsupported.
+#[cfg(target_os = "linux")]
+fn linux_tray_target_triple() -> Result<&'static str> {
+    match std::env::consts::ARCH {
+        "x86_64" => Ok("x86_64-unknown-linux-gnu"),
+        "aarch64" => Ok("aarch64-unknown-linux-gnu"),
+        other => anyhow::bail!("no prebuilt llmtrim-tray for arch {other}"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn tempfile_dir() -> Result<PathBuf> {
+    let base = std::env::temp_dir().join(format!("llmtrim-tray-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base)?;
+    Ok(base)
+}
+
+#[cfg(target_os = "linux")]
+fn download_file(url: &str, dest: &Path) -> Result<()> {
+    let mut resp = ureq::get(url)
+        .config()
+        .timeout_global(Some(std::time::Duration::from_secs(60)))
+        .http_status_as_error(false)
+        .build()
+        .call()
+        .with_context(|| format!("GET {url}"))?;
+    let code = resp.status().as_u16();
+    if !(200..300).contains(&code) {
+        anyhow::bail!("download returned HTTP {code}");
+    }
+    use std::io::Read;
+    let mut reader = resp.body_mut().as_reader();
+    let mut file = std::fs::File::create(dest)
+        .with_context(|| format!("create {}", dest.display()))?;
+    // Bound size (~64 MiB) so a runaway response cannot fill the disk.
+    let mut limited = Read::take(&mut reader, 64 * 1024 * 1024);
+    let n = std::io::copy(&mut limited, &mut file).context("write download")?;
+    if n >= 64 * 1024 * 1024 {
+        anyhow::bail!("download exceeded 64 MiB size limit");
+    }
+    Ok(())
+}
+
+/// List archive members, reject path traversal, extract into `tmp_dir`, return path to llmtrim-tray.
+#[cfg(target_os = "linux")]
+fn extract_tray_tarball_safe(tarball: &Path, tmp_dir: &Path) -> Result<PathBuf> {
+    let list = std::process::Command::new("tar")
+        .args(["-tzf"])
+        .arg(tarball)
+        .output()
+        .context("run tar -tzf")?;
+    if !list.status.success() {
+        anyhow::bail!("tar -tzf failed listing tray archive");
+    }
+    let listing = String::from_utf8_lossy(&list.stdout);
+    let mut members = Vec::new();
+    for line in listing.lines() {
+        let name = line.trim().trim_start_matches("./");
+        if name.is_empty() {
+            continue;
+        }
+        if name.starts_with('/') || name.contains("..") {
+            anyhow::bail!("tray archive has unsafe path: {name}");
+        }
+        members.push(name.to_string());
+    }
+    let has_tray = members.iter().any(|m| {
+        Path::new(m)
+            .file_name()
+            .and_then(|f| f.to_str())
+            == Some("llmtrim-tray")
+    });
+    if !has_tray {
+        anyhow::bail!("tray archive does not contain llmtrim-tray");
+    }
+    let status = std::process::Command::new("tar")
+        .args(["-xzf"])
+        .arg(tarball)
+        .arg("-C")
+        .arg(tmp_dir)
+        .status()
+        .context("run tar extract")?;
+    if !status.success() {
+        anyhow::bail!("tar extract failed");
+    }
+    // Find extracted binary (top-level or one directory deep).
+    let candidates = [
+        tmp_dir.join("llmtrim-tray"),
+        tmp_dir.join("llmtrim-tray").join("llmtrim-tray"),
+    ];
+    for c in candidates {
+        if c.is_file() {
+            return Ok(c);
+        }
+    }
+    for ent in std::fs::read_dir(tmp_dir)? {
+        let ent = ent?;
+        let p = ent.path();
+        if p.file_name().and_then(|n| n.to_str()) == Some("llmtrim-tray") && p.is_file() {
+            return Ok(p);
+        }
+        if p.is_dir() {
+            let nested = p.join("llmtrim-tray");
+            if nested.is_file() {
+                return Ok(nested);
+            }
+        }
+    }
+    anyhow::bail!("could not locate extracted llmtrim-tray");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_roundtrip() {
+        let dir = std::env::temp_dir().join(format!("llmtrim-ensure-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(STATE_FILE);
+        let mut s = State::default();
+        s.opt_out.guard = true;
+        s.last_ensured_version = Some("0.10.2".into());
+        save_at(&path, &s).unwrap();
+        let loaded = load_at(&path).unwrap();
+        assert_eq!(loaded, s);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn opt_out_defaults_are_false() {
+        let s = State::default();
+        assert!(!s.opt_out.statusline);
+        assert!(!s.opt_out.guard);
+        assert!(!s.opt_out.window_sub);
+    }
+}

--- a/crates/llmtrim-cli/src/guard.rs
+++ b/crates/llmtrim-cli/src/guard.rs
@@ -411,10 +411,69 @@ fn clear_guard_hook(settings: &mut Value, path: &Path) -> Result<bool> {
 }
 
 fn claude_settings_path() -> Result<PathBuf> {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .context("neither HOME nor USERPROFILE is set")?;
-    Ok(PathBuf::from(home).join(".claude").join("settings.json"))
+    crate::statusline::claude_settings_path()
+}
+
+/// Ownership of the guard hook relative to this binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnedStatus {
+    Missing,
+    Stale,
+    Current,
+}
+
+/// Whether ensure should wire / refresh the cold-cache guard.
+pub fn owned_status() -> OwnedStatus {
+    let Ok(path) = claude_settings_path() else {
+        return OwnedStatus::Missing;
+    };
+    let Ok(s) = std::fs::read_to_string(&path) else {
+        return OwnedStatus::Missing;
+    };
+    let Ok(settings) = serde_json::from_str::<Value>(&s) else {
+        return OwnedStatus::Missing;
+    };
+    owned_status_of(&settings)
+}
+
+fn owned_status_of(settings: &Value) -> OwnedStatus {
+    let Some(list) = settings
+        .get("hooks")
+        .and_then(|h| h.get("UserPromptSubmit"))
+        .and_then(Value::as_array)
+    else {
+        return OwnedStatus::Missing;
+    };
+    let Some(group) = list.iter().find(|g| is_ours(g)) else {
+        return OwnedStatus::Missing;
+    };
+    let desired = crate::statusline::exe_command("guard");
+    let current = group
+        .get("hooks")
+        .and_then(Value::as_array)
+        .and_then(|hooks| {
+            hooks.iter().find_map(|h| {
+                h.get("command")
+                    .and_then(Value::as_str)
+                    .filter(|c| is_llmtrim_guard_command(c))
+            })
+        });
+    match current {
+        Some(c) if c == desired => OwnedStatus::Current,
+        Some(_) => OwnedStatus::Stale,
+        None => OwnedStatus::Missing,
+    }
+}
+
+/// Install or refresh our guard hook. Returns `true` when the file changed.
+pub fn sync_owned() -> Result<bool> {
+    match owned_status() {
+        OwnedStatus::Current => Ok(false),
+        OwnedStatus::Missing | OwnedStatus::Stale => {
+            wire()?;
+            Ok(true)
+        }
+    }
 }
 
 /// Wire the hook into `~/.claude/settings.json` (merging, never clobbering). Returns the file it
@@ -432,12 +491,7 @@ fn wire_at(path: PathBuf) -> Result<PathBuf> {
         Err(_) => Value::Object(Default::default()),
     };
     set_guard_hook(&mut settings, &path)?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
-    }
-    std::fs::write(&path, serde_json::to_string_pretty(&settings)?)
-        .with_context(|| format!("failed to write {}", path.display()))?;
+    crate::statusline::atomic_write_json(&path, &settings)?;
     Ok(path)
 }
 
@@ -472,8 +526,7 @@ fn unwire_at(path: PathBuf) -> Result<bool> {
     if !clear_guard_hook(&mut settings, &path)? {
         return Ok(false);
     }
-    std::fs::write(&path, serde_json::to_string_pretty(&settings)?)
-        .with_context(|| format!("failed to write {}", path.display()))?;
+    crate::statusline::atomic_write_json(&path, &settings)?;
     Ok(true)
 }
 

--- a/crates/llmtrim-cli/src/lib.rs
+++ b/crates/llmtrim-cli/src/lib.rs
@@ -15,6 +15,7 @@ pub mod compact;
 pub mod daemon;
 pub mod discover;
 pub mod doctor;
+pub mod ensure;
 pub mod guard;
 pub mod mcp;
 pub mod monitor;

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -1594,10 +1594,8 @@ fn run() -> Result<()> {
             None => llmtrim::statusline::run()?,
             Some(StatuslineCmd::Install { print }) => {
                 llmtrim::statusline::install(print)?;
-                if !print {
-                    if let Err(e) = llmtrim::ensure::set_opt_out("statusline", false) {
-                        eprintln!("llmtrim: could not clear statusline opt-out: {e:#}");
-                    }
+                if !print && let Err(e) = llmtrim::ensure::set_opt_out("statusline", false) {
+                    eprintln!("llmtrim: could not clear statusline opt-out: {e:#}");
                 }
             }
             Some(StatuslineCmd::Uninstall) => {
@@ -1613,10 +1611,8 @@ fn run() -> Result<()> {
             None => std::process::exit(llmtrim::guard::run()),
             Some(GuardCmd::Install { print }) => {
                 llmtrim::guard::install(print)?;
-                if !print {
-                    if let Err(e) = llmtrim::ensure::set_opt_out("guard", false) {
-                        eprintln!("llmtrim: could not clear guard opt-out: {e:#}");
-                    }
+                if !print && let Err(e) = llmtrim::ensure::set_opt_out("guard", false) {
+                    eprintln!("llmtrim: could not clear guard opt-out: {e:#}");
                 }
             }
             Some(GuardCmd::Uninstall) => {

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -2939,7 +2939,6 @@ fn run_monitor(
                     let report = llmtrim::doctor::gather();
                     print!("{}", llmtrim::doctor::render(ui::color_stdout(), &report));
                 }
-                PostAction::Fix => llmtrim::ensure::run_cli(false)?,
                 PostAction::Update => llmtrim::update::run()?,
                 PostAction::Restart => {
                     // Stale daemon: restart it onto the freshly-installed binary via the shared
@@ -2949,22 +2948,6 @@ fn run_monitor(
                         eprintln!("{e:#}");
                         std::process::exit(1);
                     }
-                }
-                PostAction::SubLogin => {
-                    println!(
-                        "{}",
-                        ui::note(
-                            ui::color_stdout(),
-                            "Subscription setup: pick a provider, then log in."
-                        )
-                    );
-                    println!("  llmtrim sub auth codex login   # ChatGPT / Codex plan");
-                    println!("  llmtrim sub auth kimi login    # Kimi coding plan");
-                    println!("  llmtrim sub on codex           # enable after login");
-                    let _ = llmtrim::ensure::mark_sub_nudge_shown();
-                }
-                PostAction::SubDismiss => {
-                    let _ = llmtrim::ensure::dismiss_sub_nudge();
                 }
                 PostAction::None => {}
             }

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -46,11 +46,12 @@ const HELP_TEMPLATE: &str = "\
 {usage-heading} {usage}
 
 Get started:
-  setup      Set everything up and start saving (CA, env, autostart, daemon)
+  setup      Set everything up and start saving (CA, env, autostart, integrations, daemon)
   status     Show the savings dashboard + interceptor health  [aliases: monitor, gain]
+  update     Update to the latest release and refresh integrations
+  ensure     Bring this machine to the recommended current state
   wrap       Launch an agent (claude, codex, …) routed through the interceptor
   sub        Reroute Claude Code to another subscription's backend (codex|kimi)
-  compact    Configure cheaper models for Claude Code /compact
   tray       Open the desktop tray app (savings menu-bar / system-tray)
 
 Daemon:
@@ -59,8 +60,7 @@ Daemon:
   autostart  Run the interceptor at login (--off to disable)
 
 When something's wrong:
-  doctor     Check the install end-to-end and explain anything broken
-  update     Update llmtrim to the latest release
+  doctor     Check the install end-to-end; `--fix` applies repairs
   uninstall  Undo everything `setup` did
 
 Pipes & one-shots:
@@ -124,7 +124,9 @@ enum Commands {
     /// Configure cheaper models for Claude Code `/compact`
     ///
     /// Configured alternatives are tried in order when they fit the request. The model Claude Code
-    /// originally requested is always the implicit final fallback.
+    /// originally requested is always the implicit final fallback. Prefer `llmtrim ensure` /
+    /// `setup` for the recommended defaults — this is the power-user escape hatch.
+    #[command(hide = true)]
     Compact {
         #[command(subcommand)]
         action: CompactCmd,
@@ -154,9 +156,10 @@ enum Commands {
     ///
     /// The fastest path from install to compressing: ensures the local CA, sets
     /// HTTPS_PROXY + CA trust in your environment (shell profile on POSIX,
-    /// HKCU\Environment on Windows), enables run-at-login, and starts the
-    /// interceptor. Idempotent — re-running reuses the same port and won't restart a
-    /// healthy daemon. No IDE settings are touched, no sudo.
+    /// HKCU\Environment on Windows), enables run-at-login, wires Claude Code
+    /// integrations (statusline, guard, /sub, compact), and starts the interceptor.
+    /// Idempotent — re-running reuses the same port and won't restart a healthy daemon.
+    /// No sudo.
     Setup {
         /// Interceptor port. Omit to auto-select a free port starting at 43117.
         #[arg(long)]
@@ -165,6 +168,16 @@ enum Commands {
         /// up a new binary). By default setup leaves a healthy same-port daemon running.
         #[arg(long)]
         force: bool,
+    },
+    /// Bring this machine to the recommended current state
+    ///
+    /// Idempotent: rewrites owned Claude Code hooks/statusline when stale, installs
+    /// recommended integrations you have not opted out of, and restarts a version-skewed
+    /// daemon. Same engine `setup` and `update` use — the one verb after a release.
+    Ensure {
+        /// Suppress the summary panel (for scripts / postinstall hooks).
+        #[arg(long, short = 'q')]
+        quiet: bool,
     },
     /// Undo everything `setup` did
     ///
@@ -215,10 +228,11 @@ enum Commands {
     /// interceptor is actually running.
     #[command(name = "_alive", hide = true)]
     Alive,
-    /// Update llmtrim to the latest release
+    /// Update llmtrim to the latest release and refresh integrations
     ///
-    /// Channel-aware: a binary install self-updates via the installer; cargo and
-    /// Homebrew installs print their package manager's command.
+    /// Channel-aware: a binary install self-updates via the installer, restarts the
+    /// daemon, and runs `ensure`. Cargo / Homebrew / npm print their package command;
+    /// run `llmtrim ensure` after that finishes (or open status and press f).
     Update,
     /// Show the savings dashboard + interceptor health
     ///
@@ -272,32 +286,35 @@ enum Commands {
         #[command(subcommand)]
         action: Option<McpAction>,
     },
-    /// Render Claude Code's custom status line (or `statusline install` to wire it up)
+    /// Render Claude Code's custom status line (hook entrypoint; prefer `llmtrim ensure`)
     ///
     /// With no subcommand, reads Claude Code's JSON session blob on stdin and prints one
-    /// elegant line — model·effort→backend, a context-health gauge, compression saved, and
-    /// (when present) rate-limit usage and this turn's prompt-cache reuse. `install` wires it
-    /// into `~/.claude/settings.json`; `install --print` just prints the settings snippet.
+    /// elegant line. `install` / `uninstall` are power-user escape hatches — `setup`,
+    /// `update`, and `ensure` keep the status line current automatically.
+    #[command(hide = true)]
     Statusline {
         #[command(subcommand)]
         action: Option<StatuslineCmd>,
     },
-    /// Warn before the first turn of a resumed, cold-cache session (or `guard install` to wire it up)
+    /// Cold-cache resume warning hook (prefer `llmtrim ensure`)
     ///
-    /// With no subcommand, acts as Claude Code's `UserPromptSubmit` hook: reads the hook JSON on
-    /// stdin and, when the session has been idle past the prompt-cache TTL with a large context,
-    /// blocks that one prompt and prints what re-writing the context will cost. Resend to go ahead.
-    /// `install` wires it into `~/.claude/settings.json` (merging with your other hooks);
-    /// `install --print` just prints the settings snippet.
+    /// With no subcommand, acts as Claude Code's `UserPromptSubmit` hook. `install` /
+    /// `uninstall` are escape hatches — `setup` / `update` / `ensure` wire this for you.
+    #[command(hide = true)]
     Guard {
         #[command(subcommand)]
         action: Option<GuardCmd>,
     },
     /// Check the install end-to-end and explain anything broken
     ///
-    /// Read-only diagnosis: binary, daemon, port, env wiring (persisted + this shell),
-    /// CA, autostart, ledger, version skew. Exits non-zero if any check fails.
-    Doctor,
+    /// Diagnosis: binary, daemon, port, env wiring (persisted + this shell), CA, autostart,
+    /// ledger, version skew, Claude Code integrations. Exits non-zero if any check fails.
+    /// Pass `--fix` to apply repairs (same as `llmtrim ensure`).
+    Doctor {
+        /// Apply recommended fixes instead of only naming them.
+        #[arg(long)]
+        fix: bool,
+    },
     /// Run the interceptor at login (`--off` to disable)
     ///
     /// systemd (Linux) / launchd (macOS) / registry run-key (Windows).
@@ -778,11 +795,17 @@ fn run_window_sub(args: Vec<String>) -> Result<()> {
     };
     match action {
         "install" => {
-            llmtrim::window_sub::install(&std::env::current_exe()?.display().to_string())?;
+            llmtrim::window_sub::install(&llmtrim::statusline::stable_exe_string())?;
+            if let Err(e) = llmtrim::ensure::set_opt_out("window_sub", false) {
+                eprintln!("llmtrim: could not clear /sub opt-out: {e:#}");
+            }
             println!("Claude Code /sub integration installed.");
         }
         "uninstall" => {
             llmtrim::window_sub::uninstall()?;
+            if let Err(e) = llmtrim::ensure::set_opt_out("window_sub", true) {
+                eprintln!("llmtrim: could not record /sub opt-out: {e:#}");
+            }
             println!("Claude Code /sub integration removed.");
         }
         "hook-start" => {
@@ -969,6 +992,9 @@ fn run_compact(action: CompactCmd) -> Result<()> {
                 anyhow::bail!("compact model list is empty; use `llmtrim compact off` to disable");
             }
             llmtrim_core::config::write_compact_models(&normalized)?;
+            if let Err(e) = llmtrim::ensure::set_opt_out("compact", false) {
+                eprintln!("llmtrim: could not clear compact opt-out: {e:#}");
+            }
             println!(
                 "Compact models: {} -> original model (implicit).",
                 normalized.join(" -> ")
@@ -978,6 +1004,9 @@ fn run_compact(action: CompactCmd) -> Result<()> {
         }
         CompactCmd::Off { no_restart } => {
             llmtrim_core::config::write_compact_models(&[])?;
+            if let Err(e) = llmtrim::ensure::set_opt_out("compact", true) {
+                eprintln!("llmtrim: could not record compact opt-out: {e:#}");
+            }
             println!("Compact model substitution disabled; `/compact` uses the original model.");
             apply_sub_change(no_restart);
             Ok(())
@@ -1401,6 +1430,7 @@ fn run() -> Result<()> {
             }
         }
         Commands::Setup { port, force } => llmtrim::setup::run(port, force)?,
+        Commands::Ensure { quiet } => llmtrim::ensure::run_cli(quiet)?,
         Commands::Uninstall { purge, keep_binary } => {
             llmtrim::setup::uninstall(purge, keep_binary)?
         }
@@ -1435,6 +1465,8 @@ fn run() -> Result<()> {
                         )
                     )
                 );
+                // Quiet migration after version bumps — no prompts, no tray download.
+                let _ = llmtrim::ensure::maybe_auto();
             } else {
                 // No live daemon → resolve the port the same way `setup` does (explicit, else
                 // the one already wired into the env, else DEFAULT_PORT) so we match clients.
@@ -1447,6 +1479,7 @@ fn run() -> Result<()> {
                         &format!("Interceptor running · pid {pid} · port {port}")
                     )
                 );
+                let _ = llmtrim::ensure::maybe_auto();
                 for (label, value) in [
                     ("watch", "llmtrim status".to_string()),
                     ("stop", "llmtrim stop".to_string()),
@@ -1559,15 +1592,39 @@ fn run() -> Result<()> {
         },
         Commands::Statusline { action } => match action {
             None => llmtrim::statusline::run()?,
-            Some(StatuslineCmd::Install { print }) => llmtrim::statusline::install(print)?,
-            Some(StatuslineCmd::Uninstall) => llmtrim::statusline::uninstall()?,
+            Some(StatuslineCmd::Install { print }) => {
+                llmtrim::statusline::install(print)?;
+                if !print {
+                    if let Err(e) = llmtrim::ensure::set_opt_out("statusline", false) {
+                        eprintln!("llmtrim: could not clear statusline opt-out: {e:#}");
+                    }
+                }
+            }
+            Some(StatuslineCmd::Uninstall) => {
+                llmtrim::statusline::uninstall()?;
+                if let Err(e) = llmtrim::ensure::set_opt_out("statusline", true) {
+                    eprintln!("llmtrim: could not record statusline opt-out: {e:#}");
+                }
+            }
         },
         Commands::Guard { action } => match action {
             // The hook path: Claude Code reads the exit code, so return it rather than a Result —
             // 2 blocks the prompt, anything else lets it through.
             None => std::process::exit(llmtrim::guard::run()),
-            Some(GuardCmd::Install { print }) => llmtrim::guard::install(print)?,
-            Some(GuardCmd::Uninstall) => llmtrim::guard::uninstall()?,
+            Some(GuardCmd::Install { print }) => {
+                llmtrim::guard::install(print)?;
+                if !print {
+                    if let Err(e) = llmtrim::ensure::set_opt_out("guard", false) {
+                        eprintln!("llmtrim: could not clear guard opt-out: {e:#}");
+                    }
+                }
+            }
+            Some(GuardCmd::Uninstall) => {
+                llmtrim::guard::uninstall()?;
+                if let Err(e) = llmtrim::ensure::set_opt_out("guard", true) {
+                    eprintln!("llmtrim: could not record guard opt-out: {e:#}");
+                }
+            }
         },
         Commands::Monitor {
             // Deprecated no-op (see the field docs): accepted, then ignored.
@@ -1583,7 +1640,10 @@ fn run() -> Result<()> {
         } => run_monitor(
             interval, daily, weekly, monthly, json, breakdown, csv, quiet,
         )?,
-        Commands::Doctor => {
+        Commands::Doctor { fix } => {
+            if fix {
+                llmtrim::ensure::run_cli(false)?;
+            }
             let report = llmtrim::doctor::gather();
             print!("{}", llmtrim::doctor::render(ui::color_stdout(), &report));
             if report.problems > 0 {
@@ -2876,11 +2936,14 @@ fn run_monitor(
             // The TUI may queue a follow-up command (d = doctor/repair, u = update); run it on
             // the normal screen after the alt-screen tears down.
             use llmtrim::breakdown::app::PostAction;
+            // Heal integrations from a version bump before the TUI opens (quiet).
+            let _ = llmtrim::ensure::maybe_auto();
             match llmtrim::breakdown::app::run(interval.max(2), snapshot)? {
                 PostAction::Doctor => {
                     let report = llmtrim::doctor::gather();
                     print!("{}", llmtrim::doctor::render(ui::color_stdout(), &report));
                 }
+                PostAction::Fix => llmtrim::ensure::run_cli(false)?,
                 PostAction::Update => llmtrim::update::run()?,
                 PostAction::Restart => {
                     // Stale daemon: restart it onto the freshly-installed binary via the shared
@@ -2890,6 +2953,22 @@ fn run_monitor(
                         eprintln!("{e:#}");
                         std::process::exit(1);
                     }
+                }
+                PostAction::SubLogin => {
+                    println!(
+                        "{}",
+                        ui::note(
+                            ui::color_stdout(),
+                            "Subscription setup: pick a provider, then log in."
+                        )
+                    );
+                    println!("  llmtrim sub auth codex login   # ChatGPT / Codex plan");
+                    println!("  llmtrim sub auth kimi login    # Kimi coding plan");
+                    println!("  llmtrim sub on codex           # enable after login");
+                    let _ = llmtrim::ensure::mark_sub_nudge_shown();
+                }
+                PostAction::SubDismiss => {
+                    let _ = llmtrim::ensure::dismiss_sub_nudge();
                 }
                 PostAction::None => {}
             }

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -513,7 +513,7 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
         ));
         crate::ensure::Report::default()
     });
-    let compact_changed = ensure_report.applied.iter().any(|id| *id == "compact");
+    let compact_changed = ensure_report.applied.contains(&"compact");
     rows.extend(ensure_report.rows);
 
     // 4. Reconcile the interceptor. If a healthy daemon is already serving the resolved port,

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -495,102 +495,26 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
         Err(e) => rows.push((ui::WARN, "Autostart".into(), format!("not enabled: {e}"))),
     }
 
-    // 3b. Desktop tray. Only offered when the GUI binary is installed next to the
-    //     CLI (the desktop bundles ship it; a headless `cargo install` doesn't),
-    //     which is also how "only on a desktop OS" is enforced. Default is on;
-    //     `--force` / a non-interactive setup take that default without asking.
-    if crate::tray::tray_binary().is_some() {
-        let want = force || confirm_tray_default_yes();
-        match crate::autostart::configure_tray(want) {
-            Ok(()) if want => rows.push((
-                ui::OK,
-                "Tray".into(),
-                "opens at login · run `llmtrim tray` to open now".into(),
-            )),
-            Ok(()) => rows.push((
-                ui::OK,
-                "Tray".into(),
-                "left disabled · enable later with `llmtrim autostart --tray`".into(),
-            )),
-            Err(e) => rows.push((ui::WARN, "Tray".into(), format!("not enabled: {e}"))),
-        }
-    }
-
-    // 3c. Claude Code compaction routing. Ask only on first configuration; re-running setup must
-    // never overwrite a customized order or a remembered opt-out. Scripted setup takes the
-    // recommended default, matching the tray's non-interactive default behavior.
-    let mut compact_changed = false;
-    if crate::statusline::claude_code_present()
-        && !llmtrim_core::config::compact_models_configured()
-    {
-        let want = force || confirm_compact_default_yes();
-        let models = if want {
-            vec!["haiku".to_string(), "sonnet".to_string()]
-        } else {
-            Vec::new()
-        };
-        match llmtrim_core::config::write_compact_models(&models) {
-            Ok(()) => {
-                compact_changed = true;
-                rows.push((
-                    ui::OK,
-                    "Compact".into(),
-                    if want {
-                        "Haiku → Sonnet → original model".into()
-                    } else {
-                        "original model only".into()
-                    },
-                ));
-            }
-            Err(e) => rows.push((ui::WARN, "Compact".into(), format!("not configured: {e}"))),
-        }
-    }
-
-    // 3d. Claude Code's cold-cache guard. Offered only to Claude Code users (setup stays
-    //     client-agnostic otherwise), default on; `--force` / a non-interactive setup take that
-    //     default without asking. Merges into `hooks.UserPromptSubmit` — other hooks are kept.
-    if crate::statusline::claude_code_present() {
-        if force || confirm_guard_default_yes() {
-            match crate::guard::wire() {
-                Ok(path) => rows.push((
-                    ui::OK,
-                    "Guard".into(),
-                    format!("warns before a cold resumed turn · {}", path.display()),
-                )),
-                Err(e) => rows.push((ui::WARN, "Guard".into(), format!("not wired: {e}"))),
-            }
-        } else {
-            rows.push((
-                ui::OK,
-                "Guard".into(),
-                "left off · enable later with `llmtrim guard install`".into(),
-            ));
-        }
-    }
-    // Window-local /sub is safe to install automatically: it only adds owned hooks and a skill;
-    // it neither edits global reroute configuration nor restarts the daemon.
-    if crate::statusline::claude_code_present() {
-        match std::env::current_exe()
-            .ok()
-            .map(|p| crate::window_sub::install(&p.display().to_string()))
-        {
-            Some(Ok(())) => rows.push((
-                ui::OK,
-                "Window /sub".into(),
-                "installed Claude Code window-local controls".into(),
-            )),
-            Some(Err(e)) => rows.push((
-                ui::WARN,
-                "Window /sub".into(),
-                format!("not installed: {e}"),
-            )),
-            None => rows.push((
-                ui::WARN,
-                "Window /sub".into(),
-                "could not resolve llmtrim binary".into(),
-            )),
-        }
-    }
+    // 3b. Claude Code integrations + tray: one ensure pass (statusline, guard, /sub, compact,
+    //     tray autostart). Idempotent; honors remembered opt-outs. `--force` / non-TTY take
+    //     recommended defaults without asking.
+    let ensure_report = crate::ensure::apply(crate::ensure::Options {
+        interactive: !force && std::io::IsTerminal::is_terminal(&std::io::stdin()),
+        quiet: true,
+        restart_daemon: false, // setup reconciles the interceptor below
+        download_tray: false,
+        install_missing: true,
+    })
+    .unwrap_or_else(|e| {
+        rows.push((
+            ui::WARN,
+            "Ensure".into(),
+            format!("integrations skipped: {e:#}"),
+        ));
+        crate::ensure::Report::default()
+    });
+    let compact_changed = ensure_report.applied.iter().any(|id| *id == "compact");
+    rows.extend(ensure_report.rows);
 
     // 4. Reconcile the interceptor. If a healthy daemon is already serving the resolved port,
     //    leave it running — re-running `setup` must not drop in-flight requests (the old code
@@ -697,14 +621,8 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
         "  {}  llmtrim status",
         ui::paint(color, Tone::Dim, "watch savings")
     );
-    // Claude Code users only: hint at the status line without writing their config (setup is
-    // client-agnostic and never touches IDE settings). No-op for users of other agents.
-    if crate::statusline::claude_code_present() {
-        println!(
-            "  {}  llmtrim statusline install",
-            ui::paint(color, Tone::Dim, "status line  ")
-        );
-    }
+    // Claude Code integrations (statusline, guard, /sub, compact) are applied by ensure above —
+    // no separate install homework.
     #[cfg(windows)]
     println!(
         "{}",
@@ -759,57 +677,6 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
         println!("    gemini extensions uninstall caveman  # Gemini CLI");
     }
     Ok(())
-}
-
-/// Ask whether to route Claude Code compaction through cheaper models, defaulting to yes. A
-/// scripted setup takes the default without blocking on stdin.
-fn confirm_compact_default_yes() -> bool {
-    use std::io::{IsTerminal, Write};
-    if !std::io::stdin().is_terminal() {
-        return true;
-    }
-    print!("Use cheaper models for Claude Code /compact (Haiku -> Sonnet -> original)? [Y/n] ");
-    let _ = std::io::stdout().flush();
-    let mut line = String::new();
-    if std::io::stdin().read_line(&mut line).is_err() {
-        return false;
-    }
-    !matches!(line.trim().to_ascii_lowercase().as_str(), "n" | "no")
-}
-
-/// Ask whether to enable the desktop tray, defaulting to yes. Returns `true`
-/// (the default) without asking when stdin isn't a terminal, so a scripted
-/// `setup` stays non-interactive and still enables the tray.
-fn confirm_tray_default_yes() -> bool {
-    use std::io::{IsTerminal, Write};
-    if !std::io::stdin().is_terminal() {
-        return true;
-    }
-    print!("Enable the llmtrim desktop tray (opens at login)? [Y/n] ");
-    let _ = std::io::stdout().flush();
-    let mut line = String::new();
-    if std::io::stdin().read_line(&mut line).is_err() {
-        // The prompt couldn't be completed (broken pipe, closed stdin). Decline
-        // rather than enable an optional component the user never confirmed.
-        return false;
-    }
-    !matches!(line.trim().to_ascii_lowercase().as_str(), "n" | "no")
-}
-
-/// Ask whether to arm the cold-cache guard, defaulting to yes. Same contract as
-/// [`confirm_tray_default_yes`]: a scripted `setup` stays non-interactive and takes the default.
-fn confirm_guard_default_yes() -> bool {
-    use std::io::{IsTerminal, Write};
-    if !std::io::stdin().is_terminal() {
-        return true;
-    }
-    print!("Warn before the first turn of a resumed session whose cache went cold? [Y/n] ");
-    let _ = std::io::stdout().flush();
-    let mut line = String::new();
-    if std::io::stdin().read_line(&mut line).is_err() {
-        return false;
-    }
-    !matches!(line.trim().to_ascii_lowercase().as_str(), "n" | "no")
 }
 
 /// Best-effort caveman detection: the flag file its session hook writes, its standalone

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -1017,8 +1017,8 @@ pub fn sync_owned() -> Result<SyncOutcome> {
         Err(_) => Value::Object(Default::default()),
     };
     match owned_status_of(&settings) {
-        OwnedStatus::Foreign => return Ok(SyncOutcome::SkippedForeign),
-        OwnedStatus::Current => return Ok(SyncOutcome::AlreadyCurrent),
+        OwnedStatus::Foreign => Ok(SyncOutcome::SkippedForeign),
+        OwnedStatus::Current => Ok(SyncOutcome::AlreadyCurrent),
         OwnedStatus::Missing => {
             set_statusline(&mut settings, &path)?;
             write_settings(&path, &settings)?;

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -816,7 +816,8 @@ pub(crate) fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
     let tmp = path.with_extension("json.tmp");
     std::fs::write(&tmp, serde_json::to_string_pretty(value)?)
         .with_context(|| format!("failed to write {}", tmp.display()))?;
-    std::fs::rename(&tmp, path).with_context(|| format!("failed to rename onto {}", path.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("failed to rename onto {}", path.display()))?;
     Ok(())
 }
 
@@ -990,9 +991,7 @@ fn owned_status_of(settings: &Value) -> OwnedStatus {
         .get("refreshInterval")
         .and_then(Value::as_i64)
         .unwrap_or(REFRESH_INTERVAL_SECS);
-    let refresh = status_line
-        .get("refreshInterval")
-        .and_then(Value::as_i64);
+    let refresh = status_line.get("refreshInterval").and_then(Value::as_i64);
     if command == desired_cmd && refresh == Some(desired_refresh) {
         OwnedStatus::Current
     } else {

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -773,11 +773,51 @@ pub fn claude_code_present() -> bool {
         .unwrap_or(false)
 }
 
-fn claude_settings_path() -> Result<PathBuf> {
+/// Claude Code settings.json — honors `CLAUDE_CONFIG_DIR`, else `~/.claude`.
+pub(crate) fn claude_settings_path() -> Result<PathBuf> {
+    if let Some(dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        return Ok(PathBuf::from(dir).join("settings.json"));
+    }
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .context("neither HOME nor USERPROFILE is set")?;
     Ok(PathBuf::from(home).join(".claude").join("settings.json"))
+}
+
+/// Shell-safe single-quoted path for hook/statusline command strings (POSIX; Windows uses doubles).
+pub(crate) fn shell_quote_path(path: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!("\"{}\"", path.replace('"', "\\\""))
+    }
+    #[cfg(not(windows))]
+    {
+        // POSIX: single-quote and break/reopen for embedded quotes.
+        format!("'{}'", path.replace('\'', "'\"'\"'"))
+    }
+}
+
+/// Absolute or stable PATH path to this llmtrim binary (no subcommand).
+pub fn stable_exe_string() -> String {
+    std::env::current_exe()
+        .ok()
+        .filter(|p| p.exists())
+        .map(|p| stable_executable_path(&p, std::env::var_os("PATH").as_deref()))
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "llmtrim".to_string())
+}
+
+/// Atomically write pretty JSON (temp in same dir + rename).
+pub(crate) fn atomic_write_json(path: &Path, value: &Value) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, serde_json::to_string_pretty(value)?)
+        .with_context(|| format!("failed to write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path).with_context(|| format!("failed to rename onto {}", path.display()))?;
+    Ok(())
 }
 
 /// Return a stable PATH alias for `current_exe` when one resolves to the same binary.
@@ -818,16 +858,7 @@ fn stable_executable_path(current_exe: &Path, path: Option<&OsStr>) -> PathBuf {
 /// stable PATH alias, so it survives a package manager replacing a versioned executable. Shared
 /// with [`crate::guard`], which writes a hook command the same way.
 pub(crate) fn exe_command(subcommand: &str) -> String {
-    let exe = std::env::current_exe()
-        .ok()
-        .map(|p| stable_executable_path(&p, std::env::var_os("PATH").as_deref()))
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|| "llmtrim".to_string());
-    if exe.contains(' ') {
-        format!("\"{exe}\" {subcommand}")
-    } else {
-        format!("{exe} {subcommand}")
-    }
+    format!("{} {subcommand}", shell_quote_path(&stable_exe_string()))
 }
 
 /// The `statusLine` object we write.
@@ -851,13 +882,21 @@ pub(crate) fn is_llmtrim_command(command: &str, subcommand: &str) -> bool {
     let Some(executable) = command.strip_suffix(&format!(" {subcommand}")) else {
         return false;
     };
-    let executable = executable.trim();
-    let executable = executable
-        .strip_prefix('"')
-        .and_then(|value| value.strip_suffix('"'))
-        .unwrap_or(executable);
+    let executable = unquote_path_token(executable.trim());
     let name = executable.rsplit(['/', '\\']).next().unwrap_or(executable);
     name.strip_suffix(".exe").unwrap_or(name) == "llmtrim"
+}
+
+/// Strip one layer of shell quotes from a path token (double or single).
+pub(crate) fn unquote_path_token(s: &str) -> &str {
+    let s = s.trim();
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        return &s[1..s.len() - 1];
+    }
+    if s.len() >= 2 && s.starts_with('\'') && s.ends_with('\'') {
+        return &s[1..s.len() - 1];
+    }
+    s
 }
 
 /// Set our `statusLine` key on a parsed settings object, preserving every other key. Pure
@@ -899,8 +938,7 @@ pub fn install(print: bool) -> Result<()> {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
-    std::fs::write(&path, serde_json::to_string_pretty(&settings)?)
-        .with_context(|| format!("failed to write {}", path.display()))?;
+    write_settings(&path, &settings)?;
 
     println!(
         "Wired the llmtrim status line into {}. Restart Claude Code to see it.",
@@ -909,9 +947,99 @@ pub fn install(print: bool) -> Result<()> {
     Ok(())
 }
 
-/// Re-point an existing llmtrim-owned Claude statusline at the current binary. Only the
-/// `command` string is rewritten: a custom command is left alone, and so is any other key the
-/// user set on the `statusLine` object (`padding`, …). Returns whether anything changed.
+/// Ownership of the Claude Code `statusLine` key relative to this binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnedStatus {
+    /// No `statusLine` key (or missing settings file).
+    Missing,
+    /// Ours, but command path or refreshInterval differs from what we would write now.
+    Stale,
+    /// Ours and matches the current payload.
+    Current,
+    /// Present but not an llmtrim statusline — leave it alone.
+    Foreign,
+}
+
+/// Whether ensure should install / refresh the status line.
+pub fn owned_status() -> OwnedStatus {
+    let Ok(path) = claude_settings_path() else {
+        return OwnedStatus::Missing;
+    };
+    let Ok(s) = std::fs::read_to_string(&path) else {
+        return OwnedStatus::Missing;
+    };
+    let Ok(settings) = serde_json::from_str::<Value>(&s) else {
+        return OwnedStatus::Missing;
+    };
+    owned_status_of(&settings)
+}
+
+fn owned_status_of(settings: &Value) -> OwnedStatus {
+    let Some(status_line) = settings.get("statusLine").and_then(Value::as_object) else {
+        return OwnedStatus::Missing;
+    };
+    let Some(command) = status_line.get("command").and_then(Value::as_str) else {
+        return OwnedStatus::Foreign;
+    };
+    if !is_llmtrim_statusline_command(command) {
+        return OwnedStatus::Foreign;
+    }
+    let desired = statusline_config();
+    let desired_cmd = desired.get("command").and_then(Value::as_str).unwrap_or("");
+    let desired_refresh = desired
+        .get("refreshInterval")
+        .and_then(Value::as_i64)
+        .unwrap_or(REFRESH_INTERVAL_SECS);
+    let refresh = status_line
+        .get("refreshInterval")
+        .and_then(Value::as_i64);
+    if command == desired_cmd && refresh == Some(desired_refresh) {
+        OwnedStatus::Current
+    } else {
+        OwnedStatus::Stale
+    }
+}
+
+/// Outcome of [`sync_owned`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncOutcome {
+    Installed,
+    Refreshed,
+    AlreadyCurrent,
+    SkippedForeign,
+}
+
+/// Install or refresh our status line. Never overwrites a foreign custom status line.
+pub fn sync_owned() -> Result<SyncOutcome> {
+    let path = claude_settings_path()?;
+    let mut settings: Value = match std::fs::read_to_string(&path) {
+        Ok(s) => serde_json::from_str(&s)
+            .with_context(|| format!("{} is not valid JSON", path.display()))?,
+        Err(_) => Value::Object(Default::default()),
+    };
+    match owned_status_of(&settings) {
+        OwnedStatus::Foreign => return Ok(SyncOutcome::SkippedForeign),
+        OwnedStatus::Current => return Ok(SyncOutcome::AlreadyCurrent),
+        OwnedStatus::Missing => {
+            set_statusline(&mut settings, &path)?;
+            write_settings(&path, &settings)?;
+            Ok(SyncOutcome::Installed)
+        }
+        OwnedStatus::Stale => {
+            // Replace only our owned fields (command + refreshInterval); keep padding etc.
+            refresh_statusline_config(&mut settings)?;
+            write_settings(&path, &settings)?;
+            Ok(SyncOutcome::Refreshed)
+        }
+    }
+}
+
+fn write_settings(path: &Path, settings: &Value) -> Result<()> {
+    atomic_write_json(path, settings)
+}
+
+/// Re-point an existing llmtrim-owned Claude statusline at the current binary and ensure
+/// `refreshInterval` is set. A custom command is left alone. Returns whether anything changed.
 fn refresh_statusline_config(settings: &mut Value) -> Result<bool> {
     let Some(status_line) = settings
         .get_mut("statusLine")
@@ -926,36 +1054,49 @@ fn refresh_statusline_config(settings: &mut Value) -> Result<bool> {
         return Ok(false);
     }
 
-    let Some(current) = statusline_config()
+    let desired = statusline_config();
+    let desired_cmd = desired
         .get("command")
         .and_then(Value::as_str)
         .map(str::to_string)
-    else {
-        return Ok(false);
-    };
-    if current == command {
-        return Ok(false);
+        .unwrap_or_default();
+    let desired_refresh = desired
+        .get("refreshInterval")
+        .cloned()
+        .unwrap_or(Value::from(REFRESH_INTERVAL_SECS));
+
+    let mut changed = false;
+    if status_line.get("command").and_then(Value::as_str) != Some(desired_cmd.as_str()) {
+        status_line.insert("command".to_string(), Value::String(desired_cmd));
+        changed = true;
     }
-    status_line.insert("command".to_string(), Value::String(current));
-    Ok(true)
+    if status_line.get("refreshInterval") != Some(&desired_refresh) {
+        status_line.insert("refreshInterval".to_string(), desired_refresh);
+        changed = true;
+    }
+    Ok(changed)
 }
 
 /// Refresh an existing llmtrim-owned Claude statusline without touching custom commands.
 /// Returns whether the settings file was rewritten. This runs during `llmtrim update` before
-/// package managers can remove a versioned executable path.
+/// package managers can remove a versioned executable path. Does **not** install when missing.
 pub fn refresh_if_installed() -> Result<bool> {
-    let path = claude_settings_path()?;
-    let Ok(s) = std::fs::read_to_string(&path) else {
-        return Ok(false);
-    };
-    let mut settings: Value = serde_json::from_str(&s)
-        .with_context(|| format!("{} is not valid JSON", path.display()))?;
-    if !refresh_statusline_config(&mut settings)? {
-        return Ok(false);
+    match owned_status() {
+        OwnedStatus::Missing | OwnedStatus::Foreign | OwnedStatus::Current => Ok(false),
+        OwnedStatus::Stale => {
+            let path = claude_settings_path()?;
+            let Ok(s) = std::fs::read_to_string(&path) else {
+                return Ok(false);
+            };
+            let mut settings: Value = serde_json::from_str(&s)
+                .with_context(|| format!("{} is not valid JSON", path.display()))?;
+            if !refresh_statusline_config(&mut settings)? {
+                return Ok(false);
+            }
+            write_settings(&path, &settings)?;
+            Ok(true)
+        }
     }
-    std::fs::write(&path, serde_json::to_string_pretty(&settings)?)
-        .with_context(|| format!("failed to write {}", path.display()))?;
-    Ok(true)
 }
 
 /// Remove the `statusLine` key we wrote (leaves the rest of `settings.json` untouched).

--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -317,10 +317,7 @@ fn post_update_ensure(color: bool) {
         .status();
     match status {
         Ok(s) if s.success() => {
-            println!(
-                "{}",
-                crate::ui::ok(color, "Integrations synced.")
-            );
+            println!("{}", crate::ui::ok(color, "Integrations synced."));
         }
         Ok(_) => eprintln!(
             "{}",

--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -303,6 +303,8 @@ fn live_exe() -> std::path::PathBuf {
 }
 
 /// After a successful binary-channel update: run `ensure -q` via the **new** binary.
+/// Only used on non-Windows (Unix curl installer); Windows prints the manual panel instead.
+#[cfg(not(windows))]
 fn post_update_ensure(color: bool) {
     println!(
         "{}",

--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -17,7 +17,9 @@ const CURRENT: &str = env!("CARGO_PKG_VERSION");
 
 /// The "now restart the daemon onto the new binary" follow-up, shown after every channel's
 /// update instructions. One constant so the command and its comment stay in lockstep.
-const RESTART_HINT: &str = "llmtrim start --force    # restart the daemon on the new binary";
+/// Post-upgrade follow-up for package-manager channels: ensure restarts a skewed daemon and
+/// refreshes Claude Code integrations. Prefer this over a bare `start --force`.
+const ENSURE_HINT: &str = "llmtrim ensure           # restart daemon + refresh integrations";
 
 /// `owner/name` parsed from the crate's repository URL.
 fn repo() -> &'static str {
@@ -204,19 +206,19 @@ pub fn run() -> Result<()> {
     match channel() {
         Channel::Cargo => instructions(
             "update via cargo",
-            &["cargo install --locked llmtrim --force", RESTART_HINT],
+            &["cargo install --locked llmtrim --force", ENSURE_HINT],
         ),
         Channel::Homebrew => instructions(
             "update via Homebrew",
             &[
                 "brew tap fkiene/tap",
                 "brew upgrade fkiene/tap/llmtrim",
-                RESTART_HINT,
+                ENSURE_HINT,
             ],
         ),
         Channel::Npm => instructions(
             "update via npm",
-            &["npm install -g @llmtrim/cli@latest", RESTART_HINT],
+            &["npm install -g @llmtrim/cli@latest", ENSURE_HINT],
         ),
         Channel::Binary => {
             let tag = latest
@@ -231,7 +233,7 @@ pub fn run() -> Result<()> {
                         "iwr -useb https://raw.githubusercontent.com/{}/{tag}/install.ps1 | iex",
                         repo()
                     ),
-                    RESTART_HINT,
+                    ENSURE_HINT,
                 ],
             );
             #[cfg(not(windows))]
@@ -259,10 +261,13 @@ pub fn run() -> Result<()> {
                         crate::ui::panel(
                             color,
                             "update failed, finish it manually",
-                            &[manual_install_cmd(&url, &tag), RESTART_HINT.to_string()],
+                            &[manual_install_cmd(&url, &tag), ENSURE_HINT.to_string()],
                         )
                     );
                 };
+                // Installer runs setup (and may start the daemon). Pin NO_SETUP so we control
+                // restart + ensure from this process via the *new* on-disk binary.
+                cmd.env("LLMTRIM_NO_SETUP", "1");
                 let status = match cmd.status() {
                     Ok(s) => s,
                     Err(e) => {
@@ -278,15 +283,57 @@ pub fn run() -> Result<()> {
                 if let Some(v) = latest {
                     write_cache(&v); // clear the `monitor` banner
                 }
-                // The installer laid down the new binary, but the running daemon is still on
-                // the old one (Stale). Finish the job here so `update` leaves nothing behind —
-                // otherwise `status` would show a `u  Update` nudge for a restart the user must
-                // do by hand. Same path as the TUI's `u` (PostAction::Restart).
+                // Always finish on the new binary: in-process ensure would stamp the old
+                // CARGO_PKG_VERSION and rewrite Claude hooks with a ghost `(deleted)` path.
                 restart_daemon(color)?;
+                post_update_ensure(color);
             }
         }
     }
+    // Package-manager channels: the panel already ends with `llmtrim ensure`.
     Ok(())
+}
+
+/// Path to the on-disk llmtrim to spawn after a self-replacing install (never a deleted path).
+fn live_exe() -> std::path::PathBuf {
+    std::env::current_exe()
+        .ok()
+        .filter(|p| p.exists())
+        .unwrap_or_else(|| std::path::PathBuf::from("llmtrim"))
+}
+
+/// After a successful binary-channel update: run `ensure -q` via the **new** binary.
+fn post_update_ensure(color: bool) {
+    println!(
+        "{}",
+        crate::ui::paint(
+            color,
+            crate::ui::Tone::Dim,
+            "Syncing integrations on the new binary…"
+        )
+    );
+    let status = std::process::Command::new(live_exe())
+        .args(["ensure", "-q"])
+        .status();
+    match status {
+        Ok(s) if s.success() => {
+            println!(
+                "{}",
+                crate::ui::ok(color, "Integrations synced.")
+            );
+        }
+        Ok(_) => eprintln!(
+            "{}",
+            crate::ui::note(
+                color,
+                "ensure exited non-zero — run `llmtrim ensure` yourself."
+            )
+        ),
+        Err(e) => eprintln!(
+            "{}",
+            crate::ui::note(color, &format!("Could not run ensure: {e}"))
+        ),
+    }
 }
 
 /// Restart the daemon onto the freshly-installed binary via `start --force` (the documented
@@ -294,13 +341,6 @@ pub fn run() -> Result<()> {
 /// the installer) and the TUI's `PostAction::Restart` in `main.rs`, so the restart lives in one
 /// place. On failure it bails with an actionable message rather than leaving the user guessing.
 pub fn restart_daemon(color: bool) -> Result<()> {
-    // The installer replaces the binary on disk; on Linux `current_exe()` can then resolve to a
-    // `…/llmtrim (deleted)` ghost path. Fall back to `llmtrim` on PATH when the resolved path no
-    // longer exists, so the restart still lands on the freshly-installed binary.
-    let exe = std::env::current_exe()
-        .ok()
-        .filter(|p| p.exists())
-        .unwrap_or_else(|| std::path::PathBuf::from("llmtrim"));
     println!(
         "\n{}",
         crate::ui::paint(
@@ -309,14 +349,22 @@ pub fn restart_daemon(color: bool) -> Result<()> {
             "Restarting the daemon on the new binary…"
         )
     );
-    let status = std::process::Command::new(exe)
+    restart_daemon_silent()
+}
+
+/// Same as [`restart_daemon`] without the chatter — used by [`crate::ensure`].
+pub fn restart_daemon_silent() -> Result<()> {
+    // The installer replaces the binary on disk; on Linux `current_exe()` can then resolve to a
+    // `…/llmtrim (deleted)` ghost path. Fall back to `llmtrim` on PATH when the resolved path no
+    // longer exists, so the restart still lands on the freshly-installed binary.
+    let status = std::process::Command::new(live_exe())
         .args(["start", "--force"])
         .status()
         .context("run llmtrim start --force")?;
     if !status.success() {
         anyhow::bail!(
             "daemon restart failed (llmtrim start --force exited non-zero). \
-             Restart it yourself with: llmtrim start --force"
+             Run: llmtrim ensure   (or llmtrim start --force)"
         );
     }
     Ok(())

--- a/crates/llmtrim-cli/src/window_sub.rs
+++ b/crates/llmtrim-cli/src/window_sub.rs
@@ -332,6 +332,85 @@ fn remove_owned_hooks(groups: &mut Vec<serde_json::Value>) {
             .is_none_or(|hooks| !hooks.is_empty())
     });
 }
+/// Ownership of the `/sub` skill + hooks relative to this binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnedStatus {
+    Missing,
+    Stale,
+    Current,
+}
+
+/// Whether the Claude Code `/sub` skill + owned hooks are present.
+pub fn is_installed() -> bool {
+    !matches!(owned_status(), OwnedStatus::Missing)
+}
+
+/// Missing / present-but-stale-path / current for ensure probe + apply.
+pub fn owned_status() -> OwnedStatus {
+    let Ok(p) = settings_path() else {
+        return OwnedStatus::Missing;
+    };
+    let Some(skill) = p
+        .parent()
+        .map(|dir| dir.join("skills").join(COMMAND_NAME).join("SKILL.md"))
+    else {
+        return OwnedStatus::Missing;
+    };
+    if !fs::read_to_string(&skill)
+        .unwrap_or_default()
+        .contains("llmtrim-owned-window-sub")
+    {
+        return OwnedStatus::Missing;
+    }
+    let Some(root) = fs::read_to_string(&p)
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+    else {
+        return OwnedStatus::Missing;
+    };
+    let Some(hooks) = root.get("hooks").and_then(serde_json::Value::as_object) else {
+        return OwnedStatus::Missing;
+    };
+    let desired = crate::statusline::stable_exe_string();
+    let desired_quoted = quoted_exe(&desired);
+    let mut saw = false;
+    let mut current = true;
+    for event in ["SessionStart", "SessionEnd"] {
+        let Some(groups) = hooks.get(event).and_then(|v| v.as_array()) else {
+            return OwnedStatus::Missing;
+        };
+        let mut event_ok = false;
+        for group in groups {
+            let Some(hs) = group.get("hooks").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for h in hs {
+                if !owned(h) {
+                    continue;
+                }
+                saw = true;
+                event_ok = true;
+                let cmd = h.get("command").and_then(|c| c.as_str()).unwrap_or("");
+                // Hook is current if it embeds this binary (quoted or raw).
+                if !(cmd.contains(&desired_quoted) || cmd.contains(&desired)) {
+                    current = false;
+                }
+            }
+        }
+        if !event_ok {
+            return OwnedStatus::Missing;
+        }
+    }
+    if !saw {
+        return OwnedStatus::Missing;
+    }
+    if current {
+        OwnedStatus::Current
+    } else {
+        OwnedStatus::Stale
+    }
+}
+
 pub fn install(exe: &str) -> Result<()> {
     let hook_exe = quoted_exe(exe);
     let p = settings_path()?;

--- a/scripts/test-ensure-sandboxes.sh
+++ b/scripts/test-ensure-sandboxes.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# Independent-env checks for the smooth install / ensure surface.
+# Each step gets its own HOME + LLMTRIM_HOME + XDG_CONFIG_HOME so real installs are untouched.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${LLMTRIM_BIN:-$ROOT/target/release/llmtrim}"
+if [[ ! -x "$BIN" ]]; then
+  echo "building release binary…"
+  cargo build -p llmtrim --release --manifest-path "$ROOT/Cargo.toml"
+fi
+
+pass=0
+fail=0
+failures=()
+
+ok() {
+  echo "  OK  $1"
+  pass=$((pass + 1))
+}
+bad() {
+  echo "  FAIL $1${2:+ — $2}"
+  fail=$((fail + 1))
+  failures+=("$1")
+}
+check() {
+  local name="$1"
+  shift
+  if "$@"; then ok "$name"; else bad "$name"; fi
+}
+
+# New sandbox: sets HOME, LLMTRIM_HOME, XDG_CONFIG_HOME, PATH, optional Claude dir.
+# Usage: with_sandbox NAME [with-claude|no-claude] -- commands...
+with_sandbox() {
+  local name="$1"
+  local mode="${2:-with-claude}"
+  shift 2
+  if [[ "${1:-}" == "--" ]]; then shift; fi
+
+  local base
+  base="$(mktemp -d "/tmp/llmtrim-sb-${name}.XXXXXX")"
+  export HOME="$base/home"
+  export LLMTRIM_HOME="$base/llmtrim"
+  export XDG_CONFIG_HOME="$base/xdg"
+  export CLAUDE_CONFIG_DIR="$HOME/.claude"
+  export LLMTRIM_NO_UPDATE_CHECK=1
+  unset DISPLAY WAYLAND_DISPLAY HTTPS_PROXY NODE_EXTRA_CA_CERTS SSL_CERT_FILE CURL_CA_BUNDLE 2>/dev/null || true
+  mkdir -p "$HOME" "$LLMTRIM_HOME" "$XDG_CONFIG_HOME" "$base/bin"
+  ln -sfn "$BIN" "$base/bin/llmtrim"
+  export PATH="$base/bin:/usr/bin:/bin"
+
+  if [[ "$mode" == "with-claude" ]]; then
+    mkdir -p "$HOME/.claude"
+    echo '{}' >"$HOME/.claude/settings.json"
+  fi
+
+  # shellcheck disable=SC2064
+  trap "rm -rf '$base'; \"\$BIN\" stop >/dev/null 2>&1 || true" RETURN
+
+  echo "== $name ($mode)  sandbox=$base"
+  "$@"
+  # stop any daemon this sandbox may have started
+  "$BIN" stop >/dev/null 2>&1 || true
+  trap - RETURN
+  rm -rf "$base"
+}
+
+need_jq() {
+  command -v jq >/dev/null 2>&1 || {
+    echo "jq is required for sandbox assertions"
+    exit 2
+  }
+}
+
+need_jq
+echo "BIN=$BIN ($("$BIN" --version 2>/dev/null || echo unknown))"
+echo
+
+# ── Step 1: ensure + integrations.json + opt-out ─────────────────────────────
+with_sandbox s1 with-claude -- bash -c '
+  set -e
+  '"$BIN"' ensure -q </dev/null
+  test -f "$LLMTRIM_HOME/integrations.json"
+  ver=$('"$BIN"' --version | sed -n "s/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p" | head -1)
+  jq -e --arg v "$ver" ".last_ensured_version == \$v" "$LLMTRIM_HOME/integrations.json" >/dev/null
+  # second run is fine
+  '"$BIN"' ensure -q </dev/null
+  # opt out of guard
+  '"$BIN"' guard uninstall >/dev/null
+  jq -e ".opt_out.guard == true" "$LLMTRIM_HOME/integrations.json" >/dev/null
+  '"$BIN"' ensure -q </dev/null
+  # guard command must not be re-wired
+  if jq -e ".. | strings | select(test(\" guard$\"))" "$HOME/.claude/settings.json" >/dev/null 2>&1; then
+    exit 1
+  fi
+  # window-sub uninstall must stick
+  '$BIN' window-sub uninstall >/dev/null 2>&1 || true
+  jq -e ".opt_out.window_sub == true" "$LLMTRIM_HOME/integrations.json" >/dev/null
+  '$BIN' ensure -q </dev/null
+  test ! -f "$HOME/.claude/skills/sub/SKILL.md" || ! grep -q llmtrim-owned-window-sub "$HOME/.claude/skills/sub/SKILL.md"
+
+  exit 0
+' && ok "s1 ensure + opt-out" || bad "s1 ensure + opt-out"
+
+# ── Step 2a: setup wires integrations ────────────────────────────────────────
+with_sandbox s2a with-claude -- bash -c '
+  set -e
+  '"$BIN"' setup --force </dev/null >/tmp/llmtrim-setup-out.$$ 2>&1 || {
+    cat /tmp/llmtrim-setup-out.$$
+    exit 1
+  }
+  rm -f /tmp/llmtrim-setup-out.$$
+  test -f "$LLMTRIM_HOME/integrations.json"
+  jq -e ".statusLine.command | test(\"statusline\")" "$HOME/.claude/settings.json" >/dev/null
+  jq -e ".statusLine.refreshInterval == 300" "$HOME/.claude/settings.json" >/dev/null
+  jq -e ".. | strings | select(test(\"guard\"))" "$HOME/.claude/settings.json" >/dev/null
+  test -f "$HOME/.claude/skills/sub/SKILL.md"
+  grep -q "llmtrim-owned-window-sub" "$HOME/.claude/skills/sub/SKILL.md"
+  # compact configured somewhere under XDG
+  found=0
+  while IFS= read -r -d "" f; do
+    if grep -q "\[compact\]" "$f" 2>/dev/null; then found=1; break; fi
+  done < <(find "$XDG_CONFIG_HOME" -name "config.toml" -print0 2>/dev/null || true)
+  # also check HOME/.config
+  while IFS= read -r -d "" f; do
+    if grep -q "\[compact\]" "$f" 2>/dev/null; then found=1; break; fi
+  done < <(find "$HOME" -name "config.toml" -print0 2>/dev/null || true)
+  test "$found" = 1
+' && ok "s2a setup wires integrations" || bad "s2a setup wires integrations"
+
+# ── Step 2b: stale statusline rewrite ────────────────────────────────────────
+with_sandbox s2b with-claude -- bash -c '
+  set -e
+  '"$BIN"' ensure -q </dev/null
+  jq ".statusLine = {
+        \"type\": \"command\",
+        \"command\": \"/old/cellar/llmtrim statusline\",
+        \"padding\": 0
+      }" "$HOME/.claude/settings.json" >"$HOME/.claude/settings.json.tmp"
+  mv "$HOME/.claude/settings.json.tmp" "$HOME/.claude/settings.json"
+  '"$BIN"' ensure -q </dev/null
+  jq -e ".statusLine.command | test(\"statusline\") and (contains(\"old/cellar\") | not)" \
+    "$HOME/.claude/settings.json" >/dev/null
+  jq -e ".statusLine.refreshInterval == 300" "$HOME/.claude/settings.json" >/dev/null
+' && ok "s2b stale statusline rewrite" || bad "s2b stale statusline rewrite"
+
+# ── Step 3: ensure installs statusline; foreign left alone ───────────────────
+with_sandbox s3a with-claude -- bash -c '
+  set -e
+  echo "{}" >"$HOME/.claude/settings.json"
+  '"$BIN"' ensure -q </dev/null
+  jq -e ".statusLine.type == \"command\"" "$HOME/.claude/settings.json" >/dev/null
+  jq -e ".statusLine.command | test(\"statusline\")" "$HOME/.claude/settings.json" >/dev/null
+' && ok "s3a statusline install" || bad "s3a statusline install"
+
+with_sandbox s3b with-claude -- bash -c '
+  set -e
+  printf "%s\n" "{\"statusLine\":{\"type\":\"command\",\"command\":\"my-own-statusline\"}}" \
+    >"$HOME/.claude/settings.json"
+  '"$BIN"' ensure -q </dev/null
+  jq -e ".statusLine.command == \"my-own-statusline\"" "$HOME/.claude/settings.json" >/dev/null
+' && ok "s3b foreign statusline preserved" || bad "s3b foreign statusline preserved"
+
+# ── Step 4: doctor --fix ────────────────────────────────────────────────────
+with_sandbox s4 with-claude -- bash -c '
+  set -e
+  echo "{}" >"$HOME/.claude/settings.json"
+  # doctor alone should fail (gaps / no daemon)
+  set +e
+  '"$BIN"' doctor >/dev/null 2>&1
+  d1=$?
+  set -e
+  test "$d1" -ne 0
+  '"$BIN"' doctor --fix </dev/null >/dev/null 2>&1 || true
+  jq -e ".statusLine.command | test(\"statusline\")" "$HOME/.claude/settings.json" >/dev/null
+  test -f "$HOME/.claude/skills/sub/SKILL.md"
+' && ok "s4 doctor --fix" || bad "s4 doctor --fix"
+
+# ── Step 5: help surface (3 verbs; hidden power-user cmds) ───────────────────
+with_sandbox s5 no-claude -- bash -c '
+  set -e
+  help=$('"$BIN"' --help)
+  echo "$help" | grep -q "setup"
+  echo "$help" | grep -q "update"
+  echo "$help" | grep -q "ensure"
+  echo "$help" | grep -q "doctor"
+  # top-level list should not advertise these as Get started lines
+  ! echo "$help" | grep -E "^  statusline  " >/dev/null
+  ! echo "$help" | grep -E "^  guard  " >/dev/null
+  ! echo "$help" | grep -E "^  compact  " >/dev/null
+  # still invokable
+  '"$BIN"' statusline --help >/dev/null
+  '"$BIN"' guard --help >/dev/null
+  '"$BIN"' compact --help >/dev/null
+' && ok "s5 help surface" || bad "s5 help surface"
+
+# ── Step 6: non-interactive ensure does not require tray download ────────────
+with_sandbox s6 with-claude -- bash -c '
+  set -e
+  unset DISPLAY WAYLAND_DISPLAY
+  '"$BIN"' ensure -q </dev/null
+  # sibling tray next to release binary is unrelated; we only assert ensure succeeds
+  test -f "$LLMTRIM_HOME/integrations.json"
+' && ok "s6 ensure without tray download" || bad "s6 ensure without tray download"
+
+# ── Step 7: /sub installed; window-sub hidden ────────────────────────────────
+with_sandbox s7 with-claude -- bash -c '
+  set -e
+  '"$BIN"' ensure -q </dev/null
+  test -f "$HOME/.claude/skills/sub/SKILL.md"
+  grep -q "llmtrim-owned-window-sub" "$HOME/.claude/skills/sub/SKILL.md"
+  jq -e ".hooks.SessionStart" "$HOME/.claude/settings.json" >/dev/null
+  jq -e ".hooks.SessionEnd" "$HOME/.claude/settings.json" >/dev/null
+  ! '"$BIN"' --help | grep -qi "window-sub"
+' && ok "s7 /sub install + window-sub hidden" || bad "s7 /sub install + window-sub hidden"
+
+# ── Step 8a: no Claude → no settings writes ──────────────────────────────────
+with_sandbox s8a no-claude -- bash -c '
+  set -e
+  '"$BIN"' ensure -q </dev/null
+  test ! -d "$HOME/.claude"
+  test -f "$LLMTRIM_HOME/integrations.json"
+' && ok "s8a no-claude silent" || bad "s8a no-claude silent"
+
+# ── Step 8b: full ensure matrix (all pieces at once) ─────────────────────────
+with_sandbox s8b with-claude -- bash -c '
+  set -e
+  '"$BIN"' ensure </dev/null >/dev/null
+  jq -e ".statusLine.refreshInterval == 300" "$HOME/.claude/settings.json" >/dev/null
+  jq -e ".. | strings | select(test(\"guard\"))" "$HOME/.claude/settings.json" >/dev/null
+  test -f "$HOME/.claude/skills/sub/SKILL.md"
+  test -f "$LLMTRIM_HOME/integrations.json"
+  # update reminder path (package channel) should not crash
+  '"$BIN"' update 2>/dev/null | head -20 >/dev/null || true
+' && ok "s8b full ensure matrix" || bad "s8b full ensure matrix"
+
+echo
+echo "========"
+echo "passed=$pass failed=$fail"
+if (( fail > 0 )); then
+  echo "failures:"
+  printf '  - %s\n' "${failures[@]}"
+  exit 1
+fi
+echo "all sandbox steps passed"
+exit 0


### PR DESCRIPTION
## Summary

- **`llmtrim ensure`** brings this machine to the recommended state: Claude Code statusline, cold-cache guard, window-local `/sub`, compact model defaults, tray login when present, and restart of a version-skewed daemon.
- **`setup`**, binary-channel **`update`**, **`doctor --fix`**, and status **`f`** all use that path. Opt-outs live in `~/.llmtrim/integrations.json`.
- Quiet auto-heal on `start` / status only refreshes *stale* owned pieces (no silent first-time installs).
- Hardening: shell-quoted hooks, atomic settings writes, shared `CLAUDE_CONFIG_DIR`, ensure-on-new-binary after self-replace, safer Linux tray extract.
- **Docs:** README + INSTALL rewritten for the same lifecycle (install first, package-manager `ensure` after upgrade).

## Commits

1. `feat: ensure integrations stay current across install and update`
2. `docs: install and day-to-day docs for setup, update, and ensure`

## Test plan

- [x] `cargo test -p llmtrim --lib` (502 passed)
- [x] `scripts/test-ensure-sandboxes.sh` (independent HOME sandboxes)
- [ ] Manual: fresh `setup` with `~/.claude`; `guard uninstall` then `ensure` stays off
- [ ] Manual: package-manager upgrade path ends with `llmtrim ensure`
- [ ] Manual: status `f` when integrations are missing