### PR TITLE
feat(ledger): reconcile status dollars with Sessions via bill_micros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,28 @@ All notable changes to this project are documented here. The format follows
   further backends can land without a major bump. External exhaustive `match`es need a `_` arm.
   Workspace version is **0.11.0** (0.x minor = semver-breaking).
 
+### Changed
+
+- **Overview and non-TTY status dollars match Sessions (frozen proxy bills).** KPI "You paid" /
+  "Total saved" / today / week / trend / top models, and the piped `status` hero, read
+  `breakdown_turns.bill_micros` plus a per-turn frozen-rate input counterfactual
+  (`llmtrim-ledger::money`) — not live re-pricing of `compressions`. Lifetime $ may drop vs
+  older builds when breakdown retention is shorter than compressions, or for CLI/MCP-only
+  traffic (no session bill). Token % gauge is unchanged. When there is no proxy bill yet, the
+  UI shows a billing notice (not `$0.00`).
+- **Sessions columns:** `saved` → **`saved$`** (money) + **`trim`** (token size %). Detail bill
+  footer uses `SUM(bill_micros)` (blocks allocate; `*` when they residual).
+- **`status --json` / MCP `llmtrim_stats`:** additive **`money`** object with `unavailable` +
+  null dollars when there is no proxy attribution. Legacy **`cost`** remains compressions +
+  live list prices with `"source": "compressions_live_prices"` — prefer `money` when
+  `unavailable` is false.
+
 ### Added
 
+- **Money coverage UX** on Overview (and doctor empty-case only) when compressions exist but no
+  breakdown bills — banner instead of fake `$0.00`.
+- **`llmtrim-ledger::money`:** shared `MoneyTotals` / coverage / per-day / per-model queries;
+  shared `saved_micros` SQL for Overview and Sessions.
 - **`llmtrim ensure`:** bring this machine to the recommended state. Installs or refreshes owned
   Claude Code integrations (statusline, cold-cache guard, window-local `/sub`, default compact
   model chain), tray login when the GUI binary is present, and restarts a version-skewed daemon.

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -95,13 +95,13 @@ pub struct OverviewData {
     /// meta bar; `u` then runs the updater.
     pub update_available: Option<String>,
     /// Compressions events vs breakdown turns — drives partial/empty money UX.
-    pub coverage_compressions: i64,
-    pub coverage_turns: i64,
-    pub coverage_ratio: f64,
+    /// `pub(crate)` so adding these is not a SemVer break for external struct literals.
+    pub(crate) coverage_compressions: i64,
+    pub(crate) coverage_turns: i64,
     /// Turns with usage but zero bill (unpriced model).
-    pub turns_unpriced: i64,
+    pub(crate) turns_unpriced: i64,
     /// True when compressions exist but no breakdown bills — do not show $0 as truth.
-    pub money_unavailable: bool,
+    pub(crate) money_unavailable: bool,
 }
 
 impl OverviewData {
@@ -2394,7 +2394,6 @@ mod tests {
             update_available: None,
             coverage_compressions: 1204,
             coverage_turns: 1204,
-            coverage_ratio: 1.0,
             turns_unpriced: 0,
             money_unavailable: false,
         }

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -94,14 +94,6 @@ pub struct OverviewData {
     /// A newer release version if the (cached, opt-out) update check found one — shown in the
     /// meta bar; `u` then runs the updater.
     pub update_available: Option<String>,
-    /// Compressions events vs breakdown turns — drives partial/empty money UX.
-    /// `pub(crate)` so adding these is not a SemVer break for external struct literals.
-    pub(crate) coverage_compressions: i64,
-    pub(crate) coverage_turns: i64,
-    /// Turns with usage but zero bill (unpriced model).
-    pub(crate) turns_unpriced: i64,
-    /// True when compressions exist but no breakdown bills — do not show $0 as truth.
-    pub(crate) money_unavailable: bool,
 }
 
 impl OverviewData {
@@ -114,6 +106,12 @@ impl OverviewData {
         } else {
             self.pct_less
         }
+    }
+
+    /// No proxy bills despite traffic — do not paint `$0.00` as truth.
+    /// Derived from existing Option fields (keeps the public struct SemVer-stable).
+    pub(crate) fn money_unavailable(&self) -> bool {
+        self.has_traffic && self.paid_usd.is_none() && self.saved_usd.is_none()
     }
 }
 
