### PR TITLE
fix(compact): only redirect /compact when the prompt cache is cold

### DIFF
--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1494,8 +1494,16 @@ mod imp {
             }
             // Compact turns use an isolated candidate plan. Every attempt is rebuilt from these
             // (possibly LKG-rewritten) client bytes; ordinary requests never enter this path.
+            // The `/compact` model redirect only pays off once the original model's prompt cache
+            // has gone cold: while it's warm, a cache-read on the original model is cheaper than a
+            // cold read on the (cheaper-per-token) redirect target. So suppress the redirect for a
+            // session we can prove is still warm; unknown freshness falls through to redirect.
+            let compact_cache_warm = cc_session_id
+                .as_deref()
+                .is_some_and(crate::statusline::session_cache_warm);
             let compact_plan = if provider == ProviderKind::Anthropic
                 && !self.compact_models.is_empty()
+                && !compact_cache_warm
             {
                 std::str::from_utf8(&bytes)
                     .ok()
@@ -1754,8 +1762,13 @@ mod imp {
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string();
+            // See the non-sub path: the compact redirect only rents once the cache is cold, so a
+            // proven-warm session keeps the original model and skips the candidate plan.
+            let compact_cache_warm = session_id
+                .as_deref()
+                .is_some_and(crate::statusline::session_cache_warm);
             let mut compact_candidates = crate::compact::detect(&anthropic)
-                .filter(|_| !self.compact_models.is_empty())
+                .filter(|_| !self.compact_models.is_empty() && !compact_cache_warm)
                 .map(|original| {
                     let tiers = llmtrim_core::config::sub_tiers_for(sub.as_str());
                     crate::compact::plan(&self.compact_models, &original, Some(sub), &tiers)

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -472,6 +472,8 @@ pub(crate) fn session_sub_model(session_id: &str) -> Option<String> {
 /// model beats a cold read/write on a cheaper redirect target. Fails safe: an unknown cache (no
 /// session row, an unparseable timestamp, or a build without the `breakdown` feature) returns
 /// `false`, so the redirect proceeds exactly as before — only a *proven* warm cache suppresses it.
+/// Only the proxy (`intercept`) consults this, to gate the `/compact` redirect.
+#[cfg(feature = "intercept")]
 pub(crate) fn session_cache_warm(session_id: &str) -> bool {
     session_row(session_id).is_some_and(|r| ts_within_ttl(&r.last_ts))
 }
@@ -480,6 +482,7 @@ pub(crate) fn session_cache_warm(session_id: &str) -> bool {
 /// [`cache_cold`]'s test, but note the *opposite* fail-safe on a bad timestamp: `cache_cold`
 /// treats unparseable as not-cold (don't warn on a glitch), whereas here unparseable is not-*warm*
 /// — the two gate opposite actions, and both must fail toward "act as if the cache is cold".
+#[cfg(feature = "intercept")]
 fn ts_within_ttl(last_ts: &str) -> bool {
     chrono::DateTime::parse_from_rfc3339(last_ts)
         .map(|t| chrono::Utc::now().signed_duration_since(t).num_seconds() < CACHE_TTL_SECS)
@@ -1804,6 +1807,7 @@ mod tests {
         assert!(cache_cold(&stale), "past the TTL ⇒ cold");
     }
 
+    #[cfg(feature = "intercept")]
     #[test]
     fn ts_within_ttl_gates_the_compact_redirect() {
         // The predicate behind `session_cache_warm` (its DB lookup isn't unit-testable). It must be

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -466,6 +466,26 @@ pub(crate) fn session_sub_model(session_id: &str) -> Option<String> {
     row.last_model
 }
 
+/// Whether this session's prompt cache is *known* to still be warm: a recorded turn whose
+/// `last_ts` is within the TTL. Used to suppress the `/compact` model redirect, which only pays
+/// off once the original model's cache has gone cold — a warm cache-read (`0.1×`) on the original
+/// model beats a cold read/write on a cheaper redirect target. Fails safe: an unknown cache (no
+/// session row, an unparseable timestamp, or a build without the `breakdown` feature) returns
+/// `false`, so the redirect proceeds exactly as before — only a *proven* warm cache suppresses it.
+pub(crate) fn session_cache_warm(session_id: &str) -> bool {
+    session_row(session_id).is_some_and(|r| ts_within_ttl(&r.last_ts))
+}
+
+/// Whether an rfc3339 timestamp is newer than the cache TTL. The strict complement of
+/// [`cache_cold`]'s test, but note the *opposite* fail-safe on a bad timestamp: `cache_cold`
+/// treats unparseable as not-cold (don't warn on a glitch), whereas here unparseable is not-*warm*
+/// — the two gate opposite actions, and both must fail toward "act as if the cache is cold".
+fn ts_within_ttl(last_ts: &str) -> bool {
+    chrono::DateTime::parse_from_rfc3339(last_ts)
+        .map(|t| chrono::Utc::now().signed_duration_since(t).num_seconds() < CACHE_TTL_SECS)
+        .unwrap_or(false)
+}
+
 /// Decide the trim figure: this session's own savings when we have its row; idle (`None`) for a
 /// known Claude Code session with no recorded turn yet — *not* the lifetime figure, which would
 /// flash a misleading number for a beat before the first turn lands; and only the lifetime figure
@@ -1782,6 +1802,35 @@ mod tests {
         let stale =
             (chrono::Utc::now() - chrono::Duration::seconds(CACHE_TTL_SECS + 60)).to_rfc3339();
         assert!(cache_cold(&stale), "past the TTL ⇒ cold");
+    }
+
+    #[test]
+    fn ts_within_ttl_gates_the_compact_redirect() {
+        // The predicate behind `session_cache_warm` (its DB lookup isn't unit-testable). It must be
+        // the strict complement of `cache_cold` inside the TTL, but fail the *opposite* way on a bad
+        // timestamp: unknown ⇒ not warm ⇒ redirect still fires.
+        assert!(
+            !ts_within_ttl("garbage"),
+            "unparseable ⇒ not warm (redirect)"
+        );
+        assert!(
+            ts_within_ttl(&chrono::Utc::now().to_rfc3339()),
+            "just now ⇒ warm"
+        );
+        let stale =
+            (chrono::Utc::now() - chrono::Duration::seconds(CACHE_TTL_SECS + 60)).to_rfc3339();
+        assert!(!ts_within_ttl(&stale), "past the TTL ⇒ not warm (redirect)");
+        // Every point inside the TTL is warm here and not cold there — no boundary gap/overlap.
+        let fresh =
+            (chrono::Utc::now() - chrono::Duration::seconds(CACHE_TTL_SECS - 60)).to_rfc3339();
+        assert!(
+            ts_within_ttl(&fresh) && !cache_cold(&fresh),
+            "within TTL: warm, not cold"
+        );
+        assert!(
+            !ts_within_ttl(&stale) && cache_cold(&stale),
+            "past TTL: not warm, cold"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `/compact` model redirect (`compact_models`) fired unconditionally whenever a compaction request was detected. It only *rents* once the original model's prompt cache has gone cold.

`/compact` re-sends the full conversation, which Claude Code has been caching **against the original model**. So per input token:

| Cache state | Keep original (Opus) | Redirect → cheaper model | Winner |
|---|---|---|---|
| **Warm** (idle < TTL) | cache-read `0.1×R_opus ≈ 0.5×R_son` | full/write `≈2×R_son` | **Keep original** (redirect ~4× worse) |
| **Cold** (idle ≥ TTL) | cache-write `2×R_opus ≈ 10×R_son` | `2×R_son` | **Redirect** (~5× cheaper) |

(Using the repo's own cost model — `guard.rs`: 1h-TTL cache write = 2× base input, Claude cache read = 0.1× — and Opus base input ≈ 5× Sonnet.) The warm result holds even if the cheaper model only does a plain read. So redirecting a warm-cache compact actively costs more.

## Change

Gate both redirect sites on a **proven-warm** check and suppress the redirect only when the session's ledger row shows a `last_ts` within the cache TTL:

- `serve.rs` non-sub Anthropic path (`compact_plan`)
- `serve.rs` sub reroute path (`compact_candidates`)

Unknown freshness — no session row, an unparseable timestamp, or a build without the `breakdown` feature — falls through to redirect, so the feature is **never silently disabled**. This reuses the same `last_ts`-vs-`CACHE_TTL_SECS` signal the statusline and `guard` hook already trust.

Adds `session_cache_warm` plus the pure `ts_within_ttl` predicate (unit tested) — the strict complement of `cache_cold` inside the TTL, but failing the *opposite* way on a bad timestamp, since the two gate opposite actions and both must fail toward "act as if cold".

## Testing

- `cargo test -p llmtrim --lib statusline::` — 46 pass (new `ts_within_ttl_gates_the_compact_redirect`, asserts no boundary gap/overlap vs `cache_cold`)
- `cargo test -p llmtrim --lib compact::` — 13 pass
- `cargo clippy -p llmtrim --all-targets` clean
- Builds with default features and with `--no-default-features --features intercept,mcp` (the no-`breakdown` stub path)

## Known limitation

`/compact` can refresh the prompt cache without updating `last_ts` (see `effective_cache_cold`), so right after a compact this may under-report warmth and cause one extra, harmless redirect. It errs in the fail-safe direction and is the same `last_ts` staleness the statusline already lives with.