### PR TITLE
feat(statusline): show Codex plan rate limits under /sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Status line shows the active `/sub` plan's rate limits (Codex first).** Under a Codex
+  reroute the `◔` segment now reads the ChatGPT plan's windows (weekly always; 5h when the plan
+  reports one) from `GET /backend-api/wham/usage`, cached at `~/.llmtrim/sub-rate-limits.json` by
+  the proxy on each throttled turn. A matching snapshot replaces Claude Code's Anthropic blob
+  only while the proxy is healthy; until the first poll lands (or if the proxy is down) the
+  Claude numbers stay so the segment isn't blank. Kimi/Grok share the cache schema; their usage
+  endpoints are not wired yet.
+
 ## [0.11.3] - 2026-07-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ When `~/.claude` exists, `setup`, `update`, and `ensure` wire these. No separate
 Claude Code [custom status line](https://code.claude.com/docs/en/statusline). The arrow is the backend that answered the last turn (not merely what is configured). In `sub` fallback mode it stays off while Anthropic serves and shows up when a chain provider does.
 
 - `✂`: trim for this session (`✂ –` until something is saved)
-- `◔`: Claude.ai rate-limit windows (time left · % used)
+- `◔`: rate-limit windows (time left · % used) — Claude.ai when Anthropic is serving; under `/sub` the active plan's windows (Codex today: weekly always, 5h when the plan reports one). Kimi/Grok fill in when their usage APIs are wired
 - Context gauge: fill of the serving model's real window (green under 40%, orange 40-65%, red above)
 - `♻`: prompt-cache reuse; becomes `♻ cache cold` after the cache TTL
 

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -19,6 +19,7 @@ pub mod context_limit;
 pub mod continuation;
 pub mod grok;
 pub mod kimi;
+pub mod quota;
 pub mod read_rewrite;
 pub mod sse;
 #[cfg(feature = "breakdown")]

--- a/crates/llmtrim-cli/src/reroute/quota.rs
+++ b/crates/llmtrim-cli/src/reroute/quota.rs
@@ -171,10 +171,11 @@ fn window_from_usage_json(win: &Value) -> Option<RateWindow> {
                 .filter(|&s| s > 0)
                 .map(|s| s as u64)
         });
