### PR TITLE
Implement new `llmtrim setup --env` feature flag for outputting envvars to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable changes to this project are documented here. The format follows
 ### Added
 
 - **`llmtrim setup --env` creates CA files (if needed) and prints envvars** When this option is
-  used, setup will create CA files (if required) on non-Windows and print a Bash-compatible
-  evaluatable string which can be used to import environment variables into your session.
+  used, setup ensures the local CA (and, on POSIX, the combined OS-trust bundle) exist, then
+  prints an evaluatable snippet — `export` lines on POSIX, `$env:` assignments on Windows — to
+  wire the interceptor into your current shell.
 
 ## [0.11.4] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`llmtrim setup --env` creates CA files (if needed) and prints envvars** When this option is
+  used, setup will create CA files (if required) on non-Windows and print a Bash-compatible
+  evaluatable string which can be used to import environment variables into your session.
+
 ## [0.11.4] - 2026-07-18
 
 ### Added

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -168,6 +168,11 @@ enum Commands {
         /// up a new binary). By default setup leaves a healthy same-port daemon running.
         #[arg(long)]
         force: bool,
+        /// Print the environment variables setup would wire, then exit — no profile,
+        /// autostart, or daemon changes (the CA is still generated if missing, so the
+        /// printed paths are valid).
+        #[arg(long)]
+        env: bool,
     },
     /// Bring this machine to the recommended current state
     ///
@@ -1507,7 +1512,13 @@ fn run() -> Result<()> {
                 llmtrim::serve::run(port, force)?;
             }
         }
