### PR TITLE
feat(sub): Grok subscription reroute + remote device/paste auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,7 @@ All notable changes to this project are documented here. The format follows
   window `/sub` command. Device-code login is not available yet (browser only).
 - **Window `/sub on <provider>`.** The Claude Code slash command accepts an explicit backend:
   `/sub on codex`, `/sub on kimi`, or `/sub on grok`. Bare `/sub on` still re-enables the last
-  window provider or the global `sub` setting. Re-run `llmtrim window-sub install` (or
-  `llmtrim setup` / `ensure`) to refresh the skill text.
+  window provider or the global `sub` setting.
 - **Status line shows window `/sub` overrides immediately.** Mid-session `/sub on grok` (or any
   provider) now paints `→grok-4.5` even when earlier turns were Anthropic and global `sub` is
   `off`. Window overrides are treated as always-mode for the arrow (matching the proxy), and a
@@ -36,9 +35,9 @@ All notable changes to this project are documented here. The format follows
 - **Window `/sub` no longer inherits another provider's tier map.** With global `llmtrim sub on
   codex` and a Claude Code `/sub on grok`, the proxy was already routing to Grok but still applied
   `[sub.codex.tiers]` (e.g. `opus → gpt-5.6-terra`) on the Grok request. Tiers are now loaded per
-  serving provider, and foreign model ids in overrides are ignored. After upgrading, re-run
-  `llmtrim window-sub install` **and** `llmtrim start --force` so hooks and the daemon both know
-  the new `grok` provider.
+  serving provider, and foreign model ids in overrides are ignored. After upgrading, run
+  **`llmtrim ensure`** (or **`f`** in `status`) so owned `/sub` hooks refresh and a version-skewed
+  daemon restarts onto the new binary.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ All notable changes to this project are documented here. The format follows
   missing (optional; default off when non-interactive).
 - **One-time subscription onboarding in the status TUI** (`s` for login steps, `n` to dismiss)
   when Claude Code is present and `sub` is not configured.
+- **Subscription reroute: Grok (SuperGrok / Grok Build).** `llmtrim sub auth grok login` signs in
+  via OAuth against `auth.x.ai` (browser PKCE); `llmtrim sub use grok` maps Claude tiers to
+  `grok-4.5` (opus/sonnet/fable) and `grok-composer-2.5-fast` (haiku) and routes Claude Code's
+  Anthropic `/v1/messages` traffic to `cli-chat-proxy.grok.com/v1/responses`. Tokens live at
+  `~/.llmtrim/grok/auth.json`. Works with `sub mode fallback` chains (`codex,kimi,grok`) and the
+  window `/sub` command. Device-code login is not available yet (browser only).
+- **Window `/sub on <provider>`.** The Claude Code slash command accepts an explicit backend:
+  `/sub on codex`, `/sub on kimi`, or `/sub on grok`. Bare `/sub on` still re-enables the last
+  window provider or the global `sub` setting. Re-run `llmtrim window-sub install` (or
+  `llmtrim setup` / `ensure`) to refresh the skill text.
+- **Status line shows window `/sub` overrides immediately.** Mid-session `/sub on grok` (or any
+  provider) now paints `→grok-4.5` even when earlier turns were Anthropic and global `sub` is
+  `off`. Window overrides are treated as always-mode for the arrow (matching the proxy), and a
+  policy switch overrides a stale ledger backend until the new one serves a turn.
+- **Window `/sub` no longer inherits another provider's tier map.** With global `llmtrim sub on
+  codex` and a Claude Code `/sub on grok`, the proxy was already routing to Grok but still applied
+  `[sub.codex.tiers]` (e.g. `opus → gpt-5.6-terra`) on the Grok request. Tiers are now loaded per
+  serving provider, and foreign model ids in overrides are ignored. After upgrading, re-run
+  `llmtrim window-sub install` **and** `llmtrim start --force` so hooks and the daemon both know
+  the new `grok` provider.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Breaking
+
+- **`SubProvider` / `StreamReducer` gain a `Grok` variant** and are marked `#[non_exhaustive]` so
+  further backends can land without a major bump. External exhaustive `match`es need a `_` arm.
+  Workspace version is **0.11.0** (0.x minor = semver-breaking).
+
 ### Added
 
 - **`llmtrim ensure`:** bring this machine to the recommended state. Installs or refreshes owned
@@ -1125,7 +1131,8 @@ bill, never a broken call.
   (6 targets with SLSA build provenance), CI on Linux/macOS/Windows with secret
   scanning, license compliance, and MSRV gates.
 
-[Unreleased]: https://github.com/fkiene/llmtrim/compare/v0.10.2...HEAD
+[Unreleased]: https://github.com/fkiene/llmtrim/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/fkiene/llmtrim/compare/v0.10.2...v0.11.0
 [0.10.2]: https://github.com/fkiene/llmtrim/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/fkiene/llmtrim/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/fkiene/llmtrim/compare/v0.9.4...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ All notable changes to this project are documented here. The format follows
   `grok-4.5` (opus/sonnet/fable) and `grok-composer-2.5-fast` (haiku) and routes Claude Code's
   Anthropic `/v1/messages` traffic to `cli-chat-proxy.grok.com/v1/responses`. Tokens live at
   `~/.llmtrim/grok/auth.json`. Works with `sub mode fallback` chains (`codex,kimi,grok`) and the
-  window `/sub` command. Device-code login is not available yet (browser only).
+  window `/sub` command. Remote / headless machines can finish login by pasting the callback URL
+  or xAI one-time code into `grok login`, or with RFC 8628
+  `llmtrim sub auth grok device` (no localhost callback).
 - **Window `/sub on <provider>`.** The Claude Code slash command accepts an explicit backend:
   `/sub on codex`, `/sub on kimi`, or `/sub on grok`. Bare `/sub on` still re-enables the last
   window provider or the global `sub` setting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-core"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-ledger"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-tray"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-uniffi"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "llmtrim-core",
  "serde_json",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "llmtrim-wasm"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "llmtrim-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = [
 
 # Shared package metadata — inherited by each member via `field.workspace = true`.
 [workspace.package]
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.88"
 repository = "https://github.com/fkiene/llmtrim"

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ This window only (installed with ensure; includes subagents; survives `/clear`):
 /sub status
 ```
 
-Tokens: `~/.llmtrim/<provider>/auth.json` (mode 0600). Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_SUB_CHAIN`. After upgrading, `llmtrim ensure` (or `window-sub install` + `start --force`) so hooks and the daemon know `grok`.
+Tokens: `~/.llmtrim/<provider>/auth.json` (mode 0600). Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_SUB_CHAIN`. After upgrading, run **`llmtrim ensure`** (or **`f`** in `status`) so owned `/sub` hooks refresh and the daemon picks up the new binary (including `grok`).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ When `~/.claude` exists, `setup`, `update`, and `ensure` wire these. No separate
 | Status line | Model, context gauge, trim %, rate limits, cache warm/cold |
 | Guard | Blocks one turn if a cold-cache resume would rewrite a huge context (and bill for it) |
 | `/compact` models | Prefer Haiku → Sonnet before your selected model |
-| `/sub` | Per-window: `/sub on` · `/sub off` · `/sub status` |
+| `/sub` | Per-window: `/sub on [codex\|kimi\|grok]` · `/sub off` · `/sub status` |
 
 ```text
 ◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 3h·24% · 4d·12%   ♻ 63% cached
@@ -289,26 +289,31 @@ Candidates run in order when they fit the compressed request. Claude's selected 
 <details>
 <summary><b>Subscription reroute (`sub`)</b> (opt-in; may conflict with provider ToS)</summary>
 
-Serve Claude Code from a ChatGPT/Codex or Kimi plan instead of Anthropic, or as fallback when Anthropic fails. Login prints a warning; decide for yourself.
+Serve Claude Code from a ChatGPT/Codex, Kimi, or SuperGrok plan instead of Anthropic, or as fallback when Anthropic fails. Login prints a warning; decide for yourself.
 
 ```bash
-llmtrim sub auth codex login    # or: kimi
-llmtrim sub on codex
+llmtrim sub auth codex login    # or: kimi / grok
+llmtrim sub on codex            # or: grok
 llmtrim sub status
 llmtrim sub mode fallback       # only when Anthropic fails
-llmtrim sub chain codex,kimi
+llmtrim sub chain codex,kimi,grok
 llmtrim sub off
 ```
+
+Grok maps Claude tiers to `grok-4.5` (opus/sonnet/fable) and `grok-composer-2.5-fast` (haiku).
 
 This window only (installed with ensure; includes subagents; survives `/clear`):
 
 ```text
-/sub on
+/sub on                  # last provider for this window, or the global sub
+/sub on codex
+/sub on kimi
+/sub on grok
 /sub off
 /sub status
 ```
 
-Tokens: `~/.llmtrim/<provider>/auth.json` (mode 0600). Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_SUB_CHAIN`.
+Tokens: `~/.llmtrim/<provider>/auth.json` (mode 0600). Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_SUB_CHAIN`. After upgrading, `llmtrim ensure` (or `window-sub install` + `start --force`) so hooks and the daemon know `grok`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ When `~/.claude` exists, `setup`, `update`, and `ensure` wire these. No separate
 | Status line | Model, context gauge, trim %, rate limits, cache warm/cold |
 | Guard | Blocks one turn if a cold-cache resume would rewrite a huge context (and bill for it) |
 | `/compact` models | Prefer Haiku → Sonnet before your selected model |
-| `/sub` | Per-window: `/sub on [codex\|kimi\|grok]` · `/sub off` · `/sub status` |
+| `/sub` | Per-window: `/sub on [optional:codex\|kimi\|grok]` · `/sub off` · `/sub status` |
 
 ```text
 ◆ Opus→gpt-5.6-terra   ▓▓▓▓▓░░░ 142k   ✂ 6.8%   ◔ 3h·24% · 4d·12%   ♻ 63% cached
@@ -292,8 +292,8 @@ Candidates run in order when they fit the compressed request. Claude's selected 
 Serve Claude Code from a ChatGPT/Codex, Kimi, or SuperGrok plan instead of Anthropic, or as fallback when Anthropic fails. Login prints a warning; decide for yourself.
 
 ```bash
-llmtrim sub auth codex login    # or: kimi / grok
-llmtrim sub on codex            # or: grok
+llmtrim sub auth codex login    # or kimi / grok
+llmtrim sub on codex            # or kimi / grok
 llmtrim sub status
 llmtrim sub mode fallback       # only when Anthropic fails
 llmtrim sub chain codex,kimi,grok
@@ -305,15 +305,12 @@ Grok maps Claude tiers to `grok-4.5` (opus/sonnet/fable) and `grok-composer-2.5-
 This window only (installed with ensure; includes subagents; survives `/clear`):
 
 ```text
-/sub on                  # last provider for this window, or the global sub
-/sub on codex
-/sub on kimi
-/sub on grok
+/sub on [optional:codex|kimi|grok]   # bare /sub on = last window provider or global sub
 /sub off
 /sub status
 ```
 
-Tokens: `~/.llmtrim/<provider>/auth.json` (mode 0600). Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_SUB_CHAIN`. After upgrading, run **`llmtrim ensure`** (or **`f`** in `status`) so owned `/sub` hooks refresh and the daemon picks up the new binary (including `grok`).
+Tokens: `~/.llmtrim/<provider>/auth.json` (mode 0600). Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_SUB_CHAIN`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -300,8 +300,6 @@ llmtrim sub chain codex,kimi,grok
 llmtrim sub off
 ```
 