@@ -1214,7 +1212,7 @@ fn sheep_quip(ov: &OverviewData, secs: u64) -> String {
     // Pick the line first, then format only that one (was building all 21 strings per frame).
     let pct = ov.pct_less * 100.0;
     // When billing is unavailable, never say "$0.00 saved" — stay on token/fluff quips only.
-    if ov.money_unavailable || ov.saved_usd.is_none() {
+    if ov.money_unavailable() || ov.saved_usd.is_none() {
         const N: u64 = 8;
         return match (secs / 12) % N {
             0 => format!("Shorn {pct:.0}% of the fluff off your prompts"),
@@ -1314,20 +1312,10 @@ fn render_kpis(f: &mut Frame, area: Rect, ov: &OverviewData) {
         .add_modifier(Modifier::BOLD);
 
     // Compressions without breakdown bills / all unpriced: never paint "$0.00" as truth.
-    if ov.money_unavailable {
+    if ov.money_unavailable() {
         let block = card("BILLING", false);
         let cell = block.inner(area);
         f.render_widget(block, area);
-        let chip = if ov.coverage_turns == 0 && ov.coverage_compressions > 0 {
-            format!(
-                "0 proxy turns billed · {} compression log events",
-                ov.coverage_compressions
-            )
-        } else if ov.turns_unpriced > 0 {
-            format!("{} turns unpriced (unknown model rates)", ov.turns_unpriced)
-        } else {
-            "no proxy-attributed turns yet".into()
-        };
         f.render_widget(
             Paragraph::new(vec![
                 Line::from(Span::styled(
@@ -1338,7 +1326,7 @@ fn render_kpis(f: &mut Frame, area: Rect, ov: &OverviewData) {
                     "Dollars need traffic through the proxy (not CLI/MCP alone)",
                     dim,
                 )),
-                Line::from(Span::styled(chip, dim)),
+                Line::from(Span::styled("no proxy-attributed turns yet", dim)),
             ]),
             cell,
         );
@@ -1357,19 +1345,6 @@ fn render_kpis(f: &mut Frame, area: Rect, ov: &OverviewData) {
     };
     let delta = today - yesterday;
     let week: f64 = ov.trend_daily_usd.iter().sum();
-    let coverage_note = if ov.coverage_compressions > 0
-        && ov.coverage_turns > 0
-        && ov.coverage_turns < ov.coverage_compressions
-    {
-        format!(
-            " · {}/{} attributed",
-            ov.coverage_turns, ov.coverage_compressions
-        )
-    } else if ov.turns_unpriced > 0 {
-        format!(" · {} unpriced", ov.turns_unpriced)
-    } else {
-        String::new()
-    };
 
     // Plain-language subtitles. Money % = saved / would-have (would-have includes output).
     let tiles: [(String, String, Style, String); 5] = [
@@ -1377,10 +1352,7 @@ fn render_kpis(f: &mut Frame, area: Rect, ov: &OverviewData) {
             "TOTAL SAVED".into(),
             money(saved),
             green_b,
-            format!(
-                "{:.0}% less than without trim{coverage_note}",
-                saved_pct(ov)
-            ),
+            format!("{:.0}% less than without trim", saved_pct(ov)),
         ),
         (
             "YOU PAID".into(),
@@ -1450,7 +1422,7 @@ fn render_trend(f: &mut Frame, area: Rect, ov: &OverviewData) {
     let block = card("SAVINGS TREND · $/DAY", false);
     let inner = block.inner(area);
     f.render_widget(block, area);
-    if ov.money_unavailable || ov.saved_usd.is_none() {
+    if ov.money_unavailable() || ov.saved_usd.is_none() {
         f.render_widget(
             Paragraph::new(Line::from(Span::styled(
                 "— needs proxy bills",
@@ -1603,7 +1575,7 @@ fn render_savers(f: &mut Frame, area: Rect, ov: &OverviewData) {
     let block = card("TOP MODELS", false);
     let inner = block.inner(area);
     f.render_widget(block, area);
-    if ov.money_unavailable || ov.saved_usd.is_none() {
+    if ov.money_unavailable() || ov.saved_usd.is_none() {
         f.render_widget(
             Paragraph::new(Line::from(Span::styled(
                 "— needs proxy bills",
@@ -2392,10 +2364,6 @@ mod tests {
             approximate: false,
             sessions: 42,
             update_available: None,
-            coverage_compressions: 1204,
-            coverage_turns: 1204,
-            turns_unpriced: 0,
-            money_unavailable: false,
         }
     }
 

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -61,7 +61,8 @@ pub enum StatusKind {
 #[derive(Clone, Default)]
 pub struct OverviewData {
     pub status: StatusLine,
-    /// Money figures (`None` when no model on the screen is priced).
+    /// Money figures from frozen `breakdown_turns.bill_micros` (`None` when no billed turns
+    /// yet, or compressions exist but attribution has not landed — see `money_coverage`).
     pub paid_usd: Option<f64>,
     pub would_have_usd: Option<f64>,
     pub saved_usd: Option<f64>,
@@ -77,7 +78,7 @@ pub struct OverviewData {
     pub requests: i64,
     /// Net $ saved per day, oldest→newest, last 7 days (for the sparkline).
     pub trend_daily_usd: Vec<f64>,
-    /// Top-3 models by $ saved: (friendly name, $ saved).
+    /// Top models by $ saved (frozen-rate blend). Footer Total is all-time, not sum of rows.
     pub savers: Vec<(String, f64)>,
     /// Expert strip (behind `m`): raw input before/after, output billed, output est %.
     pub input_before: i64,
@@ -93,6 +94,14 @@ pub struct OverviewData {
     /// A newer release version if the (cached, opt-out) update check found one — shown in the
     /// meta bar; `u` then runs the updater.
     pub update_available: Option<String>,
+    /// Compressions events vs breakdown turns — drives partial/empty money UX.
+    pub coverage_compressions: i64,
+    pub coverage_turns: i64,
+    pub coverage_ratio: f64,
+    /// Turns with usage but zero bill (unpriced model).
+    pub turns_unpriced: i64,
+    /// True when compressions exist but no breakdown bills — do not show $0 as truth.
+    pub money_unavailable: bool,
 }
 
 impl OverviewData {
@@ -441,9 +450,11 @@ impl App {
         } else {
             0.0
         };
+        let saved_m: i64 = rows.iter().map(|r| r.saved_micros).sum();
         self.sessions.footer = Some(vec![
             "total".into(),
             format!("${:.2}", bill as f64 / 1_000_000.0),
+            format!("${:.2}", saved_m as f64 / 1_000_000.0),
             format!("{saved:.0}%"),
             String::new(),
             turns.to_string(),
@@ -965,8 +976,9 @@ fn render_help_overlay(f: &mut Frame, tray: bool) {
         Line::from("  u                  update / restart stale daemon"),
         Line::from("  s / n              sub setup / dismiss (when shown)"),
         Line::from(""),
-        Line::from("  \"would have cost\" = the price at your provider's"),
-        Line::from("   normal rate; \"you paid\" is after llmtrim trimmed it."),
+        Line::from("  \"you paid\" = what the proxy billed (same as Sessions)."),
+        Line::from("  \"saved$\" = input $ off at rates locked per turn."),
+        Line::from("  \"trim\" = token size % (not dollars)."),
         Line::from("  ? quit this help   q quit the app"),
     ]);
     let block = Block::default()
@@ -1200,8 +1212,30 @@ fn sheep_dizzy(secs: u64) -> &'static str {
 /// the joke never lies; rotates by the clock so the banner feels alive without any state.
 fn sheep_quip(ov: &OverviewData, secs: u64) -> String {
     // Pick the line first, then format only that one (was building all 21 strings per frame).
-    const N: u64 = 21;
     let pct = ov.pct_less * 100.0;
+    // When billing is unavailable, never say "$0.00 saved" — stay on token/fluff quips only.
+    if ov.money_unavailable || ov.saved_usd.is_none() {
+        const N: u64 = 8;
+        return match (secs / 12) % N {
+            0 => format!("Shorn {pct:.0}% of the fluff off your prompts"),
+            1 => format!(
+                "Trimmed the dead weight off {} requests",
+                group(ov.requests)
+            ),
+            2 => format!("Fleece gone, answers intact — {pct:.0}% lighter prompts"),
+            3 => format!(
+                "{} prompts through the shears, not one bleat",
+                group(ov.requests)
+            ),
+            4 => "Wool off, wisdom on.".to_string(),
+            5 => {
+                format!("Sheared {pct:.0}% off your prompts — wool's on the floor, answers aren't")
+            }
+            6 => "Less wool in, same wisdom out".to_string(),
+            _ => format!("Shears down. {pct:.0}% gone. Nothing important bleated."),
+        };
+    }
+    const N: u64 = 21;
     // One line every 12s — fast enough to feel alive, slow enough to actually read.
     match (secs / 12) % N {
         0 => format!("Shorn {pct:.0}% of the fluff off your prompts"),
@@ -1275,6 +1309,41 @@ fn render_kpis(f: &mut Frame, area: Rect, ov: &OverviewData) {
     let white_b = Style::default()
         .fg(palette::text())
         .add_modifier(Modifier::BOLD);
+    let warn_b = Style::default()
+        .fg(palette::warn())
+        .add_modifier(Modifier::BOLD);
+
+    // Compressions without breakdown bills / all unpriced: never paint "$0.00" as truth.
+    if ov.money_unavailable {
+        let block = card("BILLING", false);
+        let cell = block.inner(area);
+        f.render_widget(block, area);
+        let chip = if ov.coverage_turns == 0 && ov.coverage_compressions > 0 {
+            format!(
+                "0 proxy turns billed · {} compression log events",
+                ov.coverage_compressions
+            )
+        } else if ov.turns_unpriced > 0 {
+            format!("{} turns unpriced (unknown model rates)", ov.turns_unpriced)
+        } else {
+            "no proxy-attributed turns yet".into()
+        };
+        f.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "No session bill yet — token savings still count",
+                    warn_b,
+                )),
+                Line::from(Span::styled(
+                    "Dollars need traffic through the proxy (not CLI/MCP alone)",
+                    dim,
+                )),
+                Line::from(Span::styled(chip, dim)),
+            ]),
+            cell,
+        );
+        return;
+    }
 
     let saved = ov.saved_usd.unwrap_or(0.0);
     let paid = ov.paid_usd.unwrap_or(0.0);
@@ -1288,33 +1357,49 @@ fn render_kpis(f: &mut Frame, area: Rect, ov: &OverviewData) {
     };
     let delta = today - yesterday;
     let week: f64 = ov.trend_daily_usd.iter().sum();
+    let coverage_note = if ov.coverage_compressions > 0
+        && ov.coverage_turns > 0
+        && ov.coverage_turns < ov.coverage_compressions
+    {
+        format!(
+            " · {}/{} attributed",
+            ov.coverage_turns, ov.coverage_compressions
+        )
+    } else if ov.turns_unpriced > 0 {
+        format!(" · {} unpriced", ov.turns_unpriced)
+    } else {
+        String::new()
+    };
 
-    // (title, value, value-style, subtitle) — built in display (mockup) order.
+    // Plain-language subtitles. Money % = saved / would-have (would-have includes output).
     let tiles: [(String, String, Style, String); 5] = [
         (
             "TOTAL SAVED".into(),
             money(saved),
             green_b,
-            format!("{:.0}% less than raw", saved_pct(ov)),
+            format!(
+                "{:.0}% less than without trim{coverage_note}",
+                saved_pct(ov)
+            ),
         ),
         (
             "YOU PAID".into(),
             money(paid),
             blue_b,
-            "after discounts".into(),
+            "what the proxy billed".into(),
         ),
         (
             "WOULD HAVE COST".into(),
             money(would),
             white_b,
-            "Without llmtrim".into(),
+            "without input trim".into(),
         ),
         (
             "SAVED TODAY".into(),
             money(today),
             green_b,
             format!(
-                "{}{} vs yest.",
+                "{}{} vs yest. (UTC)",
                 if delta < 0.0 { "-" } else { "+" },
                 money(delta.abs())
             ),
@@ -1323,7 +1408,7 @@ fn render_kpis(f: &mut Frame, area: Rect, ov: &OverviewData) {
             "SAVED THIS WEEK".into(),
             money(week),
             green_b,
-            "7 days total".into(),
+            "7 days (UTC)".into(),
         ),
     ];
     // Priority when we can't fit all five (keep saved/today/week first).
@@ -1365,6 +1450,17 @@ fn render_trend(f: &mut Frame, area: Rect, ov: &OverviewData) {
     let block = card("SAVINGS TREND · $/DAY", false);
     let inner = block.inner(area);
     f.render_widget(block, area);
+    if ov.money_unavailable || ov.saved_usd.is_none() {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "— needs proxy bills",
+                Style::default().fg(palette::muted_gray()),
+            )))
+            .alignment(Alignment::Center),
+            inner,
+        );
+        return;
+    }
     if ov.trend_daily_usd.is_empty() || inner.width == 0 {
         return;
     }
@@ -1507,6 +1603,17 @@ fn render_savers(f: &mut Frame, area: Rect, ov: &OverviewData) {
     let block = card("TOP MODELS", false);
     let inner = block.inner(area);
     f.render_widget(block, area);
+    if ov.money_unavailable || ov.saved_usd.is_none() {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "— needs proxy bills",
+                Style::default().fg(palette::muted_gray()),
+            )))
+            .alignment(Alignment::Center),
+            inner,
+        );
+        return;
+    }
     let split = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(inner);
 
     let max = ov.savers.iter().map(|(_, v)| *v).fold(0.0_f64, f64::max);
@@ -1545,12 +1652,12 @@ fn render_savers(f: &mut Frame, area: Rect, ov: &OverviewData) {
     );
     f.render_widget(table, split[0]);
 
-    // Total row, right-aligned $, reconciling to all-time saved.
+    // "All models" (not sum of visible top-N rows) — all-time saved from MoneyTotals.
     let total = ov.saved_usd.unwrap_or(0.0);
     let tcols = Layout::horizontal([Constraint::Min(1), Constraint::Length(amt_w)]).split(split[1]);
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "Total",
+            "All models",
             Style::default()
                 .fg(palette::muted_gray())
                 .add_modifier(Modifier::BOLD),
@@ -1808,19 +1915,15 @@ fn render_overview_empty(f: &mut Frame, inner: Rect, ov: &OverviewData) {
 // ── column definitions ──────────────────────────────────────────────────────────
 
 fn session_columns() -> Vec<Column> {
-    // Decision metric (cost) leads, right after the name; `when` for recency; `hit` only
-    // carries a value on session leaves (blank on rollups, where it isn't meaningful).
-    // Plain words: what you spent, how much we saved, when, how many messages, how much was
-    // reused from cache. Cost + saved are the two numbers a user actually cares about, so they
-    // carry the only two hues: cost = blue (the bill, a fact), saved = green (the win — the
-    // reason anyone opens this tab). The rest ride neutral body text; header + position carry
-    // their meaning, and spending a hue on every metric is the rainbow we cut.
+    // Decision metric (cost) leads; `saved$` is money (frozen blend); `trim` is token size %
+    // (never called "saved" — that word is dollars elsewhere). `reuse` is cache hit on leaves.
     vec![
-        Column::left("agent · project · session", 34),
+        Column::left("agent · project · session", 32),
         Column::right("cost", 9).colored(palette::blue()),
-        Column::right("saved", 6).colored(palette::green()),
+        Column::right("saved$", 8).colored(palette::green()),
+        Column::right("trim", 5),
         Column::right("when", 6),
-        Column::right("msgs", 6),
+        Column::right("msgs", 5),
         Column::right("reuse", 6),
     ]
 }
@@ -1916,7 +2019,8 @@ fn build_session_tree(rows: &[SessionRow]) -> Vec<TreeNode<Node>> {
 fn session_cols(s: &SessionRow) -> Vec<String> {
     vec![
         format!("${:.2}", s.bill_usd()),
-        format!("{:.0}%", s.saved_pct()),
+        format!("${:.2}", s.saved_usd()),
+        format!("{:.0}%", s.trim_pct()),
         rel_time(&s.last_ts),
         s.turns.to_string(),
         format!("{:.0}%", s.cache_hit * 100.0),
@@ -1926,9 +2030,10 @@ fn session_cols(s: &SessionRow) -> Vec<String> {
 fn agg_cols(rows: &[&SessionRow]) -> Vec<String> {
     let turns: i64 = rows.iter().map(|r| r.turns).sum();
     let bill: i64 = rows.iter().map(|r| r.bill_micros).sum();
+    let saved_m: i64 = rows.iter().map(|r| r.saved_micros).sum();
     let before: i64 = rows.iter().map(|r| r.input_before).sum();
     let after: i64 = rows.iter().map(|r| r.input_after).sum();
-    let saved = if before > 0 {
+    let trim = if before > 0 {
         (before - after).max(0) as f64 / before as f64 * 100.0
     } else {
         0.0
@@ -1937,7 +2042,8 @@ fn agg_cols(rows: &[&SessionRow]) -> Vec<String> {
     let latest = rows.iter().map(|r| r.last_ts.as_str()).max().unwrap_or("");
     vec![
         format!("${:.2}", bill as f64 / 1_000_000.0),
-        format!("{saved:.0}%"),
+        format!("${:.2}", saved_m as f64 / 1_000_000.0),
+        format!("{trim:.0}%"),
         rel_time(latest),
         turns.to_string(),
         // Cache reuse is only meaningful per session, so it's left blank at the rollup level.
@@ -2000,14 +2106,29 @@ fn compute_detail(db: &BreakdownDb, session_id: &str) -> DetailData {
         ]);
     }
     if let Ok(rows) = db.cost(session_id) {
-        let bill: f64 = rows.iter().map(|r| r.usd).sum();
+        // Canonical paid = SUM(bill_micros); block rows allocate that bill (may residual).
+        let bill = db
+            .session_bill_micros(session_id)
+            .map(|m| m as f64 / 1_000_000.0)
+            .unwrap_or_else(|_| rows.iter().map(|r| r.usd).sum());
+        let read: f64 = rows.iter().map(|r| r.read_usd).sum();
+        let write: f64 = rows.iter().map(|r| r.write_usd).sum();
+        let new: f64 = rows.iter().map(|r| r.new_usd).sum();
+        let blocks = read + write + new;
         data.cost_roots = build_cost_tree(&rows, bill);
+        // When block realloc ≠ bill (e.g. empty blocks), keep bill as ground truth and
+        // mark the component sum so %bill does not silently over-claim.
+        let bill_label = if (blocks - bill).abs() > 0.005 && bill > 0.0 {
+            format!("${bill:.2}*")
+        } else {
+            format!("${bill:.2}")
+        };
         data.cost_footer = Some(vec![
             "bill".into(),
-            format!("${bill:.2}"),
-            format!("${:.2}", rows.iter().map(|r| r.read_usd).sum::<f64>()),
-            format!("${:.2}", rows.iter().map(|r| r.write_usd).sum::<f64>()),
-            format!("${:.2}", rows.iter().map(|r| r.new_usd).sum::<f64>()),
+            bill_label,
+            format!("${read:.2}"),
+            format!("${write:.2}"),
+            format!("${new:.2}"),
             "—".into(),
         ]);
     }
@@ -2271,6 +2392,11 @@ mod tests {
             approximate: false,
             sessions: 42,
             update_available: None,
+            coverage_compressions: 1204,
+            coverage_turns: 1204,
+            coverage_ratio: 1.0,
+            turns_unpriced: 0,
+            money_unavailable: false,
         }
     }
 
@@ -2462,6 +2588,7 @@ mod tests {
             tokens: 1000,
             cache_hit: 0.5,
             bill_micros: bill,
+            saved_micros: bill / 4,
             input_before: 1000,
             input_after: 600,
             last_ts: "2026-06-19T00:00:00+00:00".to_string(),
@@ -2488,8 +2615,8 @@ mod tests {
         // one project under claude-code, two sessions under it
         assert_eq!(claude.children.len(), 1);
         assert_eq!(claude.children[0].children.len(), 2);
-        // columns are [cost, saved, when, msgs, reuse]; rolled-up turns = 5 (msgs, index 3).
-        assert_eq!(claude.cols[3], "5");
+        // columns: [cost, saved$, trim, when, msgs, reuse]; rolled-up turns = 5 (msgs, index 4).
+        assert_eq!(claude.cols[4], "5");
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/breakdown/export.rs
+++ b/crates/llmtrim-cli/src/breakdown/export.rs
@@ -145,6 +145,7 @@ mod tests {
             tokens: 12_345,
             cache_hit: 0.5,
             bill_micros: 1_230_000,
+            saved_micros: 400_000,
             input_before: 1000,
             input_after: 600,
             last_ts: "2026-06-19T00:00:00+00:00".to_string(),

--- a/crates/llmtrim-cli/src/doctor.rs
+++ b/crates/llmtrim-cli/src/doctor.rs
@@ -109,6 +109,24 @@ pub fn gather() -> Report {
         ));
         report.problems += 1;
     }
+    // Money coverage: only the empty case is a real problem (CLI/MCP-only or attribution never
+    // ran). Partial ratio is a weak heuristic (different tables + retention caps), so we do
+    // not WARN on partial pure-proxy installs.
+    if let Ok(t) = crate::tracking::Tracker::open_reader()
+        && let Ok(cov) = llmtrim_ledger::money::money_coverage(t.connection())
+        && cov.empty_money_with_traffic()
+    {
+        report.rows.push((
+            ui::WARN,
+            "money coverage".into(),
+            format!(
+                "{} compressions, 0 proxy turns — dollars need proxy attribution \
+                 (CLI/MCP-only has no session bill)",
+                cov.compressions_events
+            ),
+        ));
+        report.problems += 1;
+    }
     report
 }
 

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -2945,7 +2945,7 @@ fn run_monitor(
             let s = tracker.summary()?;
             let models = monitor::model_views(&tracker)?;
             let daemon = daemon_view(&s);
-            let out = monitor::export_json(
+            let out = monitor::export_json_with_money(
                 &s,
                 &models,
                 monitor::monitor_cost(&tracker).as_ref(),

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -2765,7 +2765,6 @@ fn render_snapshot(
 ) -> Result<(String, monitor::Health)> {
     let summary = tracker.summary()?;
     let models = monitor::model_views(tracker)?;
-    let cost = monitor::monitor_cost(tracker);
     let daemon = daemon_view(&summary);
     let health = monitor::health(&daemon);
     // Last (up to) 7 days of input tokens saved, oldest→newest, for the 7-DAY TREND sparkline.
@@ -2778,13 +2777,15 @@ fn render_snapshot(
         .rev()
         .map(|r| (r.input_before - r.input_after).max(0))
         .collect();
+    // Frozen breakdown money for hero — same source as Overview (never live cost_estimate).
+    let (hero_saved, today_saved) = monitor::hero_money(tracker);
     let mut out = monitor::snapshot(
         color,
         Some(&daemon),
         &summary,
         &models,
-        cost.as_ref(),
-        monitor::today_saved_usd(tracker),
+        hero_saved,
+        today_saved,
         &trend,
         cache_included,
         split_marker,
@@ -2950,6 +2951,7 @@ fn run_monitor(
                 monitor::monitor_cost(&tracker).as_ref(),
                 &rows,
                 Some(&daemon),
+                monitor::money_json(&tracker),
             );
             println!("{}", merge_breakdown_json(out, breakdown));
         } else {

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -467,15 +467,19 @@ fn render_header(color: bool, d: &DaemonView) -> String {
 
 /// The savings dashboard: daemon header + health chain, a hero panel (cost / round-trip /
 /// requests), per-axis bars, and a per-model table. Returned as a string for the plain-text
-/// snapshot path (piped output, `--json/--csv`, non-TTY). `today_saved_usd` is the priced saving for today (UTC),
-/// shown next to the all-time hero when it is non-trivial.
+/// snapshot path (piped output, `--json/--csv`, non-TTY).
+///
+/// `hero_saved_usd` is the **frozen breakdown** all-time input savings (same source as Overview
+/// / Sessions). Pass `None` when money is unavailable (CLI-only compressions) so the hero falls
+/// back to token % — never mix live `cost_estimate` with breakdown "today".
+/// `today_saved_usd` is the same path for today (UTC), shown next to the hero when non-trivial.
 #[allow(clippy::too_many_arguments)]
 pub fn snapshot(
     color: bool,
     daemon: Option<&DaemonView>,
     s: &Summary,
     models: &[ModelView],
-    cost: Option<&Cost>,
+    hero_saved_usd: Option<f64>,
     today_saved_usd: Option<f64>,
     trend: &[i64],
     // When true, the input SAVINGS axis is measured over ALL input (the frozen cached prefix
@@ -511,44 +515,31 @@ pub fn snapshot(
         return o;
     }
 
-    // Hero box — one dominant figure, supporting facts demoted to a second line. The
-    // headline is the MEASURED input-side saving (real, per-row): every request's input is
-    // compressed and re-tokenized, so it is honest for all traffic. The output side is NOT
-    // in the headline — the proxy never sees the un-instructed reply, so any output saving
-    // is a benchmark projection that only holds when output is actually shaped (projecting
-    // it onto agent traffic would overstate ~2.7×); it is surfaced separately, below.
+    // Hero box — one dominant figure, supporting facts demoted to a second line.
+    // Dollars (when present) are frozen breakdown savings — same source as Overview/Sessions.
+    // No dollars → token % (CLI-only or unattributed traffic), never a mixed-base line.
     o.push('\n');
-    let (line1, line2) = match cost {
-        Some(c) => {
+    let (line1, line2) = match hero_saved_usd {
+        Some(saved) => {
             // Anchor the all-time number in the present: "what did it do for me today?"
-            // Hidden when today has no priced saving — a perpetual $0.00 reads like fake data.
+            // Same money path as all-time (breakdown frozen). Hidden when trivial.
             let today = today_saved_usd
                 .filter(|t| *t >= 0.005)
                 .map(|t| {
                     format!(
                         " {} {}",
                         ui::paint(color, Tone::Dim, "·"),
-                        // "saved today", not a bare "↑ $X" — an up-arrow next to a dollar on a
-                        // billing screen reads as spend going up, the opposite of the truth.
                         ui::paint(color, Tone::Accent, &format!("${t:.2} saved today")),
                     )
                 })
                 .unwrap_or_default();
-            // The headline is the MEASURED figure that came off the real, cache-discounted
-            // bill — the conservative truth, so it owns "off your real bill". The list-rate
-            // value and the higher live-zone estimate are upside, shown dim below as an
-            // ascending ladder, never as the hero (a headline above its own list ceiling
-            // reads as cooked).
             (
                 format!(
                     "{} {}{}",
-                    ui::hero(color, &format!("${:.2}", c.net_saved)),
-                    ui::paint(color, Tone::Dim, "off your real bill"),
+                    ui::hero(color, &format!("${saved:.2}")),
+                    ui::paint(color, Tone::Dim, "saved on proxy bills"),
                     today,
                 ),
-                // No input % here: the SAVINGS axis below carries the honest figure (over
-                // the compressible surface). Repeating the diluted all-input % would
-                // contradict it.
                 format!(
                     "{} tokens trimmed {} {} requests",
                     ui::human(s.saved()),
@@ -734,25 +725,8 @@ pub fn snapshot(
             &format!(" + ~{:.0} ms/req · compression overhead\n", us / 1000.0),
         ));
     }
-    if let Some(c) = cost {
-        // Surface the output-side projection separately and clearly as an estimate — never
-        // folded into the measured headline above. Projected ONLY onto the spend that
-        // actually carried the shaping instruction; unshaped (agent) output is billed at
-        // its own baseline, so there is nothing to project there.
-        // Only when the projection is real money — a perpetual "$0.01 more" footnote costs
-        // a line for no information (the output axis already carries the "est · if shaped"
-        // caveat, covering the shaping-off case too).
-        let extra = c.projected_saved() - c.saved;
-        if extra >= 1.0 {
-            o.push_str(&ui::paint(
-                color,
-                Tone::Dim,
-                &format!(
-                    " ~ + est. ${extra:.2} more saved by output shaping (A/B bench −73%); estimated, excluded from the headline.\n"
-                ),
-            ));
-        }
-    }
+    // Output-shaping projection stays on the SAVINGS output axis as "(estimate)" — not a
+    // second dollar hero that could reintroduce a live-price basis next to frozen bills.
     o
 }
 
@@ -803,13 +777,71 @@ pub fn period_report(color: bool, label: &str, rows: &[PeriodRow]) -> String {
 
 // ── machine-readable export ─────────────────────────────────────────────────────
 
+/// Build the additive `money` JSON object from a tracker (frozen breakdown bills).
+///
+/// When compressions exist but there are no proxy-attributed turns, `unavailable` is true and
+/// dollar fields are JSON `null` — consumers must not treat `0.0` as "you paid nothing".
+pub fn money_json(tracker: &Tracker) -> Option<serde_json::Value> {
+    use llmtrim_ledger::money::{money_coverage, money_totals, today_start_utc};
+    let c = tracker.connection();
+    let totals = money_totals(c, None).ok()?;
+    let today = money_totals(c, Some(&today_start_utc())).ok()?;
+    let coverage = money_coverage(c).ok()?;
+    let unavailable = coverage.empty_money_with_traffic() || totals.all_unpriced();
+    let dollars = |v: f64| {
+        if unavailable {
+            serde_json::Value::Null
+        } else {
+            json!(v)
+        }
+    };
+    Some(json!({
+        "source": "breakdown_turns",
+        "unavailable": unavailable,
+        "paid_usd": dollars(totals.paid_usd()),
+        "saved_usd": dollars(totals.saved_usd()),
+        "would_have_usd": dollars(totals.would_have_usd()),
+        "saved_today_usd": dollars(today.saved_usd()),
+        "turns": totals.turns,
+        "turns_unpriced": totals.turns_unpriced,
+        "coverage": {
+            "compressions_events": coverage.compressions_events,
+            "breakdown_turns": coverage.breakdown_turns,
+            "ratio": coverage.coverage_ratio,
+            "note": "heuristic event counts (compressions vs turns), not a per-request join; different retention caps apply",
+        },
+        "note": "prefer money over cost.* for spend matching Overview/Sessions; when unavailable is true, dollar fields are null"
+    }))
+}
+
+/// All-time + today savings from frozen breakdown for the text hero / Overview.
+/// Returns `(all_time_saved, today_saved)` — both `None` when money is unavailable so callers
+/// fall back to token heroes instead of painting `$0.00` or mixing live list prices.
+pub fn hero_money(tracker: &Tracker) -> (Option<f64>, Option<f64>) {
+    use llmtrim_ledger::money::{money_coverage, money_totals, today_start_utc};
+    let c = tracker.connection();
+    let coverage = money_coverage(c).unwrap_or_default();
+    let totals = money_totals(c, None).unwrap_or_default();
+    if coverage.empty_money_with_traffic() || totals.turns == 0 || totals.all_unpriced() {
+        return (None, None);
+    }
+    let today = money_totals(c, Some(&today_start_utc())).unwrap_or_default();
+    let all = (totals.saved_micros > 0 || totals.paid_micros > 0).then_some(totals.saved_usd());
+    let tod = (today.saved_micros > 0 && today.saved_usd() >= 0.005).then_some(today.saved_usd());
+    (all, tod)
+}
+
 /// Full snapshot as JSON (for Grafana/Prometheus/scripts).
+///
+/// When `money` is provided, emits additive frozen-breakdown bills alongside legacy `cost`
+/// (compressions + live list prices). Do not silently redefine `cost.*` fields.
 pub fn export_json(
     s: &Summary,
     models: &[ModelView],
     cost: Option<&Cost>,
     periods: &[PeriodRow],
     daemon: Option<&DaemonView>,
+    money: Option<serde_json::Value>,
 ) -> String {
     let reroute = {
         let cfg = llmtrim_core::config::RuntimeConfig::get();
@@ -842,10 +874,13 @@ pub fn export_json(
         "input": { "before": s.input_before, "after": s.input_after, "saved_pct": s.saved_pct() },
         "output": { "before": s.output_before, "after": s.output_after,
                     "events": s.output_events, "saved_pct": s.output_saved_pct() },
+        // Legacy: compressions + live list prices. Prefer `money` for paid/saved that match Sessions.
         "cost": cost.map(|c| json!({ "saved_usd": c.saved, "spend_usd": c.spend, "round_trip_pct": c.pct(),
                                      "net_saved_usd": c.net_saved, "out_spend_usd": c.out_spend,
                                      "out_spend_shaped_usd": c.out_spend_shaped,
-                                     "projected_saved_usd": c.projected_saved(), "projected_round_trip_pct": c.projected_pct() })),
+                                     "projected_saved_usd": c.projected_saved(), "projected_round_trip_pct": c.projected_pct(),
+                                     "source": "compressions_live_prices" })),
+        "money": money,
         "added_latency_ms": s.avg_compress_micros.map(|us| us / 1000.0),
         "cache_read_tokens": s.cache_read_tokens,
         "approximate": s.any_approximate,
@@ -881,6 +916,9 @@ pub fn export_csv(periods: &[PeriodRow]) -> String {
 /// emits. The MCP server returns this verbatim so a tool call and the dashboard never
 /// disagree. `daemon` is `None` for callers that don't inspect the proxy (the MCP tool),
 /// which renders as `"daemon": null`.
+///
+/// Dual money: legacy `cost` is still compressions + live list prices; additive `money` is
+/// frozen `breakdown_turns` (same source as Overview/Sessions). Prefer `money` for paid/saved.
 pub fn stats_json(tracker: &Tracker, daemon: Option<&DaemonView>) -> Result<String> {
     let summary = tracker.summary()?;
     let models = model_views(tracker)?;
@@ -892,6 +930,7 @@ pub fn stats_json(tracker: &Tracker, daemon: Option<&DaemonView>) -> Result<Stri
         cost.as_ref(),
         &periods,
         daemon,
+        money_json(tracker),
     ))
 }
 
@@ -957,8 +996,9 @@ pub fn model_views_from(rows: &[ModelRow]) -> Vec<ModelView> {
 /// to match the text hero's all-time figure: a list-rate "today" next to a net all-time total
 /// is what made today exceed the total (issue #100).
 pub fn today_saved_usd(tracker: &Tracker) -> Option<f64> {
-    let models = tracker.by_model_today().ok()?;
-    cost_estimate(&models).map(|c| c.net_saved)
+    use llmtrim_ledger::money::{money_totals, today_start_utc};
+    let t = money_totals(tracker.connection(), Some(&today_start_utc())).ok()?;
+    (t.saved_micros > 0).then_some(t.saved_usd())
 }
 
 /// Per-1M-token rates for one turn, frozen into the breakdown ledger so a historical session
@@ -1071,31 +1111,52 @@ pub fn cost_estimate(models: &[ModelRow]) -> Option<Cost> {
 /// Assemble the breakdown TUI's Overview view-model from the ledger. The `status` closure builds
 /// the health line from the single summary scan plus whether there's traffic, so the binary can
 /// supply the live daemon-derived status and the SVG exporter a forced-healthy one — without
-/// either re-deriving the (subtle) numeric fields. The ledger is scanned once for the summary
-/// and once for `by_model`. `sessions` is filled later by the caller's single `sessions()` scan.
+/// either re-deriving the (subtle) numeric fields.
+///
+/// **Dollars** come from frozen `breakdown_turns.bill_micros` ([`llmtrim_ledger::money`]) so
+/// Overview "You paid" matches Sessions total cost. **Token % / requests / latency** still come
+/// from `compressions` via [`Tracker::summary`].
 #[cfg(feature = "breakdown")]
 pub fn overview_data(
     tracker: &Tracker,
     status: impl FnOnce(&crate::tracking::Summary, bool) -> crate::breakdown::app::StatusLine,
 ) -> crate::breakdown::app::OverviewData {
     use crate::breakdown::app::OverviewData;
-    use crate::tracking::Period;
+    use llmtrim_ledger::money::{
+        money_by_day, money_by_model, money_coverage, money_totals, pad_daily_saved,
+        today_start_utc,
+    };
 
     let summary = tracker.summary().unwrap_or_default();
     let has_traffic = summary.events > 0;
-    let model_rows = tracker.by_model().unwrap_or_default();
-    let models = model_views_from(&model_rows);
-    let cost = cost_estimate(&model_rows);
     let status = status(&summary, has_traffic);
+    let conn = tracker.connection();
 
-    // One honest basis: cache-discounted bill and the real saving off it, so
-    // would_have − paid == saved and the savers reconcile to it.
-    let paid_usd = cost.as_ref().map(|c| c.net_spend);
-    let saved_usd = cost.as_ref().map(|c| c.net_saved);
-    let would_have_usd = match (paid_usd, saved_usd) {
-        (Some(p), Some(s)) => Some(p + s),
-        _ => None,
-    };
+    // Canonical money path (frozen rates). Empty when only compressions exist (CLI/MCP) or
+    // attribution has not landed yet — UI must not treat that as "$0 paid".
+    let coverage = money_coverage(conn).unwrap_or_default();
+    let totals = money_totals(conn, None).unwrap_or_default();
+    let today = money_totals(conn, Some(&today_start_utc())).unwrap_or_default();
+    // No proxy bills (CLI-only) or every turn unpriced → never paint $0.00 as truth.
+    let money_unavailable = coverage.empty_money_with_traffic()
+        || (totals.turns == 0 && coverage.compressions_events > 0)
+        || totals.all_unpriced();
+    let show_money = totals.turns > 0 && !money_unavailable;
+    let paid_usd = show_money.then_some(totals.paid_usd());
+    let saved_usd = show_money.then_some(totals.saved_usd());
+    let would_have_usd = show_money.then_some(totals.would_have_usd());
+    let saved_today_usd = (show_money && today.saved_micros > 0 && today.saved_usd() >= 0.005)
+        .then_some(today.saved_usd());
+
+    let by_day = money_by_day(conn, 7).unwrap_or_default();
+    let trend_daily_usd = pad_daily_saved(&by_day, 7);
+
+    let savers: Vec<(String, f64)> = money_by_model(conn, 8)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|m| m.saved_micros > 0)
+        .map(|m| (m.model, m.saved_micros as f64 / 1_000_000.0))
+        .collect();
 
     // Savings fraction over the compressible (non-frozen) surface — the honest basis.
     let new_before = summary.metered_input_before - summary.frozen_input_tokens;
@@ -1126,46 +1187,12 @@ pub fn overview_data(
         0.0
     };
 
-    // Daily $ trend: scale the daily token-savings series by the blended $/token rate.
-    let blend = match cost.as_ref() {
-        Some(c) if summary.saved() > 0 => c.net_saved / summary.saved() as f64,
-        _ => 0.0,
-    };
-    let trend_daily_usd: Vec<f64> = tracker
-        .by_period(Period::Day)
-        .unwrap_or_default()
-        .iter()
-        .rev()
-        .take(7)
-        .rev()
-        .map(|r| (r.input_before - r.input_after).max(0) as f64 * blend)
-        .collect();
-
-    // Biggest savers: priced models by $ saved, scaled to the net-of-cache basis.
-    let net_ratio = cost
-        .as_ref()
-        .map(|c| {
-            if c.saved > 0.0 {
-                c.net_saved / c.saved
-            } else {
-                0.0
-            }
-        })
-        .unwrap_or(0.0);
-    let mut savers: Vec<(String, f64)> = models
-        .iter()
-        .filter_map(|m| m.cost_saved.map(|s| (m.name.clone(), s * net_ratio)))
-        .filter(|(_, s)| *s > 0.0)
-        .collect();
-    savers.sort_by(|a, b| b.1.total_cmp(&a.1));
-    savers.truncate(8);
-
     OverviewData {
         status,
         paid_usd,
         would_have_usd,
         saved_usd,
-        saved_today_usd: today_saved_usd(tracker).filter(|t| *t >= 0.005),
+        saved_today_usd,
         pct_less,
         pct_less_whole,
         added_ms: summary.avg_compress_micros.map(|us| us / 1000.0),
@@ -1182,6 +1209,11 @@ pub fn overview_data(
         // Filled by App::reload from the single sessions() scan it already runs.
         sessions: 0,
         update_available: crate::update::check(false),
+        coverage_compressions: coverage.compressions_events,
+        coverage_turns: coverage.breakdown_turns,
+        coverage_ratio: coverage.coverage_ratio,
+        turns_unpriced: totals.turns_unpriced,
+        money_unavailable,
     }
 }
 
@@ -1292,10 +1324,30 @@ mod tests {
         s.metered_input_before = 1_000_000;
         s.metered_input_after = 933_000;
         let c = priced();
-        let excluded = snapshot(false, None, &s, &[], Some(&c), None, &[], false, false);
+        let excluded = snapshot(
+            false,
+            None,
+            &s,
+            &[],
+            Some(c.net_saved),
+            None,
+            &[],
+            false,
+            false,
+        );
         assert!(excluded.contains("(cache excluded)"));
         assert!(excluded.contains("-67%"), "cache-excluded axis: {excluded}");
-        let included = snapshot(false, None, &s, &[], Some(&c), None, &[], true, false);
+        let included = snapshot(
+            false,
+            None,
+            &s,
+            &[],
+            Some(c.net_saved),
+            None,
+            &[],
+            true,
+            false,
+        );
         assert!(included.contains("(all input · cache)"));
         assert!(included.contains("-7%"), "cache-included axis: {included}");
     }
@@ -1309,7 +1361,7 @@ mod tests {
             None,
             &summ(),
             &[],
-            Some(&c),
+            Some(c.net_saved),
             None,
             &[0, 20, 80],
             false,
@@ -1328,7 +1380,7 @@ mod tests {
             None,
             &summ(),
             &[],
-            Some(&c),
+            Some(c.net_saved),
             None,
             &[80, 10],
             false,
@@ -1344,7 +1396,7 @@ mod tests {
             None,
             &summ(),
             &[],
-            Some(&c),
+            Some(c.net_saved),
             None,
             &[5],
             false,
@@ -1373,7 +1425,7 @@ mod tests {
             None,
             &summ(),
             &models,
-            Some(&priced()),
+            Some(priced().net_saved),
             None,
             &[],
             false,
@@ -1420,7 +1472,7 @@ mod tests {
             None,
             &summ(),
             &models,
-            Some(&cost),
+            Some(cost.net_saved),
             None,
             &[],
             false,
@@ -1429,7 +1481,7 @@ mod tests {
         // Headline shows the MEASURED figures (tokens trimmed + real-bill $), not a
         // projection that assumes shaping.
         assert!(
-            out.contains("tokens trimmed") && out.contains("$12.47 off your real bill"),
+            out.contains("tokens trimmed") && out.contains("$12.47 saved on proxy bills"),
             "hero shows measured trimmed tokens + real-bill saving"
         );
         assert!(out.contains("1,204 requests"), "request count");
@@ -1470,19 +1522,19 @@ mod tests {
             None,
             &summ(),
             &[],
-            Some(&cost),
+            Some(cost.net_saved),
             None,
             &[],
             false,
             false,
         );
         assert!(
-            out.contains("$10.00 off your real bill"),
+            out.contains("$10.00 saved on proxy bills"),
             "headline = measured net saving"
         );
         assert!(
             !out.contains(&format!(
-                "${:.2} off your real bill",
+                "${:.2} saved on proxy bills",
                 cost.projected_saved()
             )),
             "projected total ({:.2}) is not the headline",
@@ -1521,7 +1573,17 @@ mod tests {
             out_spend_shaped: 0.0,
         };
         assert!((c.projected_saved() - c.saved).abs() < 1e-9);
-        let out = snapshot(false, None, &summ(), &[], Some(&c), None, &[], false, false);
+        let out = snapshot(
+            false,
+            None,
+            &summ(),
+            &[],
+            Some(c.net_saved),
+            None,
+            &[],
+            false,
+            false,
+        );
         // No footnote either way: the output axis' "(est · if output shaped)" tag carries
         // the caveat; a dedicated line only appears when the projection is ≥ $1.
         assert!(!out.contains("more saved by output shaping"));
@@ -1541,9 +1603,19 @@ mod tests {
             live_saved: 130.0,
             out_spend_shaped: 0.0,
         };
-        let out = snapshot(false, None, &summ(), &[], Some(&c), None, &[], false, false);
+        let out = snapshot(
+            false,
+            None,
+            &summ(),
+            &[],
+            Some(c.net_saved),
+            None,
+            &[],
+            false,
+            false,
+        );
         assert!(
-            out.contains("$25.00 off your real bill"),
+            out.contains("$25.00 saved on proxy bills"),
             "hero is the measured real-bill figure: {out}"
         );
         assert!(
@@ -1569,9 +1641,19 @@ mod tests {
             out_spend_shaped: 0.0,
             live_saved: 130.0,
         };
-        let out = snapshot(false, None, &s, &[], Some(&c), None, &[], false, false);
+        let out = snapshot(
+            false,
+            None,
+            &s,
+            &[],
+            Some(c.net_saved),
+            None,
+            &[],
+            false,
+            false,
+        );
         assert!(
-            out.contains("$25.00 off your real bill"),
+            out.contains("$25.00 saved on proxy bills"),
             "hero is the measured real-bill figure: {out}"
         );
         assert!(
@@ -1588,7 +1670,17 @@ mod tests {
         );
 
         // No metered rows → fall back to the all-input axis (pre-meter ledgers unchanged).
-        let out = snapshot(false, None, &summ(), &[], Some(&c), None, &[], false, false);
+        let out = snapshot(
+            false,
+            None,
+            &summ(),
+            &[],
+            Some(c.net_saved),
+            None,
+            &[],
+            false,
+            false,
+        );
         assert!(!out.contains("cache excluded"));
         assert!(out.contains("2.1M ─✂─▶ 1.2M"), "fallback axis: {out}");
     }
@@ -1611,7 +1703,7 @@ mod tests {
 
     #[test]
     fn export_json_roundtrips() {
-        let out = export_json(&summ(), &[], None, &[], None);
+        let out = export_json(&summ(), &[], None, &[], None, None);
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["requests"], 1204);
         assert_eq!(v["cost"], serde_json::Value::Null);
@@ -1648,6 +1740,97 @@ mod tests {
         assert_eq!(v["requests"], 2);
         assert_eq!(v["daemon"], serde_json::Value::Null);
         assert!(v["by_model"].as_array().is_some_and(|m| !m.is_empty()));
+    }
+
+    #[test]
+    fn overview_money_matches_sum_of_session_bills() {
+        use crate::tracking::{BreakdownTurn, Tracker};
+        use llmtrim_ledger::money::money_totals;
+
+        let tracker = Tracker::open_in_memory().unwrap();
+        let rates = (3.0, 15.0, 0.3, 3.75);
+        let bill1 = (50_000.0_f64 * 3.0 + 100.0 * 15.0).round() as i64;
+        let bill2 = (20_000.0_f64 * 3.0).round() as i64;
+        let turn = |session: &str, bill: i64, before: i64, after: i64, fresh: i64, out: i64| {
+            BreakdownTurn {
+                session_id: session.into(),
+                cc_session_id: None,
+                agent: "claude-code".into(),
+                project: Some("/p".into()),
+                session_name: None,
+                provider: "anthropic".into(),
+                model: Some("claude-sonnet-4".into()),
+                sub_provider: None,
+                window: 200_000,
+                fresh_input: fresh,
+                cache_read: 0,
+                cache_write: 0,
+                output_tok: out,
+                input_rate: rates.0,
+                output_rate: rates.1,
+                cache_read_rate: rates.2,
+                cache_write_rate: rates.3,
+                bill_micros: bill,
+                input_before: before,
+                input_after: after,
+            }
+        };
+        tracker
+            .record_breakdown(&turn("s1", bill1, 100_000, 50_000, 50_000, 100), &[])
+            .unwrap();
+        tracker
+            .record_breakdown(&turn("s2", bill2, 40_000, 20_000, 20_000, 0), &[])
+            .unwrap();
+
+        let money = money_totals(tracker.connection(), None).unwrap();
+        assert_eq!(money.paid_micros, bill1 + bill2);
+        assert_eq!(
+            money.would_have_micros,
+            money.paid_micros + money.saved_micros
+        );
+
+        let ov = overview_data(&tracker, |_, _| {
+            crate::breakdown::app::StatusLine::default()
+        });
+        assert!(!ov.money_unavailable);
+        assert_eq!(ov.paid_usd, Some(money.paid_usd()));
+        assert_eq!(ov.saved_usd, Some(money.saved_usd()));
+        assert_eq!(ov.would_have_usd, Some(money.would_have_usd()));
+
+        // Dual-run JSON exposes money without redefining legacy cost.
+        let v: serde_json::Value =
+            serde_json::from_str(&stats_json(&tracker, None).unwrap()).unwrap();
+        assert_eq!(v["money"]["source"], "breakdown_turns");
+        assert_eq!(v["money"]["unavailable"], false);
+        assert_eq!(v["money"]["paid_usd"].as_f64().unwrap(), money.paid_usd());
+
+        // Compressions-only: money is unavailable (null dollars), not $0 truth.
+        let t2 = Tracker::open_in_memory().unwrap();
+        t2.record(&crate::tracking::Record {
+            provider: "openai".into(),
+            model: Some("gpt-4o".into()),
+            tokenizer: "tiktoken".into(),
+            exact: true,
+            input_before: 1000,
+            input_after: 600,
+            output_before: None,
+            output_after: None,
+            compress_micros: None,
+            cache_read_tokens: None,
+            fresh_input_tokens: None,
+            cache_write_tokens: None,
+            output_shaped: Some(false),
+            frozen_input_tokens: Some(0),
+        })
+        .unwrap();
+        let v2: serde_json::Value = serde_json::from_str(&stats_json(&t2, None).unwrap()).unwrap();
+        assert_eq!(v2["money"]["unavailable"], true);
+        assert!(v2["money"]["paid_usd"].is_null());
+        let (hero, today) = hero_money(&t2);
+        assert!(hero.is_none() && today.is_none());
+        let ov2 = overview_data(&t2, |_, _| crate::breakdown::app::StatusLine::default());
+        assert!(ov2.money_unavailable);
+        assert!(ov2.paid_usd.is_none());
     }
 
     #[test]
@@ -2006,7 +2189,7 @@ mod tests {
             None,
             &summ(),
             &[],
-            Some(&cost),
+            Some(cost.net_saved),
             Some(1.84),
             &[],
             false,
@@ -2019,7 +2202,7 @@ mod tests {
             None,
             &summ(),
             &[],
-            Some(&cost),
+            Some(cost.net_saved),
             Some(0.0),
             &[],
             false,
@@ -2031,7 +2214,7 @@ mod tests {
             None,
             &summ(),
             &[],
-            Some(&cost),
+            Some(cost.net_saved),
             None,
             &[],
             false,
@@ -2042,7 +2225,7 @@ mod tests {
 
     #[test]
     fn export_json_carries_daemon_health() {
-        let out = export_json(&summ(), &[], None, &[], Some(&dv()));
+        let out = export_json(&summ(), &[], None, &[], Some(&dv()), None);
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["daemon"]["running"], true);
         assert_eq!(v["daemon"]["health"], "healthy");
@@ -2058,7 +2241,7 @@ mod tests {
             env_port: None,
             ..dv()
         };
-        let out = export_json(&summ(), &[], None, &[], Some(&stopped));
+        let out = export_json(&summ(), &[], None, &[], Some(&stopped), None);
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["daemon"]["running"], false);
         assert_eq!(v["daemon"]["health"], "stopped");

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -1220,10 +1220,6 @@ pub fn overview_data(
         // Filled by App::reload from the single sessions() scan it already runs.
         sessions: 0,
         update_available: crate::update::check(false),
-        coverage_compressions: coverage.compressions_events,
-        coverage_turns: coverage.breakdown_turns,
-        turns_unpriced: totals.turns_unpriced,
-        money_unavailable,
     }
 }
 
@@ -1802,7 +1798,7 @@ mod tests {
         let ov = overview_data(&tracker, |_, _| {
             crate::breakdown::app::StatusLine::default()
         });
-        assert!(!ov.money_unavailable);
+        assert!(!ov.money_unavailable());
         assert_eq!(ov.paid_usd, Some(money.paid_usd()));
         assert_eq!(ov.saved_usd, Some(money.saved_usd()));
         assert_eq!(ov.would_have_usd, Some(money.would_have_usd()));
@@ -1839,7 +1835,7 @@ mod tests {
         let (hero, today) = hero_money(&t2);
         assert!(hero.is_none() && today.is_none());
         let ov2 = overview_data(&t2, |_, _| crate::breakdown::app::StatusLine::default());
-        assert!(ov2.money_unavailable);
+        assert!(ov2.money_unavailable());
         assert!(ov2.paid_usd.is_none());
     }
 

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -833,9 +833,20 @@ pub fn hero_money(tracker: &Tracker) -> (Option<f64>, Option<f64>) {
 
 /// Full snapshot as JSON (for Grafana/Prometheus/scripts).
 ///
-/// When `money` is provided, emits additive frozen-breakdown bills alongside legacy `cost`
-/// (compressions + live list prices). Do not silently redefine `cost.*` fields.
+/// Dual-run: legacy `cost` (compressions + live list prices) plus optional additive `money`
+/// (frozen breakdown). Pass `money` via [`export_json_with_money`] or [`stats_json`].
 pub fn export_json(
+    s: &Summary,
+    models: &[ModelView],
+    cost: Option<&Cost>,
+    periods: &[PeriodRow],
+    daemon: Option<&DaemonView>,
+) -> String {
+    export_json_with_money(s, models, cost, periods, daemon, None)
+}
+
+/// Like [`export_json`], with an optional additive `money` object (frozen breakdown bills).
+pub fn export_json_with_money(
     s: &Summary,
     models: &[ModelView],
     cost: Option<&Cost>,
@@ -924,7 +935,7 @@ pub fn stats_json(tracker: &Tracker, daemon: Option<&DaemonView>) -> Result<Stri
     let models = model_views(tracker)?;
     let cost = monitor_cost(tracker);
     let periods = tracker.by_period(Period::Day)?;
-    Ok(export_json(
+    Ok(export_json_with_money(
         &summary,
         &models,
         cost.as_ref(),
@@ -1211,7 +1222,6 @@ pub fn overview_data(
         update_available: crate::update::check(false),
         coverage_compressions: coverage.compressions_events,
         coverage_turns: coverage.breakdown_turns,
-        coverage_ratio: coverage.coverage_ratio,
         turns_unpriced: totals.turns_unpriced,
         money_unavailable,
     }
@@ -1703,7 +1713,7 @@ mod tests {
 
     #[test]
     fn export_json_roundtrips() {
-        let out = export_json(&summ(), &[], None, &[], None, None);
+        let out = export_json(&summ(), &[], None, &[], None);
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["requests"], 1204);
         assert_eq!(v["cost"], serde_json::Value::Null);
@@ -2225,7 +2235,7 @@ mod tests {
 
     #[test]
     fn export_json_carries_daemon_health() {
-        let out = export_json(&summ(), &[], None, &[], Some(&dv()), None);
+        let out = export_json(&summ(), &[], None, &[], Some(&dv()));
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["daemon"]["running"], true);
         assert_eq!(v["daemon"]["health"], "healthy");
@@ -2241,7 +2251,7 @@ mod tests {
             env_port: None,
             ..dv()
         };
-        let out = export_json(&summ(), &[], None, &[], Some(&stopped), None);
+        let out = export_json(&summ(), &[], None, &[], Some(&stopped));
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["daemon"]["running"], false);
         assert_eq!(v["daemon"]["health"], "stopped");

--- a/crates/llmtrim-ledger/src/breakdown_db.rs
+++ b/crates/llmtrim-ledger/src/breakdown_db.rs
@@ -34,7 +34,10 @@ pub struct SessionRow {
     pub last_input_tokens: i64,
     /// Total bill in micro-USD (frozen per turn, summed).
     pub bill_micros: i64,
-    /// Input tokens before / after compression, summed — the session's savings.
+    /// Input-side counterfactual savings in micro-USD (blend, frozen rates), summed.
+    /// Same formula as [`crate::money::turn_saved_micros`]; 0 when meters missing.
+    pub saved_micros: i64,
+    /// Input tokens before / after compression, summed — the session's size trim.
     pub input_before: i64,
     pub input_after: i64,
     /// rfc3339 timestamp of the most recent turn, for sorting newest-first.
@@ -54,12 +57,22 @@ impl SessionRow {
     }
 
     /// Percentage of input tokens llmtrim trimmed this session (0 when nothing measured).
+    /// Token size reduction — not dollars. Prefer the name [`Self::trim_pct`].
     pub fn saved_pct(&self) -> f64 {
+        self.trim_pct()
+    }
+
+    /// Token size trim % (before→after). Distinct from money savings (`saved_micros`).
+    pub fn trim_pct(&self) -> f64 {
         if self.input_before > 0 {
             (self.input_before - self.input_after).max(0) as f64 / self.input_before as f64 * 100.0
         } else {
             0.0
         }
+    }
+
+    pub fn saved_usd(&self) -> f64 {
+        self.saved_micros as f64 / 1_000_000.0
     }
 }
 
@@ -114,57 +127,63 @@ impl BreakdownDb {
 
     /// All sessions with at least one recorded turn, newest activity first.
     pub fn sessions(&self) -> Result<Vec<SessionRow>> {
+        // Shared formula with money_totals — bare columns inside the CTE select list.
+        let saved_expr = crate::money::saved_micros_sql("");
+        let sql = format!(
+            // One pass, two rankings — instead of correlated subqueries that re-scanned the
+            // table once per session group. `rn` prefers a *named* row (so the session keeps
+            // its latest `session_name`), while `recent` is strictly newest-first: the backend
+            // that served the last turn must come from the newest row, not the newest *named*
+            // one.
+            "WITH ranked AS (
+                 SELECT session_id, cc_session_id, agent, project, session_name, ts, id,
+                        fresh_input, cache_read, cache_write, output_tok,
+                        bill_micros, input_before, input_after, sub_provider, model,
+                        input_rate, cache_read_rate, cache_write_rate,
+                        ({saved_expr}) AS saved_micros,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY session_id, cc_session_id, agent, project
+                            ORDER BY (session_name IS NOT NULL) DESC, id DESC
+                        ) AS rn,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY session_id, cc_session_id, agent, project
+                            ORDER BY id DESC
+                        ) AS recent
+                 FROM breakdown_turns
+             )
+             SELECT session_id, agent, project,
+                    MAX(CASE WHEN rn = 1 THEN session_name END),
+                    COUNT(*),
+                    COALESCE(SUM(fresh_input + cache_read + cache_write + output_tok), 0),
+                    COALESCE(SUM(cache_read), 0),
+                    COALESCE(SUM(fresh_input + cache_read + cache_write), 0),
+                    COALESCE(SUM(bill_micros), 0),
+                    COALESCE(SUM(saved_micros), 0),
+                    COALESCE(SUM(input_before), 0),
+                    COALESCE(SUM(input_after), 0),
+                    MAX(ts),
+                    cc_session_id,
+                    MAX(CASE WHEN recent = 1 THEN sub_provider END),
+                    MAX(CASE WHEN recent = 1 THEN model END),
+                    COALESCE(MAX(CASE WHEN recent = 1 THEN cache_read END), 0),
+                    COALESCE(
+                        MAX(CASE WHEN recent = 1 THEN fresh_input + cache_read + cache_write END),
+                        0
+                    )
+             FROM ranked
+             GROUP BY session_id, cc_session_id, agent, project
+             ORDER BY MAX(ts) DESC"
+        );
         let mut stmt = self
             .conn
-            .prepare(
-                // One pass, two rankings — instead of correlated subqueries that re-scanned the
-                // table once per session group. `rn` prefers a *named* row (so the session keeps
-                // its latest `session_name`), while `recent` is strictly newest-first: the backend
-                // that served the last turn must come from the newest row, not the newest *named*
-                // one.
-                "WITH ranked AS (
-                     SELECT session_id, cc_session_id, agent, project, session_name, ts, id,
-                            fresh_input, cache_read, cache_write, output_tok,
-                            bill_micros, input_before, input_after, sub_provider, model,
-                            ROW_NUMBER() OVER (
-                                PARTITION BY session_id, cc_session_id, agent, project
-                                ORDER BY (session_name IS NOT NULL) DESC, id DESC
-                            ) AS rn,
-                            ROW_NUMBER() OVER (
-                                PARTITION BY session_id, cc_session_id, agent, project
-                                ORDER BY id DESC
-                            ) AS recent
-                     FROM breakdown_turns
-                 )
-                 SELECT session_id, agent, project,
-                        MAX(CASE WHEN rn = 1 THEN session_name END),
-                        COUNT(*),
-                        COALESCE(SUM(fresh_input + cache_read + cache_write + output_tok), 0),
-                        COALESCE(SUM(cache_read), 0),
-                        COALESCE(SUM(fresh_input + cache_read + cache_write), 0),
-                        COALESCE(SUM(bill_micros), 0),
-                        COALESCE(SUM(input_before), 0),
-                        COALESCE(SUM(input_after), 0),
-                        MAX(ts),
-                        cc_session_id,
-                        MAX(CASE WHEN recent = 1 THEN sub_provider END),
-                        MAX(CASE WHEN recent = 1 THEN model END),
-                        COALESCE(MAX(CASE WHEN recent = 1 THEN cache_read END), 0),
-                        COALESCE(
-                            MAX(CASE WHEN recent = 1 THEN fresh_input + cache_read + cache_write END),
-                            0
-                        )
-                 FROM ranked
-                 GROUP BY session_id, cc_session_id, agent, project
-                 ORDER BY MAX(ts) DESC",
-            )
+            .prepare(&sql)
             .context("failed to prepare sessions query")?;
         let rows = stmt
             .query_map([], |r| {
                 let cache_read: i64 = r.get(6)?;
                 let total_in: i64 = r.get(7)?;
-                let last_read: i64 = r.get(15)?;
-                let last_total_in: i64 = r.get(16)?;
+                let last_read: i64 = r.get(16)?;
+                let last_total_in: i64 = r.get(17)?;
                 Ok(SessionRow {
                     session_id: r.get(0)?,
                     agent: r.get(1)?,
@@ -181,12 +200,13 @@ impl BreakdownDb {
                         .then(|| last_read as f64 / last_total_in as f64),
                     last_input_tokens: last_total_in,
                     bill_micros: r.get(8)?,
-                    input_before: r.get(9)?,
-                    input_after: r.get(10)?,
-                    last_ts: r.get(11)?,
-                    cc_session_id: r.get(12)?,
-                    last_sub_provider: r.get(13)?,
-                    last_model: r.get(14)?,
+                    saved_micros: r.get(9)?,
+                    input_before: r.get(10)?,
+                    input_after: r.get(11)?,
+                    last_ts: r.get(12)?,
+                    cc_session_id: r.get(13)?,
+                    last_sub_provider: r.get(14)?,
+                    last_model: r.get(15)?,
                 })
             })
             .context("failed to query sessions")?;

--- a/crates/llmtrim-ledger/src/lib.rs
+++ b/crates/llmtrim-ledger/src/lib.rs
@@ -2,7 +2,9 @@
 //!
 //! `tracking` — the core compression ledger (Tracker, Record, BreakdownTurn, …).
 //! `breakdown_db` — read-only query layer for the cost-breakdown view (BreakdownDb, SessionRow, …).
+//! `money` — canonical paid/saved dollars from frozen `breakdown_turns.bill_micros`.
 
 pub mod breakdown_db;
 pub mod dashboard;
+pub mod money;
 pub mod tracking;

--- a/crates/llmtrim-ledger/src/money.rs
+++ b/crates/llmtrim-ledger/src/money.rs
@@ -1,0 +1,746 @@
+//! Canonical money totals from `breakdown_turns` frozen rates.
+//!
+//! **Paid** is always `SUM(bill_micros)` — the same number Sessions/Detail/Tray use.
+//! **Saved** is the input-side counterfactual (blend, per turn, frozen rates), so
+//! `would_have = paid + saved` holds by construction. Output is in paid, not saved.
+//!
+//! Compressions remain the source for token volume / latency / frozen-zone gauges;
+//! this module is the sole path for dollars.
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+use serde::Serialize;
+
+use crate::breakdown_db::BreakdownDb;
+
+/// Maximum compression fraction applied in the counterfactual (matches `cost_estimate`).
+pub const PCT_CLAMP: f64 = 0.95;
+
+/// Inclusive lower bound on `breakdown_turns.ts` (rfc3339 UTC), or all time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MoneyWindow {
+    #[default]
+    All,
+    /// Rows with `ts >= start` (lexical == chronological for rfc3339 UTC).
+    SinceTs,
+}
+
+/// Aggregated money for a window on `breakdown_turns`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct MoneyTotals {
+    /// Actual bill: `SUM(bill_micros)`.
+    pub paid_micros: i64,
+    /// Input-side counterfactual savings (blend, per-turn, frozen rates).
+    pub saved_micros: i64,
+    /// `paid_micros + saved_micros` (output unchanged in the counterfactual).
+    pub would_have_micros: i64,
+    /// Turns in the money window.
+    pub turns: i64,
+    /// Turns with usage tokens but `bill_micros == 0` (unpriced model / zero rates).
+    pub turns_unpriced: i64,
+    /// Distinct models contributing to paid/saved.
+    pub models_priced: i64,
+}
+
+impl MoneyTotals {
+    pub fn paid_usd(&self) -> f64 {
+        self.paid_micros as f64 / 1_000_000.0
+    }
+    pub fn saved_usd(&self) -> f64 {
+        self.saved_micros as f64 / 1_000_000.0
+    }
+    pub fn would_have_usd(&self) -> f64 {
+        self.would_have_micros as f64 / 1_000_000.0
+    }
+
+    /// True when at least one turn contributed a non-zero bill or savings estimate.
+    pub fn has_money(&self) -> bool {
+        self.turns > 0 && (self.paid_micros > 0 || self.saved_micros > 0 || self.turns_unpriced > 0)
+    }
+
+    /// True when there are turns but every turn is unpriced (all bills zero with usage).
+    pub fn all_unpriced(&self) -> bool {
+        self.turns > 0 && self.paid_micros == 0 && self.turns_unpriced == self.turns
+    }
+}
+
+/// Coverage of money attribution vs the compressions request log.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct MoneyCoverage {
+    pub compressions_events: i64,
+    pub breakdown_turns: i64,
+    /// `breakdown_turns / compressions_events` when compressions > 0; else 1.0 if both 0.
+    pub coverage_ratio: f64,
+}
+
+impl MoneyCoverage {
+    pub fn compute(compressions_events: i64, breakdown_turns: i64) -> Self {
+        let coverage_ratio = if compressions_events > 0 {
+            (breakdown_turns as f64 / compressions_events as f64).clamp(0.0, 1.0)
+        } else if breakdown_turns > 0 {
+            1.0
+        } else {
+            1.0
+        };
+        Self {
+            compressions_events,
+            breakdown_turns,
+            coverage_ratio,
+        }
+    }
+
+    /// Compressions exist but no billed turns — Overview must not show $0 as truth.
+    pub fn empty_money_with_traffic(&self) -> bool {
+        self.compressions_events > 0 && self.breakdown_turns == 0
+    }
+
+    pub fn partial(&self) -> bool {
+        self.compressions_events > 0
+            && self.breakdown_turns > 0
+            && self.breakdown_turns < self.compressions_events
+    }
+}
+
+/// One calendar day of money (UTC date key `YYYY-MM-DD`).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct MoneyByDay {
+    pub day: String,
+    pub paid_micros: i64,
+    pub saved_micros: i64,
+}
+
+/// Per-model money rollup.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct MoneyByModel {
+    pub model: String,
+    pub paid_micros: i64,
+    pub saved_micros: i64,
+    pub turns: i64,
+}
+
+// ── pure per-turn formula (unit-tested; SQL mirrors this) ───────────────────────
+
+/// Compression fraction for one turn, clamped to `[0, PCT_CLAMP]`.
+///
+/// Returns 0 when meters are missing or non-positive before.
+pub fn turn_pct(input_before: Option<i64>, input_after: Option<i64>) -> f64 {
+    let Some(before) = input_before.filter(|&b| b > 0) else {
+        return 0.0;
+    };
+    let after = input_after.unwrap_or(before).max(0);
+    let cut = (before - after).max(0) as f64;
+    (cut / before as f64).clamp(0.0, PCT_CLAMP)
+}
+
+/// Input-side bill in micro-USD from frozen rates (excludes output).
+pub fn input_bill_micros(
+    fresh_input: i64,
+    cache_read: i64,
+    cache_write: i64,
+    input_rate: f64,
+    cache_read_rate: f64,
+    cache_write_rate: f64,
+) -> i64 {
+    (fresh_input as f64 * input_rate
+        + cache_read as f64 * cache_read_rate
+        + cache_write as f64 * cache_write_rate)
+        .round() as i64
+}
+
+/// Blend counterfactual savings for one turn (micro-USD).
+///
+/// `saved = input_bill × pct / (1 − pct)`. Same shape as `cost_estimate::net_saved`,
+/// but rates are the turn's frozen rates. **Blend** understates pure live-zone savings
+/// on cache-heavy traffic; that is intentional and labeled in the UI.
+pub fn turn_saved_micros(
+    input_before: Option<i64>,
+    input_after: Option<i64>,
+    fresh_input: i64,
+    cache_read: i64,
+    cache_write: i64,
+    input_rate: f64,
+    cache_read_rate: f64,
+    cache_write_rate: f64,
+) -> i64 {
+    let pct = turn_pct(input_before, input_after);
+    if pct <= 0.0 {
+        return 0;
+    }
+    let input_bill = input_bill_micros(
+        fresh_input,
+        cache_read,
+        cache_write,
+        input_rate,
+        cache_read_rate,
+        cache_write_rate,
+    ) as f64;
+    if input_bill <= 0.0 {
+        return 0;
+    }
+    // pct is clamped to PCT_CLAMP so (1-pct) >= 0.05.
+    (input_bill * pct / (1.0 - pct)).round() as i64
+}
+
+/// SQL expression for per-turn saved micros (mirrors [`turn_saved_micros`]).
+///
+/// `alias` is the table/CTE qualifier including a trailing `.` when non-empty
+/// (e.g. `"t."` or `""` for bare column names in a CTE select list).
+/// Used by [`money_totals`] **and** [`BreakdownDb::sessions`] so Overview and
+/// Sessions cannot drift.
+pub fn saved_micros_sql(alias: &str) -> String {
+    // pct = min(0.95, max(0, (before-after)/before)) when before > 0
+    // input_bill = fresh*input_rate + read*cache_read_rate + write*cache_write_rate
+    // saved = input_bill * pct / (1-pct)
+    let a = alias;
+    format!(
+        "CASE
+            WHEN {a}input_before IS NULL OR {a}input_before <= 0 THEN 0
+            ELSE CAST(ROUND(
+                MAX(0.0,
+                    {a}fresh_input * {a}input_rate
+                    + {a}cache_read * {a}cache_read_rate
+                    + {a}cache_write * {a}cache_write_rate
+                )
+                * MIN({clamp}, MAX(0.0,
+                    ({a}input_before - COALESCE({a}input_after, {a}input_before)) * 1.0
+                    / {a}input_before
+                  ))
+                / (1.0 - MIN({clamp}, MAX(0.0,
+                    ({a}input_before - COALESCE({a}input_after, {a}input_before)) * 1.0
+                    / {a}input_before
+                  )))
+            ) AS INTEGER)
+         END",
+        clamp = PCT_CLAMP
+    )
+}
+
+/// Money totals over all time (or since `since_ts` when set).
+///
+/// `since_ts` is an inclusive lower bound on `ts` (rfc3339 UTC). Does **not** scan sessions.
+pub fn money_totals(conn: &Connection, since_ts: Option<&str>) -> Result<MoneyTotals> {
+    let saved = saved_micros_sql("t.");
+    let (sql, use_since) = if since_ts.is_some() {
+        (
+            format!(
+                "SELECT
+                    COALESCE(SUM(t.bill_micros), 0),
+                    COALESCE(SUM({saved}), 0),
+                    COUNT(*),
+                    COALESCE(SUM(CASE
+                        WHEN t.bill_micros = 0
+                         AND (t.fresh_input + t.cache_read + t.cache_write + t.output_tok) > 0
+                        THEN 1 ELSE 0 END), 0),
+                    COUNT(DISTINCT CASE
+                        WHEN t.bill_micros > 0 OR ({saved}) > 0
+                        THEN COALESCE(t.model, '') END)
+                 FROM breakdown_turns t
+                 WHERE t.ts >= ?1"
+            ),
+            true,
+        )
+    } else {
+        (
+            format!(
+                "SELECT
+                    COALESCE(SUM(t.bill_micros), 0),
+                    COALESCE(SUM({saved}), 0),
+                    COUNT(*),
+                    COALESCE(SUM(CASE
+                        WHEN t.bill_micros = 0
+                         AND (t.fresh_input + t.cache_read + t.cache_write + t.output_tok) > 0
+                        THEN 1 ELSE 0 END), 0),
+                    COUNT(DISTINCT CASE
+                        WHEN t.bill_micros > 0 OR ({saved}) > 0
+                        THEN COALESCE(t.model, '') END)
+                 FROM breakdown_turns t"
+            ),
+            false,
+        )
+    };
+    let map = |row: &rusqlite::Row<'_>| -> rusqlite::Result<MoneyTotals> {
+        let paid: i64 = row.get(0)?;
+        let saved_m: i64 = row.get(1)?;
+        Ok(MoneyTotals {
+            paid_micros: paid,
+            saved_micros: saved_m,
+            would_have_micros: paid.saturating_add(saved_m),
+            turns: row.get(2)?,
+            turns_unpriced: row.get(3)?,
+            models_priced: row.get(4)?,
+        })
+    };
+    if use_since {
+        conn.query_row(&sql, params![since_ts.unwrap()], map)
+            .context("failed to query money_totals (since)")
+    } else {
+        conn.query_row(&sql, [], map)
+            .context("failed to query money_totals")
+    }
+}
+
+/// Last `n_days` calendar days (UTC) with activity, newest-first then reversed to oldest→newest.
+pub fn money_by_day(conn: &Connection, n_days: usize) -> Result<Vec<MoneyByDay>> {
+    if n_days == 0 {
+        return Ok(Vec::new());
+    }
+    let saved = saved_micros_sql("t.");
+    let sql = format!(
+        "SELECT substr(t.ts, 1, 10) AS day,
+                COALESCE(SUM(t.bill_micros), 0),
+                COALESCE(SUM({saved}), 0)
+         FROM breakdown_turns t
+         GROUP BY day
+         ORDER BY day DESC
+         LIMIT ?1"
+    );
+    let mut stmt = conn
+        .prepare(&sql)
+        .context("failed to prepare money_by_day")?;
+    let rows = stmt
+        .query_map(params![n_days as i64], |r| {
+            Ok(MoneyByDay {
+                day: r.get(0)?,
+                paid_micros: r.get(1)?,
+                saved_micros: r.get(2)?,
+            })
+        })
+        .context("failed to query money_by_day")?;
+    let mut out: Vec<MoneyByDay> = rows
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to read money_by_day")?;
+    out.reverse();
+    Ok(out)
+}
+
+/// Top models by saved micros (then paid), limit `n`.
+pub fn money_by_model(conn: &Connection, n: usize) -> Result<Vec<MoneyByModel>> {
+    let saved = saved_micros_sql("t.");
+    let sql = format!(
+        "SELECT COALESCE(t.model, '(unknown)'),
+                COALESCE(SUM(t.bill_micros), 0),
+                COALESCE(SUM({saved}), 0),
+                COUNT(*)
+         FROM breakdown_turns t
+         GROUP BY t.model
+         ORDER BY 3 DESC, 2 DESC
+         LIMIT ?1"
+    );
+    let mut stmt = conn
+        .prepare(&sql)
+        .context("failed to prepare money_by_model")?;
+    let rows = stmt
+        .query_map(params![n as i64], |r| {
+            Ok(MoneyByModel {
+                model: r.get(0)?,
+                paid_micros: r.get(1)?,
+                saved_micros: r.get(2)?,
+                turns: r.get(3)?,
+            })
+        })
+        .context("failed to query money_by_model")?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("failed to read money_by_model")
+}
+
+/// Paid micros for one session (canonical Detail footer).
+pub fn session_bill_micros(conn: &Connection, session_id: &str) -> Result<i64> {
+    conn.query_row(
+        "SELECT COALESCE(SUM(bill_micros), 0) FROM breakdown_turns WHERE session_id = ?1",
+        params![session_id],
+        |r| r.get(0),
+    )
+    .context("failed to query session_bill_micros")
+}
+
+/// Coverage: compressions events vs breakdown turns (same DB file).
+pub fn money_coverage(conn: &Connection) -> Result<MoneyCoverage> {
+    let compressions: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='compressions'",
+            [],
+            |r| r.get(0),
+        )
+        .context("failed to probe compressions table")?;
+    let compressions_events = if compressions > 0 {
+        conn.query_row("SELECT COUNT(*) FROM compressions", [], |r| r.get(0))
+            .context("failed to count compressions")?
+    } else {
+        0
+    };
+    let breakdown_turns: i64 = conn
+        .query_row("SELECT COUNT(*) FROM breakdown_turns", [], |r| r.get(0))
+        .context("failed to count breakdown_turns")?;
+    Ok(MoneyCoverage::compute(compressions_events, breakdown_turns))
+}
+
+impl BreakdownDb {
+    /// Ensure the ts index used by money range queries exists (idempotent).
+    pub fn ensure_money_indexes(&self) -> Result<()> {
+        self.conn
+            .execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_breakdown_turns_ts ON breakdown_turns(ts);",
+            )
+            .context("failed to create breakdown_turns ts index")?;
+        Ok(())
+    }
+
+    pub fn money_totals(&self, since_ts: Option<&str>) -> Result<MoneyTotals> {
+        money_totals(&self.conn, since_ts)
+    }
+
+    pub fn money_by_day(&self, n_days: usize) -> Result<Vec<MoneyByDay>> {
+        money_by_day(&self.conn, n_days)
+    }
+
+    pub fn money_by_model(&self, n: usize) -> Result<Vec<MoneyByModel>> {
+        money_by_model(&self.conn, n)
+    }
+
+    pub fn session_bill_micros(&self, session_id: &str) -> Result<i64> {
+        session_bill_micros(&self.conn, session_id)
+    }
+
+    pub fn money_coverage(&self) -> Result<MoneyCoverage> {
+        money_coverage(&self.conn)
+    }
+}
+
+/// Start of the current **UTC** calendar day as an rfc3339 lower bound.
+/// Documented UTC (not local) so "today" matches `by_model_today` / day buckets.
+pub fn today_start_utc() -> String {
+    let d = chrono::Utc::now().date_naive();
+    format!("{d}T00:00:00+00:00")
+}
+
+/// Pad `money_by_day` results to exactly `n` trailing UTC days (zeros for quiet days).
+pub fn pad_daily_saved(days: &[MoneyByDay], n: usize) -> Vec<f64> {
+    if n == 0 {
+        return Vec::new();
+    }
+    let today = chrono::Utc::now().date_naive();
+    let mut map: std::collections::HashMap<&str, i64> = std::collections::HashMap::new();
+    for d in days {
+        map.insert(d.day.as_str(), d.saved_micros);
+    }
+    (0..n)
+        .map(|i| {
+            let day = today - chrono::Duration::days((n - 1 - i) as i64);
+            let key = day.format("%Y-%m-%d").to_string();
+            map.get(key.as_str()).copied().unwrap_or(0) as f64 / 1_000_000.0
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tracking::{BreakdownBlock, BreakdownTurn, Tracker};
+
+    fn turn(
+        session: &str,
+        model: &str,
+        bill: i64,
+        before: i64,
+        after: i64,
+        fresh: i64,
+        cache_read: i64,
+        cache_write: i64,
+        out: i64,
+        rates: (f64, f64, f64, f64),
+    ) -> BreakdownTurn {
+        BreakdownTurn {
+            session_id: session.into(),
+            cc_session_id: None,
+            agent: "claude-code".into(),
+            project: Some("/proj".into()),
+            session_name: Some("s".into()),
+            provider: "anthropic".into(),
+            model: Some(model.into()),
+            sub_provider: None,
+            window: 200_000,
+            fresh_input: fresh,
+            cache_read,
+            cache_write,
+            output_tok: out,
+            input_rate: rates.0,
+            output_rate: rates.1,
+            cache_read_rate: rates.2,
+            cache_write_rate: rates.3,
+            bill_micros: bill,
+            input_before: before,
+            input_after: after,
+        }
+    }
+
+    fn seed(t: &Tracker, turns: &[BreakdownTurn]) {
+        for tr in turns {
+            t.record_breakdown(tr, &[]).unwrap();
+        }
+    }
+
+    #[test]
+    fn turn_pct_clamps_and_null_safe() {
+        assert_eq!(turn_pct(None, Some(10)), 0.0);
+        assert_eq!(turn_pct(Some(0), Some(0)), 0.0);
+        assert!((turn_pct(Some(100), Some(50)) - 0.5).abs() < 1e-9);
+        assert!((turn_pct(Some(100), Some(0)) - PCT_CLAMP).abs() < 1e-9);
+        assert_eq!(turn_pct(Some(100), Some(100)), 0.0);
+        assert_eq!(turn_pct(Some(100), Some(150)), 0.0); // grew
+    }
+
+    #[test]
+    fn per_turn_saved_not_equal_to_aggregate_formula() {
+        // Asymmetric cache mixes make sum(per-turn) diverge from formula-on-sums.
+        // Turn A: heavy cache, small cut. Turn B: all-fresh, large cut.
+        let r = (3.0, 15.0, 0.3, 3.75);
+        let s1 = turn_saved_micros(Some(100_000), Some(95_000), 5_000, 90_000, 0, r.0, r.2, r.3);
+        let s2 = turn_saved_micros(Some(100_000), Some(40_000), 40_000, 0, 0, r.0, r.2, r.3);
+        let sum = s1 + s2;
+        // Wrong aggregate: sum tokens then one pct.
+        let before = 200_000.0;
+        let after = 135_000.0;
+        let agg_bill = input_bill_micros(45_000, 90_000, 0, r.0, r.2, r.3) as f64;
+        let agg_pct = (before - after) / before;
+        let agg = (agg_bill * agg_pct / (1.0 - agg_pct)).round() as i64;
+        assert_ne!(
+            sum, agg,
+            "Jensen: per-turn sum must differ from aggregate ({sum} vs {agg})"
+        );
+        assert!(sum > 0 && s2 > s1);
+    }
+
+    #[test]
+    fn cache_blend_understates_live_cut_documented() {
+        // 90k cache-read @ 0.1×, 10k fresh @ 1×, cut 10k live → before=110k after=100k
+        // rates: input=3, cache_read=0.3 ($/1M micro convention)
+        let input_rate = 3.0;
+        let cache_read_rate = 0.3;
+        let saved = turn_saved_micros(
+            Some(110_000),
+            Some(100_000),
+            10_000,
+            90_000,
+            0,
+            input_rate,
+            cache_read_rate,
+            0.0,
+        );
+        let live_true = (10_000.0 * input_rate).round() as i64; // cut at full rate
+        assert!(
+            saved < live_true / 2,
+            "blend must understate live cut: saved={saved} live={live_true}"
+        );
+        // Lock expected so the understatement is intentional, not accidental drift.
+        // input_bill = 10k*3 + 90k*0.3 = 30000+27000 = 57000
+        // pct = 10000/110000 ≈ 0.090909
+        // saved = 57000 * pct/(1-pct) ≈ 5700
+        assert!(
+            (saved - 5700).abs() < 5,
+            "expected ~5700 blend micros, got {saved}"
+        );
+    }
+
+    #[test]
+    fn money_totals_matches_sum_of_bills() {
+        let t = Tracker::open_in_memory().unwrap();
+        let rates = (3.0, 15.0, 0.3, 3.75);
+        // bill = fresh*3 + out*15
+        let bill1 = (50_000.0_f64 * 3.0 + 100.0 * 15.0).round() as i64;
+        let bill2 = (80_000.0_f64 * 3.0 + 200.0 * 15.0).round() as i64;
+        seed(
+            &t,
+            &[
+                turn("s1", "m1", bill1, 100_000, 50_000, 50_000, 0, 0, 100, rates),
+                turn("s2", "m1", bill2, 100_000, 80_000, 80_000, 0, 0, 200, rates),
+            ],
+        );
+        let db = BreakdownDb::from_connection(t.into_connection());
+        let m = db.money_totals(None).unwrap();
+        assert_eq!(m.paid_micros, bill1 + bill2);
+        assert_eq!(m.turns, 2);
+        assert_eq!(m.would_have_micros, m.paid_micros + m.saved_micros);
+        assert!(m.saved_micros > 0);
+
+        // Pure formula must match SQL for each turn summed.
+        let s1 = turn_saved_micros(
+            Some(100_000),
+            Some(50_000),
+            50_000,
+            0,
+            0,
+            rates.0,
+            rates.2,
+            rates.3,
+        );
+        let s2 = turn_saved_micros(
+            Some(100_000),
+            Some(80_000),
+            80_000,
+            0,
+            0,
+            rates.0,
+            rates.2,
+            rates.3,
+        );
+        assert_eq!(m.saved_micros, s1 + s2);
+    }
+
+    #[test]
+    fn unpriced_and_premeter() {
+        let t = Tracker::open_in_memory().unwrap();
+        // Unpriced: usage but bill 0, rates 0
+        let unpriced = turn(
+            "s1",
+            "mystery",
+            0,
+            1000,
+            500,
+            500,
+            0,
+            0,
+            10,
+            (0.0, 0.0, 0.0, 0.0),
+        );
+        // Premeter-like: no compression meters (0 before → pct 0), but has bill
+        let mut premeter = turn("s2", "m1", 1000, 0, 0, 100, 0, 0, 0, (3.0, 15.0, 0.3, 3.75));
+        premeter.input_before = 0;
+        premeter.input_after = 0;
+        seed(&t, &[unpriced, premeter]);
+        let db = BreakdownDb::from_connection(t.into_connection());
+        let m = db.money_totals(None).unwrap();
+        assert_eq!(m.turns, 2);
+        assert_eq!(m.turns_unpriced, 1);
+        assert_eq!(m.paid_micros, 1000);
+        assert_eq!(m.saved_micros, 0);
+    }
+
+    #[test]
+    fn coverage_empty_money_with_traffic() {
+        let c = MoneyCoverage::compute(10, 0);
+        assert!(c.empty_money_with_traffic());
+        assert!(!c.partial());
+        let p = MoneyCoverage::compute(10, 4);
+        assert!(p.partial());
+        assert!((p.coverage_ratio - 0.4).abs() < 1e-9);
+    }
+
+    #[test]
+    fn session_bill_is_canonical_paid() {
+        let t = Tracker::open_in_memory().unwrap();
+        let rates = (3.0, 15.0, 0.3, 3.75);
+        let bill = 12_345;
+        seed(
+            &t,
+            &[turn("sess-a", "m1", bill, 1000, 800, 800, 0, 0, 0, rates)],
+        );
+        // Also write a block that would reprice differently if Detail used block sum only
+        let tr = turn("sess-a", "m1", bill, 1000, 800, 800, 0, 0, 0, rates);
+        // re-open path: second turn same session
+        let t2 = Tracker::open_in_memory().unwrap();
+        let block = BreakdownBlock {
+            zone: "messages".into(),
+            section: "user".into(),
+            bucket: "text".into(),
+            group_label: "Messages".into(),
+            label: "user".into(),
+            raw_tokens: 800,
+            fresh_tok: 800.0,
+            ..Default::default()
+        };
+        t2.record_breakdown(&tr, &[block]).unwrap();
+        let db = BreakdownDb::from_connection(t2.into_connection());
+        assert_eq!(db.session_bill_micros("sess-a").unwrap(), bill);
+        let m = db.money_totals(None).unwrap();
+        assert_eq!(m.paid_micros, bill);
+    }
+
+    #[test]
+    fn money_by_model_orders_by_saved() {
+        let t = Tracker::open_in_memory().unwrap();
+        let rates = (3.0, 15.0, 0.3, 3.75);
+        let b = (50_000.0_f64 * 3.0).round() as i64;
+        seed(
+            &t,
+            &[
+                turn("s1", "cheap", b, 100_000, 90_000, 50_000, 0, 0, 0, rates),
+                turn("s2", "saver", b, 100_000, 40_000, 50_000, 0, 0, 0, rates),
+            ],
+        );
+        let db = BreakdownDb::from_connection(t.into_connection());
+        let models = db.money_by_model(8).unwrap();
+        assert_eq!(models[0].model, "saver");
+        assert!(models[0].saved_micros > models[1].saved_micros);
+    }
+
+    #[test]
+    fn pad_daily_saved_length() {
+        let days = vec![MoneyByDay {
+            day: chrono::Utc::now()
+                .date_naive()
+                .format("%Y-%m-%d")
+                .to_string(),
+            paid_micros: 0,
+            saved_micros: 1_000_000,
+        }];
+        let v = pad_daily_saved(&days, 7);
+        assert_eq!(v.len(), 7);
+        assert!((v[6] - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn sessions_sum_matches_money_totals() {
+        let t = Tracker::open_in_memory().unwrap();
+        let rates = (3.0, 15.0, 0.3, 3.75);
+        let bill1 = (50_000.0_f64 * 3.0 + 100.0 * 15.0).round() as i64;
+        let bill2 = (20_000.0_f64 * 3.0).round() as i64;
+        seed(
+            &t,
+            &[
+                turn("s1", "m1", bill1, 100_000, 50_000, 50_000, 0, 0, 100, rates),
+                turn("s2", "m1", bill2, 40_000, 20_000, 20_000, 0, 0, 0, rates),
+            ],
+        );
+        let conn = t.into_connection();
+        let money = money_totals(&conn, None).unwrap();
+        let db = BreakdownDb::from_connection(conn);
+        let sessions = db.sessions().unwrap();
+        let bill_sum: i64 = sessions.iter().map(|s| s.bill_micros).sum();
+        let saved_sum: i64 = sessions.iter().map(|s| s.saved_micros).sum();
+        assert_eq!(bill_sum, money.paid_micros);
+        assert_eq!(saved_sum, money.saved_micros);
+        assert_eq!(
+            money.would_have_micros,
+            money.paid_micros + money.saved_micros
+        );
+    }
+
+    #[test]
+    fn compressions_only_coverage_is_empty_money() {
+        use crate::tracking::Record;
+        let t = Tracker::open_in_memory().unwrap();
+        t.record(&Record {
+            provider: "openai".into(),
+            model: Some("gpt-4o".into()),
+            tokenizer: "tiktoken".into(),
+            exact: true,
+            input_before: 1000,
+            input_after: 600,
+            output_before: None,
+            output_after: None,
+            compress_micros: None,
+            cache_read_tokens: None,
+            fresh_input_tokens: None,
+            cache_write_tokens: None,
+            output_shaped: Some(false),
+            frozen_input_tokens: Some(0),
+        })
+        .unwrap();
+        let cov = money_coverage(t.connection()).unwrap();
+        assert!(cov.empty_money_with_traffic());
+        assert_eq!(cov.breakdown_turns, 0);
+        let m = money_totals(t.connection(), None).unwrap();
+        assert_eq!(m.turns, 0);
+        assert_eq!(m.paid_micros, 0);
+    }
+}

--- a/crates/llmtrim-ledger/src/money.rs
+++ b/crates/llmtrim-ledger/src/money.rs
@@ -75,10 +75,10 @@ pub struct MoneyCoverage {
 
 impl MoneyCoverage {
     pub fn compute(compressions_events: i64, breakdown_turns: i64) -> Self {
+        // No compressions → ratio 1.0 (empty or breakdown-only is fine). With compressions,
+        // ratio is turns/events clamped to [0, 1].
         let coverage_ratio = if compressions_events > 0 {
             (breakdown_turns as f64 / compressions_events as f64).clamp(0.0, 1.0)
-        } else if breakdown_turns > 0 {
-            1.0
         } else {
             1.0
         };
@@ -132,18 +132,22 @@ pub fn turn_pct(input_before: Option<i64>, input_after: Option<i64>) -> f64 {
     (cut / before as f64).clamp(0.0, PCT_CLAMP)
 }
 
+/// Frozen input-side rates for one turn (USD per 1M tokens), plus usage counts for pricing.
+#[derive(Debug, Clone, Copy)]
+pub struct TurnInputBill {
+    pub fresh_input: i64,
+    pub cache_read: i64,
+    pub cache_write: i64,
+    pub input_rate: f64,
+    pub cache_read_rate: f64,
+    pub cache_write_rate: f64,
+}
+
 /// Input-side bill in micro-USD from frozen rates (excludes output).
-pub fn input_bill_micros(
-    fresh_input: i64,
-    cache_read: i64,
-    cache_write: i64,
-    input_rate: f64,
-    cache_read_rate: f64,
-    cache_write_rate: f64,
-) -> i64 {
-    (fresh_input as f64 * input_rate
-        + cache_read as f64 * cache_read_rate
-        + cache_write as f64 * cache_write_rate)
+pub fn input_bill_micros(b: TurnInputBill) -> i64 {
+    (b.fresh_input as f64 * b.input_rate
+        + b.cache_read as f64 * b.cache_read_rate
+        + b.cache_write as f64 * b.cache_write_rate)
         .round() as i64
 }
 
@@ -155,25 +159,13 @@ pub fn input_bill_micros(
 pub fn turn_saved_micros(
     input_before: Option<i64>,
     input_after: Option<i64>,
-    fresh_input: i64,
-    cache_read: i64,
-    cache_write: i64,
-    input_rate: f64,
-    cache_read_rate: f64,
-    cache_write_rate: f64,
+    bill: TurnInputBill,
 ) -> i64 {
     let pct = turn_pct(input_before, input_after);
     if pct <= 0.0 {
         return 0;
     }
-    let input_bill = input_bill_micros(
-        fresh_input,
-        cache_read,
-        cache_write,
-        input_rate,
-        cache_read_rate,
-        cache_write_rate,
-    ) as f64;
+    let input_bill = input_bill_micros(bill) as f64;
     if input_bill <= 0.0 {
         return 0;
     }
@@ -437,39 +429,58 @@ mod tests {
     use super::*;
     use crate::tracking::{BreakdownBlock, BreakdownTurn, Tracker};
 
-    fn turn(
-        session: &str,
-        model: &str,
+    struct SeedTurn {
+        session: &'static str,
+        model: &'static str,
         bill: i64,
         before: i64,
         after: i64,
         fresh: i64,
         cache_read: i64,
-        cache_write: i64,
         out: i64,
         rates: (f64, f64, f64, f64),
-    ) -> BreakdownTurn {
+    }
+
+    fn turn(s: SeedTurn) -> BreakdownTurn {
         BreakdownTurn {
-            session_id: session.into(),
+            session_id: s.session.into(),
             cc_session_id: None,
             agent: "claude-code".into(),
             project: Some("/proj".into()),
             session_name: Some("s".into()),
             provider: "anthropic".into(),
-            model: Some(model.into()),
+            model: Some(s.model.into()),
             sub_provider: None,
             window: 200_000,
+            fresh_input: s.fresh,
+            cache_read: s.cache_read,
+            cache_write: 0,
+            output_tok: s.out,
+            input_rate: s.rates.0,
+            output_rate: s.rates.1,
+            cache_read_rate: s.rates.2,
+            cache_write_rate: s.rates.3,
+            bill_micros: s.bill,
+            input_before: s.before,
+            input_after: s.after,
+        }
+    }
+
+    fn bill(
+        fresh: i64,
+        cache_read: i64,
+        cache_write: i64,
+        input_rate: f64,
+        cache_read_rate: f64,
+        cache_write_rate: f64,
+    ) -> TurnInputBill {
+        TurnInputBill {
             fresh_input: fresh,
             cache_read,
             cache_write,
-            output_tok: out,
-            input_rate: rates.0,
-            output_rate: rates.1,
-            cache_read_rate: rates.2,
-            cache_write_rate: rates.3,
-            bill_micros: bill,
-            input_before: before,
-            input_after: after,
+            input_rate,
+            cache_read_rate,
+            cache_write_rate,
         }
     }
 
@@ -494,13 +505,21 @@ mod tests {
         // Asymmetric cache mixes make sum(per-turn) diverge from formula-on-sums.
         // Turn A: heavy cache, small cut. Turn B: all-fresh, large cut.
         let r = (3.0, 15.0, 0.3, 3.75);
-        let s1 = turn_saved_micros(Some(100_000), Some(95_000), 5_000, 90_000, 0, r.0, r.2, r.3);
-        let s2 = turn_saved_micros(Some(100_000), Some(40_000), 40_000, 0, 0, r.0, r.2, r.3);
+        let s1 = turn_saved_micros(
+            Some(100_000),
+            Some(95_000),
+            bill(5_000, 90_000, 0, r.0, r.2, r.3),
+        );
+        let s2 = turn_saved_micros(
+            Some(100_000),
+            Some(40_000),
+            bill(40_000, 0, 0, r.0, r.2, r.3),
+        );
         let sum = s1 + s2;
         // Wrong aggregate: sum tokens then one pct.
         let before = 200_000.0;
         let after = 135_000.0;
-        let agg_bill = input_bill_micros(45_000, 90_000, 0, r.0, r.2, r.3) as f64;
+        let agg_bill = input_bill_micros(bill(45_000, 90_000, 0, r.0, r.2, r.3)) as f64;
         let agg_pct = (before - after) / before;
         let agg = (agg_bill * agg_pct / (1.0 - agg_pct)).round() as i64;
         assert_ne!(
@@ -519,12 +538,7 @@ mod tests {
         let saved = turn_saved_micros(
             Some(110_000),
             Some(100_000),
-            10_000,
-            90_000,
-            0,
-            input_rate,
-            cache_read_rate,
-            0.0,
+            bill(10_000, 90_000, 0, input_rate, cache_read_rate, 0.0),
         );
         let live_true = (10_000.0 * input_rate).round() as i64; // cut at full rate
         assert!(
@@ -551,8 +565,28 @@ mod tests {
         seed(
             &t,
             &[
-                turn("s1", "m1", bill1, 100_000, 50_000, 50_000, 0, 0, 100, rates),
-                turn("s2", "m1", bill2, 100_000, 80_000, 80_000, 0, 0, 200, rates),
+                turn(SeedTurn {
+                    session: "s1",
+                    model: "m1",
+                    bill: bill1,
+                    before: 100_000,
+                    after: 50_000,
+                    fresh: 50_000,
+                    cache_read: 0,
+                    out: 100,
+                    rates,
+                }),
+                turn(SeedTurn {
+                    session: "s2",
+                    model: "m1",
+                    bill: bill2,
+                    before: 100_000,
+                    after: 80_000,
+                    fresh: 80_000,
+                    cache_read: 0,
+                    out: 200,
+                    rates,
+                }),
             ],
         );
         let db = BreakdownDb::from_connection(t.into_connection());
@@ -566,22 +600,12 @@ mod tests {
         let s1 = turn_saved_micros(
             Some(100_000),
             Some(50_000),
-            50_000,
-            0,
-            0,
-            rates.0,
-            rates.2,
-            rates.3,
+            bill(50_000, 0, 0, rates.0, rates.2, rates.3),
         );
         let s2 = turn_saved_micros(
             Some(100_000),
             Some(80_000),
-            80_000,
-            0,
-            0,
-            rates.0,
-            rates.2,
-            rates.3,
+            bill(80_000, 0, 0, rates.0, rates.2, rates.3),
         );
         assert_eq!(m.saved_micros, s1 + s2);
     }
@@ -590,20 +614,29 @@ mod tests {
     fn unpriced_and_premeter() {
         let t = Tracker::open_in_memory().unwrap();
         // Unpriced: usage but bill 0, rates 0
-        let unpriced = turn(
-            "s1",
-            "mystery",
-            0,
-            1000,
-            500,
-            500,
-            0,
-            0,
-            10,
-            (0.0, 0.0, 0.0, 0.0),
-        );
+        let unpriced = turn(SeedTurn {
+            session: "s1",
+            model: "mystery",
+            bill: 0,
+            before: 1000,
+            after: 500,
+            fresh: 500,
+            cache_read: 0,
+            out: 10,
+            rates: (0.0, 0.0, 0.0, 0.0),
+        });
         // Premeter-like: no compression meters (0 before → pct 0), but has bill
-        let mut premeter = turn("s2", "m1", 1000, 0, 0, 100, 0, 0, 0, (3.0, 15.0, 0.3, 3.75));
+        let mut premeter = turn(SeedTurn {
+            session: "s2",
+            model: "m1",
+            bill: 1000,
+            before: 0,
+            after: 0,
+            fresh: 100,
+            cache_read: 0,
+            out: 0,
+            rates: (3.0, 15.0, 0.3, 3.75),
+        });
         premeter.input_before = 0;
         premeter.input_after = 0;
         seed(&t, &[unpriced, premeter]);
@@ -632,10 +665,30 @@ mod tests {
         let bill = 12_345;
         seed(
             &t,
-            &[turn("sess-a", "m1", bill, 1000, 800, 800, 0, 0, 0, rates)],
+            &[turn(SeedTurn {
+                session: "sess-a",
+                model: "m1",
+                bill,
+                before: 1000,
+                after: 800,
+                fresh: 800,
+                cache_read: 0,
+                out: 0,
+                rates,
+            })],
         );
         // Also write a block that would reprice differently if Detail used block sum only
-        let tr = turn("sess-a", "m1", bill, 1000, 800, 800, 0, 0, 0, rates);
+        let tr = turn(SeedTurn {
+            session: "sess-a",
+            model: "m1",
+            bill,
+            before: 1000,
+            after: 800,
+            fresh: 800,
+            cache_read: 0,
+            out: 0,
+            rates,
+        });
         // re-open path: second turn same session
         let t2 = Tracker::open_in_memory().unwrap();
         let block = BreakdownBlock {
@@ -663,8 +716,28 @@ mod tests {
         seed(
             &t,
             &[
-                turn("s1", "cheap", b, 100_000, 90_000, 50_000, 0, 0, 0, rates),
-                turn("s2", "saver", b, 100_000, 40_000, 50_000, 0, 0, 0, rates),
+                turn(SeedTurn {
+                    session: "s1",
+                    model: "cheap",
+                    bill: b,
+                    before: 100_000,
+                    after: 90_000,
+                    fresh: 50_000,
+                    cache_read: 0,
+                    out: 0,
+                    rates,
+                }),
+                turn(SeedTurn {
+                    session: "s2",
+                    model: "saver",
+                    bill: b,
+                    before: 100_000,
+                    after: 40_000,
+                    fresh: 50_000,
+                    cache_read: 0,
+                    out: 0,
+                    rates,
+                }),
             ],
         );
         let db = BreakdownDb::from_connection(t.into_connection());
@@ -697,8 +770,28 @@ mod tests {
         seed(
             &t,
             &[
-                turn("s1", "m1", bill1, 100_000, 50_000, 50_000, 0, 0, 100, rates),
-                turn("s2", "m1", bill2, 40_000, 20_000, 20_000, 0, 0, 0, rates),
+                turn(SeedTurn {
+                    session: "s1",
+                    model: "m1",
+                    bill: bill1,
+                    before: 100_000,
+                    after: 50_000,
+                    fresh: 50_000,
+                    cache_read: 0,
+                    out: 100,
+                    rates,
+                }),
+                turn(SeedTurn {
+                    session: "s2",
+                    model: "m1",
+                    bill: bill2,
+                    before: 40_000,
+                    after: 20_000,
+                    fresh: 20_000,
+                    cache_read: 0,
+                    out: 0,
+                    rates,
+                }),
             ],
         );
         let conn = t.into_connection();

--- a/crates/llmtrim-ledger/src/tracking.rs
+++ b/crates/llmtrim-ledger/src/tracking.rs
@@ -329,6 +329,13 @@ impl Tracker {
         self.conn
     }
 
+    /// Shared connection for read-side money / breakdown queries that live outside `Tracker`
+    /// (e.g. [`crate::money::money_totals`]). Prefer this over re-opening the file so in-memory
+    /// test ledgers and the daemon's live path stay on one SQLite handle.
+    pub fn connection(&self) -> &Connection {
+        &self.conn
+    }
+
     /// In-memory ledger (tests).
     pub fn open_in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory().context("failed to open in-memory ledger")?;
@@ -413,6 +420,8 @@ impl Tracker {
                 CREATE INDEX IF NOT EXISTS idx_breakdown_blocks_turn ON breakdown_blocks(turn_id);
                 -- Serves sessions()'s GROUP BY + per-session ROW_NUMBER ordering and latest_turn().
                 CREATE INDEX IF NOT EXISTS idx_breakdown_turns_group ON breakdown_turns(session_id, agent, project, id);
+                -- Money range queries (today / week) and prune-friendly scans.
+                CREATE INDEX IF NOT EXISTS idx_breakdown_turns_ts ON breakdown_turns(ts);
                 -- Lets the day-scoped aggregate (by_model_today) range-seek instead of scanning.
                 CREATE INDEX IF NOT EXISTS idx_compressions_ts ON compressions(ts);",
             )


### PR DESCRIPTION
## Summary

- Makes frozen `breakdown_turns.bill_micros` the canonical money path for Overview, piped `status`, and Sessions so **You paid / saved** match the proxy bill instead of live re-pricing `compressions`.
- Adds `llmtrim-ledger::money` (`MoneyTotals`, shared `saved_micros` SQL, coverage, per-day / per-model rollups) with identity tests (Sessions sum ↔ money totals).
- Dual-run JSON: additive `money` (with `unavailable` + null dollars when there is no proxy attribution); legacy `cost` kept as `compressions_live_prices`.
- Sessions columns: `saved$` (money) + `trim` (token %); Detail bill footer from `SUM(bill_micros)`; coverage UX instead of fake `$0.00`.

## Motivation

Overview used live list prices on the compressions table while Sessions used frozen per-turn bills. That dual ledger made “You paid” disagree with the Sessions total. Reviewers also flagged a non-TTY dual-base hero (live all-time + frozen today) and false `$0` for CLI/MCP-only traffic.

## Test plan

- [x] `cargo test -p llmtrim-ledger --lib`
- [x] `cargo test -p llmtrim --lib --features breakdown` (one pre-existing MCP malformed-request failure on main lineage)
- [ ] Manual: `llmtrim status` on a machine with proxy traffic — Overview paid equals Sessions footer
- [ ] Manual: compressions-only / empty breakdown — billing banner, no `$0.00`; JSON `money.unavailable: true`
- [ ] Manual: `status --json` — `money` present; `cost.source` still `compressions_live_prices`