### PR TITLE
docs(compact): note the /compact redirect only fires on a cold cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/compact` redirects to a cheaper model only when the prompt cache is cold.** The redirect
+  used to run on every `/compact`. But `/compact` re-sends the conversation Claude Code has been
+  caching against your selected model, so while that cache is warm a cache-read there is cheaper
+  than a cold read on a smaller model, so redirecting a warm compact cost more, not less. The
+  redirect now stays on your selected model when the session's last turn is within the cache TTL.
+  Unknown freshness (no session row yet, or a build without the `breakdown` feature) still
+  redirects, so the feature is never silently disabled.
+
 ## [0.11.2] - 2026-07-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ When `~/.claude` exists, `setup`, `update`, and `ensure` wire these. No separate
 |---|---|
 | Status line | Model, context gauge, trim %, rate limits, cache warm/cold |
 | Guard | Blocks one turn if a cold-cache resume would rewrite a huge context (and bill for it) |
-| `/compact` models | Prefer Haiku → Sonnet before your selected model |
+| `/compact` models | Prefer Haiku → Sonnet before your selected model, but only when the prompt cache is cold |
 | `/sub` | Per-window: `/sub on [optional:codex\|kimi\|grok]` · `/sub off` · `/sub status` |
 
 ```text
@@ -300,6 +300,8 @@ models = ["haiku", "sonnet"]
 ```
 
 Candidates run in order when they fit the compressed request. Claude's selected model is always the last fallback (do not put it in the list). Empty `models = []` records opt-out.
+
+The redirect only fires once the prompt cache has gone cold. `/compact` re-sends the conversation Claude Code has been caching against your selected model, so while that cache is warm a cache-read there costs less than a cold read on a smaller model, and the compact stays home. After the cache expires the cheaper model wins, so that is when the redirect takes over.
 
 </details>
 


### PR DESCRIPTION
Follow-up to #190, which changed the `/compact` cheaper-model redirect to fire only when the session's prompt cache has gone cold.

This documents that behavior:

- **CHANGELOG.md** — a `Fixed` entry under `[Unreleased]`.
- **README.md** — the feature-table row for `/compact` models now says "only when the prompt cache is cold", and the "Cheaper `/compact`" section gains a short paragraph explaining why: `/compact` re-sends the conversation cached against your selected model, so while that cache is warm a cache-read there beats a cold read on a smaller model. The redirect kicks in once the cache expires.

Docs only — no code change.