-Grok maps Claude tiers to `grok-4.5` (opus/sonnet/fable) and `grok-composer-2.5-fast` (haiku).
-
 This window only (installed with ensure; includes subagents; survives `/clear`):
 
 ```text

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -37,10 +37,10 @@ path = "src/main.rs"
 [dependencies]
 # `version` is required for `cargo publish` (path alone isn't publishable) and is kept in
 # lockstep with llmtrim-core by cargo-release's shared-version on every bump.
-llmtrim-core = { path = "../llmtrim-core", version = "0.10.2" }
+llmtrim-core = { path = "../llmtrim-core", version = "0.11.0" }
 # Published alongside core (see release.yml publish order). `version` is required
 # for `cargo publish` and is kept in lockstep by cargo-release's shared-version.
-llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.10.2" }
+llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.11.0" }
 anyhow.workspace = true
 chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive"] }

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -1131,6 +1131,8 @@ fn run_sub(action: SubCmd) -> Result<()> {
                             }
                         }
                         SubProvider::Kimi => {}
+                        // SubProvider is non_exhaustive for semver; new backends need a map here.
+                        _ => {}
                     }
                     llmtrim_core::config::write_sub_mapping(p.as_str(), &map)?;
                     print_reroute_enabled(p)
@@ -1373,6 +1375,7 @@ fn run_sub(action: SubCmd) -> Result<()> {
                         SubProvider::Kimi => {
                             println!("  all tiers -> {}", llmtrim::reroute::KIMI_MODEL);
                         }
+                        _ => println!("  (unknown provider)"),
                     }
                     // Auth is what makes reroute actually work — surface it here, not just in JSON.
                     let auth = llmtrim::reroute::auth::auth_status_json(p);

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -565,9 +565,12 @@ enum CompactCmd {
 /// OAuth management for a subscription provider (codex / kimi).
 #[derive(Subcommand)]
 enum AuthAction {
-    /// Sign in (browser OAuth for codex; device-code for kimi).
+    /// Sign in (browser OAuth for codex/grok; device-code for kimi).
+    ///
+    /// Grok also accepts a pasted callback URL or one-time code when the browser
+    /// cannot reach this machine (SSH / remote).
     Login,
-    /// Device-code sign-in for headless machines (codex only).
+    /// Device-code sign-in for headless machines (codex / grok).
     Device,
     /// Show stored credentials + token expiry. `--json` for machine output.
     Status {

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -779,8 +779,8 @@ fn window_sub_provider(requested: Option<&str>) -> Result<String> {
                 "no provider to re-enable — pass one (`/sub on grok`) or run `llmtrim sub on codex|kimi|grok` first",
             )?,
     };
-    let provider = SubProvider::parse(&configured)
-        .context("configured subscription provider is invalid")?;
+    let provider =
+        SubProvider::parse(&configured).context("configured subscription provider is invalid")?;
     let logged_in = llmtrim::reroute::auth::auth_status_json(provider)
         .get("logged_in")
         .and_then(serde_json::Value::as_bool)
@@ -1356,11 +1356,8 @@ fn run_sub(action: SubCmd) -> Result<()> {
                         }
                         SubProvider::Grok => {
                             for t in Tier::ALL {
-                                let model = cfg
-                                    .sub_tiers
-                                    .get(t.as_str())
-                                    .cloned()
-                                    .unwrap_or_else(|| {
+                                let model =
+                                    cfg.sub_tiers.get(t.as_str()).cloned().unwrap_or_else(|| {
                                         llmtrim::reroute::default_grok_tier_model(t).to_string()
                                     });
                                 println!("  {:<7} -> {model}", t.as_str());

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -51,7 +51,7 @@ Get started:
   update     Update to the latest release and refresh integrations
   ensure     Bring this machine to the recommended current state
   wrap       Launch an agent (claude, codex, …) routed through the interceptor
-  sub        Reroute Claude Code to another subscription's backend (codex|kimi)
+  sub        Reroute Claude Code to another subscription's backend (codex|kimi|grok)
   tray       Open the desktop tray app (savings menu-bar / system-tray)
 
 Daemon:
@@ -116,7 +116,7 @@ enum Commands {
     ///
     /// With `sub` enabled, intercepted Anthropic traffic is translated and sent to your
     /// ChatGPT (codex) or Kimi subscription instead of Anthropic. Authenticate first with
-    /// `llmtrim sub auth codex login` / `llmtrim sub auth kimi login`.
+    /// `llmtrim sub auth codex login` / `llmtrim sub auth kimi login` / `llmtrim sub auth grok login`.
     Sub {
         #[command(subcommand)]
         action: SubCmd,
@@ -439,9 +439,9 @@ enum BenchCmd {
 /// Subscription reroute: send Claude Code traffic to another subscription's backend.
 #[derive(Subcommand)]
 enum SubCmd {
-    /// Open the interactive tier→model mapping editor for a provider (codex|kimi).
+    /// Open the interactive tier→model mapping editor for a provider (codex|kimi|grok).
     Setup {
-        /// Provider to edit: codex|kimi.
+        /// Provider to edit: codex|kimi|grok.
         provider: String,
     },
     /// Enable reroute to a provider (writes `sub = <provider>` to the config).
@@ -450,7 +450,7 @@ enum SubCmd {
     /// are accepted aliases.
     #[command(visible_alias = "use", alias = "start")]
     On {
-        /// Provider to route to: codex|kimi. Omit to re-enable the last provider used.
+        /// Provider to route to: codex|kimi|grok. Omit to re-enable the last provider used.
         provider: Option<String>,
         /// Don't restart a running interceptor to apply the change (just print the hint).
         #[arg(long)]
@@ -474,9 +474,9 @@ enum SubCmd {
         #[arg(long)]
         no_restart: bool,
     },
-    /// Set the ordered providers used by `sub mode fallback` (for example `codex,kimi`).
+    /// Set the ordered providers used by `sub mode fallback` (for example `codex,kimi,grok`).
     Chain {
-        /// Comma-separated providers in try order: codex,kimi.
+        /// Comma-separated providers in try order: codex,kimi,grok.
         providers: String,
         /// Don't restart a running interceptor to apply the change.
         #[arg(long)]
@@ -494,7 +494,7 @@ enum SubCmd {
     /// Map one incoming model (a Claude tier `opus|sonnet|haiku|fable`, or an exact model id) to a
     /// provider model. Non-interactive form of `setup`, for scripts and the tray.
     Map {
-        /// Provider whose mapping to edit: codex|kimi.
+        /// Provider whose mapping to edit: codex|kimi|grok.
         provider: String,
         /// Incoming model or tier name to map from.
         from: String,
@@ -506,7 +506,7 @@ enum SubCmd {
     },
     /// Remove one mapping entry (falls back to the preset default for that model).
     Unmap {
-        /// Provider whose mapping to edit: codex|kimi.
+        /// Provider whose mapping to edit: codex|kimi|grok.
         provider: String,
         /// Incoming model or tier name to unmap.
         from: String,
@@ -516,7 +516,7 @@ enum SubCmd {
     },
     /// List the provider's candidate models (for autocompletion). `--json` for machine output.
     Models {
-        /// Provider: codex|kimi.
+        /// Provider: codex|kimi|grok.
         provider: String,
         /// Emit a JSON array of model ids.
         #[arg(long)]
@@ -530,7 +530,7 @@ enum SubCmd {
     },
     /// Sign in / out of a subscription (`llmtrim sub auth codex login`).
     Auth {
-        /// Provider: codex|kimi.
+        /// Provider: codex|kimi|grok.
         provider: String,
         #[command(subcommand)]
         action: AuthAction,
@@ -758,14 +758,28 @@ fn read_stdin() -> Result<String> {
     Ok(buf)
 }
 
+/// Resolve which subscription backend a window `/sub on [provider]` should use, and require it
+/// to be signed in. With an explicit name (`/sub on grok`), only that provider is considered.
+/// Without one (`/sub on`), fall back to the global/last-enabled `sub` config.
 #[cfg(feature = "intercept")]
-fn window_sub_provider() -> Result<String> {
-    let configured = llmtrim_core::config::RuntimeConfig::get()
-        .sub
-        .clone()
-        .or_else(llmtrim_core::config::sub_reenable_provider)
-        .context("no provider to re-enable — run `llmtrim sub on codex` (or kimi) first")?;
-    let provider = llmtrim::reroute::SubProvider::parse(&configured)
+fn window_sub_provider(requested: Option<&str>) -> Result<String> {
+    use llmtrim::reroute::SubProvider;
+    let configured = match requested {
+        Some(raw) => {
+            let p = SubProvider::parse(raw).ok_or_else(|| {
+                anyhow::anyhow!("unknown provider '{raw}' (codex|kimi|grok)")
+            })?;
+            p.as_str().to_string()
+        }
+        None => llmtrim_core::config::RuntimeConfig::get()
+            .sub
+            .clone()
+            .or_else(llmtrim_core::config::sub_reenable_provider)
+            .context(
+                "no provider to re-enable — pass one (`/sub on grok`) or run `llmtrim sub on codex|kimi|grok` first",
+            )?,
+    };
+    let provider = SubProvider::parse(&configured)
         .context("configured subscription provider is invalid")?;
     let logged_in = llmtrim::reroute::auth::auth_status_json(provider)
         .get("logged_in")
@@ -782,7 +796,7 @@ fn window_sub_provider() -> Result<String> {
 }
 
 #[cfg(not(feature = "intercept"))]
-fn window_sub_provider() -> Result<String> {
+fn window_sub_provider(_requested: Option<&str>) -> Result<String> {
     bail!("window-scoped rerouting needs the `intercept` feature")
 }
 
@@ -843,26 +857,40 @@ fn run_window_sub(args: Vec<String>) -> Result<()> {
             }
         }
         "slash" => {
-            let command = args.get(1).map(String::as_str).unwrap_or("status");
+            // `$ARGUMENTS` arrives as a single string: "on", "on grok", "off", "status", …
+            let raw = args.get(1).map(String::as_str).unwrap_or("status");
+            let parts: Vec<&str> = raw.split_whitespace().collect();
             let session = args
                 .get(2)
                 .filter(|x| !x.is_empty())
                 .cloned()
                 .or_else(session_from_env)
                 .context("Claude Code session unavailable")?;
-            match command.trim() {
-                "on" => {
-                    let provider = window_sub_provider()?;
+            match parts.as_slice() {
+                ["on"] => {
+                    // Re-enable *this window's* last provider, or the global `sub` if none.
+                    // Do not silently fall back to another backend when preferred auth fails —
+                    // that used to flip grok → codex and clobber `last_provider`.
+                    let preferred = llmtrim::window_sub::last_provider(&session);
+                    let provider = match preferred.as_deref() {
+                        Some(p) => window_sub_provider(Some(p))?,
+                        None => window_sub_provider(None)?,
+                    };
                     llmtrim::window_sub::set(&session, true, Some(&provider))?;
                     println!("Subscription rerouting enabled for this window ({provider}).");
                 }
-                "off" => {
+                ["on", provider_name] => {
+                    let provider = window_sub_provider(Some(provider_name))?;
+                    llmtrim::window_sub::set(&session, true, Some(&provider))?;
+                    println!("Subscription rerouting enabled for this window ({provider}).");
+                }
+                ["off"] => {
                     llmtrim::window_sub::set(&session, false, None)?;
                     println!(
                         "Subscription rerouting disabled for this window; Anthropic compression remains active."
                     );
                 }
-                "status" | "" => match llmtrim::window_sub::status(&session)? {
+                ["status"] | [] => match llmtrim::window_sub::status(&session)? {
                     Some(llmtrim::window_sub::Intent::Enabled { provider }) => {
                         println!("This window: subscription rerouting enabled ({provider}).")
                     }
@@ -871,7 +899,7 @@ fn run_window_sub(args: Vec<String>) -> Result<()> {
                     }
                     None => println!("This window follows the global subscription policy."),
                 },
-                _ => bail!("usage: /sub on|off|status"),
+                _ => bail!("usage: /sub on [codex|kimi|grok] | off | status"),
             }
         }
         _ => bail!("unknown window-sub action"),
@@ -886,7 +914,7 @@ fn main() {
     }
 }
 
-/// Handle `llmtrim <codex|kimi> auth <action>`.
+/// Handle `llmtrim <codex|kimi|grok> auth <action>`.
 #[cfg(feature = "intercept")]
 fn run_auth(provider: &str, action: AuthAction) -> Result<()> {
     use llmtrim::reroute::{SubProvider, auth};
@@ -907,7 +935,11 @@ fn run_auth(provider: &str, action: AuthAction) -> Result<()> {
         }
         ("kimi", AuthAction::Status { .. }) => auth::kimi_status(),
         ("kimi", AuthAction::Logout) => auth::kimi_logout(),
-        (other, _) => anyhow::bail!("unknown provider '{other}' (codex|kimi)"),
+        ("grok", AuthAction::Login) => auth::grok_login(),
+        ("grok", AuthAction::Device) => auth::grok_device(),
+        ("grok", AuthAction::Status { .. }) => auth::grok_status(),
+        ("grok", AuthAction::Logout) => auth::grok_logout(),
+        (other, _) => anyhow::bail!("unknown provider '{other}' (codex|kimi|grok)"),
     }
 }
 
@@ -1056,7 +1088,8 @@ fn run_compact(action: CompactCmd) -> Result<()> {
 fn run_sub(action: SubCmd) -> Result<()> {
     use llmtrim::reroute::{SubProvider, Tier, default_codex_tier_model};
     let parse = |p: &str| {
-        SubProvider::parse(p).ok_or_else(|| anyhow::anyhow!("unknown provider '{p}' (codex|kimi)"))
+        SubProvider::parse(p)
+            .ok_or_else(|| anyhow::anyhow!("unknown provider '{p}' (codex|kimi|grok)"))
     };
     match action {
         SubCmd::Setup { provider } => {
@@ -1080,13 +1113,24 @@ fn run_sub(action: SubCmd) -> Result<()> {
                 Some(provider) => {
                     let p = parse(&provider)?;
                     let mut map = std::collections::BTreeMap::new();
-                    if p == SubProvider::Codex {
-                        for t in Tier::ALL {
-                            map.insert(
-                                t.as_str().to_string(),
-                                default_codex_tier_model(t).to_string(),
-                            );
+                    match p {
+                        SubProvider::Codex => {
+                            for t in Tier::ALL {
+                                map.insert(
+                                    t.as_str().to_string(),
+                                    default_codex_tier_model(t).to_string(),
+                                );
+                            }
                         }
+                        SubProvider::Grok => {
+                            for t in Tier::ALL {
+                                map.insert(
+                                    t.as_str().to_string(),
+                                    llmtrim::reroute::default_grok_tier_model(t).to_string(),
+                                );
+                            }
+                        }
+                        SubProvider::Kimi => {}
                     }
                     llmtrim_core::config::write_sub_mapping(p.as_str(), &map)?;
                     print_reroute_enabled(p)
@@ -1095,7 +1139,7 @@ fn run_sub(action: SubCmd) -> Result<()> {
                 None => {
                     let provider = llmtrim_core::config::sub_reenable_provider().ok_or_else(|| {
                         anyhow::anyhow!(
-                            "no provider to re-enable — run `llmtrim sub on codex` (or kimi) first"
+                            "no provider to re-enable — run `llmtrim sub on codex` (or kimi|grok) first"
                         )
                     })?;
                     let p = parse(&provider)?;
@@ -1235,6 +1279,15 @@ fn run_sub(action: SubCmd) -> Result<()> {
                             )
                         })
                         .collect(),
+                    Some(SubProvider::Grok) => Tier::ALL
+                        .iter()
+                        .map(|t| {
+                            (
+                                t.as_str().to_string(),
+                                llmtrim::reroute::default_grok_tier_model(*t).to_string(),
+                            )
+                        })
+                        .collect(),
                     _ => std::collections::BTreeMap::new(),
                 };
                 for (k, v) in &cfg.sub_tiers {
@@ -1249,6 +1302,7 @@ fn run_sub(action: SubCmd) -> Result<()> {
                     "auth": {
                         "codex": llmtrim::reroute::auth::auth_status_json(SubProvider::Codex),
                         "kimi": llmtrim::reroute::auth::auth_status_json(SubProvider::Kimi),
+                        "grok": llmtrim::reroute::auth::auth_status_json(SubProvider::Grok),
                     },
                 });
                 println!("{}", serde_json::to_string_pretty(&out)?);
@@ -1276,28 +1330,49 @@ fn run_sub(action: SubCmd) -> Result<()> {
                             }
                         );
                     }
-                    if p == SubProvider::Codex {
-                        println!(
-                            "  effort  -> {}",
-                            cfg.sub_effort.as_deref().unwrap_or("none")
-                        );
-                        for t in Tier::ALL {
-                            let model = cfg
-                                .sub_tiers
-                                .get(t.as_str())
-                                .cloned()
-                                .unwrap_or_else(|| default_codex_tier_model(t).to_string());
-                            println!("  {:<7} -> {model}", t.as_str());
-                        }
-                        // Free-form model→model overrides (keys that aren't one of the four tiers).
-                        let tier_keys: [&str; 4] = Tier::ALL.map(|t| t.as_str());
-                        for (from, to) in &cfg.sub_tiers {
-                            if !tier_keys.contains(&from.as_str()) {
-                                println!("  {from} -> {to}");
+                    match p {
+                        SubProvider::Codex => {
+                            println!(
+                                "  effort  -> {}",
+                                cfg.sub_effort.as_deref().unwrap_or("none")
+                            );
+                            for t in Tier::ALL {
+                                let model = cfg
+                                    .sub_tiers
+                                    .get(t.as_str())
+                                    .cloned()
+                                    .unwrap_or_else(|| default_codex_tier_model(t).to_string());
+                                println!("  {:<7} -> {model}", t.as_str());
+                            }
+                            // Free-form model→model overrides (keys that aren't one of the four tiers).
+                            let tier_keys: [&str; 4] = Tier::ALL.map(|t| t.as_str());
+                            for (from, to) in &cfg.sub_tiers {
+                                if !tier_keys.contains(&from.as_str()) {
+                                    println!("  {from} -> {to}");
+                                }
                             }
                         }
-                    } else {
-                        println!("  all tiers -> {}", llmtrim::reroute::KIMI_MODEL);
+                        SubProvider::Grok => {
+                            for t in Tier::ALL {
+                                let model = cfg
+                                    .sub_tiers
+                                    .get(t.as_str())
+                                    .cloned()
+                                    .unwrap_or_else(|| {
+                                        llmtrim::reroute::default_grok_tier_model(t).to_string()
+                                    });
+                                println!("  {:<7} -> {model}", t.as_str());
+                            }
+                            let tier_keys: [&str; 4] = Tier::ALL.map(|t| t.as_str());
+                            for (from, to) in &cfg.sub_tiers {
+                                if !tier_keys.contains(&from.as_str()) {
+                                    println!("  {from} -> {to}");
+                                }
+                            }
+                        }
+                        SubProvider::Kimi => {
+                            println!("  all tiers -> {}", llmtrim::reroute::KIMI_MODEL);
+                        }
                     }
                     // Auth is what makes reroute actually work — surface it here, not just in JSON.
                     let auth = llmtrim::reroute::auth::auth_status_json(p);

--- a/crates/llmtrim-cli/src/reroute/auth.rs
+++ b/crates/llmtrim-cli/src/reroute/auth.rs
@@ -82,8 +82,8 @@ pub fn get_token(provider: SubProvider) -> Result<TokenSet> {
             })
         }
         SubProvider::Grok => {
-            let stored =
-                read_grok().context("no Grok credentials — run `llmtrim sub auth grok login` first")?;
+            let stored = read_grok()
+                .context("no Grok credentials — run `llmtrim sub auth grok login` first")?;
             let now = now_ms();
             let stored = if needs_refresh(stored.expires, now) {
                 grok_refresh(&stored)?
@@ -115,8 +115,7 @@ const KIMI_CLI_VERSION: &str = "1.37.0";
 /// Grok CLI public OAuth client (same as Grok Build / claude-code-proxy).
 const GROK_ISSUER: &str = "https://auth.x.ai";
 const GROK_CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
-const GROK_SCOPES: &str =
-    "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write";
+const GROK_SCOPES: &str = "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write";
 
 /// Refresh anything within 5 minutes of expiry.
 const REFRESH_MARGIN_MS: u64 = 5 * 60 * 1000;
@@ -1174,12 +1173,7 @@ pub fn grok_login() -> Result<()> {
     println!("Waiting for the authorization callback (up to 5 minutes)...");
 
     let code = wait_for_grok_callback(listener, &state)?;
-    let tr = grok_exchange_code(
-        &discovery.token_endpoint,
-        &code,
-        &redirect_uri,
-        &verifier,
-    )?;
+    let tr = grok_exchange_code(&discovery.token_endpoint, &code, &redirect_uri, &verifier)?;
     let stored = grok_stored_from(tr, true, None)?;
     write_grok(&stored)?;
     println!("Grok login complete.");

--- a/crates/llmtrim-cli/src/reroute/auth.rs
+++ b/crates/llmtrim-cli/src/reroute/auth.rs
@@ -1,5 +1,5 @@
-//! OAuth + runtime token supply for the two subscription reroute providers (Codex/ChatGPT and
-//! Kimi). Owns the interactive login flows (PKCE browser + device-code) and [`get_token`], the
+//! OAuth + runtime token supply for the subscription reroute providers (Codex/ChatGPT, Kimi, and
+//! Grok). Owns the interactive login flows (PKCE browser + device-code) and [`get_token`], the
 //! hot-path token accessor that refreshes on the fly.
 //!
 //! **Blocking by design.** Everything here uses blocking `ureq` (no async): the CLI login
@@ -11,12 +11,12 @@
 //! guards each provider with a process-wide `Mutex` and re-checks expiry after taking the lock,
 //! so only one caller ever fires a refresh.
 //!
-//! **Terms of service.** Driving a ChatGPT/Kimi subscription through a non-official client
+//! **Terms of service.** Driving a ChatGPT/Kimi/Grok subscription through a non-official client
 //! violates the provider ToS and can get the account restricted. The login flows print this
 //! warning before starting; use at your own risk.
 //!
-//! Storage: `~/.llmtrim/codex/auth.json` and `~/.llmtrim/kimi/auth.json` (dir `0700`, file
-//! `0600` on unix), written atomically (temp file + rename).
+//! Storage: `~/.llmtrim/{codex,kimi,grok}/auth.json` (dir `0700`, file `0600` on unix), written
+//! atomically (temp file + rename).
 
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -81,6 +81,20 @@ pub fn get_token(provider: SubProvider) -> Result<TokenSet> {
                 account_id: None,
             })
         }
+        SubProvider::Grok => {
+            let stored =
+                read_grok().context("no Grok credentials — run `llmtrim sub auth grok login` first")?;
+            let now = now_ms();
+            let stored = if needs_refresh(stored.expires, now) {
+                grok_refresh(&stored)?
+            } else {
+                stored
+            };
+            Ok(TokenSet {
+                access: stored.access,
+                account_id: None,
+            })
+        }
     }
 }
 
@@ -98,6 +112,12 @@ const KIMI_HOST: &str = "https://auth.kimi.com";
 const KIMI_CLIENT_ID: &str = "17e5f671-d194-4dfb-9706-5516cb48c098";
 const KIMI_CLI_VERSION: &str = "1.37.0";
 
+/// Grok CLI public OAuth client (same as Grok Build / claude-code-proxy).
+const GROK_ISSUER: &str = "https://auth.x.ai";
+const GROK_CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+const GROK_SCOPES: &str =
+    "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write";
+
 /// Refresh anything within 5 minutes of expiry.
 const REFRESH_MARGIN_MS: u64 = 5 * 60 * 1000;
 
@@ -108,7 +128,7 @@ const HTTP_TIMEOUT: Duration = Duration::from_secs(60);
 const FLOW_TIMEOUT: Duration = Duration::from_secs(300);
 
 const TOS_WARNING: &str = "\
-WARNING: Using a ChatGPT/Kimi subscription through a non-official client violates the
+WARNING: Using a ChatGPT/Kimi/Grok subscription through a non-official client violates the
 provider's Terms of Service and can get your account restricted or banned. This is
 opt-in and unsupported. Proceed at your own risk.\n";
 
@@ -144,6 +164,18 @@ struct KimiStored {
     user_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GrokStored {
+    access: String,
+    refresh: String,
+    /// Epoch milliseconds.
+    expires: u64,
+    #[serde(default)]
+    issuer: String,
+    #[serde(rename = "clientId", default)]
+    client_id: String,
+}
+
 // ---------------------------------------------------------------------------
 // Wire response shapes
 // ---------------------------------------------------------------------------
@@ -167,11 +199,13 @@ struct TokenResponse {
 
 static CODEX_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 static KIMI_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static GROK_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 fn provider_lock(provider: SubProvider) -> &'static Mutex<()> {
     match provider {
         SubProvider::Codex => &CODEX_LOCK,
         SubProvider::Kimi => &KIMI_LOCK,
+        SubProvider::Grok => &GROK_LOCK,
     }
 }
 
@@ -298,12 +332,20 @@ fn kimi_dir() -> Result<PathBuf> {
     Ok(home_dir()?.join("kimi"))
 }
 
+fn grok_dir() -> Result<PathBuf> {
+    Ok(home_dir()?.join("grok"))
+}
+
 fn codex_auth_path() -> Result<PathBuf> {
     Ok(codex_dir()?.join("auth.json"))
 }
 
 fn kimi_auth_path() -> Result<PathBuf> {
     Ok(kimi_dir()?.join("auth.json"))
+}
+
+fn grok_auth_path() -> Result<PathBuf> {
+    Ok(grok_dir()?.join("auth.json"))
 }
 
 /// Create `dir` (recursively) and, on unix, tighten it to `0700`.
@@ -376,6 +418,19 @@ fn read_kimi() -> Result<KimiStored> {
 fn write_kimi(auth: &KimiStored) -> Result<()> {
     let path = kimi_auth_path()?;
     let json = serde_json::to_string_pretty(auth).context("failed to serialize Kimi auth")?;
+    write_atomic(&path, &json)
+}
+
+fn read_grok() -> Result<GrokStored> {
+    let path = grok_auth_path()?;
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn write_grok(auth: &GrokStored) -> Result<()> {
+    let path = grok_auth_path()?;
+    let json = serde_json::to_string_pretty(auth).context("failed to serialize Grok auth")?;
     write_atomic(&path, &json)
 }
 
@@ -789,6 +844,7 @@ pub fn auth_status_json(provider: super::SubProvider) -> serde_json::Value {
     let stored = match provider {
         SubProvider::Codex => read_codex().ok().map(|s| (s.expires, s.account_id)),
         SubProvider::Kimi => read_kimi().ok().map(|s| (s.expires, None)),
+        SubProvider::Grok => read_grok().ok().map(|s| (s.expires, None)),
     };
     match stored {
         Some((expires, account_id)) => serde_json::json!({
@@ -958,6 +1014,258 @@ pub fn kimi_status() -> Result<()> {
 pub fn kimi_logout() -> Result<()> {
     delete_if_exists(&kimi_auth_path()?)?;
     println!("Kimi credentials deleted.");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Grok — OIDC discovery + PKCE browser login
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct GrokDiscovery {
+    issuer: String,
+    authorization_endpoint: String,
+    token_endpoint: String,
+}
+
+fn grok_discover() -> Result<GrokDiscovery> {
+    let url = format!("{GROK_ISSUER}/.well-known/openid-configuration");
+    let mut resp = ureq::get(&url)
+        .config()
+        .proxy(None)
+        .http_status_as_error(false)
+        .timeout_global(Some(HTTP_TIMEOUT))
+        .build()
+        .call()
+        .map_err(|e| anyhow!("Grok OIDC discovery failed: {e}"))?;
+    let status = resp.status().as_u16();
+    let text = resp.body_mut().read_to_string().unwrap_or_default();
+    if !(200..300).contains(&status) {
+        bail!("Grok OIDC discovery failed (HTTP {status}): {text}");
+    }
+    let discovery: GrokDiscovery =
+        serde_json::from_str(&text).context("failed to parse Grok OIDC discovery")?;
+    if discovery.issuer != GROK_ISSUER {
+        bail!("Grok OIDC discovery issuer mismatch");
+    }
+    // Endpoints must stay on auth.x.ai.
+    for endpoint in [&discovery.authorization_endpoint, &discovery.token_endpoint] {
+        if !endpoint.starts_with(GROK_ISSUER) {
+            bail!("Grok OIDC endpoint is outside the canonical issuer: {endpoint}");
+        }
+    }
+    Ok(discovery)
+}
+
+/// Build stored creds from a token response.
+///
+/// `require_refresh`: login/authorization-code must grant an offline session. Refresh responses
+/// often omit `refresh_token` (RFC 6749); pass `false` and supply `prev_refresh` so the chain
+/// survives (same pattern as Codex/Kimi).
+fn grok_stored_from(
+    tr: TokenResponse,
+    require_refresh: bool,
+    prev_refresh: Option<&str>,
+) -> Result<GrokStored> {
+    if tr.access_token.is_empty() {
+        bail!("Grok token response missing access_token");
+    }
+    let refresh = tr
+        .refresh_token
+        .filter(|r| !r.is_empty())
+        .or_else(|| prev_refresh.map(str::to_string))
+        .filter(|r| !r.is_empty());
+    let refresh = match refresh {
+        Some(r) => r,
+        None if require_refresh => {
+            bail!("Grok login did not grant an offline session (no refresh_token)")
+        }
+        None => bail!("Grok token response missing refresh_token and no prior session to keep"),
+    };
+    Ok(GrokStored {
+        access: tr.access_token,
+        refresh,
+        expires: expiry_ms(tr.expires_in, 3600),
+        issuer: GROK_ISSUER.to_string(),
+        client_id: GROK_CLIENT_ID.to_string(),
+    })
+}
+
+fn grok_exchange_code(
+    token_endpoint: &str,
+    code: &str,
+    redirect_uri: &str,
+    code_verifier: &str,
+) -> Result<TokenResponse> {
+    let form = [
+        ("grant_type", "authorization_code".to_string()),
+        ("code", code.to_string()),
+        ("redirect_uri", redirect_uri.to_string()),
+        ("client_id", GROK_CLIENT_ID.to_string()),
+        ("code_verifier", code_verifier.to_string()),
+    ];
+    let (status, body) = post_form(token_endpoint, &[], &form)?;
+    if !(200..300).contains(&status) {
+        bail!("Grok token exchange failed (HTTP {status}): {body}");
+    }
+    serde_json::from_str(&body).context("failed to parse Grok token response")
+}
+
+fn grok_refresh(stored: &GrokStored) -> Result<GrokStored> {
+    if stored.issuer != GROK_ISSUER || stored.client_id != GROK_CLIENT_ID {
+        bail!("unsupported Grok OAuth session — run `llmtrim sub auth grok login` again");
+    }
+    let discovery = grok_discover()?;
+    let form = [
+        ("grant_type", "refresh_token".to_string()),
+        ("refresh_token", stored.refresh.clone()),
+        ("client_id", GROK_CLIENT_ID.to_string()),
+    ];
+    let (status, body) = post_form(&discovery.token_endpoint, &[], &form)?;
+    if status == 401 || status == 403 {
+        let _ = delete_if_exists(&grok_auth_path()?);
+        bail!(
+            "Grok refresh rejected (HTTP {status}); credentials cleared — run \
+             `llmtrim sub auth grok login` again"
+        );
+    }
+    if !(200..300).contains(&status) {
+        bail!("Grok refresh failed (HTTP {status}): {body}");
+    }
+    let tr: TokenResponse =
+        serde_json::from_str(&body).context("failed to parse Grok refresh response")?;
+    // Refresh responses may omit refresh_token; keep the prior one (Codex/Kimi do the same).
+    let fresh = grok_stored_from(tr, false, Some(&stored.refresh))?;
+    write_grok(&fresh)?;
+    Ok(fresh)
+}
+
+/// PKCE browser flow against `auth.x.ai` with an ephemeral loopback callback.
+pub fn grok_login() -> Result<()> {
+    print!("{TOS_WARNING}");
+
+    let discovery = grok_discover()?;
+    let verifier = random_b64url_32();
+    let challenge = pkce_challenge(&verifier);
+    let state = random_b64url_32();
+
+    // Ephemeral port (unlike Codex's fixed 1455) so concurrent tools don't collide.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .context("failed to bind loopback for the Grok OAuth callback")?;
+    let port = listener
+        .local_addr()
+        .context("failed to read Grok callback port")?
+        .port();
+    let redirect_uri = format!("http://127.0.0.1:{port}/callback");
+
+    let authorize = format!(
+        "{auth}?response_type=code&client_id={cid}&redirect_uri={redir}&scope={scope}\
+         &code_challenge={chal}&code_challenge_method=S256&state={state}",
+        auth = discovery.authorization_endpoint,
+        cid = urlencode(GROK_CLIENT_ID),
+        redir = urlencode(&redirect_uri),
+        scope = urlencode(GROK_SCOPES),
+        chal = challenge,
+        state = state,
+    );
+
+    println!("Open this URL in your browser to authorize llmtrim:\n\n  {authorize}\n");
+    try_open_browser(&authorize);
+    println!("Waiting for the authorization callback (up to 5 minutes)...");
+
+    let code = wait_for_grok_callback(listener, &state)?;
+    let tr = grok_exchange_code(
+        &discovery.token_endpoint,
+        &code,
+        &redirect_uri,
+        &verifier,
+    )?;
+    let stored = grok_stored_from(tr, true, None)?;
+    write_grok(&stored)?;
+    println!("Grok login complete.");
+    Ok(())
+}
+
+/// Same shape as Codex's callback waiter, but the path is `/callback` (Grok OIDC convention)
+/// rather than `/auth/callback`.
+fn wait_for_grok_callback(listener: std::net::TcpListener, expected_state: &str) -> Result<String> {
+    listener
+        .set_nonblocking(true)
+        .context("failed to set Grok callback listener non-blocking")?;
+    let deadline = std::time::Instant::now() + FLOW_TIMEOUT;
+
+    loop {
+        if std::time::Instant::now() >= deadline {
+            bail!("timed out waiting for the Grok OAuth callback after 5 minutes");
+        }
+        match listener.accept() {
+            Ok((mut stream, _addr)) => {
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+                let mut buf = [0u8; 8192];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let target = first_request_target(&req);
+
+                match target.and_then(parse_grok_callback) {
+                    Some((code, state)) => {
+                        if state != expected_state {
+                            respond(&mut stream, "state mismatch — please retry the login");
+                            bail!("OAuth state mismatch (possible CSRF); aborting");
+                        }
+                        respond(
+                            &mut stream,
+                            "llmtrim authorization received. You can close this tab.",
+                        );
+                        return Ok(code);
+                    }
+                    None => {
+                        respond(&mut stream, "waiting for the authorization callback...");
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => return Err(e).context("Grok callback listener accept failed"),
+        }
+    }
+}
+
+/// Parse `/callback?code=X&state=Y` into `(code, state)`.
+fn parse_grok_callback(target: &str) -> Option<(String, String)> {
+    let (path, query) = target.split_once('?')?;
+    if path != "/callback" {
+        return None;
+    }
+    let mut code = None;
+    let mut state = None;
+    for pair in query.split('&') {
+        let (k, v) = pair.split_once('=')?;
+        match k {
+            "code" => code = Some(urldecode(v)),
+            "state" => state = Some(urldecode(v)),
+            "error" => return None,
+            _ => {}
+        }
+    }
+    Some((code?, state.unwrap_or_default()))
+}
+
+/// Device-code login is not supported for Grok yet (browser PKCE only).
+pub fn grok_device() -> Result<()> {
+    bail!("Grok device login is unavailable — use `llmtrim sub auth grok login` (browser OAuth)")
+}
+
+pub fn grok_status() -> Result<()> {
+    let stored = read_grok().context("no Grok credentials stored")?;
+    println!("Grok: logged in");
+    println!("  {}", expiry_line(stored.expires));
+    Ok(())
+}
+
+pub fn grok_logout() -> Result<()> {
+    delete_if_exists(&grok_auth_path()?)?;
+    println!("Grok credentials deleted.");
     Ok(())
 }
 

--- a/crates/llmtrim-cli/src/reroute/auth.rs
+++ b/crates/llmtrim-cli/src/reroute/auth.rs
@@ -18,9 +18,10 @@
 //! Storage: `~/.llmtrim/{codex,kimi,grok}/auth.json` (dir `0700`, file `0600` on unix), written
 //! atomically (temp file + rename).
 
-use std::io::{Read, Write};
+use std::io::{BufRead, Read, Write};
 use std::path::PathBuf;
 use std::sync::Mutex;
+use std::sync::mpsc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -1017,7 +1018,7 @@ pub fn kimi_logout() -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Grok — OIDC discovery + PKCE browser login
+// Grok — OIDC discovery + PKCE browser login + device-code / paste fallback
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
@@ -1025,6 +1026,9 @@ struct GrokDiscovery {
     issuer: String,
     authorization_endpoint: String,
     token_endpoint: String,
+    /// Present when the issuer supports RFC 8628 device authorization.
+    #[serde(default)]
+    device_authorization_endpoint: Option<String>,
 }
 
 fn grok_discover() -> Result<GrokDiscovery> {
@@ -1048,7 +1052,14 @@ fn grok_discover() -> Result<GrokDiscovery> {
         bail!("Grok OIDC discovery issuer mismatch");
     }
     // Endpoints must stay on auth.x.ai.
-    for endpoint in [&discovery.authorization_endpoint, &discovery.token_endpoint] {
+    let mut endpoints = vec![
+        discovery.authorization_endpoint.as_str(),
+        discovery.token_endpoint.as_str(),
+    ];
+    if let Some(ref d) = discovery.device_authorization_endpoint {
+        endpoints.push(d.as_str());
+    }
+    for endpoint in endpoints {
         if !endpoint.starts_with(GROK_ISSUER) {
             bail!("Grok OIDC endpoint is outside the canonical issuer: {endpoint}");
         }
@@ -1140,6 +1151,11 @@ fn grok_refresh(stored: &GrokStored) -> Result<GrokStored> {
 }
 
 /// PKCE browser flow against `auth.x.ai` with an ephemeral loopback callback.
+///
+/// When the browser cannot reach this machine (SSH, container, remote desktop),
+/// xAI may show a one-time code (or a `http://127.0.0.1.../callback?...` URL).
+/// Paste that into the terminal — same pattern as pi-grok-cli / Hermes paste
+/// fallback. For fully headless machines prefer [`grok_device`].
 pub fn grok_login() -> Result<()> {
     print!("{TOS_WARNING}");
 
@@ -1170,7 +1186,12 @@ pub fn grok_login() -> Result<()> {
 
     println!("Open this URL in your browser to authorize llmtrim:\n\n  {authorize}\n");
     try_open_browser(&authorize);
-    println!("Waiting for the authorization callback (up to 5 minutes)...");
+    println!(
+        "Waiting for the authorization callback (up to 5 minutes)...\n\
+         If the browser cannot reach this machine, paste the full callback URL\n\
+         or the one-time code xAI shows (\"copy into Grok Build\") and press Enter.\n\
+         Headless alternative: `llmtrim sub auth grok device`.\n"
+    );
 
     let code = wait_for_grok_callback(listener, &state)?;
     let tr = grok_exchange_code(&discovery.token_endpoint, &code, &redirect_uri, &verifier)?;
@@ -1181,17 +1202,40 @@ pub fn grok_login() -> Result<()> {
 }
 
 /// Same shape as Codex's callback waiter, but the path is `/callback` (Grok OIDC convention)
-/// rather than `/auth/callback`.
+/// rather than `/auth/callback`. Also accepts a pasted callback URL or bare authorization
+/// code from stdin so remote users can finish login on their own device.
 fn wait_for_grok_callback(listener: std::net::TcpListener, expected_state: &str) -> Result<String> {
     listener
         .set_nonblocking(true)
         .context("failed to set Grok callback listener non-blocking")?;
     let deadline = std::time::Instant::now() + FLOW_TIMEOUT;
 
+    // Background stdin reader: paste races the loopback callback; first valid wins.
+    let paste_rx = spawn_stdin_line_reader();
+
     loop {
         if std::time::Instant::now() >= deadline {
             bail!("timed out waiting for the Grok OAuth callback after 5 minutes");
         }
+
+        // Manual paste (callback URL, query string, or bare code) from the other device.
+        match paste_rx.try_recv() {
+            Ok(line) => match parse_grok_manual_paste(line.trim(), expected_state) {
+                Ok(code) => return Ok(code),
+                Err(err) => {
+                    eprintln!("Ignored pasted input: {err}");
+                    eprintln!(
+                        "Paste the complete callback URL (http://127.0.0.1.../callback?code=...)\n\
+                         or the one-time code xAI showed, then press Enter."
+                    );
+                }
+            },
+            Err(mpsc::TryRecvError::Empty) => {}
+            Err(mpsc::TryRecvError::Disconnected) => {
+                // Stdin closed (EOF); loopback callback can still finish the flow.
+            }
+        }
+
         match listener.accept() {
             Ok((mut stream, _addr)) => {
                 let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
@@ -1225,16 +1269,45 @@ fn wait_for_grok_callback(listener: std::net::TcpListener, expected_state: &str)
     }
 }
 
+/// Spawn a thread that forwards non-empty stdin lines until EOF or the receiver drops.
+fn spawn_stdin_line_reader() -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        let mut stdin = stdin.lock();
+        loop {
+            let mut line = String::new();
+            match stdin.read_line(&mut line) {
+                Ok(0) => break, // EOF
+                Ok(_) if line.trim().is_empty() => continue,
+                Ok(_) => {
+                    if tx.send(line).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+    rx
+}
+
 /// Parse `/callback?code=X&state=Y` into `(code, state)`.
 fn parse_grok_callback(target: &str) -> Option<(String, String)> {
     let (path, query) = target.split_once('?')?;
     if path != "/callback" {
         return None;
     }
+    parse_grok_callback_query(query)
+}
+
+fn parse_grok_callback_query(query: &str) -> Option<(String, String)> {
     let mut code = None;
     let mut state = None;
     for pair in query.split('&') {
-        let (k, v) = pair.split_once('=')?;
+        let Some((k, v)) = pair.split_once('=') else {
+            continue;
+        };
         match k {
             "code" => code = Some(urldecode(v)),
             "state" => state = Some(urldecode(v)),
@@ -1245,9 +1318,201 @@ fn parse_grok_callback(target: &str) -> Option<(String, String)> {
     Some((code?, state.unwrap_or_default()))
 }
 
-/// Device-code login is not supported for Grok yet (browser PKCE only).
+/// Accept a pasted callback URL, `?code=&state=` query, or bare authorization code.
+///
+/// Matches pi-grok-cli / Hermes remote paste: when xAI cannot redirect to loopback it
+/// shows a one-time code (French UI: "copiez le code dans Grok Build") for the CLI.
+fn parse_grok_manual_paste(input: &str, expected_state: &str) -> Result<String> {
+    let value = input.trim();
+    if value.is_empty() {
+        bail!("pasted input was empty");
+    }
+
+    // Full URL: http://127.0.0.1:PORT/callback?code=...&state=...
+    if value.starts_with("http://") || value.starts_with("https://") {
+        let after_scheme = value
+            .split_once("://")
+            .map(|(_, rest)| rest)
+            .unwrap_or(value);
+        let path_and_query = after_scheme
+            .find('/')
+            .map(|i| &after_scheme[i..])
+            .unwrap_or("/");
+        let (code, state) = parse_grok_callback(path_and_query)
+            .ok_or_else(|| anyhow!("pasted URL is not a Grok /callback with code="))?;
+        if !state.is_empty() && state != expected_state {
+            bail!("OAuth state mismatch (possible CSRF); aborting");
+        }
+        return Ok(code);
+    }
+
+    // Query fragment: code=...&state=...  (optional leading ?)
+    let as_query = value.strip_prefix('?').unwrap_or(value);
+    if as_query.contains("code=") {
+        let (code, state) = parse_grok_callback_query(as_query)
+            .ok_or_else(|| anyhow!("pasted query did not contain a valid code="))?;
+        if !state.is_empty() && state != expected_state {
+            bail!("OAuth state mismatch (possible CSRF); aborting");
+        }
+        return Ok(code);
+    }
+
+    // Bare one-time authorization code (xAI "copy into Grok Build" page).
+    if is_plausible_oauth_code(value) {
+        return Ok(value.to_string());
+    }
+
+    bail!("unrecognized paste — expected a callback URL, code=... query, or one-time auth code")
+}
+
+/// Heuristic for a bare OAuth authorization code (not a short device user_code like ABCD-1234).
+fn is_plausible_oauth_code(s: &str) -> bool {
+    let len = s.len();
+    (32..=2048).contains(&len)
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '~'))
+}
+
+/// True for `https://x.ai/...` or `https://*.x.ai/...` (with optional port). Used to reject
+/// open redirects from a compromised discovery/device response.
+fn is_trusted_xai_https_url(url: &str) -> bool {
+    let Some(rest) = url.strip_prefix("https://") else {
+        return false;
+    };
+    let host_port = rest.split(['/', '?', '#']).next().unwrap_or("");
+    let host = host_port
+        .rsplit_once('@')
+        .map(|(_, h)| h)
+        .unwrap_or(host_port);
+    // Drop port; IPv6 literals are not expected for xAI hosts.
+    let host = host.split(':').next().unwrap_or(host).to_ascii_lowercase();
+    host == "x.ai" || host.ends_with(".x.ai")
+}
+
+#[derive(Debug, Deserialize)]
+struct GrokDeviceStart {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    #[serde(default)]
+    verification_uri_complete: Option<String>,
+    #[serde(default, deserialize_with = "de_opt_u64")]
+    expires_in: Option<u64>,
+    #[serde(default, deserialize_with = "de_opt_u64")]
+    interval: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GrokPollError {
+    error: String,
+}
+
+/// RFC 8628 device-code login for headless / remote machines.
+///
+/// Prints a verification URL + user code; the user completes sign-in on any
+/// browser (laptop/phone). llmtrim polls `auth.x.ai` until approved — no
+/// localhost callback required. Same public client id as Grok Build / OpenClaw /
+/// pi-grok-cli (consent UI may still say "Grok Build").
 pub fn grok_device() -> Result<()> {
-    bail!("Grok device login is unavailable — use `llmtrim sub auth grok login` (browser OAuth)")
+    print!("{TOS_WARNING}");
+
+    let discovery = grok_discover()?;
+    let device_endpoint = discovery
+        .device_authorization_endpoint
+        .as_deref()
+        .ok_or_else(|| {
+            anyhow!(
+                "Grok OIDC discovery has no device_authorization_endpoint — \
+                 use `llmtrim sub auth grok login` instead"
+            )
+        })?;
+
+    let (status, body) = post_form(
+        device_endpoint,
+        &[],
+        &[
+            ("client_id", GROK_CLIENT_ID.to_string()),
+            ("scope", GROK_SCOPES.to_string()),
+        ],
+    )?;
+    if !(200..300).contains(&status) {
+        bail!("Grok device authorization failed (HTTP {status}): {body}");
+    }
+    let start: GrokDeviceStart = serde_json::from_str(&body)
+        .context("failed to parse Grok device-authorization response")?;
+
+    let verify_url = start
+        .verification_uri_complete
+        .as_deref()
+        .filter(|u| !u.is_empty())
+        .unwrap_or(start.verification_uri.as_str());
+    if !is_trusted_xai_https_url(verify_url) {
+        bail!("Grok device verification URI is outside a trusted xAI host: {verify_url}");
+    }
+    // Base verification_uri is also user-visible if complete URI is used only for open.
+    if !is_trusted_xai_https_url(&start.verification_uri) {
+        bail!(
+            "Grok device verification_uri is outside a trusted xAI host: {}",
+            start.verification_uri
+        );
+    }
+
+    println!(
+        "To authorize llmtrim on any device, open:\n\n  {verify_url}\n\n\
+         and confirm the code: {}\n\n\
+         Waiting for approval (up to 5 minutes)...\n",
+        start.user_code
+    );
+    try_open_browser(verify_url);
+
+    let mut interval = start.interval.unwrap_or(5).max(1);
+    let deadline = std::time::Instant::now()
+        + start
+            .expires_in
+            .map(|s| Duration::from_secs(s.min(FLOW_TIMEOUT.as_secs())))
+            .unwrap_or(FLOW_TIMEOUT);
+
+    // Poll immediately, then back off (same shape as OpenClaw / RFC 8628 clients).
+    let tr: TokenResponse = loop {
+        if std::time::Instant::now() >= deadline {
+            bail!("timed out waiting for Grok device authorization");
+        }
+        let (status, body) = post_form(
+            &discovery.token_endpoint,
+            &[],
+            &[
+                ("client_id", GROK_CLIENT_ID.to_string()),
+                ("device_code", start.device_code.clone()),
+                (
+                    "grant_type",
+                    "urn:ietf:params:oauth:grant-type:device_code".to_string(),
+                ),
+            ],
+        )?;
+        if (200..300).contains(&status) {
+            break serde_json::from_str(&body).context("failed to parse Grok token response")?;
+        }
+        match serde_json::from_str::<GrokPollError>(&body) {
+            Ok(e) => match e.error.as_str() {
+                "authorization_pending" => {}
+                "slow_down" => interval = interval.saturating_add(5),
+                "expired_token" => bail!("Grok device code expired; run login again"),
+                "access_denied" | "authorization_denied" => {
+                    bail!("Grok device authorization was denied")
+                }
+                other => bail!("Grok authorization failed: {other}"),
+            },
+            Err(_) => bail!("Grok device poll failed (HTTP {status}): {body}"),
+        }
+        std::thread::sleep(
+            Duration::from_secs(interval).saturating_add(Duration::from_millis(500)),
+        );
+    };
+
+    let stored = grok_stored_from(tr, true, None)?;
+    write_grok(&stored)?;
+    println!("Grok login complete.");
+    Ok(())
 }
 
 pub fn grok_status() -> Result<()> {
@@ -1563,5 +1828,65 @@ mod tests {
     fn first_request_target_parses_get_line() {
         let req = "GET /auth/callback?code=1 HTTP/1.1\r\nHost: x\r\n\r\n";
         assert_eq!(first_request_target(req), Some("/auth/callback?code=1"));
+    }
+
+    #[test]
+    fn grok_callback_path_parses() {
+        let (code, state) =
+            parse_grok_callback("/callback?code=tok&state=st").expect("should parse");
+        assert_eq!(code, "tok");
+        assert_eq!(state, "st");
+        assert!(parse_grok_callback("/auth/callback?code=tok&state=st").is_none());
+    }
+
+    #[test]
+    fn grok_manual_paste_accepts_url_query_and_bare_code() {
+        let state = "expected-state";
+        let code = "a".repeat(40);
+
+        let url = format!("http://127.0.0.1:4242/callback?code={code}&state={state}");
+        assert_eq!(parse_grok_manual_paste(&url, state).unwrap(), code);
+
+        let query = format!("code={code}&state={state}");
+        assert_eq!(parse_grok_manual_paste(&query, state).unwrap(), code);
+
+        assert_eq!(parse_grok_manual_paste(&code, state).unwrap(), code);
+
+        // Short device-style codes are not authorization codes.
+        assert!(parse_grok_manual_paste("ABCD-12", state).is_err());
+
+        // State mismatch on URL paste is rejected.
+        let bad = format!("http://127.0.0.1:1/callback?code={code}&state=other");
+        assert!(parse_grok_manual_paste(&bad, state).is_err());
+    }
+
+    #[test]
+    fn grok_device_start_accepts_string_or_number_fields() {
+        let raw = r#"{
+            "device_code": "dc",
+            "user_code": "WDJB-MJHT",
+            "verification_uri": "https://auth.x.ai/device",
+            "verification_uri_complete": "https://auth.x.ai/device?user_code=WDJB-MJHT",
+            "expires_in": "600",
+            "interval": "5"
+        }"#;
+        let s: GrokDeviceStart = serde_json::from_str(raw).unwrap();
+        assert_eq!(s.user_code, "WDJB-MJHT");
+        assert_eq!(s.expires_in, Some(600));
+        assert_eq!(s.interval, Some(5));
+        assert!(s.verification_uri_complete.unwrap().contains("user_code"));
+    }
+
+    #[test]
+    fn trusted_xai_https_url_allows_issuer_hosts_only() {
+        assert!(is_trusted_xai_https_url("https://auth.x.ai/oauth2/device"));
+        assert!(is_trusted_xai_https_url(
+            "https://accounts.x.ai/device?user_code=X"
+        ));
+        assert!(is_trusted_xai_https_url("https://x.ai/device"));
+        assert!(!is_trusted_xai_https_url("http://auth.x.ai/device"));
+        assert!(!is_trusted_xai_https_url("https://evil.com/"));
+        assert!(!is_trusted_xai_https_url("https://evil.x.ai.attacker.com/"));
+        assert!(!is_trusted_xai_https_url("https://notx.ai/"));
     }
 }

--- a/crates/llmtrim-cli/src/reroute/catalog.rs
+++ b/crates/llmtrim-cli/src/reroute/catalog.rs
@@ -8,7 +8,7 @@
 use once_cell::sync::Lazy;
 use serde_json::Value;
 
-use crate::reroute::{CODEX_MODELS, KIMI_MODEL, SubProvider};
+use crate::reroute::{CODEX_MODELS, GROK_MODELS, KIMI_MODEL, SubProvider};
 
 /// The models.dev pricing snapshot, embedded at build time. Ids are provider-prefixed, e.g.
 /// `"openai/gpt-5.5"` or `"moonshotai/kimi-k2.7-code"`.
@@ -37,6 +37,10 @@ pub fn models_for(provider: SubProvider) -> Vec<CatalogEntry> {
         SubProvider::Kimi => {
             vec![entry_for(KIMI_MODEL, &["moonshotai/", "moonshot/"])]
         }
+        SubProvider::Grok => GROK_MODELS
+            .iter()
+            .map(|id| entry_for(id, &["x-ai/", "xai/"]))
+            .collect(),
     }
 }
 
@@ -113,6 +117,15 @@ mod tests {
         let entries = models_for(SubProvider::Kimi);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].id, KIMI_MODEL);
+    }
+
+    #[test]
+    fn grok_returns_curated_ids() {
+        let ids: Vec<String> = models_for(SubProvider::Grok)
+            .into_iter()
+            .map(|e| e.id)
+            .collect();
+        assert_eq!(ids, GROK_MODELS.to_vec());
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/context_limit.rs
+++ b/crates/llmtrim-cli/src/reroute/context_limit.rs
@@ -562,9 +562,10 @@ mod tests {
     #[test]
     fn pre_output_helper_requires_no_content_commit() {
         let _lock = test_lock();
-        assert!(pre_output_context_limit(&[
-            (false, "context_length_exceeded"),
-        ]));
+        assert!(pre_output_context_limit(&[(
+            false,
+            "context_length_exceeded"
+        ),]));
         assert!(!pre_output_context_limit(&[
             (true, ""),
             (false, "context_length_exceeded"),

--- a/crates/llmtrim-cli/src/reroute/context_limit.rs
+++ b/crates/llmtrim-cli/src/reroute/context_limit.rs
@@ -1,0 +1,621 @@
+//! Session-scoped guard for subscription context-window rejections.
+//!
+//! When a Codex/Kimi backend refuses a turn because the conversation no longer fits its context
+//! window, retrying or compressing cannot recover: the *history* is too large. This module:
+//!
+//! 1. Keeps a last-known-good Anthropic request snapshot per Claude Code session
+//!    (`x-claude-code-session-id`).
+//! 2. On a pre-output context-limit rejection, marks the session `must_compact` and returns a
+//!    local explanation (no retry, no truncate, no llmtrim compression).
+//! 3. While blocked, rejects ordinary turns locally and only allows Claude Code's real `/compact`
+//!    request — rewritten to use the stored snapshot — or a cleared/new session.
+//!
+//! State is process-local, TTL-bound, and capped (same spirit as [`super::continuation`]).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use serde_json::Value;
+
+/// Client-facing explanation when a subscription backend rejected a turn for context length, or
+/// when a blocked session receives another ordinary request.
+pub const GUARD_MESSAGE: &str = "\
+Subscription context limit reached.\n\
+This turn was not accepted by the subscription backend. Run /compact to continue this session, or /clear to start fresh. After compaction, resend your last request.";
+
+const TTL_MS: u64 = 30 * 60 * 1000;
+const MAX_STATES: usize = 10_000;
+/// Cap a single snapshot so a pathological history cannot pin tens of MB per session.
+const MAX_SNAPSHOT_BYTES: u64 = 2_000_000;
+const MAX_TOTAL_SNAPSHOT_BYTES: u64 = 20_000_000;
+
+#[derive(Clone)]
+struct SessionState {
+    must_compact: bool,
+    /// Anthropic-shaped body of the last request the backend accepted (messages + system).
+    last_good: Option<Value>,
+    last_good_bytes: u64,
+    updated_at: u64,
+}
+
+static STATES: Mutex<Option<HashMap<String, SessionState>>> = Mutex::new(None);
+static TOTAL_BYTES: Mutex<u64> = Mutex::new(0);
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Slim the full Anthropic body down to the fields compaction needs to restore history.
+fn snapshot_body(body: &Value) -> Value {
+    let mut out = serde_json::Map::new();
+    if let Some(messages) = body.get("messages") {
+        out.insert("messages".to_string(), messages.clone());
+    }
+    if let Some(system) = body.get("system") {
+        out.insert("system".to_string(), system.clone());
+    }
+    Value::Object(out)
+}
+
+fn message_count(body: &Value) -> usize {
+    body.get("messages")
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .unwrap_or(0)
+}
+
+/// True when `text` (HTTP body, SSE error message, or status phrase) describes a context-window
+/// rejection from Codex, Kimi, OpenAI-compatible, or Anthropic-shaped error payloads.
+pub fn is_context_limit_text(text: &str) -> bool {
+    let m = text.to_lowercase();
+    if m.is_empty() {
+        return false;
+    }
+    // Explicit codes / types first.
+    if m.contains("context_length_exceeded")
+        || m.contains("context_length")
+        || m.contains("max_tokens_exceeded")
+        || m.contains("token_limit")
+        || m.contains("prompt_too_long")
+        || m.contains("input_too_long")
+        || m.contains("string_above_max_length")
+    {
+        return true;
+    }
+    // Natural-language forms used by ChatGPT/Codex, Kimi, and Anthropic.
+    let contextish = m.contains("context")
+        && (m.contains("window")
+            || m.contains("length")
+            || m.contains("limit")
+            || m.contains("overflow")
+            || m.contains("exceed"));
+    let tokenish =
+        (m.contains("too many tokens") || m.contains("too long") || m.contains("maximum"))
+            && (m.contains("token")
+                || m.contains("prompt")
+                || m.contains("input")
+                || m.contains("message"));
+    let exceeds_model = m.contains("exceeds")
+        && (m.contains("context") || m.contains("maximum") || m.contains("model"));
+    contextish || tokenish || exceeds_model
+}
+
+/// HTTP-path detection: non-success status whose body (or extracted error message) is a
+/// context-window rejection. Success statuses are handled via the SSE reducer path instead.
+pub fn is_context_limit_http(status: u16, body: &[u8]) -> bool {
+    if (200..300).contains(&status) {
+        return false;
+    }
+    // Most providers use 400; some return 413. Be liberal on status when the body is clear.
+    let text = String::from_utf8_lossy(body);
+    if is_context_limit_text(&text) {
+        return true;
+    }
+    if let Ok(v) = serde_json::from_slice::<Value>(body) {
+        let msg = v
+            .pointer("/error/message")
+            .or_else(|| v.pointer("/error/code"))
+            .or_else(|| v.get("detail"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if is_context_limit_text(msg) {
+            return true;
+        }
+        let code = v
+            .pointer("/error/type")
+            .or_else(|| v.pointer("/error/code"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if is_context_limit_text(code) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether this session is currently blocked pending `/compact` (or a cleared session).
+pub fn must_compact(session_id: Option<&str>) -> bool {
+    let Some(session_id) = session_id else {
+        return false;
+    };
+    let now = now_ms();
+    let guard = STATES.lock().unwrap();
+    guard.as_ref().is_some_and(|m| {
+        m.get(session_id)
+            .is_some_and(|s| s.must_compact && now.saturating_sub(s.updated_at) <= TTL_MS)
+    })
+}
+
+/// Mark the session blocked after a pre-output context-limit rejection. Does not replace an
+/// existing last-known-good snapshot (the rejected turn is intentionally discarded).
+pub fn mark_must_compact(session_id: Option<&str>) {
+    let Some(session_id) = session_id else {
+        return;
+    };
+    let now = now_ms();
+    let mut guard = STATES.lock().unwrap();
+    let map = guard.get_or_insert_with(HashMap::new);
+    match map.get_mut(session_id) {
+        Some(state) => {
+            state.must_compact = true;
+            state.updated_at = now;
+        }
+        None => {
+            map.insert(
+                session_id.to_string(),
+                SessionState {
+                    must_compact: true,
+                    last_good: None,
+                    last_good_bytes: 0,
+                    updated_at: now,
+                },
+            );
+        }
+    }
+    drop(guard);
+    evict_oldest();
+}
+
+/// Record a request the subscription backend accepted (content committed / successful completion).
+/// Clears `must_compact` — a successful compact or ordinary turn unblocks the session.
+pub fn record_accepted(session_id: Option<&str>, anthropic_body: &Value) {
+    let Some(session_id) = session_id else {
+        return;
+    };
+    let snap = snapshot_body(anthropic_body);
+    let bytes = serde_json::to_vec(&snap)
+        .map(|b| b.len() as u64)
+        .unwrap_or(0);
+    if bytes == 0 || bytes > MAX_SNAPSHOT_BYTES {
+        // Oversized or empty: keep must_compact clear but drop the snapshot rather than OOM.
+        let mut guard = STATES.lock().unwrap();
+        if let Some(map) = guard.as_mut()
+            && let Some(state) = map.get_mut(session_id)
+        {
+            if let Some(old) = state.last_good.take() {
+                let old_b = state.last_good_bytes;
+                state.last_good_bytes = 0;
+                drop(old);
+                let mut total = TOTAL_BYTES.lock().unwrap();
+                *total = total.saturating_sub(old_b);
+            }
+            state.must_compact = false;
+            state.updated_at = now_ms();
+        }
+        return;
+    }
+
+    // Evict prior bytes for this session first.
+    clear_snapshot_bytes(session_id);
+
+    let state = SessionState {
+        must_compact: false,
+        last_good: Some(snap),
+        last_good_bytes: bytes,
+        updated_at: now_ms(),
+    };
+    {
+        let mut total = TOTAL_BYTES.lock().unwrap();
+        *total = total.saturating_add(bytes);
+    }
+    {
+        let mut guard = STATES.lock().unwrap();
+        let map = guard.get_or_insert_with(HashMap::new);
+        map.insert(session_id.to_string(), state);
+    }
+    evict_oldest();
+}
+
+fn clear_snapshot_bytes(session_id: &str) {
+    let mut guard = STATES.lock().unwrap();
+    if let Some(map) = guard.as_mut()
+        && let Some(state) = map.get_mut(session_id)
+        && let Some(old) = state.last_good.take()
+    {
+        let old_b = state.last_good_bytes;
+        state.last_good_bytes = 0;
+        drop(old);
+        let mut total = TOTAL_BYTES.lock().unwrap();
+        *total = total.saturating_sub(old_b);
+    }
+}
+
+/// Drop all guard state for a session (session reset / `/clear` with a new id naturally misses).
+pub fn clear(session_id: Option<&str>) {
+    let Some(session_id) = session_id else {
+        return;
+    };
+    let mut guard = STATES.lock().unwrap();
+    if let Some(map) = guard.as_mut()
+        && let Some(existing) = map.remove(session_id)
+    {
+        let mut total = TOTAL_BYTES.lock().unwrap();
+        *total = total.saturating_sub(existing.last_good_bytes);
+    }
+}
+
+/// True when the inbound request looks like a fresh conversation on the same session id
+/// (history shorter than the stored snapshot — e.g. after a local clear that reused the id).
+pub fn looks_like_session_reset(session_id: Option<&str>, body: &Value) -> bool {
+    let Some(session_id) = session_id else {
+        return false;
+    };
+    let cur = message_count(body);
+    if cur == 0 {
+        return true;
+    }
+    let guard = STATES.lock().unwrap();
+    let Some(state) = guard.as_ref().and_then(|m| m.get(session_id)) else {
+        return false;
+    };
+    let good = state.last_good.as_ref().map(message_count).unwrap_or(0);
+    // A reset is shorter than what we last accepted; ordinary turns only grow (or stay
+    // similar when the client re-sends). Compact requests keep the full overflowing history
+    // and are handled separately.
+    good > 0 && cur < good
+}
+
+/// While `must_compact`, rewrite a real Claude Code compact request so its conversation history
+/// is the last-known-good snapshot, preserving the final summarization user turn. Returns whether
+/// the body was rewritten.
+pub fn apply_last_good_to_compact(session_id: Option<&str>, body: &mut Value) -> bool {
+    let Some(session_id) = session_id else {
+        return false;
+    };
+    let last_good = {
+        let guard = STATES.lock().unwrap();
+        guard
+            .as_ref()
+            .and_then(|m| m.get(session_id))
+            .and_then(|s| s.last_good.clone())
+    };
+    let Some(last_good) = last_good else {
+        return false;
+    };
+    let Some(good_messages) = last_good.get("messages").and_then(Value::as_array).cloned() else {
+        return false;
+    };
+    let compact_prompt = body
+        .get("messages")
+        .and_then(Value::as_array)
+        .and_then(|a| a.last().cloned());
+    let mut messages = good_messages;
+    if let Some(prompt) = compact_prompt {
+        messages.push(prompt);
+    }
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("messages".to_string(), Value::Array(messages));
+        // Prefer the system prompt that last fit, when the snapshot carried one.
+        if let Some(system) = last_good.get("system") {
+            obj.insert("system".to_string(), system.clone());
+        }
+        return true;
+    }
+    false
+}
+
+/// Decision for an inbound subscription request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InboundAction {
+    /// Forward normally (optionally after compact rewrite).
+    Allow { rewrote_compact: bool },
+    /// Reject locally with [`GUARD_MESSAGE`].
+    Block,
+}
+
+/// Gate an inbound Anthropic `/v1/messages` body for a subscription-backed session.
+///
+/// - Not blocked → allow.
+/// - Blocked + real `/compact` → rewrite history from last-known-good and allow.
+/// - Blocked + session reset → clear state and allow.
+/// - Blocked + ordinary turn → block.
+///
+/// Compact is checked before the reset heuristic: a compact request often carries fewer
+/// messages than the overflowing local transcript (or just a long history that still
+/// happens to be shorter than a prior snapshot after client-side trimming), and must not
+/// be mistaken for `/clear`.
+pub fn gate_inbound(session_id: Option<&str>, body: &mut Value, is_compact: bool) -> InboundAction {
+    if !must_compact(session_id) {
+        return InboundAction::Allow {
+            rewrote_compact: false,
+        };
+    }
+    if is_compact {
+        let rewrote = apply_last_good_to_compact(session_id, body);
+        return InboundAction::Allow {
+            rewrote_compact: rewrote,
+        };
+    }
+    if looks_like_session_reset(session_id, body) {
+        clear(session_id);
+        return InboundAction::Allow {
+            rewrote_compact: false,
+        };
+    }
+    InboundAction::Block
+}
+
+fn evict_oldest() {
+    let mut guard = STATES.lock().unwrap();
+    let map = match guard.as_mut() {
+        Some(m) if !m.is_empty() => m,
+        _ => return,
+    };
+    let now = now_ms();
+    // Drop expired first.
+    let expired: Vec<String> = map
+        .iter()
+        .filter(|(_, s)| now.saturating_sub(s.updated_at) > TTL_MS)
+        .map(|(k, _)| k.clone())
+        .collect();
+    let mut total = TOTAL_BYTES.lock().unwrap();
+    for key in expired {
+        if let Some(old) = map.remove(&key) {
+            *total = total.saturating_sub(old.last_good_bytes);
+        }
+    }
+    while (map.len() > MAX_STATES || *total > MAX_TOTAL_SNAPSHOT_BYTES) && !map.is_empty() {
+        if let Some((oldest_key, _)) = map.iter().min_by_key(|(_, s)| s.updated_at) {
+            let key = oldest_key.clone();
+            if let Some(old) = map.remove(&key) {
+                *total = total.saturating_sub(old.last_good_bytes);
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+// ── test helpers ──────────────────────────────────────────────────────────────
+
+/// Process-global state is shared across tests; serialize them so `clear_all_for_tests`
+/// cannot wipe another test mid-flight.
+#[cfg(test)]
+pub fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+#[cfg(test)]
+pub fn clear_all_for_tests() {
+    let mut guard = STATES.lock().unwrap();
+    *guard = None;
+    let mut b = TOTAL_BYTES.lock().unwrap();
+    *b = 0;
+}
+
+#[cfg(test)]
+pub fn last_good_message_count_for_tests(session_id: &str) -> Option<usize> {
+    let guard = STATES.lock().unwrap();
+    guard
+        .as_ref()
+        .and_then(|m| m.get(session_id))
+        .and_then(|s| s.last_good.as_ref())
+        .map(message_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn body_with_n_messages(n: usize) -> Value {
+        let messages: Vec<Value> = (0..n)
+            .map(|i| {
+                json!({
+                    "role": if i % 2 == 0 { "user" } else { "assistant" },
+                    "content": format!("m{i}")
+                })
+            })
+            .collect();
+        json!({ "model": "claude-opus-4-8", "messages": messages })
+    }
+
+    fn compact_body(history_n: usize) -> Value {
+        let mut messages: Vec<Value> = (0..history_n)
+            .map(|i| {
+                json!({
+                    "role": if i % 2 == 0 { "user" } else { "assistant" },
+                    "content": format!("h{i}")
+                })
+            })
+            .collect();
+        messages.push(json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": format!(
+                    "{}\n{}\n{}",
+                    crate::compact::MARKERS[0],
+                    crate::compact::MARKERS[1],
+                    crate::compact::MARKERS[2]
+                )}
+            ]
+        }));
+        json!({
+            "model": "claude-opus-4-8",
+            "stream": true,
+            "max_tokens": 64000,
+            "output_config": {"effort": "low"},
+            "messages": messages
+        })
+    }
+
+    #[test]
+    fn detects_context_limit_phrases_for_codex_and_kimi() {
+        let _lock = test_lock();
+        assert!(is_context_limit_text(
+            "Your input exceeds the context window of this model."
+        ));
+        assert!(is_context_limit_text("context_length_exceeded"));
+        assert!(is_context_limit_text(
+            "This model's maximum context length is 128000 tokens."
+        ));
+        assert!(is_context_limit_text("prompt is too long: 200000 tokens"));
+        assert!(is_context_limit_http(
+            400,
+            br#"{"error":{"message":"Your input exceeds the context window of this model.","type":"invalid_request_error"}}"#
+        ));
+        assert!(is_context_limit_http(
+            400,
+            br#"{"error":{"code":"context_length_exceeded","message":"too big"}}"#
+        ));
+        assert!(!is_context_limit_text("rate limit reached"));
+        assert!(!is_context_limit_http(
+            429,
+            br#"{"error":{"message":"rate limit"}}"#
+        ));
+        assert!(!is_context_limit_http(
+            200,
+            br#"{"error":{"message":"context_length_exceeded"}}"#
+        ));
+    }
+
+    #[test]
+    fn block_compact_resume_flow() {
+        let _lock = test_lock();
+        clear_all_for_tests();
+        let sid = Some("sess-guard-1");
+
+        // Successful history lands in the snapshot.
+        let good = body_with_n_messages(4);
+        record_accepted(sid, &good);
+        assert!(!must_compact(sid));
+        assert_eq!(last_good_message_count_for_tests("sess-guard-1"), Some(4));
+
+        // Context limit on the next turn: block, keep snapshot.
+        mark_must_compact(sid);
+        assert!(must_compact(sid));
+        assert_eq!(last_good_message_count_for_tests("sess-guard-1"), Some(4));
+
+        // Ordinary request while blocked.
+        let mut ordinary = body_with_n_messages(5);
+        assert_eq!(
+            gate_inbound(sid, &mut ordinary, false),
+            InboundAction::Block
+        );
+
+        // Real compact: rewrite history to LKG + compact prompt.
+        let mut compact = compact_body(20);
+        let action = gate_inbound(sid, &mut compact, true);
+        assert_eq!(
+            action,
+            InboundAction::Allow {
+                rewrote_compact: true
+            }
+        );
+        let msgs = compact["messages"].as_array().unwrap();
+        // 4 from LKG + 1 compact prompt.
+        assert_eq!(msgs.len(), 5);
+        assert_eq!(msgs[0]["content"], "m0");
+        assert!(
+            msgs[4]["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains(crate::compact::MARKERS[0])
+        );
+
+        // Successful compact clears the block and refreshes the snapshot.
+        record_accepted(sid, &compact);
+        assert!(!must_compact(sid));
+        assert_eq!(last_good_message_count_for_tests("sess-guard-1"), Some(5));
+
+        // Ordinary traffic resumes.
+        let mut next = body_with_n_messages(2);
+        assert_eq!(
+            gate_inbound(sid, &mut next, false),
+            InboundAction::Allow {
+                rewrote_compact: false
+            }
+        );
+    }
+
+    #[test]
+    fn session_reset_clears_block() {
+        let _lock = test_lock();
+        clear_all_for_tests();
+        let sid = Some("sess-reset");
+        record_accepted(sid, &body_with_n_messages(6));
+        mark_must_compact(sid);
+        assert!(must_compact(sid));
+
+        // A short new conversation is treated as /clear on a reused id.
+        let mut fresh = body_with_n_messages(1);
+        assert_eq!(
+            gate_inbound(sid, &mut fresh, false),
+            InboundAction::Allow {
+                rewrote_compact: false
+            }
+        );
+        assert!(!must_compact(sid));
+    }
+
+    #[test]
+    fn clear_drops_state() {
+        let _lock = test_lock();
+        clear_all_for_tests();
+        let sid = Some("sess-clear");
+        record_accepted(sid, &body_with_n_messages(3));
+        mark_must_compact(sid);
+        clear(sid);
+        assert!(!must_compact(sid));
+        assert_eq!(last_good_message_count_for_tests("sess-clear"), None);
+    }
+
+    #[test]
+    fn rejected_turn_is_not_recorded_as_last_good() {
+        let _lock = test_lock();
+        clear_all_for_tests();
+        let sid = Some("sess-no-replay");
+        record_accepted(sid, &body_with_n_messages(2));
+        // Overflowing turn is never passed to record_accepted — only mark_must_compact.
+        mark_must_compact(sid);
+        assert_eq!(last_good_message_count_for_tests("sess-no-replay"), Some(2));
+    }
+
+    #[test]
+    fn missing_session_never_blocks() {
+        let _lock = test_lock();
+        clear_all_for_tests();
+        mark_must_compact(None);
+        assert!(!must_compact(None));
+        let mut body = body_with_n_messages(3);
+        assert_eq!(
+            gate_inbound(None, &mut body, false),
+            InboundAction::Allow {
+                rewrote_compact: false
+            }
+        );
+    }
+
+    #[test]
+    fn guard_message_tells_user_to_compact_or_clear() {
+        let _lock = test_lock();
+        assert!(GUARD_MESSAGE.contains("Subscription context limit reached."));
+        assert!(GUARD_MESSAGE.contains("Run /compact"));
+        assert!(GUARD_MESSAGE.contains("/clear"));
+        assert!(GUARD_MESSAGE.contains("resend your last request"));
+    }
+}

--- a/crates/llmtrim-cli/src/reroute/context_limit.rs
+++ b/crates/llmtrim-cli/src/reroute/context_limit.rs
@@ -69,38 +69,53 @@ fn message_count(body: &Value) -> usize {
 
 /// True when `text` (HTTP body, SSE error message, or status phrase) describes a context-window
 /// rejection from Codex, Kimi, OpenAI-compatible, or Anthropic-shaped error payloads.
+///
+/// Prefer explicit codes and tight collocations. Loose pairs like `context`∩`limit` or
+/// `exceeds`∩`maximum` false-positive on deadlines, rate limits that mention “context”,
+/// max-images validation, and parameter bounds — those must not latch a session.
 pub fn is_context_limit_text(text: &str) -> bool {
     let m = text.to_lowercase();
     if m.is_empty() {
         return false;
     }
-    // Explicit codes / types first.
+    // Deadlines / cancellations often contain both "context" and "exceed" — never treat as overflow.
+    if m.contains("deadline") || m.contains("canceled") || m.contains("cancelled") {
+        return false;
+    }
+
+    // Explicit API codes / types first.
     if m.contains("context_length_exceeded")
-        || m.contains("context_length")
-        || m.contains("max_tokens_exceeded")
-        || m.contains("token_limit")
         || m.contains("prompt_too_long")
         || m.contains("input_too_long")
         || m.contains("string_above_max_length")
+        || m.contains("context_length_limit")
     {
         return true;
     }
-    // Natural-language forms used by ChatGPT/Codex, Kimi, and Anthropic.
-    let contextish = m.contains("context")
-        && (m.contains("window")
-            || m.contains("length")
-            || m.contains("limit")
-            || m.contains("overflow")
-            || m.contains("exceed"));
-    let tokenish =
-        (m.contains("too many tokens") || m.contains("too long") || m.contains("maximum"))
-            && (m.contains("token")
-                || m.contains("prompt")
-                || m.contains("input")
-                || m.contains("message"));
-    let exceeds_model = m.contains("exceeds")
-        && (m.contains("context") || m.contains("maximum") || m.contains("model"));
-    contextish || tokenish || exceeds_model
+
+    // Tight natural-language collocations used by ChatGPT/Codex, Kimi, and Anthropic.
+    if m.contains("context window")
+        || m.contains("context length")
+        || m.contains("maximum context")
+        || m.contains("max context")
+        || m.contains("context overflow")
+        || m.contains("too many tokens")
+        || m.contains("prompt is too long")
+        || m.contains("input is too long")
+        || m.contains("request too large")
+    {
+        return true;
+    }
+
+    // "exceeds the context window of this model" / "input exceeds … context"
+    if m.contains("exceed")
+        && m.contains("context")
+        && (m.contains("window") || m.contains("length") || m.contains("limit"))
+    {
+        return true;
+    }
+
+    false
 }
 
 /// HTTP-path detection: non-success status whose body (or extracted error message) is a
@@ -179,6 +194,21 @@ pub fn mark_must_compact(session_id: Option<&str>) {
     evict_oldest();
 }
 
+/// Clear the block latch without replacing the last-known-good snapshot. Used when a non-sub
+/// (Anthropic) path accepts a turn and we may not have a body worth storing.
+pub fn clear_must_compact(session_id: Option<&str>) {
+    let Some(session_id) = session_id else {
+        return;
+    };
+    let mut guard = STATES.lock().unwrap();
+    if let Some(map) = guard.as_mut()
+        && let Some(state) = map.get_mut(session_id)
+    {
+        state.must_compact = false;
+        state.updated_at = now_ms();
+    }
+}
+
 /// Record a request the subscription backend accepted (content committed / successful completion).
 /// Clears `must_compact` — a successful compact or ordinary turn unblocks the session.
 pub fn record_accepted(session_id: Option<&str>, anthropic_body: &Value) {
@@ -190,21 +220,9 @@ pub fn record_accepted(session_id: Option<&str>, anthropic_body: &Value) {
         .map(|b| b.len() as u64)
         .unwrap_or(0);
     if bytes == 0 || bytes > MAX_SNAPSHOT_BYTES {
-        // Oversized or empty: keep must_compact clear but drop the snapshot rather than OOM.
-        let mut guard = STATES.lock().unwrap();
-        if let Some(map) = guard.as_mut()
-            && let Some(state) = map.get_mut(session_id)
-        {
-            if let Some(old) = state.last_good.take() {
-                let old_b = state.last_good_bytes;
-                state.last_good_bytes = 0;
-                drop(old);
-                let mut total = TOTAL_BYTES.lock().unwrap();
-                *total = total.saturating_sub(old_b);
-            }
-            state.must_compact = false;
-            state.updated_at = now_ms();
-        }
+        // Oversized or empty: clear the latch but keep any prior last-known-good. Wiping LKG
+        // here would leave a later context-limit with nothing to rewrite onto for /compact.
+        clear_must_compact(Some(session_id));
         return;
     }
 
@@ -272,10 +290,15 @@ pub fn looks_like_session_reset(session_id: Option<&str>, body: &Value) -> bool 
         return false;
     };
     let good = state.last_good.as_ref().map(message_count).unwrap_or(0);
+    if good == 0 {
+        // Blocked with no snapshot (first-turn overflow, or oversized accept kept LKG empty):
+        // a short bootstrap conversation is the only non-compact recovery for a reused id.
+        return cur <= 1;
+    }
     // A reset is shorter than what we last accepted; ordinary turns only grow (or stay
     // similar when the client re-sends). Compact requests keep the full overflowing history
     // and are handled separately.
-    good > 0 && cur < good
+    cur < good
 }
 
 /// While `must_compact`, rewrite a real Claude Code compact request so its conversation history
@@ -356,6 +379,24 @@ pub fn gate_inbound(session_id: Option<&str>, body: &mut Value, is_compact: bool
         };
     }
     InboundAction::Block
+}
+
+/// True when events show a context-limit error before any content/tool/thinking event.
+/// Each entry is `(is_content_commit, error_message_or_empty)`. Safe to call
+/// [`mark_must_compact`] only when this returns true.
+pub fn pre_output_context_limit(events: &[(bool, &str)]) -> bool {
+    let mut committed = false;
+    let mut saw_context_limit = false;
+    for (is_content, err_msg) in events {
+        if *is_content {
+            committed = true;
+            break;
+        }
+        if !err_msg.is_empty() && is_context_limit_text(err_msg) {
+            saw_context_limit = true;
+        }
+    }
+    !committed && saw_context_limit
 }
 
 fn evict_oldest() {
@@ -474,6 +515,7 @@ mod tests {
             "This model's maximum context length is 128000 tokens."
         ));
         assert!(is_context_limit_text("prompt is too long: 200000 tokens"));
+        assert!(is_context_limit_text("too many tokens in the request"));
         assert!(is_context_limit_http(
             400,
             br#"{"error":{"message":"Your input exceeds the context window of this model.","type":"invalid_request_error"}}"#
@@ -482,7 +524,31 @@ mod tests {
             400,
             br#"{"error":{"code":"context_length_exceeded","message":"too big"}}"#
         ));
+    }
+
+    #[test]
+    fn rejects_non_context_errors_that_share_loose_substrings() {
+        let _lock = test_lock();
         assert!(!is_context_limit_text("rate limit reached"));
+        assert!(!is_context_limit_text(
+            "Please provide more context. Rate limit reached."
+        ));
+        assert!(!is_context_limit_text("context deadline exceeded"));
+        assert!(!is_context_limit_text(
+            "rpc error: code = DeadlineExceeded desc = context deadline exceeded"
+        ));
+        assert!(!is_context_limit_text(
+            "Invalid parameter: max_tokens exceeds maximum"
+        ));
+        assert!(!is_context_limit_text(
+            "The maximum number of images per message is 100"
+        ));
+        assert!(!is_context_limit_text(
+            "tools.0.custom.input_schema: JSON schema is too long"
+        ));
+        assert!(!is_context_limit_text(
+            "Value exceeds maximum allowed for temperature"
+        ));
         assert!(!is_context_limit_http(
             429,
             br#"{"error":{"message":"rate limit"}}"#
@@ -491,6 +557,19 @@ mod tests {
             200,
             br#"{"error":{"message":"context_length_exceeded"}}"#
         ));
+    }
+
+    #[test]
+    fn pre_output_helper_requires_no_content_commit() {
+        let _lock = test_lock();
+        assert!(pre_output_context_limit(&[
+            (false, "context_length_exceeded"),
+        ]));
+        assert!(!pre_output_context_limit(&[
+            (true, ""),
+            (false, "context_length_exceeded"),
+        ]));
+        assert!(!pre_output_context_limit(&[(false, "rate limit reached")]));
     }
 
     #[test]
@@ -570,6 +649,48 @@ mod tests {
             }
         );
         assert!(!must_compact(sid));
+    }
+
+    #[test]
+    fn reset_works_when_blocked_without_last_good() {
+        let _lock = test_lock();
+        clear_all_for_tests();
+        let sid = Some("sess-no-lkg");
+        // First-turn overflow: latch with no prior snapshot.
+        mark_must_compact(sid);
+        assert!(must_compact(sid));
+        assert_eq!(last_good_message_count_for_tests("sess-no-lkg"), None);
+
+        let mut fresh = body_with_n_messages(1);
+        assert_eq!(
+            gate_inbound(sid, &mut fresh, false),
+            InboundAction::Allow {
+                rewrote_compact: false
+            }
+        );
+        assert!(!must_compact(sid));
+    }
+
+    #[test]
+    fn oversized_accept_keeps_prior_last_good() {
+        let _lock = test_lock();
+        clear_all_for_tests();
+        let sid = Some("sess-oversize");
+        record_accepted(sid, &body_with_n_messages(3));
+        assert_eq!(last_good_message_count_for_tests("sess-oversize"), Some(3));
+
+        // Build a body larger than MAX_SNAPSHOT_BYTES so record_accepted refuses to store it.
+        let huge_text = "x".repeat((MAX_SNAPSHOT_BYTES as usize) + 64);
+        let huge = json!({
+            "messages": [{"role": "user", "content": huge_text}]
+        });
+        record_accepted(sid, &huge);
+        assert!(!must_compact(sid));
+        assert_eq!(
+            last_good_message_count_for_tests("sess-oversize"),
+            Some(3),
+            "prior LKG must survive an oversized accept"
+        );
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/grok.rs
+++ b/crates/llmtrim-cli/src/reroute/grok.rs
@@ -458,11 +458,9 @@ impl Reducer {
     fn emit_remaining_tools(&mut self, out: &mut Vec<ReduceEvent>) {
         let order = self.tool_order.clone();
         for id in order {
-            if self
-                .tools
-                .get(&id)
-                .is_some_and(|t| !t.stopped && (t.started || !t.buf.is_empty() || !t.name.is_empty()))
-            {
+            if self.tools.get(&id).is_some_and(|t| {
+                !t.stopped && (t.started || !t.buf.is_empty() || !t.name.is_empty())
+            }) {
                 // Close thinking/text first so nesting stays valid.
                 if matches!(self.open, Open::Thinking | Open::Text) {
                     self.close_open(out);
@@ -480,7 +478,10 @@ impl Reducer {
     }
 
     fn resolve_call_id(&self, v: &Value) -> Option<String> {
-        if let Some(id) = v.get("call_id").and_then(Value::as_str).filter(|s| !s.is_empty())
+        if let Some(id) = v
+            .get("call_id")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
         {
             return Some(id.to_string());
         }
@@ -624,7 +625,8 @@ impl Reducer {
                 // Stream deltas live only for the currently open Anthropic tool block.
                 if self.open == Open::Tool && self.open_tool.as_deref() == Some(call_id.as_str()) {
                     // Keep buffering; flush happens on done so sanitize_read_args sees full JSON.
-                } else if self.open != Open::Tool && !matches!(self.open, Open::Thinking | Open::Text)
+                } else if self.open != Open::Tool
+                    && !matches!(self.open, Open::Thinking | Open::Text)
                 {
                     self.open_tool_stream(&call_id, out);
                 }
@@ -935,7 +937,11 @@ mod tests {
             "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"web_search_call\"}}\n\n",
             "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n",
         );
-        let events: Vec<_> = r.push(chunk.as_bytes()).into_iter().chain(r.finish()).collect();
+        let events: Vec<_> = r
+            .push(chunk.as_bytes())
+            .into_iter()
+            .chain(r.finish())
+            .collect();
         let starts: Vec<_> = events
             .iter()
             .filter_map(|e| match e {

--- a/crates/llmtrim-cli/src/reroute/grok.rs
+++ b/crates/llmtrim-cli/src/reroute/grok.rs
@@ -1,0 +1,989 @@
+//! Grok (xAI SuperGrok / Grok Build) subscription reroute provider.
+//!
+//! Translates an Anthropic `/v1/messages` request into the Grok CLI Responses API shape
+//! (`POST https://cli-chat-proxy.grok.com/v1/responses`) and reduces the Responses SSE stream
+//! back into the shared [`ReduceEvent`] stream that
+//! [`crate::reroute::sse::AnthropicSseEncoder`] re-encodes as Anthropic SSE.
+//!
+//! Wire models: `grok-4.5` (flagship) and `grok-composer-2.5-fast` (cheap/fast). Auth is OAuth
+//! against `auth.x.ai` (see [`crate::reroute::auth`]).
+
+use anyhow::Result;
+use serde_json::{Map, Value, json};
+
+use crate::reroute::sse::{ReduceEvent, SseLineParser, StopReason, Usage};
+
+pub const HOST: &str = "cli-chat-proxy.grok.com";
+pub const PATH: &str = "/v1/responses";
+const CLIENT_VERSION: &str = "0.2.93";
+
+/// Claude Code hosted web-search tool id (translated to Grok `web_search`).
+const WEB_SEARCH_TOOL: &str = "web_search_20250305";
+
+// ---------------------------------------------------------------------------------------------
+// Request
+// ---------------------------------------------------------------------------------------------
+
+/// Headers for the rewritten upstream request.
+pub fn request_headers(
+    access_token: &str,
+    _account_id: Option<&str>,
+    _session_id: Option<&str>,
+) -> Vec<(String, String)> {
+    vec![
+        ("content-type".to_string(), "application/json".to_string()),
+        ("accept".to_string(), "text/event-stream".to_string()),
+        (
+            "authorization".to_string(),
+            format!("Bearer {access_token}"),
+        ),
+        ("x-xai-token-auth".to_string(), "xai-grok-cli".to_string()),
+        (
+            "x-grok-client-identifier".to_string(),
+            "grok-shell".to_string(),
+        ),
+        (
+            "x-grok-client-version".to_string(),
+            CLIENT_VERSION.to_string(),
+        ),
+        (
+            "user-agent".to_string(),
+            format!("llmtrim/{}", env!("CARGO_PKG_VERSION")),
+        ),
+    ]
+}
+
+/// Build the Grok Responses request body from an intercepted Anthropic `/v1/messages` body.
+///
+/// `model` is already resolved to an upstream id. `session_id` is unused today (Grok does not
+/// require a prompt-cache key the way Codex does).
+pub fn build_request_body(
+    anthropic: &Value,
+    model: &str,
+    _session_id: Option<&str>,
+) -> Result<Value> {
+    let mut body = Map::new();
+    body.insert("model".into(), json!(model));
+
+    let mut instructions = crate::reroute::flatten_system_text(anthropic.get("system"));
+    // Only advertise hosted tools when Claude Code offered them. We do not yet reduce hosted
+    // search streams back into Anthropic server_tool blocks, so auto-injecting x_search every
+    // turn would steer the model into tools Claude Code never sees.
+    let tools = build_tools(anthropic);
+    if tools
+        .iter()
+        .any(|t| t.get("type").and_then(Value::as_str) == Some("x_search"))
+    {
+        append_guidance(
+            &mut instructions,
+            "For requests to search X or Twitter, use the hosted x_search tool. Do not use Bash, curl, HTTP clients, or general web_search for X searches.",
+        );
+    }
+    if tools
+        .iter()
+        .any(|t| t.get("type").and_then(Value::as_str) == Some("web_search"))
+    {
+        append_guidance(
+            &mut instructions,
+            "For general web searches, use the hosted web_search tool. Do not use shell commands, HTTP clients, or local tools to search the web.",
+        );
+    }
+    if let Some(instr) = instructions {
+        body.insert("instructions".into(), json!(instr));
+    }
+
+    body.insert("input".into(), Value::Array(build_input(anthropic)));
+    if !tools.is_empty() {
+        body.insert("tools".into(), Value::Array(tools));
+    }
+    if let Some(tc) = build_tool_choice(anthropic.get("tool_choice")) {
+        body.insert("tool_choice".into(), tc);
+    }
+
+    body.insert("store".into(), json!(false));
+    body.insert("stream".into(), json!(true));
+
+    if let Some(max) = anthropic.get("max_tokens").and_then(Value::as_u64) {
+        body.insert("max_output_tokens".into(), json!(max));
+    }
+
+    Ok(Value::Object(body))
+}
+
+fn append_guidance(instructions: &mut Option<String>, guidance: &str) {
+    *instructions = Some(match instructions.take() {
+        Some(existing) if !existing.is_empty() => format!("{existing}\n\n{guidance}"),
+        _ => guidance.into(),
+    });
+}
+
+fn flatten_text(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Array(blocks) => blocks
+            .iter()
+            .filter_map(|b| b.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+fn content_blocks(content: &Value) -> Vec<Value> {
+    match content {
+        Value::String(s) => vec![json!({ "type": "text", "text": s })],
+        Value::Array(arr) => arr.clone(),
+        _ => Vec::new(),
+    }
+}
+
+fn tool_result_output(block: &Value) -> String {
+    let body = match block.get("content") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(parts)) => parts
+            .iter()
+            .map(|p| match p.get("type").and_then(Value::as_str) {
+                Some("image") => "[image omitted]".to_string(),
+                _ => p
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    };
+    if block.get("is_error").and_then(Value::as_bool) == Some(true) {
+        format!("[tool execution error]\n{body}")
+    } else {
+        body
+    }
+}
+
+/// Build Responses `input[]` from Anthropic `messages`. Thinking / hosted-search history is
+/// dropped (Grok does not need encrypted reasoning replay the way Codex does).
+fn build_input(anthropic: &Value) -> Vec<Value> {
+    let mut input = Vec::new();
+    let Some(messages) = anthropic.get("messages").and_then(Value::as_array) else {
+        return input;
+    };
+
+    for msg in messages {
+        let role = msg.get("role").and_then(Value::as_str).unwrap_or("user");
+        let content = msg.get("content").cloned().unwrap_or(Value::Null);
+        let blocks = content_blocks(&content);
+
+        match role {
+            "assistant" => {
+                let mut parts: Vec<Value> = Vec::new();
+                for b in &blocks {
+                    match b.get("type").and_then(Value::as_str) {
+                        Some("thinking") | Some("redacted_thinking") => {
+                            // Drop — no encrypted_content to replay.
+                        }
+                        Some("text") => {
+                            if let Some(t) = b.get("text").and_then(Value::as_str) {
+                                parts.push(json!({ "type": "output_text", "text": t }));
+                            }
+                        }
+                        Some("tool_use") => {
+                            flush_message(&mut input, "assistant", &mut parts);
+                            let args = b.get("input").cloned().unwrap_or(json!({}));
+                            let args_str = if args.is_null() {
+                                "{}".to_string()
+                            } else {
+                                serde_json::to_string(&args).unwrap_or_else(|_| "{}".into())
+                            };
+                            input.push(json!({
+                                "type": "function_call",
+                                "call_id": b.get("id").and_then(Value::as_str).unwrap_or(""),
+                                "name": b.get("name").and_then(Value::as_str).unwrap_or(""),
+                                "arguments": args_str,
+                            }));
+                        }
+                        Some("server_tool_use")
+                        | Some("web_search_tool_result")
+                        | Some("x_search_tool_result") => {}
+                        _ => {}
+                    }
+                }
+                flush_message(&mut input, "assistant", &mut parts);
+            }
+            "system" | "developer" => {
+                let text = flatten_text(&content);
+                input.push(json!({
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{ "type": "input_text", "text": text }],
+                }));
+            }
+            _ => {
+                let mut parts: Vec<Value> = Vec::new();
+                for b in &blocks {
+                    match b.get("type").and_then(Value::as_str) {
+                        Some("text") => {
+                            if let Some(t) = b.get("text").and_then(Value::as_str) {
+                                parts.push(json!({ "type": "input_text", "text": t }));
+                            }
+                        }
+                        Some("image") => {
+                            // Keep a visible placeholder so multimodal context is not silently lost.
+                            parts.push(json!({ "type": "input_text", "text": "[image omitted]" }));
+                        }
+                        Some("tool_result") => {
+                            flush_message(&mut input, "user", &mut parts);
+                            let call_id =
+                                b.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
+                            input.push(json!({
+                                "type": "function_call_output",
+                                "call_id": call_id,
+                                "output": tool_result_output(b),
+                            }));
+                        }
+                        Some("web_search_tool_result") | Some("x_search_tool_result") => {}
+                        _ => {}
+                    }
+                }
+                flush_message(&mut input, "user", &mut parts);
+            }
+        }
+    }
+    input
+}
+
+fn flush_message(input: &mut Vec<Value>, role: &str, parts: &mut Vec<Value>) {
+    if parts.is_empty() {
+        return;
+    }
+    input.push(json!({
+        "type": "message",
+        "role": role,
+        "content": Value::Array(std::mem::take(parts)),
+    }));
+}
+
+fn build_tools(anthropic: &Value) -> Vec<Value> {
+    let Some(tools) = anthropic.get("tools").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for t in tools {
+        let name = t.get("name").and_then(Value::as_str).unwrap_or("");
+        let ty = t.get("type").and_then(Value::as_str).unwrap_or("");
+        if name == "WebSearch"
+            || name == WEB_SEARCH_TOOL
+            || ty == WEB_SEARCH_TOOL
+            || name.eq_ignore_ascii_case("web_search")
+        {
+            out.push(json!({ "type": "web_search" }));
+            continue;
+        }
+        if name == "XSearch" || name.eq_ignore_ascii_case("x_search") {
+            out.push(json!({ "type": "x_search" }));
+            continue;
+        }
+        // Skip pure hosted-type entries already handled.
+        if ty == "web_search" || ty == "x_search" {
+            out.push(json!({ "type": ty }));
+            continue;
+        }
+        if name.is_empty() {
+            continue;
+        }
+        let mut obj = Map::new();
+        obj.insert("type".into(), json!("function"));
+        obj.insert("name".into(), json!(name));
+        if let Some(desc) = t.get("description").and_then(Value::as_str) {
+            obj.insert("description".into(), json!(desc));
+        }
+        obj.insert(
+            "parameters".into(),
+            t.get("input_schema").cloned().unwrap_or(json!({})),
+        );
+        out.push(Value::Object(obj));
+    }
+    out
+}
+
+fn build_tool_choice(tc: Option<&Value>) -> Option<Value> {
+    let tc = tc?;
+    match tc.get("type").and_then(Value::as_str) {
+        Some("auto") | None => None,
+        Some("none") => Some(json!("none")),
+        Some("any") | Some("required") => Some(json!("required")),
+        Some("tool") => {
+            let name = tc.get("name").and_then(Value::as_str)?;
+            if name == WEB_SEARCH_TOOL || name == "WebSearch" {
+                return None;
+            }
+            Some(json!({ "type": "function", "name": name }))
+        }
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Response reducer (Responses SSE → ReduceEvent)
+// ---------------------------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Open {
+    None,
+    Thinking,
+    Text,
+    /// Currently streaming Anthropic tool block for this call_id (blocks do not interleave).
+    Tool,
+}
+
+struct ToolCall {
+    name: String,
+    buf: String,
+    /// ToolStart already emitted on the Anthropic stream.
+    started: bool,
+    flushed: bool,
+    stopped: bool,
+}
+
+/// Stateful reducer: Grok Responses SSE → shared [`ReduceEvent`] stream.
+///
+/// Tool calls are keyed by `call_id` (with `item_id` → `call_id` fallback) so interleaved
+/// argument deltas on the wire buffer correctly. Anthropic SSE still requires non-interleaved
+/// blocks, so each tool is emitted as ToolStart/Delta/Stop only when that call completes or
+/// when a different block (text/thinking) must open.
+pub struct Reducer {
+    parser: SseLineParser,
+    open: Open,
+    /// call_id of the Anthropic tool block currently open (if `open == Tool`).
+    open_tool: Option<String>,
+    saw_tool_use: bool,
+    tools: std::collections::HashMap<String, ToolCall>,
+    item_to_call: std::collections::HashMap<String, String>,
+    /// Stable emission order for tools registered this turn.
+    tool_order: Vec<String>,
+    terminal_seen: bool,
+}
+
+impl Reducer {
+    pub fn new(_model: &str) -> Self {
+        Self {
+            parser: SseLineParser::new(),
+            open: Open::None,
+            open_tool: None,
+            saw_tool_use: false,
+            tools: std::collections::HashMap::new(),
+            item_to_call: std::collections::HashMap::new(),
+            tool_order: Vec::new(),
+            terminal_seen: false,
+        }
+    }
+
+    pub fn push(&mut self, chunk: &[u8]) -> Vec<ReduceEvent> {
+        let mut out = Vec::new();
+        for v in self.parser.push(chunk) {
+            self.handle(&v, &mut out);
+        }
+        out
+    }
+
+    pub fn finish(&mut self) -> Vec<ReduceEvent> {
+        let mut out = Vec::new();
+        self.close_open(&mut out);
+        self.emit_remaining_tools(&mut out);
+        if !self.terminal_seen {
+            self.terminal_seen = true;
+            out.push(ReduceEvent::Finish {
+                stop_reason: StopReason::EndTurn,
+                usage: Usage::default(),
+                response_id: None,
+                continuation_eligible: false,
+            });
+        }
+        out
+    }
+
+    fn close_open(&mut self, out: &mut Vec<ReduceEvent>) {
+        match self.open {
+            Open::Thinking => {
+                out.push(ReduceEvent::ThinkingStop);
+                self.open = Open::None;
+            }
+            Open::Text => {
+                out.push(ReduceEvent::TextStop);
+                self.open = Open::None;
+            }
+            Open::Tool => {
+                if let Some(id) = self.open_tool.clone() {
+                    self.emit_tool_complete(&id, out);
+                }
+                self.open = Open::None;
+                self.open_tool = None;
+            }
+            Open::None => {}
+        }
+    }
+
+    fn emit_tool_complete(&mut self, call_id: &str, out: &mut Vec<ReduceEvent>) {
+        let Some(tool) = self.tools.get_mut(call_id) else {
+            return;
+        };
+        if tool.stopped {
+            return;
+        }
+        if !tool.started {
+            out.push(ReduceEvent::ToolStart {
+                id: call_id.to_string(),
+                name: tool.name.clone(),
+            });
+            tool.started = true;
+        }
+        if !tool.flushed {
+            let sanitized = crate::reroute::read_rewrite::sanitize_read_args(
+                &tool.name,
+                &tool.buf,
+                Some(call_id),
+            );
+            if !sanitized.is_empty() {
+                out.push(ReduceEvent::ToolDelta(sanitized));
+            } else if !tool.buf.is_empty() {
+                out.push(ReduceEvent::ToolDelta(tool.buf.clone()));
+            }
+            tool.flushed = true;
+        }
+        out.push(ReduceEvent::ToolStop);
+        tool.stopped = true;
+    }
+
+    /// Emit any tools that received args/registration but were never closed (stream end).
+    fn emit_remaining_tools(&mut self, out: &mut Vec<ReduceEvent>) {
+        let order = self.tool_order.clone();
+        for id in order {
+            if self
+                .tools
+                .get(&id)
+                .is_some_and(|t| !t.stopped && (t.started || !t.buf.is_empty() || !t.name.is_empty()))
+            {
+                // Close thinking/text first so nesting stays valid.
+                if matches!(self.open, Open::Thinking | Open::Text) {
+                    self.close_open(out);
+                }
+                if self.open == Open::Tool && self.open_tool.as_deref() != Some(id.as_str()) {
+                    self.close_open(out);
+                }
+                self.open = Open::Tool;
+                self.open_tool = Some(id.clone());
+                self.emit_tool_complete(&id, out);
+                self.open = Open::None;
+                self.open_tool = None;
+            }
+        }
+    }
+
+    fn resolve_call_id(&self, v: &Value) -> Option<String> {
+        if let Some(id) = v.get("call_id").and_then(Value::as_str).filter(|s| !s.is_empty())
+        {
+            return Some(id.to_string());
+        }
+        v.get("item_id")
+            .and_then(Value::as_str)
+            .and_then(|item| self.item_to_call.get(item).cloned())
+    }
+
+    fn ensure_tool(&mut self, call_id: &str, name: &str) {
+        if !self.tools.contains_key(call_id) {
+            self.tool_order.push(call_id.to_string());
+            self.tools.insert(
+                call_id.to_string(),
+                ToolCall {
+                    name: name.to_string(),
+                    buf: String::new(),
+                    started: false,
+                    flushed: false,
+                    stopped: false,
+                },
+            );
+        } else if !name.is_empty() {
+            if let Some(t) = self.tools.get_mut(call_id) {
+                if t.name.is_empty() {
+                    t.name = name.to_string();
+                }
+            }
+        }
+    }
+
+    fn open_thinking(&mut self, out: &mut Vec<ReduceEvent>) {
+        if self.open == Open::Thinking {
+            return;
+        }
+        self.close_open(out);
+        out.push(ReduceEvent::ThinkingStart);
+        self.open = Open::Thinking;
+    }
+
+    fn open_text(&mut self, out: &mut Vec<ReduceEvent>) {
+        if self.open == Open::Text {
+            return;
+        }
+        self.close_open(out);
+        out.push(ReduceEvent::TextStart);
+        self.open = Open::Text;
+    }
+
+    /// Begin Anthropic streaming for `call_id` if nothing else is open (or after closing it).
+    fn open_tool_stream(&mut self, call_id: &str, out: &mut Vec<ReduceEvent>) {
+        if self.open == Open::Tool && self.open_tool.as_deref() == Some(call_id) {
+            return;
+        }
+        self.close_open(out);
+        let Some(tool) = self.tools.get_mut(call_id) else {
+            return;
+        };
+        if tool.stopped {
+            return;
+        }
+        if !tool.started {
+            out.push(ReduceEvent::ToolStart {
+                id: call_id.to_string(),
+                name: tool.name.clone(),
+            });
+            tool.started = true;
+        }
+        self.open = Open::Tool;
+        self.open_tool = Some(call_id.to_string());
+    }
+
+    fn handle(&mut self, v: &Value, out: &mut Vec<ReduceEvent>) {
+        let ty = v.get("type").and_then(Value::as_str).unwrap_or("");
+        match ty {
+            "response.output_item.added" => {
+                let item = v.get("item").cloned().unwrap_or(Value::Null);
+                match item.get("type").and_then(Value::as_str) {
+                    Some("message") => {
+                        self.open_text(out);
+                    }
+                    Some("function_call") => {
+                        let call_id = item
+                            .get("call_id")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string();
+                        if call_id.is_empty() {
+                            return;
+                        }
+                        let name = item
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string();
+                        self.saw_tool_use = true;
+                        self.ensure_tool(&call_id, &name);
+                        if let Some(item_id) = item.get("id").and_then(Value::as_str) {
+                            self.item_to_call
+                                .insert(item_id.to_string(), call_id.clone());
+                        }
+                        // Do not close an already-open tool for a different call_id here —
+                        // argument deltas may still arrive for the first call. Start streaming
+                        // only when no other tool is open.
+                        if self.open != Open::Tool {
+                            if matches!(self.open, Open::Thinking | Open::Text) {
+                                self.close_open(out);
+                            }
+                            self.open_tool_stream(&call_id, out);
+                        }
+                    }
+                    // Hosted search / custom tools — no Claude function block (Grok runs them).
+                    // Must not close an open client function tool when these complete later.
+                    Some("custom_tool_call") | Some("web_search_call") | Some("reasoning") => {}
+                    _ => {}
+                }
+            }
+            "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
+                let delta = v.get("delta").and_then(Value::as_str).unwrap_or("");
+                if delta.is_empty() {
+                    return;
+                }
+                self.open_thinking(out);
+                out.push(ReduceEvent::ThinkingDelta(delta.to_string()));
+            }
+            "response.output_text.delta" => {
+                let delta = v.get("delta").and_then(Value::as_str).unwrap_or("");
+                if delta.is_empty() {
+                    return;
+                }
+                self.open_text(out);
+                out.push(ReduceEvent::TextDelta(delta.to_string()));
+            }
+            "response.function_call_arguments.delta" => {
+                let Some(call_id) = self.resolve_call_id(v) else {
+                    return;
+                };
+                let delta = v.get("delta").and_then(Value::as_str).unwrap_or("");
+                self.ensure_tool(&call_id, "");
+                if let Some(tool) = self.tools.get_mut(&call_id) {
+                    tool.buf.push_str(delta);
+                }
+                // Stream deltas live only for the currently open Anthropic tool block.
+                if self.open == Open::Tool && self.open_tool.as_deref() == Some(call_id.as_str()) {
+                    // Keep buffering; flush happens on done so sanitize_read_args sees full JSON.
+                } else if self.open != Open::Tool && !matches!(self.open, Open::Thinking | Open::Text)
+                {
+                    self.open_tool_stream(&call_id, out);
+                }
+            }
+            "response.function_call_arguments.done" => {
+                let Some(call_id) = self.resolve_call_id(v) else {
+                    return;
+                };
+                self.ensure_tool(&call_id, "");
+                if let Some(tool) = self.tools.get_mut(&call_id) {
+                    if tool.buf.is_empty()
+                        && let Some(args) = v.get("arguments").and_then(Value::as_str)
+                    {
+                        tool.buf.push_str(args);
+                    }
+                }
+                // Prefer completing this call if it is the open one; otherwise leave buffered
+                // until its output_item.done or stream end.
+                if self.open_tool.as_deref() == Some(call_id.as_str()) || self.open != Open::Tool {
+                    self.open_tool_stream(&call_id, out);
+                    self.emit_tool_complete(&call_id, out);
+                    self.open = Open::None;
+                    self.open_tool = None;
+                }
+            }
+            "response.output_item.done" => {
+                let item = v.get("item").cloned().unwrap_or(Value::Null);
+                match item.get("type").and_then(Value::as_str) {
+                    Some("function_call") => {
+                        let call_id = item
+                            .get("call_id")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                            .or_else(|| {
+                                item.get("id")
+                                    .and_then(Value::as_str)
+                                    .and_then(|id| self.item_to_call.get(id).cloned())
+                            });
+                        let Some(call_id) = call_id else {
+                            return;
+                        };
+                        self.ensure_tool(&call_id, "");
+                        self.open_tool_stream(&call_id, out);
+                        self.emit_tool_complete(&call_id, out);
+                        self.open = Open::None;
+                        self.open_tool = None;
+                    }
+                    Some("message") => {
+                        if self.open == Open::Text {
+                            self.close_open(out);
+                        }
+                    }
+                    // Hosted / reasoning done must not close an open function tool.
+                    Some("custom_tool_call")
+                    | Some("web_search_call")
+                    | Some("reasoning")
+                    | None => {}
+                    _ => {}
+                }
+            }
+            "response.completed" | "response.done" => {
+                self.finish_terminal(v, false, out);
+            }
+            "response.incomplete" => {
+                self.finish_terminal(v, true, out);
+            }
+            "response.failed" | "response.error" | "error" => {
+                self.terminal_seen = true;
+                out.push(ReduceEvent::Error {
+                    message: error_message(v),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    fn finish_terminal(&mut self, v: &Value, incomplete: bool, out: &mut Vec<ReduceEvent>) {
+        if self.terminal_seen {
+            return;
+        }
+        self.close_open(out);
+        self.emit_remaining_tools(out);
+        let stop_reason = if incomplete {
+            StopReason::MaxTokens
+        } else if self.saw_tool_use {
+            StopReason::ToolUse
+        } else {
+            StopReason::EndTurn
+        };
+        let usage = v
+            .get("response")
+            .and_then(|r| r.get("usage"))
+            .or_else(|| v.get("usage"))
+            .map(map_usage)
+            .unwrap_or_default();
+        self.terminal_seen = true;
+        out.push(ReduceEvent::Finish {
+            stop_reason,
+            usage,
+            response_id: v
+                .get("response")
+                .and_then(|r| r.get("id"))
+                .and_then(|i| i.as_str())
+                .map(|s| s.to_string())
+                .or_else(|| v.get("id").and_then(|i| i.as_str()).map(|s| s.to_string())),
+            continuation_eligible: false,
+        });
+    }
+}
+
+fn error_message(v: &Value) -> String {
+    v.get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            v.get("response")
+                .and_then(|r| r.get("error"))
+                .and_then(|e| e.get("message"))
+                .and_then(Value::as_str)
+        })
+        .or_else(|| v.get("message").and_then(Value::as_str))
+        .unwrap_or("upstream error")
+        .to_string()
+}
+
+fn map_usage(u: &Value) -> Usage {
+    let input_tokens = u.get("input_tokens").and_then(Value::as_i64).unwrap_or(0);
+    let cached = u
+        .get("input_tokens_details")
+        .and_then(|d| d.get("cached_tokens"))
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let output = u.get("output_tokens").and_then(Value::as_i64).unwrap_or(0);
+    Usage {
+        input: (input_tokens - cached).max(0),
+        output,
+        cache_read: cached,
+        cache_write: 0,
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_becomes_instructions() {
+        let body = build_request_body(
+            &json!({ "system": "Be concise.", "messages": [] }),
+            "grok-4.5",
+            None,
+        )
+        .expect("build");
+        assert!(
+            body["instructions"]
+                .as_str()
+                .unwrap()
+                .starts_with("Be concise.")
+        );
+        assert_eq!(body["model"], "grok-4.5");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["store"], false);
+    }
+
+    #[test]
+    fn tools_map_functions_and_web_search() {
+        let body = build_request_body(
+            &json!({
+                "messages": [],
+                "tools": [
+                    {
+                        "name": "Bash",
+                        "description": "run",
+                        "input_schema": { "type": "object", "properties": {} }
+                    },
+                    { "name": "WebSearch", "description": "search", "input_schema": {} }
+                ]
+            }),
+            "grok-4.5",
+            None,
+        )
+        .expect("build");
+        let tools = body["tools"].as_array().unwrap();
+        assert!(
+            tools
+                .iter()
+                .any(|t| t["type"] == "function" && t["name"] == "Bash")
+        );
+        assert!(tools.iter().any(|t| t["type"] == "web_search"));
+        // x_search is not auto-injected unless Claude Code offered XSearch.
+        assert!(!tools.iter().any(|t| t["type"] == "x_search"));
+    }
+
+    #[test]
+    fn assistant_tool_use_and_user_result_roundtrip() {
+        let body = build_request_body(
+            &json!({
+                "messages": [
+                    {"role":"user","content":"hi"},
+                    {"role":"assistant","content":[
+                        {"type":"tool_use","id":"call_1","name":"Bash","input":{"command":"ls"}}
+                    ]},
+                    {"role":"user","content":[
+                        {"type":"tool_result","tool_use_id":"call_1","content":"ok"}
+                    ]}
+                ]
+            }),
+            "grok-composer-2.5-fast",
+            None,
+        )
+        .expect("build");
+        let input = body["input"].as_array().unwrap();
+        assert!(
+            input
+                .iter()
+                .any(|i| i["type"] == "function_call" && i["call_id"] == "call_1")
+        );
+        assert!(
+            input
+                .iter()
+                .any(|i| i["type"] == "function_call_output" && i["output"] == "ok")
+        );
+    }
+
+    #[test]
+    fn headers_carry_grok_identity() {
+        let h = request_headers("tok", None, None);
+        assert!(
+            h.iter()
+                .any(|(k, v)| k == "authorization" && v == "Bearer tok")
+        );
+        assert!(
+            h.iter()
+                .any(|(k, v)| k == "x-xai-token-auth" && v == "xai-grok-cli")
+        );
+        assert!(
+            h.iter()
+                .any(|(k, v)| k == "x-grok-client-identifier" && v == "grok-shell")
+        );
+    }
+
+    #[test]
+    fn reducer_streams_text_and_tools() {
+        let mut r = Reducer::new("grok-4.5");
+        let chunk = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"Bash\"},\"output_index\":1}\n\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"call_id\":\"c1\",\"delta\":\"{\\\"command\\\":\\\"ls\\\"}\"}\n\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"call_id\":\"c1\",\"arguments\":\"{\\\"command\\\":\\\"ls\\\"}\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\"}}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":3}}}\n\n",
+        );
+        let events = r.push(chunk.as_bytes());
+        let finish = r.finish();
+        let all: Vec<_> = events.into_iter().chain(finish).collect();
+        assert!(all.iter().any(|e| matches!(e, ReduceEvent::TextStart)));
+        assert!(
+            all.iter()
+                .any(|e| matches!(e, ReduceEvent::TextDelta(s) if s == "hi"))
+        );
+        assert!(all.iter().any(
+            |e| matches!(e, ReduceEvent::ToolStart { id, name } if id == "c1" && name == "Bash")
+        ));
+        assert!(
+            all.iter()
+                .any(|e| matches!(e, ReduceEvent::Finish { stop_reason, .. } if *stop_reason == StopReason::ToolUse))
+        );
+    }
+
+    #[test]
+    fn reducer_maps_reasoning_to_thinking() {
+        let mut r = Reducer::new("grok-4.5");
+        let chunk = concat!(
+            "data: {\"type\":\"response.reasoning_text.delta\",\"delta\":\"hmm\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{}}}\n\n",
+        );
+        let events = r.push(chunk.as_bytes());
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ReduceEvent::ThinkingDelta(s) if s == "hmm"))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ReduceEvent::TextDelta(s) if s == "ok"))
+        );
+    }
+
+    #[test]
+    fn reducer_buffers_interleaved_tool_args_by_call_id() {
+        let mut r = Reducer::new("grok-4.5");
+        // Two function calls; argument deltas arrive interleaved without output_index.
+        let chunk = concat!(
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"Bash\",\"id\":\"item_1\"}}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"call_id\":\"c2\",\"name\":\"Read\",\"id\":\"item_2\"}}\n\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"call_id\":\"c2\",\"delta\":\"{\\\"file\\\"\"}\n\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"call_id\":\"c1\",\"delta\":\"{\\\"command\\\":\\\"ls\\\"}\"}\n\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"call_id\":\"c2\",\"delta\":\":\\\"a.rs\\\"}\"}\n\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"call_id\":\"c1\",\"arguments\":\"{\\\"command\\\":\\\"ls\\\"}\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\"}}\n\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"call_id\":\"c2\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"call_id\":\"c2\"}}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"web_search_call\"}}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n",
+        );
+        let events: Vec<_> = r.push(chunk.as_bytes()).into_iter().chain(r.finish()).collect();
+        let starts: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                ReduceEvent::ToolStart { id, name } => Some((id.as_str(), name.as_str())),
+                _ => None,
+            })
+            .collect();
+        assert!(starts.contains(&("c1", "Bash")), "starts={starts:?}");
+        assert!(starts.contains(&("c2", "Read")), "starts={starts:?}");
+        assert!(
+            events.iter().any(
+                |e| matches!(e, ReduceEvent::ToolDelta(s) if s.contains("command") && s.contains("ls"))
+            ),
+            "c1 args present: {events:?}"
+        );
+        assert!(
+            events.iter().any(
+                |e| matches!(e, ReduceEvent::ToolDelta(s) if s.contains("file") && s.contains("a.rs"))
+            ),
+            "c2 args present: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, ReduceEvent::Finish { stop_reason, .. } if *stop_reason == StopReason::ToolUse))
+        );
+    }
+
+    #[test]
+    fn user_image_becomes_placeholder() {
+        let body = build_request_body(
+            &json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "see"},
+                        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "xx"}}
+                    ]
+                }]
+            }),
+            "grok-4.5",
+            None,
+        )
+        .expect("build");
+        let input = body["input"].as_array().unwrap();
+        let text = serde_json::to_string(input).unwrap();
+        assert!(text.contains("[image omitted]"), "{text}");
+    }
+}

--- a/crates/llmtrim-cli/src/reroute/grok.rs
+++ b/crates/llmtrim-cli/src/reroute/grok.rs
@@ -502,12 +502,11 @@ impl Reducer {
                     stopped: false,
                 },
             );
-        } else if !name.is_empty() {
-            if let Some(t) = self.tools.get_mut(call_id) {
-                if t.name.is_empty() {
-                    t.name = name.to_string();
-                }
-            }
+        } else if !name.is_empty()
+            && let Some(t) = self.tools.get_mut(call_id)
+            && t.name.is_empty()
+        {
+            t.name = name.to_string();
         }
     }
 
@@ -635,12 +634,11 @@ impl Reducer {
                     return;
                 };
                 self.ensure_tool(&call_id, "");
-                if let Some(tool) = self.tools.get_mut(&call_id) {
-                    if tool.buf.is_empty()
-                        && let Some(args) = v.get("arguments").and_then(Value::as_str)
-                    {
-                        tool.buf.push_str(args);
-                    }
+                if let Some(tool) = self.tools.get_mut(&call_id)
+                    && tool.buf.is_empty()
+                    && let Some(args) = v.get("arguments").and_then(Value::as_str)
+                {
+                    tool.buf.push_str(args);
                 }
                 // Prefer completing this call if it is the open one; otherwise leave buffered
                 // until its output_item.done or stream end.

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -1,22 +1,23 @@
 //! Subscription reroute: send intercepted Anthropic `/v1/messages` traffic to a *different*
-//! subscription's backend (ChatGPT/Codex or Kimi) instead of Anthropic, translating the request
-//! and streamed response between wire shapes.
+//! subscription's backend (ChatGPT/Codex, Kimi, or Grok) instead of Anthropic, translating the
+//! request and streamed response between wire shapes.
 //!
-//! This is opt-in (`sub = "codex"|"kimi"` in the config, off by default) and rides the existing
-//! MITM path: [`crate::serve`] rewrites the intercepted request's URI authority to the provider
-//! host and swaps in the translated body + provider auth, so hudsucker forwards it over the same
-//! client and `handle_response` streams the translated reply back. Nothing here opens its own
-//! socket except the one-time OAuth flows in [`auth`].
+//! This is opt-in (`sub = "codex"|"kimi"|"grok"` in the config, off by default) and rides the
+//! existing MITM path: [`crate::serve`] rewrites the intercepted request's URI authority to the
+//! provider host and swaps in the translated body + provider auth, so hudsucker forwards it over
+//! the same client and `handle_response` streams the translated reply back. Nothing here opens its
+//! own socket except the one-time OAuth flows in [`auth`].
 //!
-//! **Terms of service:** driving a ChatGPT/Kimi *subscription* through a non-official client is a
-//! gray area and can get that account restricted. Reroute is off by default and the `auth login`
-//! commands print this warning. Use at your own risk.
+//! **Terms of service:** driving a ChatGPT/Kimi/Grok *subscription* through a non-official client
+//! is a gray area and can get that account restricted. Reroute is off by default and the
+//! `auth login` commands print this warning. Use at your own risk.
 
 pub mod auth;
 pub mod catalog;
 pub mod codex;
 pub mod context_limit;
 pub mod continuation;
+pub mod grok;
 pub mod kimi;
 pub mod read_rewrite;
 pub mod sse;
@@ -86,6 +87,11 @@ pub(crate) fn build_upstream_for_model(
             let h = kimi::request_headers(&token.access, token.account_id.as_deref(), session_id);
             (kimi::HOST, kimi::PATH, serde_json::to_vec(&b)?, h)
         }
+        SubProvider::Grok => {
+            let b = grok::build_request_body(anthropic_body, &model, session_id)?;
+            let h = grok::request_headers(&token.access, token.account_id.as_deref(), session_id);
+            (grok::HOST, grok::PATH, serde_json::to_vec(&b)?, h)
+        }
     };
     Ok(UpstreamRewrite {
         host: host.to_string(),
@@ -102,6 +108,7 @@ pub(crate) fn build_upstream_for_model(
 pub enum StreamReducer {
     Codex(codex::Reducer),
     Kimi(kimi::Reducer),
+    Grok(grok::Reducer),
 }
 
 impl StreamReducer {
@@ -109,6 +116,7 @@ impl StreamReducer {
         match provider {
             SubProvider::Codex => StreamReducer::Codex(codex::Reducer::new(model)),
             SubProvider::Kimi => StreamReducer::Kimi(kimi::Reducer::new(model)),
+            SubProvider::Grok => StreamReducer::Grok(grok::Reducer::new(model)),
         }
     }
 
@@ -116,6 +124,7 @@ impl StreamReducer {
         match self {
             StreamReducer::Codex(r) => r.push(chunk),
             StreamReducer::Kimi(r) => r.push(chunk),
+            StreamReducer::Grok(r) => r.push(chunk),
         }
     }
 
@@ -123,16 +132,17 @@ impl StreamReducer {
         match self {
             StreamReducer::Codex(r) => r.finish(),
             StreamReducer::Kimi(r) => r.finish(),
+            StreamReducer::Grok(r) => r.finish(),
         }
     }
 
     /// For Codex continuation: take the assistant output items (text + function calls)
     /// accumulated during reduction for this turn, to append to the transcript for next-turn
-    /// delta detection. Safe no-op for Kimi.
+    /// delta detection. Safe no-op for Kimi/Grok.
     pub fn take_codex_output_items(&mut self) -> Vec<Value> {
         match self {
             StreamReducer::Codex(r) => r.take_output_items(),
-            StreamReducer::Kimi(_) => vec![],
+            StreamReducer::Kimi(_) | StreamReducer::Grok(_) => vec![],
         }
     }
 }
@@ -194,6 +204,7 @@ fn count_text_tokens(text: &str, model: Option<&str>) -> i64 {
 pub enum SubProvider {
     Codex,
     Kimi,
+    Grok,
 }
 
 impl SubProvider {
@@ -203,6 +214,7 @@ impl SubProvider {
         match s.trim().to_ascii_lowercase().as_str() {
             "codex" | "chatgpt" | "openai" => Some(SubProvider::Codex),
             "kimi" | "moonshot" => Some(SubProvider::Kimi),
+            "grok" | "xai" | "x-ai" => Some(SubProvider::Grok),
             _ => None,
         }
     }
@@ -211,6 +223,7 @@ impl SubProvider {
         match self {
             SubProvider::Codex => "codex",
             SubProvider::Kimi => "kimi",
+            SubProvider::Grok => "grok",
         }
     }
 }
@@ -272,8 +285,20 @@ pub fn default_codex_tier_model(tier: Tier) -> &'static str {
     }
 }
 
+/// Built-in Grok tier preset: flagship for heavy tiers, composer-fast for Haiku (background
+/// title/token calls).
+pub fn default_grok_tier_model(tier: Tier) -> &'static str {
+    match tier {
+        Tier::Opus | Tier::Sonnet | Tier::Fable => "grok-4.5",
+        Tier::Haiku => "grok-composer-2.5-fast",
+    }
+}
+
 /// Kimi exposes a single wire model; every tier and alias collapses to it.
 pub const KIMI_MODEL: &str = "kimi-for-coding";
+
+/// Grok models the CLI subscription endpoint accepts.
+pub const GROK_MODELS: [&str; 2] = ["grok-4.5", "grok-composer-2.5-fast"];
 
 /// Resolve the incoming Anthropic model id to the upstream provider model for `provider`, applying
 /// (in order): an exact-id override, then the tier's override, then the preset default. `overrides`
@@ -287,31 +312,64 @@ pub fn resolve_model(
     incoming: &str,
     overrides: &std::collections::BTreeMap<String, String>,
 ) -> String {
-    let (base, _fast) = normalize_incoming(incoming);
+    let (base, fast) = normalize_incoming(incoming);
+    // Codex uses a trailing `-fast` as a service-tier hint. Grok model ids include it literally
+    // (`grok-composer-2.5-fast`), so reattach it for Grok before any lookup/passthrough.
+    let base = if provider == SubProvider::Grok && fast {
+        format!("{base}-fast")
+    } else {
+        base
+    };
     if provider == SubProvider::Kimi {
         return KIMI_MODEL.to_string();
     }
     let key = base.to_ascii_lowercase();
-    // 1. Exact-id override.
-    if let Some(m) = overrides.get(&key) {
+    // 1. Exact-id override (only if it is a model this provider can actually serve — a window
+    //    `/sub on grok` with global `sub = codex` must not apply `opus = "gpt-5.6-terra"`).
+    if let Some(m) = overrides.get(&key)
+        && model_ok_for(provider, m)
+    {
         return m.clone();
     }
     // 2. Tier override, then preset default.
     if let Some(tier) = classify_tier(&base) {
-        if let Some(m) = overrides.get(tier.as_str()) {
+        if let Some(m) = overrides.get(tier.as_str())
+            && model_ok_for(provider, m)
+        {
             return m.clone();
         }
-        return default_codex_tier_model(tier).to_string();
+        return match provider {
+            SubProvider::Codex => default_codex_tier_model(tier).to_string(),
+            SubProvider::Grok => default_grok_tier_model(tier).to_string(),
+            SubProvider::Kimi => KIMI_MODEL.to_string(),
+        };
     }
-    // 3. Not a Claude tier: if it already looks like a Codex model, pass it through; otherwise fall
-    //    back to the sonnet tier (conservative, always-works default).
-    if is_codex_model(&base) {
-        return base;
+    // 3. Not a Claude tier: pass through known provider ids; otherwise fall back to sonnet.
+    match provider {
+        SubProvider::Codex if is_codex_model(&base) => base,
+        SubProvider::Grok if is_grok_model(&base) => base,
+        SubProvider::Codex => overrides
+            .get(Tier::Sonnet.as_str())
+            .filter(|m| model_ok_for(SubProvider::Codex, m))
+            .cloned()
+            .unwrap_or_else(|| default_codex_tier_model(Tier::Sonnet).to_string()),
+        SubProvider::Grok => overrides
+            .get(Tier::Sonnet.as_str())
+            .filter(|m| model_ok_for(SubProvider::Grok, m))
+            .cloned()
+            .unwrap_or_else(|| default_grok_tier_model(Tier::Sonnet).to_string()),
+        SubProvider::Kimi => KIMI_MODEL.to_string(),
     }
-    overrides
-        .get(Tier::Sonnet.as_str())
-        .cloned()
-        .unwrap_or_else(|| default_codex_tier_model(Tier::Sonnet).to_string())
+}
+
+/// Whether `model` is a wire id the given subscription backend can accept. Foreign ids (Codex
+/// models under a Grok window override, etc.) are rejected so the tier preset fills in instead.
+fn model_ok_for(provider: SubProvider, model: &str) -> bool {
+    match provider {
+        SubProvider::Codex => is_codex_model(model),
+        SubProvider::Grok => is_grok_model(model),
+        SubProvider::Kimi => model == KIMI_MODEL || model.starts_with("kimi"),
+    }
 }
 
 /// System text blocks beginning with this marker are Claude Code billing metadata smuggled as a
@@ -359,6 +417,11 @@ pub const CODEX_MODELS: [&str; 9] = [
 fn is_codex_model(m: &str) -> bool {
     let m = m.to_ascii_lowercase();
     CODEX_MODELS.contains(&m.as_str()) || m.starts_with("gpt-")
+}
+
+fn is_grok_model(m: &str) -> bool {
+    let m = m.to_ascii_lowercase();
+    GROK_MODELS.contains(&m.as_str()) || m.starts_with("grok-")
 }
 
 /// Strip Claude Code's local `[1m]` context-window hint and a trailing `-fast` service-tier
@@ -458,6 +521,68 @@ mod tests {
             KIMI_MODEL
         );
         assert_eq!(resolve_model(SubProvider::Kimi, "gpt-5.5", &ov), KIMI_MODEL);
+    }
+
+    #[test]
+    fn default_grok_preset_maps_tiers() {
+        let ov = BTreeMap::new();
+        assert_eq!(
+            resolve_model(SubProvider::Grok, "claude-opus-4-8", &ov),
+            "grok-4.5"
+        );
+        assert_eq!(
+            resolve_model(SubProvider::Grok, "sonnet", &ov),
+            "grok-4.5"
+        );
+        assert_eq!(
+            resolve_model(SubProvider::Grok, "haiku", &ov),
+            "grok-composer-2.5-fast"
+        );
+        assert_eq!(
+            resolve_model(SubProvider::Grok, "grok-composer-2.5-fast", &ov),
+            "grok-composer-2.5-fast"
+        );
+    }
+
+    #[test]
+    fn parse_accepts_grok_aliases() {
+        assert_eq!(SubProvider::parse("grok"), Some(SubProvider::Grok));
+        assert_eq!(SubProvider::parse("xai"), Some(SubProvider::Grok));
+        assert_eq!(SubProvider::as_str(SubProvider::Grok), "grok");
+    }
+
+    #[test]
+    fn grok_ignores_codex_tier_overrides() {
+        // Global `sub on codex` writes opus→gpt-5.6-terra; a window `/sub on grok` must not
+        // forward that Codex model id to the Grok backend.
+        let mut ov = BTreeMap::new();
+        ov.insert("opus".to_string(), "gpt-5.6-terra".to_string());
+        ov.insert("sonnet".to_string(), "gpt-5.6-luna".to_string());
+        ov.insert("haiku".to_string(), "gpt-5.4-mini".to_string());
+        assert_eq!(
+            resolve_model(SubProvider::Grok, "claude-opus-4-8", &ov),
+            "grok-4.5"
+        );
+        assert_eq!(
+            resolve_model(SubProvider::Grok, "haiku", &ov),
+            "grok-composer-2.5-fast"
+        );
+        // A legitimate Grok override still wins.
+        ov.insert("opus".to_string(), "grok-4.5".to_string());
+        assert_eq!(
+            resolve_model(SubProvider::Grok, "claude-opus-4-8", &ov),
+            "grok-4.5"
+        );
+    }
+
+    #[test]
+    fn codex_ignores_grok_tier_overrides() {
+        let mut ov = BTreeMap::new();
+        ov.insert("opus".to_string(), "grok-4.5".to_string());
+        assert_eq!(
+            resolve_model(SubProvider::Codex, "claude-opus-4-8", &ov),
+            "gpt-5.6-terra"
+        );
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -103,8 +103,9 @@ pub(crate) fn build_upstream_for_model(
     })
 }
 
-/// Provider-dispatching wrapper over the two [`sse`] reducers, so [`crate::serve`] can hold one
+/// Provider-dispatching wrapper over the provider reducers, so [`crate::serve`] can hold one
 /// reducer regardless of provider and stream the translated Anthropic SSE incrementally.
+#[non_exhaustive]
 pub enum StreamReducer {
     Codex(codex::Reducer),
     Kimi(kimi::Reducer),
@@ -201,6 +202,7 @@ fn count_text_tokens(text: &str, model: Option<&str>) -> i64 {
 
 /// Which subscription backend intercepted Anthropic traffic is rerouted to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SubProvider {
     Codex,
     Kimi,

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -532,10 +532,7 @@ mod tests {
             resolve_model(SubProvider::Grok, "claude-opus-4-8", &ov),
             "grok-4.5"
         );
-        assert_eq!(
-            resolve_model(SubProvider::Grok, "sonnet", &ov),
-            "grok-4.5"
-        );
+        assert_eq!(resolve_model(SubProvider::Grok, "sonnet", &ov), "grok-4.5");
         assert_eq!(
             resolve_model(SubProvider::Grok, "haiku", &ov),
             "grok-composer-2.5-fast"

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -15,6 +15,7 @@
 pub mod auth;
 pub mod catalog;
 pub mod codex;
+pub mod context_limit;
 pub mod continuation;
 pub mod kimi;
 pub mod read_rewrite;

--- a/crates/llmtrim-cli/src/reroute/tui.rs
+++ b/crates/llmtrim-cli/src/reroute/tui.rs
@@ -54,15 +54,23 @@ impl App {
     fn new(provider: SubProvider) -> Self {
         let tiers = Tier::ALL;
         let catalog = catalog::models_for(provider);
-        // Seed each tier from the current config override, else the built-in preset default.
+        // Seed from *this* provider's table — not RuntimeConfig::sub_tiers (active provider only).
+        // Global `sub = codex` must not seed `llmtrim sub setup grok` with gpt-5.6-* ids.
         let rc = llmtrim_core::config::RuntimeConfig::get();
-        let overrides = &rc.sub_tiers;
+        let overrides = llmtrim_core::config::sub_tiers_for(provider.as_str());
+        let in_catalog = |id: &str| catalog.iter().any(|e| e.id == id);
         let chosen = tiers.map(|t| match provider {
             SubProvider::Kimi => super::KIMI_MODEL.to_string(),
             SubProvider::Codex => overrides
                 .get(t.as_str())
+                .filter(|m| in_catalog(m) || m.starts_with("gpt-"))
                 .cloned()
                 .unwrap_or_else(|| default_codex_tier_model(t).to_string()),
+            SubProvider::Grok => overrides
+                .get(t.as_str())
+                .filter(|m| in_catalog(m) || m.starts_with("grok-"))
+                .cloned()
+                .unwrap_or_else(|| super::default_grok_tier_model(t).to_string()),
         });
         Self {
             provider,

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1757,12 +1757,8 @@ mod imp {
             let mut compact_candidates = crate::compact::detect(&anthropic)
                 .filter(|_| !self.compact_models.is_empty())
                 .map(|original| {
-                    crate::compact::plan(
-                        &self.compact_models,
-                        &original,
-                        Some(sub),
-                        &self.sub_tiers,
-                    )
+                    let tiers = llmtrim_core::config::sub_tiers_for(sub.as_str());
+                    crate::compact::plan(&self.compact_models, &original, Some(sub), &tiers)
                 })
                 .unwrap_or_default();
             let max_tokens = anthropic
@@ -1873,11 +1869,15 @@ mod imp {
                 Err(_) => return anthropic_error(500, "llmtrim: auth task failed").into(),
             };
 
+            // Tiers must match the provider actually serving this turn. A window `/sub on grok`
+            // with global `sub = codex` must use `[sub.grok.tiers]` (or Grok defaults), not the
+            // Codex mapping snapshotted into `self.sub_tiers` at daemon start.
+            let tiers = llmtrim_core::config::sub_tiers_for(sub.as_str());
             let rewrite = match crate::reroute::build_upstream_for_model(
                 sub,
                 &translate_value,
                 compact_current.as_ref().map(|c| c.logical_model.as_str()),
-                &self.sub_tiers,
+                &tiers,
                 &token,
                 session_id.as_deref(),
             ) {
@@ -2627,11 +2627,12 @@ mod imp {
                     .await
                     .map_err(|_| "auth task failed".to_string())?
                     .map_err(|e| format!("not authenticated ({e})"))?;
+            let tiers = llmtrim_core::config::sub_tiers_for(provider.as_str());
             let rewrite = crate::reroute::build_upstream_for_model(
                 provider,
                 anthropic,
                 logical_model,
-                &self.sub_tiers,
+                &tiers,
                 &token,
                 session_id,
             )

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -414,6 +414,10 @@ mod imp {
         logical_body: Option<Value>,
         /// The CC session id (x-claude-code-session-id), used as key for continuation state.
         session_id: Option<String>,
+        /// Anthropic-shaped body that was forwarded this turn (post-compress). On a successful
+        /// acceptance it becomes the session's last-known-good snapshot for the context-limit
+        /// guard; never recorded when the backend rejects before any output is exposed.
+        anthropic_snapshot: Option<Value>,
     }
 
     /// Enough of the rewritten upstream request to re-issue it on a retryable failure. The body is
@@ -703,14 +707,36 @@ mod imp {
     /// client input error (400); an explicit rate/usage limit is 429; anything else is treated as a
     /// bad gateway (502).
     fn reroute_stream_error_status(message: &str) -> u16 {
-        let m = message.to_lowercase();
-        if m.contains("context") && (m.contains("window") || m.contains("length")) {
+        if crate::reroute::context_limit::is_context_limit_text(message) {
             400
-        } else if m.contains("rate limit") || m.contains("usage limit") {
-            429
         } else {
-            502
+            let m = message.to_lowercase();
+            if m.contains("rate limit") || m.contains("usage limit") {
+                429
+            } else {
+                502
+            }
         }
+    }
+
+    /// Local Anthropic error returned when a subscription backend hits a context-window limit
+    /// (or when the session is already blocked pending `/compact`). Never retries or compresses.
+    fn context_limit_guard_response(
+        pending: Option<Pending>,
+        ledger: &Sender<Record>,
+        breakdown: &Sender<BreakdownPayload>,
+    ) -> Response<Body> {
+        let message = crate::reroute::context_limit::GUARD_MESSAGE;
+        if let Some(pending) = pending {
+            let acc = Arc::new(Mutex::new(message.as_bytes().to_vec()));
+            let _finalize = Finalize {
+                acc,
+                pending: Some(pending),
+                ledger: ledger.clone(),
+                breakdown_ledger: breakdown.clone(),
+            };
+        }
+        anthropic_error_typed(400, "invalid_request_error", message, None)
     }
 
     /// Statuses worth re-issuing against the subscription backend: transient server/overload
@@ -1623,13 +1649,37 @@ mod imp {
                 return anthropic_error(400, "llmtrim: could not read request body").into();
             };
             let bytes = collected.to_bytes();
-            let Ok(anthropic) = std::str::from_utf8(&bytes)
+            let Ok(mut anthropic) = std::str::from_utf8(&bytes)
                 .ok()
                 .and_then(|t| serde_json::from_str::<serde_json::Value>(t).ok())
                 .ok_or(())
             else {
                 return anthropic_error(400, "llmtrim: request body is not JSON").into();
             };
+
+            // Session-scoped context-limit guard: while blocked, only a real Claude Code
+            // `/compact` (rewritten onto the last-known-good history) or a cleared session may
+            // proceed. Ordinary turns are rejected locally — no compress, no upstream call.
+            let is_compact = crate::compact::detect(&anthropic).is_some();
+            match crate::reroute::context_limit::gate_inbound(
+                session_id.as_deref(),
+                &mut anthropic,
+                is_compact,
+            ) {
+                crate::reroute::context_limit::InboundAction::Block => {
+                    return context_limit_guard_response(
+                        None,
+                        &self.ledger,
+                        &self.breakdown_ledger,
+                    )
+                    .into();
+                }
+                crate::reroute::context_limit::InboundAction::Allow { .. } => {}
+            }
+            // After a possible LKG rewrite, re-serialize so compact candidates and compression
+            // see the body we will actually forward.
+            let bytes =
+                Bytes::from(serde_json::to_vec(&anthropic).unwrap_or_else(|_| bytes.to_vec()));
 
             let client_model = anthropic
                 .get("model")
@@ -1799,6 +1849,8 @@ mod imp {
 
             // Record intent: provider stays Anthropic (we emit Anthropic SSE, which `Finalize`
             // measures); model is the resolved upstream model; `reroute` marks the response path.
+            // `anthropic_snapshot` is the Anthropic body actually translated (post-compress) so a
+            // successful acceptance can become the session's last-known-good history.
             self.pending = Some(Pending {
                 provider: ProviderKind::Anthropic,
                 model: Some(rewrite.model.clone()),
@@ -1823,6 +1875,7 @@ mod imp {
                     }),
                     logical_body,
                     session_id: session_id.clone(),
+                    anthropic_snapshot: Some(translate_value.clone()),
                 }),
                 fallback: None,
                 compact: compact_current.map(|_| CompactAttempt {
@@ -1893,6 +1946,19 @@ mod imp {
                     .unwrap_or_default();
                 let mut retry_after = reroute_retry_after_from_headers(&parts.headers, &cur_body);
 
+                // Context-window rejection: no retry, no compact-candidate chain, no compression
+                // replay. Mark the session blocked and return a local guard explanation. Only
+                // applies before any upstream output is exposed (HTTP error path is pre-output).
+                if crate::reroute::context_limit::is_context_limit_http(cur_status, &cur_body) {
+                    crate::reroute::continuation::clear_continuation(info.session_id.as_deref());
+                    crate::reroute::context_limit::mark_must_compact(info.session_id.as_deref());
+                    return context_limit_guard_response(
+                        Some(pending),
+                        &self.ledger,
+                        &self.breakdown_ledger,
+                    );
+                }
+
                 if pending.compact.is_some()
                     && compact_should_retry(cur_status)
                     && let Some(retried) = self.retry_compact_sub(pending.clone()).await
@@ -1948,6 +2014,20 @@ mod imp {
                         };
                         if (200..300).contains(&s) {
                             return self.finish_buffered_reroute(pending, &info, raw);
+                        }
+                        // A context-limit response on retry is terminal: do not keep re-issuing.
+                        if crate::reroute::context_limit::is_context_limit_http(s, &raw) {
+                            crate::reroute::continuation::clear_continuation(
+                                info.session_id.as_deref(),
+                            );
+                            crate::reroute::context_limit::mark_must_compact(
+                                info.session_id.as_deref(),
+                            );
+                            return context_limit_guard_response(
+                                Some(pending),
+                                &self.ledger,
+                                &self.breakdown_ledger,
+                            );
                         }
                         cur_status = s;
                         cur_body = raw;
@@ -2026,6 +2106,17 @@ mod imp {
             }
 
             if let Some(detail) = fatal {
+                // Pre-output stream error only (`committed` is still false). A context-limit
+                // rejection blocks the session; other errors keep the existing compact-retry path.
+                if crate::reroute::context_limit::is_context_limit_text(&detail) {
+                    crate::reroute::continuation::clear_continuation(info.session_id.as_deref());
+                    crate::reroute::context_limit::mark_must_compact(info.session_id.as_deref());
+                    return context_limit_guard_response(
+                        Some(pending),
+                        &self.ledger,
+                        &self.breakdown_ledger,
+                    );
+                }
                 if pending.compact.is_some()
                     && let Some(retried) = self.retry_compact_sub(pending.clone()).await
                 {
@@ -2045,6 +2136,12 @@ mod imp {
                     breakdown_ledger: self.breakdown_ledger.clone(),
                 };
                 return anthropic_error_typed(status, reroute_error_kind(status), &message, None);
+            }
+
+            // Backend accepted this turn (content committed, no pre-output fatal): refresh the
+            // last-known-good snapshot and clear any prior must_compact latch.
+            if let Some(snap) = info.anthropic_snapshot.as_ref() {
+                crate::reroute::context_limit::record_accepted(info.session_id.as_deref(), snap);
             }
 
             let acc = Arc::new(Mutex::new(Vec::<u8>::new()));
@@ -2231,31 +2328,57 @@ mod imp {
             info: &RerouteInfo,
             raw: Vec<u8>,
         ) -> Response<Body> {
-            use crate::reroute::sse::AnthropicSseEncoder;
+            use crate::reroute::sse::{AnthropicSseEncoder, ReduceEvent};
             let mut enc = AnthropicSseEncoder::new(&info.client_model);
             let mut out = String::new();
             let mut reducer = crate::reroute::StreamReducer::new(info.provider, &info.model);
-            for ev in reducer.push(&raw) {
-                record_codex_continuation(
-                    &ev,
-                    &mut reducer,
-                    info.provider,
-                    info.logical_body.as_ref(),
-                    info.session_id.as_deref(),
-                );
-                enc.encode(&ev, &mut out);
+            let mut events = Vec::new();
+            events.extend(reducer.push(&raw));
+            events.extend(reducer.finish());
+
+            // Mirror the live peek: if the first meaningful event is a context-limit error and
+            // nothing client-visible was committed, trip the guard instead of streaming.
+            let mut committed = false;
+            let mut pre_output_context_limit = false;
+            for ev in &events {
+                match ev {
+                    ReduceEvent::Error { message } if !committed => {
+                        if crate::reroute::context_limit::is_context_limit_text(message) {
+                            pre_output_context_limit = true;
+                        }
+                    }
+                    ReduceEvent::Finish { .. } => {}
+                    ReduceEvent::Error { .. } => {}
+                    _ => committed = true,
+                }
             }
-            for ev in reducer.finish() {
+            if pre_output_context_limit && !committed {
+                crate::reroute::continuation::clear_continuation(info.session_id.as_deref());
+                crate::reroute::context_limit::mark_must_compact(info.session_id.as_deref());
+                return context_limit_guard_response(
+                    Some(pending),
+                    &self.ledger,
+                    &self.breakdown_ledger,
+                );
+            }
+
+            for ev in &events {
                 record_codex_continuation(
-                    &ev,
+                    ev,
                     &mut reducer,
                     info.provider,
                     info.logical_body.as_ref(),
                     info.session_id.as_deref(),
                 );
-                enc.encode(&ev, &mut out);
+                enc.encode(ev, &mut out);
             }
             enc.finish_if_open(&mut out);
+
+            if committed
+                && let Some(snap) = info.anthropic_snapshot.as_ref()
+            {
+                crate::reroute::context_limit::record_accepted(info.session_id.as_deref(), snap);
+            }
 
             let acc = Arc::new(Mutex::new(out.clone().into_bytes()));
             let _finalize = Finalize {
@@ -2317,6 +2440,19 @@ mod imp {
                 {
                     Ok(attempt) => attempt,
                     Err(error) => {
+                        if crate::reroute::context_limit::is_context_limit_text(&error) {
+                            crate::reroute::continuation::clear_continuation(
+                                fb.session_id.as_deref(),
+                            );
+                            crate::reroute::context_limit::mark_must_compact(
+                                fb.session_id.as_deref(),
+                            );
+                            return context_limit_guard_response(
+                                Some(pending),
+                                &self.ledger,
+                                &self.breakdown_ledger,
+                            );
+                        }
                         failures.push(format!("{}: {error}", provider.as_str()));
                         continue;
                     }
@@ -2356,6 +2492,17 @@ mod imp {
                 }
                 if let Some(error) = stream_error {
                     crate::reroute::continuation::clear_continuation(fb.session_id.as_deref());
+                    // Context-limit on a fallback provider: block the session (same as always-sub).
+                    // Do not advance to the next provider — history will not fit them either, and
+                    // we must not expose partial output (none was committed: stream_error only).
+                    if crate::reroute::context_limit::is_context_limit_text(&error) {
+                        crate::reroute::context_limit::mark_must_compact(fb.session_id.as_deref());
+                        return context_limit_guard_response(
+                            Some(pending),
+                            &self.ledger,
+                            &self.breakdown_ledger,
+                        );
+                    }
                     failures.push(format!("{}: {error}", attempt.provider.as_str()));
                     continue;
                 }
@@ -2368,7 +2515,16 @@ mod imp {
                     replay: None,
                     logical_body: attempt.logical_body,
                     session_id: fb.session_id.clone(),
+                    anthropic_snapshot: Some(anthropic.clone()),
                 });
+                if let Some(info) = pending.reroute.as_ref()
+                    && let Some(snap) = info.anthropic_snapshot.as_ref()
+                {
+                    crate::reroute::context_limit::record_accepted(
+                        info.session_id.as_deref(),
+                        snap,
+                    );
+                }
                 let acc = Arc::new(Mutex::new(output.clone().into_bytes()));
                 let _finalize = Finalize {
                     acc,
@@ -2465,6 +2621,11 @@ mod imp {
                         logical_body,
                         body,
                     });
+                }
+                if crate::reroute::context_limit::is_context_limit_http(status, &body) {
+                    let snippet: String =
+                        String::from_utf8_lossy(&body).chars().take(300).collect();
+                    return Err(format!("HTTP {status}: {snippet}"));
                 }
                 if !reroute_should_retry(status) || attempt >= REROUTE_RETRY_MAX {
                     let snippet: String =
@@ -2609,6 +2770,7 @@ mod imp {
                     replay: None,
                     logical_body: attempt.logical_body,
                     session_id: state.session_id.clone(),
+                    anthropic_snapshot: Some(body),
                 });
                 let info = winner.reroute.clone().expect("reroute set above");
                 return Some(self.finish_buffered_reroute(winner, &info, attempt.body));
@@ -4152,6 +4314,157 @@ mod imp {
                 429
             );
             assert_eq!(reroute_stream_error_status("something else broke"), 502);
+        }
+
+        #[test]
+        fn context_limit_guard_response_is_local_and_actionable() {
+            let (tx, _rx) = std::sync::mpsc::channel();
+            let (btx, _brx) = std::sync::mpsc::channel();
+            let res = context_limit_guard_response(None, &tx, &btx);
+            assert_eq!(res.status().as_u16(), 400);
+            // Body is built synchronously; drain via try_into_data isn't available on Body here,
+            // so re-build the same payload the helper returns and check the shared message.
+            let message = crate::reroute::context_limit::GUARD_MESSAGE;
+            assert!(message.contains("Subscription context limit reached."));
+            assert!(message.contains("Run /compact"));
+            assert!(message.contains("/clear"));
+            assert!(message.contains("resend your last request"));
+            // The typed error kind matches a client input failure (not a retryable overload).
+            let body = serde_json::json!({
+                "type": "error",
+                "error": { "type": "invalid_request_error", "message": message },
+            })
+            .to_string();
+            assert!(body.contains("invalid_request_error"));
+        }
+
+        #[test]
+        fn context_limit_block_compact_resume_and_reset_session() {
+            // End-to-end of the session latch the serve path uses (without a live upstream).
+            let _lock = crate::reroute::context_limit::test_lock();
+            crate::reroute::context_limit::clear_all_for_tests();
+            let sid = Some("serve-sess-guard");
+            let good = serde_json::json!({
+                "model": "claude-opus-4-8",
+                "messages": [
+                    {"role": "user", "content": "a"},
+                    {"role": "assistant", "content": "b"},
+                    {"role": "user", "content": "c"},
+                    {"role": "assistant", "content": "d"}
+                ]
+            });
+            crate::reroute::context_limit::record_accepted(sid, &good);
+            assert!(!crate::reroute::context_limit::must_compact(sid));
+
+            // Pre-output rejection → block. Snapshot stays at last good (no rejected turn).
+            crate::reroute::context_limit::mark_must_compact(sid);
+            assert!(crate::reroute::context_limit::must_compact(sid));
+            assert_eq!(
+                crate::reroute::context_limit::last_good_message_count_for_tests(
+                    "serve-sess-guard"
+                ),
+                Some(4)
+            );
+
+            let mut ordinary = serde_json::json!({
+                "model": "claude-opus-4-8",
+                "messages": [
+                    {"role": "user", "content": "a"},
+                    {"role": "assistant", "content": "b"},
+                    {"role": "user", "content": "c"},
+                    {"role": "assistant", "content": "d"},
+                    {"role": "user", "content": "overflow"}
+                ]
+            });
+            assert_eq!(
+                crate::reroute::context_limit::gate_inbound(sid, &mut ordinary, false),
+                crate::reroute::context_limit::InboundAction::Block
+            );
+
+            // Real compact is rewritten onto the LKG history + summarization prompt.
+            let markers = format!(
+                "{}\n{}\n{}",
+                crate::compact::MARKERS[0],
+                crate::compact::MARKERS[1],
+                crate::compact::MARKERS[2]
+            );
+            let mut compact = serde_json::json!({
+                "model": "claude-opus-4-8",
+                "stream": true,
+                "max_tokens": 64000,
+                "output_config": {"effort": "low"},
+                "messages": [
+                    {"role": "user", "content": "overflow-history"},
+                    {"role": "user", "content": [{"type": "text", "text": markers}]}
+                ]
+            });
+            assert!(crate::compact::detect(&compact).is_some());
+            let action = crate::reroute::context_limit::gate_inbound(sid, &mut compact, true);
+            assert_eq!(
+                action,
+                crate::reroute::context_limit::InboundAction::Allow {
+                    rewrote_compact: true
+                }
+            );
+            assert_eq!(compact["messages"].as_array().unwrap().len(), 5);
+            assert_eq!(compact["messages"][0]["content"], "a");
+
+            // Successful compact clears the latch.
+            crate::reroute::context_limit::record_accepted(sid, &compact);
+            assert!(!crate::reroute::context_limit::must_compact(sid));
+
+            // A short request after re-blocking is treated as session reset (/clear).
+            crate::reroute::context_limit::mark_must_compact(sid);
+            let mut fresh = serde_json::json!({
+                "model": "claude-opus-4-8",
+                "messages": [{"role": "user", "content": "hi"}]
+            });
+            assert_eq!(
+                crate::reroute::context_limit::gate_inbound(sid, &mut fresh, false),
+                crate::reroute::context_limit::InboundAction::Allow {
+                    rewrote_compact: false
+                }
+            );
+            assert!(!crate::reroute::context_limit::must_compact(sid));
+            crate::reroute::context_limit::clear_all_for_tests();
+        }
+
+        #[test]
+        fn context_limit_never_replays_a_turn_after_output_would_commit() {
+            // Safety: record_accepted only on success; mark_must_compact never stores the
+            // rejected body. A turn that already emitted content is not the trigger path —
+            // only pre-output detections call mark_must_compact (asserted by code structure
+            // and the unit tests above: rejected turn is not last_good).
+            let _lock = crate::reroute::context_limit::test_lock();
+            crate::reroute::context_limit::clear_all_for_tests();
+            let sid = Some("serve-no-replay");
+            let accepted = serde_json::json!({
+                "messages": [
+                    {"role": "user", "content": "keep"},
+                    {"role": "assistant", "content": "this"}
+                ]
+            });
+            crate::reroute::context_limit::record_accepted(sid, &accepted);
+            // Simulate a rejected overflowing turn: only mark, never record_accepted.
+            crate::reroute::context_limit::mark_must_compact(sid);
+            assert_eq!(
+                crate::reroute::context_limit::last_good_message_count_for_tests("serve-no-replay"),
+                Some(2),
+                "rejected turn must not become the snapshot"
+            );
+            // After a later successful compact, snapshot updates and block clears.
+            let after = serde_json::json!({
+                "messages": [
+                    {"role": "user", "content": "summary only"}
+                ]
+            });
+            crate::reroute::context_limit::record_accepted(sid, &after);
+            assert!(!crate::reroute::context_limit::must_compact(sid));
+            assert_eq!(
+                crate::reroute::context_limit::last_good_message_count_for_tests("serve-no-replay"),
+                Some(1)
+            );
+            crate::reroute::context_limit::clear_all_for_tests();
         }
 
         /// `Accept: text/event-stream` is what the Anthropic SDK (so Claude Code) sends on a

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -325,7 +325,7 @@ mod imp {
         /// Per-source attribution of the forwarded request (breakdown view). `None` on bodies we
         /// couldn't attribute; never affects proxying.
         breakdown: Option<BreakdownPending>,
-        /// Set when this request was rerouted to a subscription backend (`sub = codex|kimi`): the
+        /// Set when this request was rerouted to a subscription backend (`sub = codex|kimi|grok`): the
         /// target provider + resolved upstream model. `handle_response` uses it to translate the
         /// provider's SSE back into Anthropic SSE. `provider` above is kept `Anthropic` so the
         /// output-usage parser and ledger see the Anthropic-shaped reply we emit to the client.
@@ -737,6 +737,44 @@ mod imp {
             };
         }
         anthropic_error_typed(400, "invalid_request_error", message, None)
+    }
+
+    /// After Anthropic (or a non-sub path) accepts a turn, clear any context-limit latch and
+    /// refresh the last-known-good snapshot when we still have the request body.
+    fn note_session_accepted(pending: &Pending) {
+        let session_id = pending
+            .fallback
+            .as_ref()
+            .and_then(|f| f.session_id.as_deref())
+            .or_else(|| {
+                pending
+                    .breakdown
+                    .as_ref()
+                    .and_then(|b| b.cc_session_id.as_deref())
+            })
+            .or_else(|| {
+                pending
+                    .compact
+                    .as_ref()
+                    .and_then(|c| c.session_id.as_deref())
+            });
+        if session_id.is_none() {
+            return;
+        }
+        // Prefer the full Anthropic body kept for fallback / original replay.
+        if let Some(fb) = pending.fallback.as_ref()
+            && let Ok(body) = serde_json::from_slice::<Value>(&fb.anthropic_body)
+        {
+            crate::reroute::context_limit::record_accepted(session_id, &body);
+            return;
+        }
+        if let Some(orig) = pending.original.as_ref()
+            && let Ok(body) = serde_json::from_slice::<Value>(&orig.body)
+        {
+            crate::reroute::context_limit::record_accepted(session_id, &body);
+            return;
+        }
+        crate::reroute::context_limit::clear_must_compact(session_id);
     }
 
     /// Statuses worth re-issuing against the subscription backend: transient server/overload
@@ -1218,7 +1256,7 @@ mod imp {
         /// forwarded verbatim (still intercepted, just not compressed).
         exclude_hosts: Arc<Vec<String>>,
         exclude_providers: Arc<Vec<String>>,
-        /// Subscription reroute target (`sub = codex|kimi`), snapshotted from [`RuntimeConfig`] at
+        /// Subscription reroute target (`sub = codex|kimi|grok`), snapshotted from [`RuntimeConfig`] at
         /// construction. `None` = normal transparent compress-and-forward. When set, intercepted
         /// Anthropic `/v1/messages` traffic is translated and sent to that subscription's backend.
         sub: Option<crate::reroute::SubProvider>,
@@ -1424,8 +1462,38 @@ mod imp {
                 Ok(c) => c.to_bytes(),
                 Err(_) => return Request::from_parts(parts, Body::empty()).into(),
             };
+            // Context-limit guard on the Anthropic path (fallback mode and any latched session).
+            // Always-sub is gated inside `reroute_messages`; this covers the compress+forward
+            // path so a blocked session cannot keep compressing/overflowing after a sub latch.
+            let mut bytes = bytes;
+            if provider == ProviderKind::Anthropic
+                && let Some(mut anthropic) = std::str::from_utf8(&bytes)
+                    .ok()
+                    .and_then(|t| serde_json::from_str::<Value>(t).ok())
+            {
+                let is_compact = crate::compact::detect(&anthropic).is_some();
+                match crate::reroute::context_limit::gate_inbound(
+                    cc_session_id.as_deref(),
+                    &mut anthropic,
+                    is_compact,
+                ) {
+                    crate::reroute::context_limit::InboundAction::Block => {
+                        return context_limit_guard_response(
+                            None,
+                            &self.ledger,
+                            &self.breakdown_ledger,
+                        )
+                        .into();
+                    }
+                    crate::reroute::context_limit::InboundAction::Allow { .. } => {
+                        if let Ok(serialized) = serde_json::to_vec(&anthropic) {
+                            bytes = Bytes::from(serialized);
+                        }
+                    }
+                }
+            }
             // Compact turns use an isolated candidate plan. Every attempt is rebuilt from these
-            // untouched client bytes; ordinary requests never enter this runtime-only path.
+            // (possibly LKG-rewritten) client bytes; ordinary requests never enter this path.
             let compact_plan = if provider == ProviderKind::Anthropic
                 && !self.compact_models.is_empty()
             {
@@ -2106,9 +2174,9 @@ mod imp {
             }
 
             if let Some(detail) = fatal {
-                // Pre-output stream error only (`committed` is still false). A context-limit
-                // rejection blocks the session; other errors keep the existing compact-retry path.
-                if crate::reroute::context_limit::is_context_limit_text(&detail) {
+                // Only latch when nothing client-visible was committed. A single chunk can yield
+                // content then Error; marking then would discard the prelude and force /compact.
+                if crate::reroute::context_limit::is_context_limit_text(&detail) && !committed {
                     crate::reroute::continuation::clear_continuation(info.session_id.as_deref());
                     crate::reroute::context_limit::mark_must_compact(info.session_id.as_deref());
                     return context_limit_guard_response(
@@ -2140,7 +2208,9 @@ mod imp {
 
             // Backend accepted this turn (content committed, no pre-output fatal): refresh the
             // last-known-good snapshot and clear any prior must_compact latch.
-            if let Some(snap) = info.anthropic_snapshot.as_ref() {
+            if committed
+                && let Some(snap) = info.anthropic_snapshot.as_ref()
+            {
                 crate::reroute::context_limit::record_accepted(info.session_id.as_deref(), snap);
             }
 
@@ -2462,46 +2532,43 @@ mod imp {
                 let mut encoder = AnthropicSseEncoder::new(&client_model);
                 let mut output = String::new();
                 let mut stream_error = None;
-                for event in reducer.push(&attempt.body) {
+                let mut committed = false;
+                let mut events = reducer.push(&attempt.body);
+                events.extend(reducer.finish());
+                for event in &events {
+                    match event {
+                        ReduceEvent::Error { message } if !committed => {
+                            stream_error = Some(message.clone());
+                        }
+                        ReduceEvent::Error { .. } | ReduceEvent::Finish { .. } => {}
+                        _ => committed = true,
+                    }
                     record_codex_continuation(
-                        &event,
+                        event,
                         &mut reducer,
                         attempt.provider,
                         attempt.logical_body.as_ref(),
                         fb.session_id.as_deref(),
                     );
-                    if let ReduceEvent::Error { message } = &event {
-                        stream_error = Some(message.clone());
-                    }
-                    encoder.encode(&event, &mut output);
-                }
-                if stream_error.is_none() {
-                    for event in reducer.finish() {
-                        record_codex_continuation(
-                            &event,
-                            &mut reducer,
-                            attempt.provider,
-                            attempt.logical_body.as_ref(),
-                            fb.session_id.as_deref(),
-                        );
-                        if let ReduceEvent::Error { message } = &event {
-                            stream_error = Some(message.clone());
-                        }
-                        encoder.encode(&event, &mut output);
-                    }
+                    encoder.encode(event, &mut output);
                 }
                 if let Some(error) = stream_error {
                     crate::reroute::continuation::clear_continuation(fb.session_id.as_deref());
-                    // Context-limit on a fallback provider: block the session (same as always-sub).
-                    // Do not advance to the next provider — history will not fit them either, and
-                    // we must not expose partial output (none was committed: stream_error only).
-                    if crate::reroute::context_limit::is_context_limit_text(&error) {
+                    // Pre-output context-limit only — never latch after client-visible content.
+                    if crate::reroute::context_limit::is_context_limit_text(&error) && !committed {
                         crate::reroute::context_limit::mark_must_compact(fb.session_id.as_deref());
                         return context_limit_guard_response(
                             Some(pending),
                             &self.ledger,
                             &self.breakdown_ledger,
                         );
+                    }
+                    // Content already committed: do not surface as a clean next-provider attempt
+                    // (partial answer may already be in `output`); treat as terminal for this
+                    // provider and continue the chain only when nothing was committed.
+                    if committed {
+                        failures.push(format!("{}: {error}", attempt.provider.as_str()));
+                        continue;
                     }
                     failures.push(format!("{}: {error}", attempt.provider.as_str()));
                     continue;
@@ -2680,6 +2747,7 @@ mod imp {
             }
             pending.input_after = pending.input_before;
             pending.output_shaped = false;
+            note_session_accepted(&pending);
             let _finalize = Finalize {
                 acc: Arc::new(Mutex::new(body.clone())),
                 pending: Some(pending),
@@ -2747,15 +2815,51 @@ mod imp {
                     .await
                 {
                     Ok(attempt) => attempt,
-                    Err(_) => continue,
+                    Err(error) => {
+                        // Context-limit is terminal for the compact chain: mark and stop (no more
+                        // candidates, no silent swallow of the overflow).
+                        if crate::reroute::context_limit::is_context_limit_text(&error) {
+                            crate::reroute::continuation::clear_continuation(
+                                state.session_id.as_deref(),
+                            );
+                            crate::reroute::context_limit::mark_must_compact(
+                                state.session_id.as_deref(),
+                            );
+                            return Some(context_limit_guard_response(
+                                Some(pending),
+                                &self.ledger,
+                                &self.breakdown_ledger,
+                            ));
+                        }
+                        continue;
+                    }
                 };
 
                 let mut reducer = crate::reroute::StreamReducer::new(provider, &attempt.model);
                 let mut events = reducer.push(&attempt.body);
                 events.extend(reducer.finish());
-                let committed = events
-                    .iter()
-                    .any(|event| !matches!(event, ReduceEvent::Error { .. }));
+                let mut committed = false;
+                let mut pre_output_ctx = false;
+                for event in &events {
+                    match event {
+                        ReduceEvent::Error { message } if !committed => {
+                            if crate::reroute::context_limit::is_context_limit_text(message) {
+                                pre_output_ctx = true;
+                            }
+                        }
+                        ReduceEvent::Error { .. } | ReduceEvent::Finish { .. } => {}
+                        _ => committed = true,
+                    }
+                }
+                if pre_output_ctx && !committed {
+                    crate::reroute::continuation::clear_continuation(state.session_id.as_deref());
+                    crate::reroute::context_limit::mark_must_compact(state.session_id.as_deref());
+                    return Some(context_limit_guard_response(
+                        Some(pending),
+                        &self.ledger,
+                        &self.breakdown_ledger,
+                    ));
+                }
                 if compact_precommit_error(&events) || !committed {
                     crate::reroute::continuation::clear_continuation(state.session_id.as_deref());
                     continue;
@@ -2835,6 +2939,9 @@ mod imp {
                     pending.model = Some(candidate.upstream_model.clone());
                     pending.compact = None;
                     let body = client_model_json(&fetched.2, &state.client_model);
+                    if (200..300).contains(&fetched.0) {
+                        note_session_accepted(&pending);
+                    }
                     let _finalize = Finalize {
                         acc: Arc::new(Mutex::new(body.clone())),
                         pending: Some(pending),
@@ -2998,6 +3105,11 @@ mod imp {
                 rec.output_shaped = Some(false);
                 let _ = self.ledger.send(rec);
                 return replayed;
+            }
+            // Anthropic accepted the turn (we are not failing over): clear any context-limit
+            // latch so a later always-sub flip does not block against a stale LKG.
+            if (200..300).contains(&status.as_u16()) {
+                note_session_accepted(&pending);
             }
             let is_sse = res
                 .headers()
@@ -3903,7 +4015,7 @@ mod imp {
                     && let Some(r) = raw
                 {
                     eprintln!(
-                        "llmtrim: unknown sub provider '{r}' — reroute disabled (expected codex|kimi)"
+                        "llmtrim: unknown sub provider '{r}' — reroute disabled (expected codex|kimi|grok)"
                     );
                 }
                 parsed
@@ -3918,7 +4030,7 @@ mod imp {
                             // Silently dropping it would leave a typo'd chain quietly shorter than
                             // the user configured — and the fallback they think they have missing.
                             eprintln!(
-                                "llmtrim: unknown provider '{p}' in the sub fallback chain — ignored (expected codex|kimi)"
+                                "llmtrim: unknown provider '{p}' in the sub fallback chain — ignored (expected codex|kimi|grok)"
                             );
                         }
                         parsed
@@ -4465,6 +4577,27 @@ mod imp {
                 Some(1)
             );
             crate::reroute::context_limit::clear_all_for_tests();
+        }
+
+        #[test]
+        fn context_limit_pre_output_decision_requires_no_content_commit() {
+            // Locks the live-path invariant: content then error must not latch.
+            use crate::reroute::context_limit::pre_output_context_limit;
+            assert!(pre_output_context_limit(&[(
+                false,
+                "Your input exceeds the context window of this model."
+            )]));
+            assert!(
+                !pre_output_context_limit(&[
+                    (true, ""),
+                    (false, "Your input exceeds the context window of this model."),
+                ]),
+                "content commit before error: do not mark must_compact"
+            );
+            assert!(!pre_output_context_limit(&[(
+                false,
+                "context deadline exceeded"
+            )]));
         }
 
         /// `Accept: text/event-stream` is what the Anthropic SDK (so Claude Code) sends on a

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -2208,9 +2208,7 @@ mod imp {
 
             // Backend accepted this turn (content committed, no pre-output fatal): refresh the
             // last-known-good snapshot and clear any prior must_compact latch.
-            if committed
-                && let Some(snap) = info.anthropic_snapshot.as_ref()
-            {
+            if committed && let Some(snap) = info.anthropic_snapshot.as_ref() {
                 crate::reroute::context_limit::record_accepted(info.session_id.as_deref(), snap);
             }
 
@@ -2444,9 +2442,7 @@ mod imp {
             }
             enc.finish_if_open(&mut out);
 
-            if committed
-                && let Some(snap) = info.anthropic_snapshot.as_ref()
-            {
+            if committed && let Some(snap) = info.anthropic_snapshot.as_ref() {
                 crate::reroute::context_limit::record_accepted(info.session_id.as_deref(), snap);
             }
 
@@ -4591,7 +4587,10 @@ mod imp {
             assert!(
                 !pre_output_context_limit(&[
                     (true, ""),
-                    (false, "Your input exceeds the context window of this model."),
+                    (
+                        false,
+                        "Your input exceeds the context window of this model."
+                    ),
                 ]),
                 "content commit before error: do not mark must_compact"
             );

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -68,6 +68,7 @@ const REFRESH_INTERVAL_SECS: i64 = 300;
 const BRAND: &str = "38;2;153;204;255"; // llmtrim accent blue
 const CYAN: &str = "36"; // codex
 const VIOLET: &str = "38;2;181;137;255"; // kimi
+const YELLOW: &str = "33"; // grok
 const GREEN: &str = "32";
 const AMBER: &str = "33";
 const ORANGE: &str = "38;2;255;140;0"; // true orange, distinct from amber quota tiers
@@ -282,7 +283,15 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
     let arrow = if matches!(window_intent, Some(crate::window_sub::Intent::Disabled)) {
         ArrowSource::None
     } else {
-        arrow_source(configured.as_deref(), cfg.sub_fallback, row.as_ref())
+        // A window `/sub on <provider>` always reroutes that window (see serve.rs), even when the
+        // global policy is `fallback`. Treat it as always-mode for the arrow so the status line
+        // shows `→grok` as soon as the user flips the override — not only after a sub turn lands.
+        let window_forces = matches!(
+            window_intent,
+            Some(crate::window_sub::Intent::Enabled { .. })
+        );
+        let effective_fallback = cfg.sub_fallback && !window_forces;
+        arrow_source(configured.as_deref(), effective_fallback, row.as_ref())
     };
     let (reroute, reroute_window, resolved_model) = match arrow {
         // Truth: the backend that answered the last turn, and the model recorded on it.
@@ -293,12 +302,16 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
             let shown = model.filter(|_| provider != "kimi");
             (Some(provider), window, shown)
         }
-        // Prediction (always mode, no turn yet): resolve from the configured tier mapping.
-        ArrowSource::Predicted(provider) => (
-            Some(provider.clone()),
-            reroute_real_window(&provider, &cc.model_id, &cfg.sub_tiers),
-            reroute_resolved_model(&provider, &cc.model_id, &cfg.sub_tiers),
-        ),
+        // Prediction (always mode, no turn yet / policy switch): resolve from *this* provider's
+        // tier table, not the global active one (window `/sub on grok` while global is codex).
+        ArrowSource::Predicted(provider) => {
+            let tiers = llmtrim_core::config::sub_tiers_for(&provider);
+            (
+                Some(provider.clone()),
+                reroute_real_window(&provider, &cc.model_id, &tiers),
+                reroute_resolved_model(&provider, &cc.model_id, &tiers),
+            )
+        }
         ArrowSource::None => (None, None, None),
     };
 
@@ -351,31 +364,46 @@ enum ArrowSource {
 
 /// Decide what the reroute arrow may claim.
 ///
-/// The ledger wins whenever it has a turn for this session, because only it knows who actually
-/// answered. Config is consulted solely to bridge the gap before the first turn lands, and only in
-/// `always` mode — where every turn reroutes, so the prediction is sound and the arrow doesn't have
-/// to blink in late on a fresh session.
-///
-/// In `fallback` mode config predicts nothing: the chain fires only when Anthropic actually fails.
-/// Claiming a reroute there would be a lie on every healthy turn (and would rescale the context
-/// gauge to the wrong backend's window), so the arrow stays off until the ledger shows a turn a
-/// backend really served.
+/// - When the ledger recorded a *subscription* backend on the last turn, that is ground truth
+///   (`Served`) — unless the operator has since switched the policy to a different provider
+///   (window `/sub on grok` after a codex turn), in which case we predict the new target so the
+///   line doesn't keep advertising a backend that will no longer answer.
+/// - When the last turn was Anthropic (`last_sub_provider` absent) or there is no row yet, config
+///   predicts in non-fallback mode: every future turn will reroute, so showing `→grok` after
+///   `/sub on grok` mid-session is correct even if earlier turns were Anthropic.
+/// - In pure `fallback` mode config predicts nothing: the chain fires only when Anthropic fails,
+///   and claiming a reroute on healthy turns would be a lie (and would rescale the gauge).
 fn arrow_source(
     configured: Option<&str>,
     fallback_mode: bool,
     row: Option<&SessionLedgerRow>,
 ) -> ArrowSource {
+    let predict = |p: &str| ArrowSource::Predicted(p.to_string());
     match row {
         Some(r) => match &r.last_sub_provider {
-            Some(provider) => ArrowSource::Served {
-                provider: provider.clone(),
-                model: r.last_model.clone(),
+            Some(provider) => {
+                // Policy switched under us (window override / global sub change): prefer the new
+                // target until a turn from that backend overwrites the ledger.
+                if let Some(p) = configured
+                    && !fallback_mode
+                    && p != provider.as_str()
+                {
+                    return predict(p);
+                }
+                ArrowSource::Served {
+                    provider: provider.clone(),
+                    model: r.last_model.clone(),
+                }
+            }
+            // Last turn was Anthropic. Still predict when policy says every turn will reroute
+            // (always mode or a window `/sub on` override treated as always).
+            None => match configured {
+                Some(p) if !fallback_mode => predict(p),
+                _ => ArrowSource::None,
             },
-            // A recorded turn that no backend served: Anthropic answered it.
-            None => ArrowSource::None,
         },
         None => match configured {
-            Some(p) if !fallback_mode => ArrowSource::Predicted(p.to_string()),
+            Some(p) if !fallback_mode => predict(p),
             _ => ArrowSource::None,
         },
     }
@@ -473,6 +501,7 @@ fn reroute_real_window(
     let sp = match provider {
         "codex" => SubProvider::Codex,
         "kimi" => SubProvider::Kimi,
+        "grok" => SubProvider::Grok,
         _ => return None,
     };
     upstream_window(&crate::reroute::resolve_model(sp, incoming_model_id, tiers))
@@ -505,8 +534,8 @@ fn reroute_real_window(
 }
 
 /// Parallel to [`reroute_real_window`]: returns the concrete upstream model id (e.g.
-/// "gpt-5.6-terra") chosen by tier mapping for the status line. `None` for Kimi, whose tiers all
-/// collapse to one internal wire id: the shortname is what a reader wants there.
+/// "gpt-5.6-terra" / "grok-4.5") chosen by tier mapping for the status line. `None` for Kimi,
+/// whose tiers all collapse to one internal wire id: the shortname is what a reader wants there.
 #[cfg(feature = "intercept")]
 fn reroute_resolved_model(
     provider: &str,
@@ -514,11 +543,13 @@ fn reroute_resolved_model(
     tiers: &std::collections::BTreeMap<String, String>,
 ) -> Option<String> {
     use crate::reroute::SubProvider;
-    if provider != "codex" {
-        return None;
-    }
+    let sp = match provider {
+        "codex" => SubProvider::Codex,
+        "grok" => SubProvider::Grok,
+        _ => return None,
+    };
     Some(crate::reroute::resolve_model(
-        SubProvider::Codex,
+        sp,
         incoming_model_id,
         tiers,
     ))
@@ -601,6 +632,7 @@ fn model_segment(cc: &CcInput, led: &Led, color: bool) -> String {
     if let (Health::Healthy, Some(p)) = (led.health, &led.reroute) {
         let code = match p.as_str() {
             "kimi" => VIOLET,
+            "grok" => YELLOW,
             _ => CYAN,
         };
         let tail = led.resolved_model.clone().unwrap_or_else(|| p.clone());
@@ -1381,6 +1413,17 @@ mod tests {
         );
     }
 
+    #[test]
+    fn grok_reroute_shows_resolved_model_when_healthy() {
+        let tiers = std::collections::BTreeMap::new();
+        let mut l = led(Health::Healthy);
+        l.reroute = Some("grok".to_string());
+        l.resolved_model = reroute_resolved_model("grok", "claude-opus-4-8", &tiers);
+        assert_eq!(l.resolved_model.as_deref(), Some("grok-4.5"));
+        let out = render_line(&cc(72_000), &l, 0, true);
+        assert!(out.contains("→grok-4.5"), "grok arrow shows model: {out}");
+    }
+
     fn ledger_row(sub: Option<&str>, model: Option<&str>) -> SessionLedgerRow {
         SessionLedgerRow {
             input_before: 1000,
@@ -1402,6 +1445,38 @@ mod tests {
             arrow_source(Some("codex"), true, Some(&row)),
             ArrowSource::None
         ));
+    }
+
+    #[test]
+    fn always_mode_predicts_after_anthropic_turns() {
+        // Mid-session `/sub on grok` (or global always): earlier Anthropic turns leave a ledger
+        // row with no sub provider. The next turn will reroute — show the prediction.
+        let row = ledger_row(None, Some("claude-opus-4-8"));
+        let ArrowSource::Predicted(p) = arrow_source(Some("grok"), false, Some(&row)) else {
+            panic!("always mode must predict after Anthropic-only history");
+        };
+        assert_eq!(p, "grok");
+    }
+
+    #[test]
+    fn always_mode_predicts_switched_provider_over_stale_served() {
+        // Window was on codex (ledger still says codex); user ran `/sub on grok`.
+        let row = ledger_row(Some("codex"), Some("gpt-5.6-terra"));
+        let ArrowSource::Predicted(p) = arrow_source(Some("grok"), false, Some(&row)) else {
+            panic!("switched provider must override stale Served");
+        };
+        assert_eq!(p, "grok");
+    }
+
+    #[test]
+    fn fallback_mode_keeps_stale_served_until_ledger_moves() {
+        // In fallback, a prior codex fire is still truth; config must not invent a new target.
+        let row = ledger_row(Some("codex"), Some("gpt-5.6-terra"));
+        let ArrowSource::Served { provider, .. } = arrow_source(Some("grok"), true, Some(&row))
+        else {
+            panic!("fallback keeps Served");
+        };
+        assert_eq!(provider, "codex");
     }
 
     #[test]
@@ -1430,14 +1505,16 @@ mod tests {
     }
 
     #[test]
-    fn ledger_truth_overrides_a_stale_config_prediction() {
-        // `sub` says kimi, but the last turn was actually served by codex — show what happened.
+    fn ledger_truth_wins_when_it_matches_policy() {
+        // Last turn was codex and policy still says codex: advertise what just served.
         let row = ledger_row(Some("codex"), Some("gpt-5.6-terra"));
-        let ArrowSource::Served { provider, .. } = arrow_source(Some("kimi"), false, Some(&row))
+        let ArrowSource::Served { provider, model } =
+            arrow_source(Some("codex"), false, Some(&row))
         else {
-            panic!("the ledger outranks config");
+            panic!("matching policy keeps Served");
         };
         assert_eq!(provider, "codex");
+        assert_eq!(model.as_deref(), Some("gpt-5.6-terra"));
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -548,11 +548,7 @@ fn reroute_resolved_model(
         "grok" => SubProvider::Grok,
         _ => return None,
     };
-    Some(crate::reroute::resolve_model(
-        sp,
-        incoming_model_id,
-        tiers,
-    ))
+    Some(crate::reroute::resolve_model(sp, incoming_model_id, tiers))
 }
 
 #[cfg(not(feature = "intercept"))]

--- a/crates/llmtrim-cli/src/window_sub.rs
+++ b/crates/llmtrim-cli/src/window_sub.rs
@@ -52,7 +52,7 @@ fn valid(value: &str) -> bool {
         && !value.contains("..")
 }
 fn valid_provider(value: &str) -> bool {
-    matches!(value, "codex" | "kimi")
+    matches!(value, "codex" | "kimi" | "grok")
 }
 
 pub fn registry_path() -> Result<PathBuf> {
@@ -238,7 +238,7 @@ pub fn set(session: &str, enabled: bool, provider: Option<&str>) -> Result<()> {
             .map(str::to_owned)
             .or_else(|| w.last_provider.clone())
             .context(
-                "no configured subscription provider; run llmtrim sub on codex or kimi first",
+                "no configured subscription provider; run llmtrim sub on codex, kimi, or grok first",
             )?;
         if !valid_provider(&p) {
             bail!("unsupported subscription provider");
@@ -276,6 +276,23 @@ pub fn status(session: &str) -> Result<Option<Intent>> {
     Ok(lookup(Some(session)))
 }
 
+/// Last provider this window successfully enabled, if any (used by bare `/sub on`).
+pub fn last_provider(session: &str) -> Option<String> {
+    if !valid(session) {
+        return None;
+    }
+    let path = registry_path().ok()?;
+    let _lock = lock_registry(&path).ok()?;
+    let r = load_at(&path).ok()?;
+    let token = r.sessions.get(session)?;
+    let window = r.windows.get(token)?;
+    let current = now();
+    if current.saturating_sub(window.touched) > TTL.as_secs() {
+        return None;
+    }
+    window.last_provider.clone()
+}
+
 #[cfg(unix)]
 fn quoted_exe(exe: &str) -> String {
     format!("'{}'", exe.replace('\'', "'\"'\"'"))
@@ -294,7 +311,22 @@ fn quoted_exe(exe: &str) -> String {
 pub fn command_markdown(exe: &str) -> String {
     let exe = quoted_exe(exe);
     format!(
-        "---\ndescription: Toggle llmtrim subscription rerouting for this Claude Code window only.\ndisable-model-invocation: true\nargument-hint: \"on|off|status\"\n---\n\n<!-- llmtrim-owned-window-sub -->\n!`{exe} window-sub slash \"$ARGUMENTS\" \"$CLAUDE_CODE_SESSION_ID\"`\n"
+        "---\n\
+         description: Toggle llmtrim subscription rerouting for this Claude Code window only.\n\
+         disable-model-invocation: true\n\
+         argument-hint: \"on [codex|kimi|grok]|off|status\"\n\
+         ---\n\
+         \n\
+         <!-- llmtrim-owned-window-sub -->\n\
+         Window-local subscription override (does not change other windows or the global\n\
+         `llmtrim sub` setting).\n\
+         \n\
+         - `/sub on` — enable using the last provider for this window, or the global `sub`\n\
+         - `/sub on codex` / `/sub on kimi` / `/sub on grok` — enable a specific provider\n\
+         - `/sub off` — force Anthropic (with compression) for this window\n\
+         - `/sub status` — show this window's override\n\
+         \n\
+         !`{exe} window-sub slash \"$ARGUMENTS\" \"$CLAUDE_CODE_SESSION_ID\"`\n"
     )
 }
 fn settings_path() -> Result<PathBuf> {
@@ -537,6 +569,23 @@ mod tests {
         let text = command_markdown("llmtrim");
         assert!(text.contains("CLAUDE_CODE_SESSION_ID"));
         assert!(!text.contains("LLMTRIM_CLAUDE_WINDOW_TOKEN"));
+        assert!(
+            text.contains("on [codex|kimi|grok]"),
+            "argument-hint should list providers: {text}"
+        );
+        assert!(
+            text.contains("/sub on grok"),
+            "skill body should document explicit provider: {text}"
+        );
+    }
+
+    #[test]
+    fn accepts_all_subscription_providers() {
+        assert!(valid_provider("codex"));
+        assert!(valid_provider("kimi"));
+        assert!(valid_provider("grok"));
+        assert!(!valid_provider("anthropic"));
+        assert!(!valid_provider("openai"));
     }
 
     #[test]

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -812,7 +812,7 @@ pub struct RuntimeConfig {
     /// name (`mocha`/`macchiato`/`frappe`/`latte`). The `t` key persists the user's choice
     /// here via [`save_theme`]. The TUI validates the name and falls back to its default.
     pub theme: Option<String>,
-    /// Subscription reroute target (env `LLMTRIM_SUB` / file `sub`): `codex` or `kimi` reroutes
+    /// Subscription reroute target (env `LLMTRIM_SUB` / file `sub`): `codex`, `kimi`, or `grok` reroutes
     /// intercepted Anthropic `/v1/messages` traffic to that subscription's backend instead of
     /// Anthropic (translating the request/response wire shapes). `off`/unset keeps the
     /// transparent compress-and-forward behavior. Lowercased; an unknown value is left as-is
@@ -968,13 +968,39 @@ fn resolve_sub_tiers(
     env: &impl Fn(&str) -> Option<String>,
     file: Option<&toml::Value>,
 ) -> std::collections::BTreeMap<String, String> {
+    let Some(provider) = resolve_sub_provider(env, file) else {
+        return std::collections::BTreeMap::new();
+    };
+    sub_tiers_from_file(file, &provider)
+}
+
+/// Read `[sub.<provider>.tiers]` for a *specific* provider, independent of who is currently
+/// active. Used when a window `/sub on grok` overrides a global `sub = codex`: the request is
+/// routed to Grok and must map tiers from `[sub.grok.tiers]` (or Grok defaults), never from
+/// Codex's mapping (which would send `gpt-5.6-terra` to the Grok backend).
+pub fn sub_tiers_for(provider: &str) -> std::collections::BTreeMap<String, String> {
+    let provider = provider.trim().to_ascii_lowercase();
+    if provider.is_empty() || provider == "off" {
+        return std::collections::BTreeMap::new();
+    }
+    let file = config_path()
+        .filter(|p| p.exists())
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| toml::from_str::<toml::Value>(&s).ok());
+    sub_tiers_from_file(file.as_ref(), &provider)
+}
+
+fn sub_tiers_from_file(
+    file: Option<&toml::Value>,
+    provider: &str,
+) -> std::collections::BTreeMap<String, String> {
     let mut map = std::collections::BTreeMap::new();
-    let (Some(provider), Some(file)) = (resolve_sub_provider(env, file), file) else {
+    let Some(file) = file else {
         return map;
     };
     if let Some(tiers) = file
         .get("sub")
-        .and_then(|v| v.get(&provider))
+        .and_then(|v| v.get(provider))
         .and_then(|v| v.get("tiers"))
         .and_then(toml::Value::as_table)
     {

--- a/crates/llmtrim-ledger/Cargo.toml
+++ b/crates/llmtrim-ledger/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["llm", "sqlite", "tokens", "compression", "tracking"]
 categories = ["database", "development-tools"]
 
 [dependencies]
-llmtrim-core = { path = "../llmtrim-core", version = "0.10.2" }
+llmtrim-core = { path = "../llmtrim-core", version = "0.11.0" }
 anyhow.workspace = true
 chrono = "0.4.45"
 rusqlite = { version = "0.39", features = ["bundled"] }

--- a/crates/llmtrim-ledger/src/dashboard.rs
+++ b/crates/llmtrim-ledger/src/dashboard.rs
@@ -369,6 +369,7 @@ fn known_display_name(agent: &str) -> Option<&'static str> {
     match agent {
         "claude-code" => Some("Claude Code"),
         "codex" => Some("Codex"),
+        "grok" => Some("Grok"),
         "gemini" => Some("Gemini"),
         _ => None,
     }

--- a/crates/llmtrim-tray/Cargo.toml
+++ b/crates/llmtrim-tray/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.10.2" }
+llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.11.0" }
 # image-png: required for Image::from_bytes to decode the embedded PNG tray icon.
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }


### PR DESCRIPTION
## Summary

- Add Grok (SuperGrok / Grok Build) as a subscription reroute backend for Claude Code (`llmtrim sub use grok`), mapping tiers to `grok-4.5` / `grok-composer-2.5-fast` and translating Anthropic `/v1/messages` to `cli-chat-proxy.grok.com/v1/responses`.
- Finish remote OAuth: `llmtrim sub auth grok login` accepts a pasted callback URL or xAI one-time code when the browser cannot hit loopback (SSH / containers).
- Add RFC 8628 device login: `llmtrim sub auth grok device` (URL + user code, poll token endpoint — no localhost callback), using `auth.x.ai` discovery and the public Grok CLI client (same pattern as OpenClaw / pi-grok-cli).

## Test plan

- [x] `cargo test -p llmtrim --lib reroute::auth::tests`
- [x] `cargo clippy -p llmtrim --lib -- -D warnings`
- [ ] CI green on this PR
- [ ] Manual: `llmtrim sub auth grok login` on a local machine (browser callback)
- [ ] Manual: paste flow or `llmtrim sub auth grok device` from SSH/remote
- [ ] Manual: `llmtrim sub on grok` + Claude Code turn routes to Grok