-    let resets_at = win
-        .get("reset_at")
-        .and_then(Value::as_i64)
-        .or_else(|| win.get("reset_at").and_then(Value::as_u64).map(|u| u as i64));
+    let resets_at = win.get("reset_at").and_then(Value::as_i64).or_else(|| {
+        win.get("reset_at")
+            .and_then(Value::as_u64)
+            .map(|u| u as i64)
+    });
     Some(RateWindow {
         used_percent: used,
         resets_at,
@@ -208,7 +209,7 @@ pub fn classify_window(limit_window_seconds: Option<u64>) -> WindowKind {
 /// Fallback label when `resets_at` is missing: `5h` / `7d` / `Nh` / `Nd` from window size.
 pub fn size_label(limit_window_seconds: Option<u64>) -> String {
     match limit_window_seconds {
-        Some(s) if s > 0 && s < 3600 => format!("{}m", (s + 59) / 60),
+        Some(s) if s > 0 && s < 3600 => format!("{}m", s.div_ceil(60)),
         Some(s) if s < 12 * 3600 => {
             let h = (s + 1800) / 3600;
             if h <= 1 {
@@ -301,14 +302,15 @@ pub fn fetch_codex_usage(access_token: &str, account_id: Option<&str>) -> Option
 /// Fire-and-forget a throttled Codex usage poll on a detached thread.
 ///
 /// Safe to call on every Codex sub turn: process-local gate + on-disk `fetched_at` keep it to
-/// roughly one live GET per [`POLL_MIN_INTERVAL_SECS`]. Never blocks the caller for network I/O.
+/// roughly one live GET per minute. Never blocks the caller for network I/O.
 pub fn maybe_schedule_codex_poll(access_token: String, account_id: Option<String>) {
     if access_token.is_empty() || account_id.as_deref().unwrap_or("").is_empty() {
         return;
     }
     // Disk freshness: skip even scheduling if a recent snapshot already exists.
     if load_raw().is_some_and(|s| {
-        s.provider == "codex" && now_secs().saturating_sub(s.fetched_at) < POLL_MIN_INTERVAL_SECS as i64
+        s.provider == "codex"
+            && now_secs().saturating_sub(s.fetched_at) < POLL_MIN_INTERVAL_SECS as i64
     }) {
         return;
     }
@@ -336,10 +338,10 @@ pub fn maybe_schedule_codex_poll(access_token: String, account_id: Option<String
                 gate.inflight = false;
             }
         });
-    if spawn.is_err() {
-        if let Ok(mut gate) = POLL_GATE.lock() {
-            gate.inflight = false;
-        }
+    if spawn.is_err()
+        && let Ok(mut gate) = POLL_GATE.lock()
+    {
+        gate.inflight = false;
     }
 }
 

--- a/crates/llmtrim-cli/src/reroute/quota.rs
+++ b/crates/llmtrim-cli/src/reroute/quota.rs
@@ -1,0 +1,438 @@
+//! Subscription rate-limit windows for the Claude Code status line under `/sub`.
+//!
+//! Claude Code's stdin blob only carries *Anthropic* 5h/7d quotas. When traffic is rerouted to a
+//! ChatGPT/Codex plan those numbers are the wrong account (and often absent). This module polls the
+//! provider's usage endpoint, caches the result under `~/.llmtrim/sub-rate-limits.json`, and lets
+//! the status line render the *active* plan's windows instead.
+//!
+//! **Codex (v1).** `GET https://chatgpt.com/backend-api/wham/usage` with the ChatGPT OAuth bearer
+//! token + `ChatGPT-Account-Id` — the same endpoint headroom and CodeBurn use. The response's
+//! `rate_limit.primary_window` / `secondary_window` each carry `used_percent`,
+//! `limit_window_seconds`, and `reset_at`. Window size is dynamic per plan (Plus is often
+//! weekly-only; Pro-style plans add a ~5h primary next to a weekly secondary), so labels are
+//! derived from `limit_window_seconds`, not from primary/secondary position.
+//!
+//! **Kimi / Grok.** No public usage endpoint is wired yet; the cache schema is provider-keyed so
+//! they can fill in later without touching the status line.
+//!
+//! Polling is throttled (default 60s) and never raises: a failed or unauthenticated fetch leaves
+//! the previous cache (if any) alone. The status line only *reads* the cache — network work
+//! happens on the proxy path when a Codex sub turn is about to fire.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// ChatGPT Codex usage endpoint. Overridable for tests via `LLMTRIM_CODEX_USAGE_URL`.
+fn codex_usage_url() -> String {
+    std::env::var("LLMTRIM_CODEX_USAGE_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "https://chatgpt.com/backend-api/wham/usage".to_string())
+}
+
+/// Minimum seconds between live usage polls (process-local + honored via `fetched_at` on disk).
+const POLL_MIN_INTERVAL_SECS: u64 = 60;
+/// Bound the usage GET so a slow upstream never wedges a request path.
+const POLL_TIMEOUT: Duration = Duration::from_secs(8);
+/// Status line still renders a cache this old; older snapshots are treated as absent.
+const CACHE_MAX_AGE_SECS: i64 = 30 * 60;
+
+static POLL_GATE: Lazy<Mutex<PollGate>> = Lazy::new(|| Mutex::new(PollGate::default()));
+
+#[derive(Default)]
+struct PollGate {
+    last_attempt: Option<Instant>,
+    inflight: bool,
+}
+
+/// One rolling rate-limit window from a provider usage response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RateWindow {
+    pub used_percent: f64,
+    /// Unix epoch seconds when the window resets, when the provider sends one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resets_at: Option<i64>,
+    /// Nominal window length in seconds (`18000` ≈ 5h, `604800` ≈ 7d). Used only to label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit_window_seconds: Option<u64>,
+}
+
+/// Cached snapshot of the active subscription's rate-limit windows.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SubQuotaSnapshot {
+    /// Provider shortname (`codex` today; `kimi`/`grok` reserved).
+    pub provider: String,
+    /// Unix epoch seconds when this snapshot was written.
+    pub fetched_at: i64,
+    /// Windows in provider order (primary then secondary for Codex). Empty means "no data".
+    #[serde(default)]
+    pub windows: Vec<RateWindow>,
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn cache_path() -> Option<PathBuf> {
+    crate::daemon::home_dir()
+        .ok()
+        .map(|h| h.join("sub-rate-limits.json"))
+}
+
+/// Read the on-disk snapshot if it is present, parseable, and fresh enough for the status line.
+pub fn load_fresh() -> Option<SubQuotaSnapshot> {
+    load_raw().filter(|s| now_secs().saturating_sub(s.fetched_at) <= CACHE_MAX_AGE_SECS)
+}
+
+/// Read whatever is on disk, ignoring age. Used by tests and the poller (to preserve last-good).
+pub fn load_raw() -> Option<SubQuotaSnapshot> {
+    let path = cache_path()?;
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn store(snapshot: &SubQuotaSnapshot) {
+    let Some(path) = cache_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let Ok(json) = serde_json::to_string_pretty(snapshot) else {
+        return;
+    };
+    // Same-dir temp + rename so a concurrent statusline read never sees a half-write.
+    // Pid + monotonic nanos keeps concurrent writers (restart race, two daemons) from
+    // clobbering each other's temp file; `with_extension` would also mangle a multi-dot
+    // basename, so build the sibling name explicitly.
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp = path.with_file_name(format!(
+        "sub-rate-limits.{}.{}.tmp",
+        std::process::id(),
+        nonce
+    ));
+    if fs::write(&tmp, json.as_bytes()).is_ok() {
+        if fs::rename(&tmp, &path).is_err() {
+            let _ = fs::remove_file(&tmp);
+        }
+    } else {
+        let _ = fs::remove_file(&tmp);
+    }
+}
+
+/// Parse a `GET /wham/usage` JSON body into a snapshot. `None` when no usable windows are present.
+pub fn parse_codex_usage_payload(payload: &Value) -> Option<SubQuotaSnapshot> {
+    let rate_limit = payload.get("rate_limit")?;
+    let mut windows = Vec::new();
+    for key in ["primary_window", "secondary_window"] {
+        // Missing *or* JSON-null secondary must not abort parse of a good primary.
+        if let Some(w) = rate_limit.get(key).and_then(window_from_usage_json) {
+            windows.push(w);
+        }
+    }
+    // Some plans put extra per-model buckets under `additional_rate_limits`; the status line only
+    // has room for the two main windows, so they are intentionally ignored here.
+    if windows.is_empty() {
+        return None;
+    }
+    Some(SubQuotaSnapshot {
+        provider: "codex".to_string(),
+        fetched_at: now_secs(),
+        windows,
+    })
+}
+
+fn window_from_usage_json(win: &Value) -> Option<RateWindow> {
+    let used = win.get("used_percent")?.as_f64().or_else(|| {
+        // chatgpt.com has been observed sending integers; accept both.
+        win.get("used_percent")?.as_i64().map(|i| i as f64)
+    })?;
+    if !used.is_finite() {
+        return None;
+    }
+    let limit_window_seconds = win
+        .get("limit_window_seconds")
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            win.get("limit_window_seconds")
+                .and_then(Value::as_i64)
+                .filter(|&s| s > 0)
+                .map(|s| s as u64)
+        });
+    let resets_at = win
+        .get("reset_at")
+        .and_then(Value::as_i64)
+        .or_else(|| win.get("reset_at").and_then(Value::as_u64).map(|u| u as i64));
+    Some(RateWindow {
+        used_percent: used,
+        resets_at,
+        limit_window_seconds,
+    })
+}
+
+/// Classify a window by its nominal length for status-line labelling.
+///
+/// Codex does not name windows "5h"/"7d" on the wire — Plus often exposes only a weekly primary,
+/// while Pro-style plans add a ~5h primary next to a weekly secondary. Thresholds are wide so a
+/// 4h or 6h short window still maps to the short bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowKind {
+    /// Rolling short window (≈ 5 hours).
+    Short,
+    /// Rolling weekly (or multi-day) window.
+    Weekly,
+    /// Anything else — still renderable, labelled from size / reset time.
+    Other,
+}
+
+pub fn classify_window(limit_window_seconds: Option<u64>) -> WindowKind {
+    match limit_window_seconds {
+        Some(s) if s > 0 && s < 12 * 3600 => WindowKind::Short,
+        Some(s) if s >= 3 * 24 * 3600 => WindowKind::Weekly,
+        _ => WindowKind::Other,
+    }
+}
+
+/// Fallback label when `resets_at` is missing: `5h` / `7d` / `Nh` / `Nd` from window size.
+pub fn size_label(limit_window_seconds: Option<u64>) -> String {
+    match limit_window_seconds {
+        Some(s) if s > 0 && s < 3600 => format!("{}m", (s + 59) / 60),
+        Some(s) if s < 12 * 3600 => {
+            let h = (s + 1800) / 3600;
+            if h <= 1 {
+                "1h".to_string()
+            } else {
+                format!("{h}h")
+            }
+        }
+        Some(s) if s >= 24 * 3600 => {
+            let d = (s + 12 * 3600) / (24 * 3600);
+            if d <= 1 {
+                "1d".to_string()
+            } else {
+                format!("{d}d")
+            }
+        }
+        Some(s) if s > 0 => format!("{}h", (s + 1800) / 3600),
+        _ => "?".to_string(),
+    }
+}
+
+/// Split a snapshot into (short/5h, weekly/7d) slots for the status-line segment.
+///
+/// When only one window is present it goes into the matching slot; a lone weekly does **not**
+/// invent a 5h row. If both windows share a kind (schema drift), the first keeps the slot and the
+/// second is dropped rather than double-rendering.
+pub fn split_short_weekly(
+    snapshot: &SubQuotaSnapshot,
+) -> (Option<&RateWindow>, Option<&RateWindow>) {
+    let mut short = None;
+    let mut weekly = None;
+    for w in &snapshot.windows {
+        match classify_window(w.limit_window_seconds) {
+            WindowKind::Short if short.is_none() => short = Some(w),
+            WindowKind::Weekly if weekly.is_none() => weekly = Some(w),
+            WindowKind::Other => {
+                // Prefer to surface an unclassified window as weekly (longer-horizon) when that
+                // slot is free; otherwise as short. Keeps a single unknown window visible.
+                if weekly.is_none() && short.is_some() {
+                    weekly = Some(w);
+                } else if short.is_none() {
+                    short = Some(w);
+                } else if weekly.is_none() {
+                    weekly = Some(w);
+                }
+            }
+            _ => {}
+        }
+    }
+    // Single weekly-classified window with empty short is the Plus shape (primary = 7d).
+    if short.is_none() && weekly.is_none() {
+        // Defensive: classification filtered everything — surface first window as weekly.
+        if let Some(w) = snapshot.windows.first() {
+            return (None, Some(w));
+        }
+    }
+    (short, weekly)
+}
+
+/// Blocking GET of the Codex usage endpoint. Returns a stored snapshot on success.
+pub fn fetch_codex_usage(access_token: &str, account_id: Option<&str>) -> Option<SubQuotaSnapshot> {
+    let account_id = account_id.filter(|s| !s.is_empty())?;
+    if access_token.is_empty() {
+        return None;
+    }
+    let url = codex_usage_url();
+    let mut resp = ureq::get(&url)
+        .config()
+        .proxy(None)
+        .http_status_as_error(false)
+        .timeout_global(Some(POLL_TIMEOUT))
+        .build()
+        .header("Authorization", &format!("Bearer {access_token}"))
+        .header("ChatGPT-Account-Id", account_id)
+        .header("Accept", "application/json")
+        .header("User-Agent", "llmtrim")
+        .call()
+        .ok()?;
+    let status = resp.status().as_u16();
+    let body = resp.body_mut().read_to_string().ok()?;
+    if !(200..300).contains(&status) {
+        return None;
+    }
+    let payload: Value = serde_json::from_str(&body).ok()?;
+    let snap = parse_codex_usage_payload(&payload)?;
+    store(&snap);
+    Some(snap)
+}
+
+/// Fire-and-forget a throttled Codex usage poll on a detached thread.
+///
+/// Safe to call on every Codex sub turn: process-local gate + on-disk `fetched_at` keep it to
+/// roughly one live GET per [`POLL_MIN_INTERVAL_SECS`]. Never blocks the caller for network I/O.
+pub fn maybe_schedule_codex_poll(access_token: String, account_id: Option<String>) {
+    if access_token.is_empty() || account_id.as_deref().unwrap_or("").is_empty() {
+        return;
+    }
+    // Disk freshness: skip even scheduling if a recent snapshot already exists.
+    if load_raw().is_some_and(|s| {
+        s.provider == "codex" && now_secs().saturating_sub(s.fetched_at) < POLL_MIN_INTERVAL_SECS as i64
+    }) {
+        return;
+    }
+    {
+        let mut gate = POLL_GATE.lock().unwrap_or_else(|p| p.into_inner());
+        if gate.inflight {
+            return;
+        }
+        if gate
+            .last_attempt
+            .is_some_and(|t| t.elapsed() < Duration::from_secs(POLL_MIN_INTERVAL_SECS))
+        {
+            return;
+        }
+        gate.inflight = true;
+        gate.last_attempt = Some(Instant::now());
+    }
+    // If spawn itself fails, clear inflight immediately — otherwise the flag stays true
+    // for the life of the process and every later Codex turn skips the poll forever.
+    let spawn = std::thread::Builder::new()
+        .name("llmtrim-codex-quota".into())
+        .spawn(move || {
+            let _ = fetch_codex_usage(&access_token, account_id.as_deref());
+            if let Ok(mut gate) = POLL_GATE.lock() {
+                gate.inflight = false;
+            }
+        });
+    if spawn.is_err() {
+        if let Ok(mut gate) = POLL_GATE.lock() {
+            gate.inflight = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_plus_weekly_only_primary() {
+        let payload = json!({
+            "plan_type": "plus",
+            "rate_limit": {
+                "allowed": true,
+                "limit_reached": false,
+                "primary_window": {
+                    "used_percent": 1,
+                    "limit_window_seconds": 604800,
+                    "reset_after_seconds": 498478,
+                    "reset_at": 1784791984
+                },
+                "secondary_window": null
+            }
+        });
+        let snap = parse_codex_usage_payload(&payload).expect("snapshot");
+        assert_eq!(snap.provider, "codex");
+        assert_eq!(snap.windows.len(), 1);
+        assert_eq!(snap.windows[0].used_percent, 1.0);
+        assert_eq!(snap.windows[0].limit_window_seconds, Some(604_800));
+        assert_eq!(snap.windows[0].resets_at, Some(1_784_791_984));
+        let (short, weekly) = split_short_weekly(&snap);
+        assert!(short.is_none(), "Plus weekly-only must not invent a 5h row");
+        assert_eq!(weekly.unwrap().used_percent, 1.0);
+    }
+
+    #[test]
+    fn parses_pro_style_primary_5h_secondary_weekly() {
+        let payload = json!({
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 23.5,
+                    "limit_window_seconds": 18000,
+                    "reset_at": 1700000000
+                },
+                "secondary_window": {
+                    "used_percent": 6,
+                    "limit_window_seconds": 604800,
+                    "reset_at": 1700500000
+                }
+            }
+        });
+        let snap = parse_codex_usage_payload(&payload).unwrap();
+        let (short, weekly) = split_short_weekly(&snap);
+        assert_eq!(short.unwrap().used_percent, 23.5);
+        assert_eq!(weekly.unwrap().used_percent, 6.0);
+        assert_eq!(classify_window(Some(18_000)), WindowKind::Short);
+        assert_eq!(classify_window(Some(604_800)), WindowKind::Weekly);
+    }
+
+    #[test]
+    fn empty_rate_limit_returns_none() {
+        assert!(parse_codex_usage_payload(&json!({"rate_limit": {}})).is_none());
+        assert!(parse_codex_usage_payload(&json!({})).is_none());
+        assert!(
+            parse_codex_usage_payload(&json!({
+                "rate_limit": {"primary_window": {"limit_window_seconds": 60}}
+            }))
+            .is_none(),
+            "missing used_percent skips the window"
+        );
+    }
+
+    #[test]
+    fn size_label_rounds_common_windows() {
+        assert_eq!(size_label(Some(18_000)), "5h");
+        assert_eq!(size_label(Some(604_800)), "7d");
+        assert_eq!(size_label(Some(3600)), "1h");
+        assert_eq!(size_label(None), "?");
+    }
+
+    #[test]
+    fn snapshot_json_round_trip() {
+        let snap = SubQuotaSnapshot {
+            provider: "codex".into(),
+            fetched_at: 1_700_000_000,
+            windows: vec![RateWindow {
+                used_percent: 42.0,
+                resets_at: Some(1_700_000_000),
+                limit_window_seconds: Some(18_000),
+            }],
+        };
+        let json = serde_json::to_string_pretty(&snap).unwrap();
+        let loaded: SubQuotaSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded, snap);
+    }
+}

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1882,6 +1882,15 @@ mod imp {
                 Err(_) => return anthropic_error(500, "llmtrim: auth task failed").into(),
             };
 
+            // Refresh the Codex plan's rate-limit windows for the status line (throttled,
+            // fire-and-forget). Claude Code's stdin blob only carries Anthropic quotas.
+            if sub == crate::reroute::SubProvider::Codex {
+                crate::reroute::quota::maybe_schedule_codex_poll(
+                    token.access.clone(),
+                    token.account_id.clone(),
+                );
+            }
+
             // Tiers must match the provider actually serving this turn. A window `/sub on grok`
             // with global `sub = codex` must use `[sub.grok.tiers]` (or Grok defaults), not the
             // Codex mapping snapshotted into `self.sub_tiers` at daemon start.
@@ -2636,6 +2645,12 @@ mod imp {
                     .await
                     .map_err(|_| "auth task failed".to_string())?
                     .map_err(|e| format!("not authenticated ({e})"))?;
+            if provider == crate::reroute::SubProvider::Codex {
+                crate::reroute::quota::maybe_schedule_codex_poll(
+                    token.access.clone(),
+                    token.account_id.clone(),
+                );
+            }
             let tiers = llmtrim_core::config::sub_tiers_for(provider.as_str());
             let rewrite = crate::reroute::build_upstream_for_model(
                 provider,

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -228,9 +228,12 @@ struct Led {
     /// short (~5h) window and the weekly window; either may be `None`. When the proxy is healthy
     /// and at least one is present these replace Claude Code's Anthropic blob; otherwise the
     /// blob is used (predicted always-mode before the first poll, or a degraded/stopped proxy).
-    sub_five: Option<(String, f64)>,
-    sub_seven: Option<(String, f64)>,
+    sub_five: Option<QuotaSlot>,
+    sub_seven: Option<QuotaSlot>,
 }
+
+/// One rate-limit window ready for the status line: display label + used %.
+type QuotaSlot = (String, f64);
 
 /// Minimal [`DaemonView`] for the health check — mirrors `main::daemon_view` but fills only
 /// the fields [`monitor::health`] reads (running/pid/port/port_accepting/env_port/ca), since
@@ -352,7 +355,7 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
 /// Load the provider quota snapshot the proxy cached for the status line, if it matches the
 /// active reroute. Returns `(short_window, weekly_window)` as `(label, used_percent)`.
 #[cfg(feature = "intercept")]
-fn sub_quota_for(reroute: Option<&str>) -> (Option<(String, f64)>, Option<(String, f64)>) {
+fn sub_quota_for(reroute: Option<&str>) -> (Option<QuotaSlot>, Option<QuotaSlot>) {
     let Some(provider) = reroute else {
         return (None, None);
     };
@@ -366,11 +369,7 @@ fn sub_quota_for(reroute: Option<&str>) -> (Option<(String, f64)>, Option<(Strin
     let label = |w: &crate::reroute::quota::RateWindow, fallback: &str| {
         remaining_time_label(w.resets_at).unwrap_or_else(|| {
             let s = crate::reroute::quota::size_label(w.limit_window_seconds);
-            if s == "?" {
-                fallback.to_string()
-            } else {
-                s
-            }
+            if s == "?" { fallback.to_string() } else { s }
         })
     };
     (
@@ -380,7 +379,7 @@ fn sub_quota_for(reroute: Option<&str>) -> (Option<(String, f64)>, Option<(Strin
 }
 
 #[cfg(not(feature = "intercept"))]
-fn sub_quota_for(_reroute: Option<&str>) -> (Option<(String, f64)>, Option<(String, f64)>) {
+fn sub_quota_for(_reroute: Option<&str>) -> (Option<QuotaSlot>, Option<QuotaSlot>) {
     (None, None)
 }
 
@@ -777,7 +776,7 @@ fn trim_or_health_segment(led: &Led, color: bool) -> Option<String> {
 ///   minutes on a fresh login;
 /// - a degraded/stopped proxy is not actually rerouting, so Anthropic's numbers are the
 ///   ones that will matter on the next turn (and the arrow is already hidden).
-fn quota_windows(cc: &CcInput, led: &Led) -> (Option<(String, f64)>, Option<(String, f64)>) {
+fn quota_windows(cc: &CcInput, led: &Led) -> (Option<QuotaSlot>, Option<QuotaSlot>) {
     if led.health == Health::Healthy
         && led.reroute.is_some()
         && (led.sub_five.is_some() || led.sub_seven.is_some())
@@ -823,12 +822,8 @@ fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
                 quota(&seven_label, d)
             ));
         }
-        (Some((five_label, h)), None) => {
-            out.push(format!("{glyph} {}", quota(&five_label, h)))
-        }
-        (None, Some((seven_label, d))) => {
-            out.push(format!("{glyph} {}", quota(&seven_label, d)))
-        }
+        (Some((five_label, h)), None) => out.push(format!("{glyph} {}", quota(&five_label, h))),
+        (None, Some((seven_label, d))) => out.push(format!("{glyph} {}", quota(&seven_label, d))),
         (None, None) => {}
     }
     if led.cache_cold {

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -18,6 +18,13 @@
 //! gone cold, where the cache segment becomes `♻ cache cold`. Segments whose data is
 //! absent — no reroute, an API-key user with no rate limits — simply don't render.
 //!
+//! Under `sub`, the quota segment prefers the active provider's windows (cached under
+//! `~/.llmtrim/sub-rate-limits.json` by the proxy when a Codex turn fires) over Claude Code's
+//! Anthropic blob, but only once a matching snapshot exists and the proxy is healthy —
+//! otherwise the Claude blob stays so a fresh always-mode session isn't blank for minutes.
+//! Weekly is always shown when known; the short (~5h) window only appears when the provider
+//! reports one. Kimi/Grok fill in later.
+//!
 //! Under `sub` the arrow shows the concrete model that served the last turn (e.g.
 //! `→gpt-5.6-terra`) for Codex reroutes; Kimi shows the provider shortname (`→kimi`), since all
 //! its tiers collapse to one internal wire id. The arrow is read from the ledger — what actually
@@ -26,7 +33,8 @@
 //! a backend really served, and the gauge keeps Claude's window until one does.
 //!
 //! `install` wires it into `~/.claude/settings.json`; rendering itself never touches the
-//! network or API tokens.
+//! network or API tokens (the proxy polls usage on the request path; this process only reads
+//! the resulting cache file).
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -215,6 +223,13 @@ struct Led {
     /// Input tokens of that same turn — stands in for the blob's `total_input_tokens` while a
     /// turn is in flight, so the gauge doesn't empty. See [`ctx_tokens_for`].
     last_ctx_tokens: i64,
+    /// Under `sub`, the active provider's rate-limit windows from
+    /// `~/.llmtrim/sub-rate-limits.json` (populated by the proxy). `(label, used_percent)` for the
+    /// short (~5h) window and the weekly window; either may be `None`. When the proxy is healthy
+    /// and at least one is present these replace Claude Code's Anthropic blob; otherwise the
+    /// blob is used (predicted always-mode before the first poll, or a degraded/stopped proxy).
+    sub_five: Option<(String, f64)>,
+    sub_seven: Option<(String, f64)>,
 }
 
 /// Minimal [`DaemonView`] for the health check — mirrors `main::daemon_view` but fills only
@@ -315,6 +330,8 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
         ArrowSource::None => (None, None, None),
     };
 
+    let (sub_five, sub_seven) = sub_quota_for(reroute.as_deref());
+
     Led {
         health,
         trim_pct,
@@ -327,7 +344,44 @@ fn ledger_snapshot(cc: &CcInput) -> Led {
             .and_then(|r| r.last_cache_hit)
             .map(|f| f * 100.0),
         last_ctx_tokens: row.as_ref().map_or(0, |r| r.last_input_tokens),
+        sub_five,
+        sub_seven,
     }
+}
+
+/// Load the provider quota snapshot the proxy cached for the status line, if it matches the
+/// active reroute. Returns `(short_window, weekly_window)` as `(label, used_percent)`.
+#[cfg(feature = "intercept")]
+fn sub_quota_for(reroute: Option<&str>) -> (Option<(String, f64)>, Option<(String, f64)>) {
+    let Some(provider) = reroute else {
+        return (None, None);
+    };
+    let Some(snap) = crate::reroute::quota::load_fresh() else {
+        return (None, None);
+    };
+    if snap.provider != provider {
+        return (None, None);
+    }
+    let (short, weekly) = crate::reroute::quota::split_short_weekly(&snap);
+    let label = |w: &crate::reroute::quota::RateWindow, fallback: &str| {
+        remaining_time_label(w.resets_at).unwrap_or_else(|| {
+            let s = crate::reroute::quota::size_label(w.limit_window_seconds);
+            if s == "?" {
+                fallback.to_string()
+            } else {
+                s
+            }
+        })
+    };
+    (
+        short.map(|w| (label(w, "5h"), w.used_percent)),
+        weekly.map(|w| (label(w, "7d"), w.used_percent)),
+    )
+}
+
+#[cfg(not(feature = "intercept"))]
+fn sub_quota_for(_reroute: Option<&str>) -> (Option<(String, f64)>, Option<(String, f64)>) {
+    (None, None)
 }
 
 /// Resolve the context occupancy the gauge fills against. Claude Code reports
@@ -714,6 +768,37 @@ fn trim_or_health_segment(led: &Led, color: bool) -> Option<String> {
     }
 }
 
+/// Resolve which rate-limit windows to render.
+///
+/// Prefer the provider snapshot the proxy cached into `Led` (Codex today) only when the
+/// proxy is healthy *and* we actually have a matching snapshot. Otherwise fall back to
+/// Claude Code's 5h/7d blob:
+/// - predicted always-mode before the first poll would otherwise blank the segment for
+///   minutes on a fresh login;
+/// - a degraded/stopped proxy is not actually rerouting, so Anthropic's numbers are the
+///   ones that will matter on the next turn (and the arrow is already hidden).
+fn quota_windows(cc: &CcInput, led: &Led) -> (Option<(String, f64)>, Option<(String, f64)>) {
+    if led.health == Health::Healthy
+        && led.reroute.is_some()
+        && (led.sub_five.is_some() || led.sub_seven.is_some())
+    {
+        return (led.sub_five.clone(), led.sub_seven.clone());
+    }
+    let five = cc.five_hour_pct.map(|p| {
+        (
+            remaining_time_label(cc.five_hour_resets_at).unwrap_or_else(|| "5h".to_string()),
+            p,
+        )
+    });
+    let seven = cc.seven_day_pct.map(|p| {
+        (
+            remaining_time_label(cc.seven_day_resets_at).unwrap_or_else(|| "7d".to_string()),
+            p,
+        )
+    });
+    (five, seven)
+}
+
 /// Build the ordered extra segments (quota, then this session's cache); later ones drop first on
 /// a narrow terminal.
 fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
@@ -730,20 +815,20 @@ fn extra_segments(cc: &CcInput, led: &Led, color: bool) -> Vec<String> {
     };
     let glyph = paint(color, DIM, "◔");
     let sep = paint(color, DIM, "·");
-    let five_label =
-        remaining_time_label(cc.five_hour_resets_at).unwrap_or_else(|| "5h".to_string());
-    let seven_label =
-        remaining_time_label(cc.seven_day_resets_at).unwrap_or_else(|| "7d".to_string());
-    match (cc.five_hour_pct, cc.seven_day_pct) {
-        (Some(h), Some(d)) => {
+    match quota_windows(cc, led) {
+        (Some((five_label, h)), Some((seven_label, d))) => {
             out.push(format!(
                 "{glyph} {} {sep} {}",
                 quota(&five_label, h),
                 quota(&seven_label, d)
             ));
         }
-        (Some(h), None) => out.push(format!("{glyph} {}", quota(&five_label, h))),
-        (None, Some(d)) => out.push(format!("{glyph} {}", quota(&seven_label, d))),
+        (Some((five_label, h)), None) => {
+            out.push(format!("{glyph} {}", quota(&five_label, h)))
+        }
+        (None, Some((seven_label, d))) => {
+            out.push(format!("{glyph} {}", quota(&seven_label, d)))
+        }
         (None, None) => {}
     }
     if led.cache_cold {
@@ -1182,6 +1267,10 @@ mod tests {
             cache_cold: false,
             last_cache_pct: None,
             last_ctx_tokens: 0,
+            // Tests that exercise the Claude blob path clear reroute; tests that keep the
+            // codex arrow inject sub windows explicitly (or inherit these placeholders).
+            sub_five: Some(("5h".into(), 24.0)),
+            sub_seven: Some(("7d".into(), 12.0)),
         }
     }
 
@@ -1335,6 +1424,7 @@ mod tests {
 
     #[test]
     fn quota_labels_show_time_remaining_until_reset() {
+        // Claude blob path (no sub): labels come from resets_at on the stdin payload.
         let mut c = cc(48_000);
         c.five_hour_resets_at = Some(
             (chrono::Utc::now() + chrono::Duration::hours(3) + chrono::Duration::minutes(30))
@@ -1344,7 +1434,12 @@ mod tests {
             (chrono::Utc::now() + chrono::Duration::days(4) + chrono::Duration::hours(12))
                 .timestamp(),
         );
-        let out = render_line(&c, &led(Health::Healthy), 0, false);
+        let mut l = led(Health::Healthy);
+        l.reroute = None;
+        l.resolved_model = None;
+        l.sub_five = None;
+        l.sub_seven = None;
+        let out = render_line(&c, &l, 0, false);
         assert!(out.contains("◔ 3h·24% · 4d·12%"), "remaining labels: {out}");
     }
 
@@ -1359,10 +1454,10 @@ mod tests {
     #[test]
     fn quota_windows_colour_independently() {
         // A maxed 5h next to a comfortable 7d: 5h red, 7d green — not both painted by the worse.
-        let mut c = cc(48_000);
-        c.five_hour_pct = Some(95.0);
-        c.seven_day_pct = Some(12.0);
-        let segs = extra_segments(&c, &led(Health::Healthy), true);
+        let mut l = led(Health::Healthy);
+        l.sub_five = Some(("5h".into(), 95.0));
+        l.sub_seven = Some(("7d".into(), 12.0));
+        let segs = extra_segments(&cc(48_000), &l, true);
         let quota = segs
             .iter()
             .find(|s| s.contains("5h"))
@@ -1405,12 +1500,67 @@ mod tests {
         // Both windows in one `◔` segment; only one present ⇒ just that one.
         let out = render_line(&cc(48_000), &led(Health::Healthy), 0, false);
         assert!(out.contains("◔ 5h·24% · 7d·12%"), "both windows: {out}");
-        let mut c = cc(48_000);
-        c.seven_day_pct = None;
-        let out = render_line(&c, &led(Health::Healthy), 0, false);
+        let mut l = led(Health::Healthy);
+        l.sub_seven = None;
+        let out = render_line(&cc(48_000), &l, 0, false);
         assert!(
             out.contains("◔ 5h·24%") && !out.contains("7d"),
             "5h only: {out}"
+        );
+    }
+
+    #[test]
+    fn sub_weekly_only_omits_invented_five_hour() {
+        // Plus-style Codex plan: only a weekly window. Must not paint a fake 5h.
+        let mut l = led(Health::Healthy);
+        l.sub_five = None;
+        l.sub_seven = Some(("7d".into(), 1.0));
+        let out = render_line(&cc(48_000), &l, 0, false);
+        assert!(out.contains("◔ 7d·1%"), "weekly shown: {out}");
+        assert!(!out.contains("5h"), "no invented 5h: {out}");
+    }
+
+    #[test]
+    fn sub_without_snapshot_falls_back_to_claude_blob() {
+        // Predicted always-mode / first turn before the proxy poll lands: keep Claude's
+        // numbers rather than a blank segment. Once a snapshot exists it wins (see
+        // `sub_weekly_only_omits_invented_five_hour`).
+        let mut l = led(Health::Healthy);
+        l.sub_five = None;
+        l.sub_seven = None;
+        let out = render_line(&cc(48_000), &l, 0, false);
+        assert!(
+            out.contains("◔ 5h·24% · 7d·12%"),
+            "claude blob until sub cache arrives: {out}"
+        );
+    }
+
+    #[test]
+    fn degraded_proxy_falls_back_to_claude_blob_even_with_sub_cache() {
+        // Unhealthy proxy is not intercepting, so the arrow is hidden and Anthropic will
+        // serve — prefer its blob over a stale codex snapshot.
+        let mut l = led(Health::Degraded);
+        l.sub_five = Some(("5h".into(), 95.0));
+        l.sub_seven = Some(("7d".into(), 1.0));
+        let out = render_line(&cc(48_000), &l, 0, false);
+        assert!(
+            out.contains("◔ 5h·24% · 7d·12%"),
+            "claude blob when degraded: {out}"
+        );
+        assert!(!out.contains("95%"), "stale sub 5h not shown: {out}");
+    }
+
+    #[test]
+    fn off_sub_still_uses_claude_blob_quota() {
+        let mut l = led(Health::Healthy);
+        l.reroute = None;
+        l.resolved_model = None;
+        l.sub_five = None;
+        l.sub_seven = None;
+        let out = render_line(&cc(48_000), &l, 0, false);
+        assert!(
+            out.contains("◔ 5h·24% · 7d·12%"),
+            "claude blob when not rerouted: {out}"
         );
     }
 
@@ -1606,9 +1756,10 @@ mod tests {
     fn quota_and_cache_floor_not_round() {
         // 99.9% cache is not 100%; 89.9% quota is not 90%.
         let mut c = cc(48_000);
-        c.five_hour_pct = Some(89.9);
         c.cache_pct = Some(99.9);
-        let out = render_line(&c, &led(Health::Healthy), 0, false);
+        let mut l = led(Health::Healthy);
+        l.sub_five = Some(("5h".into(), 89.9));
+        let out = render_line(&c, &l, 0, false);
         assert!(out.contains("5h·89%"), "quota floored: {out}");
         assert!(out.contains("♻ 99% cached"), "cache floored: {out}");
     }


### PR DESCRIPTION
## Summary

- Under `/sub` Codex, the status line `◔` segment now shows the **ChatGPT plan** rate limits (weekly always; 5h when the plan reports one) instead of Claude Code's Anthropic blob.
- Proxy polls `GET https://chatgpt.com/backend-api/wham/usage` on each throttled Codex turn (60s, fire-and-forget) and caches `~/.llmtrim/sub-rate-limits.json`.
- Labels come from `limit_window_seconds` (Plus can be weekly-only — no invented 5h). Falls back to Claude's blob until a matching snapshot exists, or when the proxy is unhealthy.
- Kimi/Grok share the cache schema; usage endpoints not wired yet.

## Test plan

- [x] `cargo test -p llmtrim --lib statusline` (50)
- [x] `cargo test -p llmtrim --lib reroute::quota` (5)
- [x] Live probe of `/wham/usage` with stored Codex auth (Plus weekly-only shape)
- [ ] Restart daemon, run a Codex `/sub` turn, confirm `~/.llmtrim/sub-rate-limits.json` updates and status line shows `◔ 7d·N%` (or 5h+7d on Pro)
- [ ] `/sub off` still shows Claude blob quotas when present
- [ ] Degraded/stopped proxy falls back to Claude blob even if a stale codex cache exists