-        Commands::Setup { port, force } => llmtrim::setup::run(port, force)?,
+        Commands::Setup { port, force, env } => {
+            if env {
+                llmtrim::setup::print_env(port)?
+            } else {
+                llmtrim::setup::run(port, force)?
+            }
+        }
         Commands::Ensure { quiet } => llmtrim::ensure::run_cli(quiet)?,
         Commands::Uninstall { purge, keep_binary } => {
             llmtrim::setup::uninstall(purge, keep_binary)?

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -171,7 +171,7 @@ enum Commands {
         /// Print the environment variables setup would wire, then exit — no profile,
         /// autostart, or daemon changes (the CA is still generated if missing, so the
         /// printed paths are valid).
-        #[arg(long)]
+        #[arg(long, conflicts_with = "force")]
         env: bool,
     },
     /// Bring this machine to the recommended current state

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -570,12 +570,8 @@ pub fn run(requested: Option<u16>, force: bool) -> Result<()> {
     if manual_env {
         println!();
         println!("Export these in your shell yourself:");
-        println!("    export HTTPS_PROXY={proxy}");
-        println!("    export NO_PROXY={NO_PROXY}");
-        println!("    export NODE_EXTRA_CA_CERTS={ca}");
-        if let Some(b) = bundle.as_deref() {
-            println!("    export SSL_CERT_FILE={b}");
-            println!("    export CURL_CA_BUNDLE={b}");
+        for line in manual_env_lines(&proxy, &ca, bundle.as_deref()) {
+            println!("    {line}");
         }
     }
 
@@ -1586,6 +1582,66 @@ fn env_block(proxy: &str, ca: &str, bundle: Option<&str>, syntax: Syntax) -> Str
     }
 }
 
+/// The interceptor env as standalone, ungated shell lines — one `export`/`$env:` assignment
+/// per variable, no `BEGIN`/`END` markers and no `llmtrim _alive` liveness gate (unlike
+/// [`env_block`], this isn't a persisted block that must self-disable when the daemon later
+/// stops; it's a one-shot snippet the caller evals or copies immediately). Shared by `run`'s
+/// "no profile found" fallback and `print_env`, so both always report the same variables.
+fn manual_env_lines(proxy: &str, ca: &str, bundle: Option<&str>) -> Vec<String> {
+    #[cfg(not(windows))]
+    {
+        let mut lines = vec![
+            format!("export HTTPS_PROXY=\"{proxy}\""),
+            format!("export HTTP_PROXY=\"{proxy}\""),
+            format!("export NO_PROXY=\"{NO_PROXY}\""),
+            format!("export no_proxy=\"{NO_PROXY}\""),
+            format!("export NODE_EXTRA_CA_CERTS=\"{ca}\""),
+        ];
+        if let Some(b) = bundle {
+            lines.push(format!("export SSL_CERT_FILE=\"{b}\""));
+            lines.push(format!("export CURL_CA_BUNDLE=\"{b}\""));
+        }
+        lines
+    }
+    #[cfg(windows)]
+    {
+        let _ = bundle; // no combined bundle on Windows — see env_block's PowerShell arm
+        vec![
+            format!("$env:HTTPS_PROXY = \"{proxy}\""),
+            format!("$env:HTTP_PROXY = \"{proxy}\""),
+            format!("$env:NO_PROXY = \"{NO_PROXY}\""),
+            format!("$env:NODE_EXTRA_CA_CERTS = \"{ca}\""),
+        ]
+    }
+}
+
+/// `llmtrim setup --env` — print the interceptor environment variables `setup` would wire,
+/// then exit. No shell profile, autostart, or daemon changes; the CA (and, on POSIX, the
+/// combined CA bundle) are generated if missing so the printed paths are valid immediately.
+/// Port resolution mirrors `run`'s real precedence (`--port` > running daemon > already-
+/// configured env > scan from default) via [`resolve_port`], but skips the orphaned-port
+/// reclaim dance in `run` — that's tied to actually taking over a port to start a daemon,
+/// not to printing.
+pub fn print_env(requested: Option<u16>) -> Result<()> {
+    let running = crate::daemon::running();
+    let port = resolve_port(requested, running.as_ref().map(|s| s.port))?;
+    crate::serve::ensure_ca()?;
+    let ca_path = crate::serve::ca_cert_path()?;
+    let ca = ca_path.to_string_lossy().into_owned();
+    let proxy = format!("http://127.0.0.1:{port}");
+    #[cfg(not(windows))]
+    let bundle = ensure_ca_bundle(&ca_path)
+        .ok()
+        .flatten()
+        .map(|p| p.to_string_lossy().into_owned());
+    #[cfg(windows)]
+    let bundle: Option<String> = None;
+    for line in manual_env_lines(&proxy, &ca, bundle.as_deref()) {
+        println!("{line}");
+    }
+    Ok(())
+}
+
 /// Inner seam for [`write_profile_block`]: write into a profile file named by `shell` (the
 /// basename of `$SHELL`, e.g. `"bash"` → `.bashrc`, `"zsh"` → `.zshrc`) under `base` as the
 /// home directory. Sweeps stale blocks from all other candidates under `base` first, then
@@ -2012,6 +2068,52 @@ mod tests {
         assert!(b.contains("export SSL_CERT_FILE=\"/home/u/.llmtrim/ca-bundle.pem\""));
         assert!(b.contains("export CURL_CA_BUNDLE=\"/home/u/.llmtrim/ca-bundle.pem\""));
         assert!(b.trim_end().ends_with(END));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn manual_env_lines_posix_omits_bundle_vars_when_none() {
+        let lines = manual_env_lines("http://127.0.0.1:8787", "/home/u/ca.pem", None);
+        assert!(lines.contains(&"export HTTPS_PROXY=\"http://127.0.0.1:8787\"".to_string()));
+        assert!(lines.contains(&"export HTTP_PROXY=\"http://127.0.0.1:8787\"".to_string()));
+        assert!(lines.contains(&format!("export NO_PROXY=\"{NO_PROXY}\"")));
+        assert!(lines.contains(&format!("export no_proxy=\"{NO_PROXY}\"")));
+        assert!(lines.contains(&"export NODE_EXTRA_CA_CERTS=\"/home/u/ca.pem\"".to_string()));
+        assert!(!lines.iter().any(|l| l.contains("SSL_CERT_FILE")));
+        assert!(!lines.iter().any(|l| l.contains("CURL_CA_BUNDLE")));
+        // Unlike env_block, this is a standalone eval-able snippet: no BEGIN/END markers,
+        // no `llmtrim _alive` liveness gate.
+        assert!(!lines.iter().any(|l| l.contains(BEGIN) || l.contains("_alive")));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn manual_env_lines_posix_includes_bundle_vars_when_present() {
+        let lines = manual_env_lines(
+            "http://127.0.0.1:8787",
+            "/home/u/.llmtrim/ca.pem",
+            Some("/home/u/.llmtrim/ca-bundle.pem"),
+        );
+        assert!(
+            lines.contains(&"export SSL_CERT_FILE=\"/home/u/.llmtrim/ca-bundle.pem\"".to_string())
+        );
+        assert!(
+            lines
+                .contains(&"export CURL_CA_BUNDLE=\"/home/u/.llmtrim/ca-bundle.pem\"".to_string())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn manual_env_lines_windows_uses_env_assignment_and_ignores_bundle() {
+        let lines = manual_env_lines(
+            "http://127.0.0.1:8787",
+            "C:\\Users\\u\\.llmtrim\\ca.pem",
+            Some("C:\\Users\\u\\.llmtrim\\ca-bundle.pem"),
+        );
+        assert!(lines.contains(&"$env:HTTPS_PROXY = \"http://127.0.0.1:8787\"".to_string()));
+        assert!(!lines.iter().any(|l| l.contains("SSL_CERT_FILE")));
+        assert!(!lines.iter().any(|l| l.contains("CURL_CA_BUNDLE")));
     }
 
     #[cfg(not(windows))] // system_ca_bundle/ensure_ca_bundle are POSIX-only (Windows uses the cert store)

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -1582,24 +1582,33 @@ fn env_block(proxy: &str, ca: &str, bundle: Option<&str>, syntax: Syntax) -> Str
     }
 }
 
+/// Escape `s` for a single-quoted PowerShell literal: `'…'`, doubling any embedded `'`.
+#[cfg(windows)]
+fn powershell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}
+
 /// The interceptor env as standalone, ungated shell lines — one `export`/`$env:` assignment
 /// per variable, no `BEGIN`/`END` markers and no `llmtrim _alive` liveness gate (unlike
 /// [`env_block`], this isn't a persisted block that must self-disable when the daemon later
 /// stops; it's a one-shot snippet the caller evals or copies immediately). Shared by `run`'s
 /// "no profile found" fallback and `print_env`, so both always report the same variables.
+/// Values are single-quoted (not `env_block`'s bare double quotes) since this snippet exists
+/// specifically to be `eval`'d.
 fn manual_env_lines(proxy: &str, ca: &str, bundle: Option<&str>) -> Vec<String> {
     #[cfg(not(windows))]
     {
+        use crate::statusline::shell_quote_path as q;
         let mut lines = vec![
-            format!("export HTTPS_PROXY=\"{proxy}\""),
-            format!("export HTTP_PROXY=\"{proxy}\""),
-            format!("export NO_PROXY=\"{NO_PROXY}\""),
-            format!("export no_proxy=\"{NO_PROXY}\""),
-            format!("export NODE_EXTRA_CA_CERTS=\"{ca}\""),
+            format!("export HTTPS_PROXY={}", q(proxy)),
+            format!("export HTTP_PROXY={}", q(proxy)),
+            format!("export NO_PROXY={}", q(NO_PROXY)),
+            format!("export no_proxy={}", q(NO_PROXY)),
+            format!("export NODE_EXTRA_CA_CERTS={}", q(ca)),
         ];
         if let Some(b) = bundle {
-            lines.push(format!("export SSL_CERT_FILE=\"{b}\""));
-            lines.push(format!("export CURL_CA_BUNDLE=\"{b}\""));
+            lines.push(format!("export SSL_CERT_FILE={}", q(b)));
+            lines.push(format!("export CURL_CA_BUNDLE={}", q(b)));
         }
         lines
     }
@@ -1607,10 +1616,10 @@ fn manual_env_lines(proxy: &str, ca: &str, bundle: Option<&str>) -> Vec<String> 
     {
         let _ = bundle; // no combined bundle on Windows — see env_block's PowerShell arm
         vec![
-            format!("$env:HTTPS_PROXY = \"{proxy}\""),
-            format!("$env:HTTP_PROXY = \"{proxy}\""),
-            format!("$env:NO_PROXY = \"{NO_PROXY}\""),
-            format!("$env:NODE_EXTRA_CA_CERTS = \"{ca}\""),
+            format!("$env:HTTPS_PROXY = {}", powershell_quote(proxy)),
+            format!("$env:HTTP_PROXY = {}", powershell_quote(proxy)),
+            format!("$env:NO_PROXY = {}", powershell_quote(NO_PROXY)),
+            format!("$env:NODE_EXTRA_CA_CERTS = {}", powershell_quote(ca)),
         ]
     }
 }
@@ -1625,15 +1634,34 @@ fn manual_env_lines(proxy: &str, ca: &str, bundle: Option<&str>) -> Vec<String> 
 pub fn print_env(requested: Option<u16>) -> Result<()> {
     let running = crate::daemon::running();
     let port = resolve_port(requested, running.as_ref().map(|s| s.port))?;
+    if running.map(|s| s.port) != Some(port) {
+        eprintln!(
+            "{}",
+            ui::warn(
+                ui::color_stderr(),
+                &format!(
+                    "no llmtrim daemon is running on port {port} — start one with \
+                     `llmtrim start --port {port}` before eval'ing this, or HTTPS_PROXY will \
+                     point at a dead port"
+                )
+            )
+        );
+    }
     crate::serve::ensure_ca()?;
     let ca_path = crate::serve::ca_cert_path()?;
     let ca = ca_path.to_string_lossy().into_owned();
     let proxy = format!("http://127.0.0.1:{port}");
     #[cfg(not(windows))]
-    let bundle = ensure_ca_bundle(&ca_path)
-        .ok()
-        .flatten()
-        .map(|p| p.to_string_lossy().into_owned());
+    let bundle = match ensure_ca_bundle(&ca_path) {
+        Ok(b) => b.map(|p| p.to_string_lossy().into_owned()),
+        Err(e) => {
+            eprintln!(
+                "{}",
+                ui::warn(ui::color_stderr(), &format!("CA bundle not built: {e}"))
+            );
+            None
+        }
+    };
     #[cfg(windows)]
     let bundle: Option<String> = None;
     for line in manual_env_lines(&proxy, &ca, bundle.as_deref()) {
@@ -2074,16 +2102,20 @@ mod tests {
     #[test]
     fn manual_env_lines_posix_omits_bundle_vars_when_none() {
         let lines = manual_env_lines("http://127.0.0.1:8787", "/home/u/ca.pem", None);
-        assert!(lines.contains(&"export HTTPS_PROXY=\"http://127.0.0.1:8787\"".to_string()));
-        assert!(lines.contains(&"export HTTP_PROXY=\"http://127.0.0.1:8787\"".to_string()));
-        assert!(lines.contains(&format!("export NO_PROXY=\"{NO_PROXY}\"")));
-        assert!(lines.contains(&format!("export no_proxy=\"{NO_PROXY}\"")));
-        assert!(lines.contains(&"export NODE_EXTRA_CA_CERTS=\"/home/u/ca.pem\"".to_string()));
+        assert!(lines.contains(&"export HTTPS_PROXY='http://127.0.0.1:8787'".to_string()));
+        assert!(lines.contains(&"export HTTP_PROXY='http://127.0.0.1:8787'".to_string()));
+        assert!(lines.contains(&format!("export NO_PROXY='{NO_PROXY}'")));
+        assert!(lines.contains(&format!("export no_proxy='{NO_PROXY}'")));
+        assert!(lines.contains(&"export NODE_EXTRA_CA_CERTS='/home/u/ca.pem'".to_string()));
         assert!(!lines.iter().any(|l| l.contains("SSL_CERT_FILE")));
         assert!(!lines.iter().any(|l| l.contains("CURL_CA_BUNDLE")));
         // Unlike env_block, this is a standalone eval-able snippet: no BEGIN/END markers,
         // no `llmtrim _alive` liveness gate.
-        assert!(!lines.iter().any(|l| l.contains(BEGIN) || l.contains("_alive")));
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.contains(BEGIN) || l.contains("_alive"))
+        );
     }
 
     #[cfg(not(windows))]
@@ -2095,11 +2127,10 @@ mod tests {
             Some("/home/u/.llmtrim/ca-bundle.pem"),
         );
         assert!(
-            lines.contains(&"export SSL_CERT_FILE=\"/home/u/.llmtrim/ca-bundle.pem\"".to_string())
+            lines.contains(&"export SSL_CERT_FILE='/home/u/.llmtrim/ca-bundle.pem'".to_string())
         );
         assert!(
-            lines
-                .contains(&"export CURL_CA_BUNDLE=\"/home/u/.llmtrim/ca-bundle.pem\"".to_string())
+            lines.contains(&"export CURL_CA_BUNDLE='/home/u/.llmtrim/ca-bundle.pem'".to_string())
         );
     }
 
@@ -2111,7 +2142,7 @@ mod tests {
             "C:\\Users\\u\\.llmtrim\\ca.pem",
             Some("C:\\Users\\u\\.llmtrim\\ca-bundle.pem"),
         );
-        assert!(lines.contains(&"$env:HTTPS_PROXY = \"http://127.0.0.1:8787\"".to_string()));
+        assert!(lines.contains(&"$env:HTTPS_PROXY = 'http://127.0.0.1:8787'".to_string()));
         assert!(!lines.iter().any(|l| l.contains("SSL_CERT_FILE")));
         assert!(!lines.iter().any(|l| l.contains("CURL_CA_BUNDLE")));
     }


### PR DESCRIPTION
<!-- Thanks for contributing to llmtrim! -->

## What & why

This change implements a `--env` flag to `llmtrim setup`.  The purpose of this flag is to output a direct `eval`-able fragment of the envvars that would normally be present in your `.profile`.

What this accomplishes is allows you to not have llmtrim envvars in your shell under normal circumstances, and you can instead load them on demand precisely when you are going to run a wrappable command.

This feature is primarily relevant for non-Windows builds, but it should work for Windows too.

## Linked issue

No linked issue.  This change is minor and focused exclusively on a small new feature and tests around it.

## How it was verified

Check loop passes.  Verify that `llmtrim setup` still works as expected.  Verify that `llmtrim setup --env` outputs envvars as expected.

- [Y ] `cargo fmt` is clean
- [Y] `cargo clippy --features intercept` is clean
- [Y] `cargo nextest run --features intercept` passes
- [Y] New behavior is covered by a test
- [Y] `CHANGELOG.md` has an entry under `## [Unreleased]` (or the change is invisible to users)
- [Y] Commits are signed off (`git commit -s`, DCO, see CONTRIBUTING.md)

## Notes

In my workflow, I don't want to leave llmtrim's HTTPS_PROXY envvars floating in my sessions.  Therefore I have a script which inserts the envvars and then uses `llmtrim wrap` to wrap Claude or OpenCode etc.  Previously I'd been doing this by parsing out .profile again and stripping comments, but it would be cleaner to just have llmtrim output its envvars in a format that can simply be `eval`ed into the current shell with something like `eval $(llmtrim setup --env)`.