### PR TITLE
fix(config): consume the whole array when rewriting compact.models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **`compact.models` no longer corrupts the config when it was written as a multi-line array.**
+  The writer replaced the single `models = [` line and left the array's continuation lines
+  behind, stranding `"haiku",` / `]` after the new value and producing a `config.toml` that
+  llmtrim could no longer parse. It now consumes the whole array. A file already damaged this
+  way still needs a manual edit: once the tail is orphaned nothing distinguishes it from real
+  config, so repairing it automatically would risk deleting keys.
+
 ### Added
 
 - **`llmtrim setup --env` creates CA files (if needed) and prints envvars** When this option is

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1202,14 +1202,28 @@ pub fn compact_models_configured() -> bool {
         .is_some()
 }
 
+/// Whether `line` is a table header (`[compact]`, `[sub.codex.tiers]`) rather than array
+/// content. Used as a hard stop while skipping a multi-line array: an array left unterminated
+/// is already-invalid TOML, and bracket counting alone can never recover from it because a
+/// header nets to zero depth, so the skip would run to EOF and delete every later section.
+///
+/// A trailing comma or an unclosed bracket disqualifies, which is what separates a header from
+/// an array element line like `[1, 2],`.
+fn is_section_header(line: &str) -> bool {
+    let s = line.trim();
+    let s = s.split('#').next().unwrap_or_default().trim();
+    s.len() > 2 && s.starts_with('[') && s.ends_with(']') && !s.contains(',')
+}
+
 /// Net `[` minus `]` on one TOML line, ignoring brackets that sit inside a string or after a
 /// `#` comment. Used to tell an open multi-line array (`models = [`) from a closed one
 /// (`models = ["haiku"]`) and to find where the open one ends.
 ///
 /// Deliberately small: it handles basic (`"…"`, with `\` escapes) and literal (`'…'`, no
-/// escapes) strings, which is everything the value of `compact.models` can contain. Multi-line
-/// basic strings (`"""`) would need a cross-line state machine; a model name can't contain one,
-/// and mis-parsing one only means we copy a stale line through rather than corrupt the file.
+/// escapes) strings, which is everything the value of `compact.models` can contain. It is not a
+/// TOML parser. A multi-line basic string (`"""`) holding a `]` closes the count early and can
+/// strand a line — the same outcome the old writer had for that input, unreachable for a list
+/// of model names, and bounded by the [`is_section_header`] stop either way.
 ///
 /// This prevents *new* corruption; it does not repair a file already corrupted by the old
 /// writer. There the `models` line is itself complete, so nothing marks the orphaned tail as
@@ -1285,8 +1299,15 @@ fn write_compact_models_at(path: &std::path::Path, models: &[String]) -> Result<
     let mut out = Vec::new();
     for raw in existing.lines() {
         if pending_array > 0 {
-            pending_array += bracket_depth_delta(raw);
-            continue;
+            // A section header ends the swallow no matter what the brackets say. An array left
+            // unterminated (already-invalid TOML) would otherwise run to EOF and delete every
+            // later section: `[sub]` nets to zero depth, so counting alone never recovers.
+            if is_section_header(raw) {
+                pending_array = 0;
+            } else {
+                pending_array += bracket_depth_delta(raw);
+                continue;
+            }
         }
         let trimmed = raw.trim();
         let section = trimmed.split('#').next().unwrap_or_default().trim();
@@ -2149,6 +2170,76 @@ mod tests {
         assert!(text.contains("capture_dir = \"/tmp/cap\""));
         assert!(text.contains("[sub]") && text.contains("active = \"off\""));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An array left unterminated is already-invalid TOML, but the rewrite must still not eat
+    /// the rest of the file: a table header stops the skip, so later sections survive. Bracket
+    /// counting alone can't do this — `[sub]` nets to zero depth.
+    #[test]
+    fn compact_models_unterminated_array_stops_at_the_next_section() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmtrim-cfg-unterminated-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        std::fs::write(
+            &path,
+            "[compact]\nmodels = [\n    \"haiku\",\n\n[sub]\nactive = \"off\"\nlast = \"grok\"\n",
+        )
+        .unwrap();
+        write_compact_models_at(&path, &["sonnet".into()]).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        // The later section and every key under it survive.
+        assert!(text.contains("[sub]"), "later section deleted: {text}");
+        assert!(text.contains("active = \"off\""), "key deleted: {text}");
+        assert!(text.contains("last = \"grok\""), "key deleted: {text}");
+        let file: toml::Value = toml::from_str(&text)
+            .unwrap_or_else(|e| panic!("rewrite must parse, got {e}\n---\n{text}"));
+        assert_eq!(resolve_compact_models(Some(&file)), vec!["sonnet"]);
+    }
+
+    /// A file already damaged by the old writer is left exactly as-is apart from the value: the
+    /// orphaned tail is neither repaired nor deleted. The CHANGELOG promises this; pin it.
+    #[test]
+    fn compact_models_leaves_an_already_corrupted_tail_alone() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmtrim-cfg-corrupt-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        std::fs::write(
+            &path,
+            "[compact]\nmodels = [\"haiku\", \"sonnet\"]\n    \"haiku\",\n]\n\n[sub]\nactive = \"off\"\n",
+        )
+        .unwrap();
+        write_compact_models_at(&path, &["opus".into()]).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            text.contains("models = [\"opus\"]"),
+            "value not set: {text}"
+        );
+        // Untouched: no silent deletion of lines we can't classify.
+        assert!(text.contains("    \"haiku\","), "tail deleted: {text}");
+        assert!(text.contains("[sub]") && text.contains("active = \"off\""));
+    }
+
+    #[test]
+    fn is_section_header_accepts_tables_and_rejects_array_content() {
+        assert!(is_section_header("[compact]"));
+        assert!(is_section_header("  [sub.codex.tiers]  "));
+        assert!(is_section_header("[compact] # routing policy"));
+        assert!(!is_section_header("models = ["));
+        assert!(!is_section_header("    \"haiku\","));
+        assert!(
+            !is_section_header("[1, 2],"),
+            "array element is not a header"
+        );
+        assert!(!is_section_header("]"));
+        assert!(!is_section_header(""));
     }
 
     #[test]

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1202,6 +1202,53 @@ pub fn compact_models_configured() -> bool {
         .is_some()
 }
 
+/// Net `[` minus `]` on one TOML line, ignoring brackets that sit inside a string or after a
+/// `#` comment. Used to tell an open multi-line array (`models = [`) from a closed one
+/// (`models = ["haiku"]`) and to find where the open one ends.
+///
+/// Deliberately small: it handles basic (`"…"`, with `\` escapes) and literal (`'…'`, no
+/// escapes) strings, which is everything the value of `compact.models` can contain. Multi-line
+/// basic strings (`"""`) would need a cross-line state machine; a model name can't contain one,
+/// and mis-parsing one only means we copy a stale line through rather than corrupt the file.
+///
+/// This prevents *new* corruption; it does not repair a file already corrupted by the old
+/// writer. There the `models` line is itself complete, so nothing marks the orphaned tail as
+/// array leftovers rather than real config, and guessing risks deleting a user's keys. Such a
+/// file no longer parses, so llmtrim reports it and the user edits it by hand.
+fn bracket_depth_delta(line: &str) -> i32 {
+    let mut depth = 0i32;
+    let mut chars = line.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '#' => break,
+            '[' => depth += 1,
+            ']' => depth -= 1,
+            '"' => {
+                // Basic string: honor backslash escapes so `"a\"]"` doesn't end early.
+                while let Some(s) = chars.next() {
+                    match s {
+                        '\\' => {
+                            chars.next();
+                        }
+                        '"' => break,
+                        _ => {}
+                    }
+                }
+            }
+            '\'' => {
+                // Literal string: no escapes, runs to the next quote.
+                for s in chars.by_ref() {
+                    if s == '\'' {
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    depth
+}
+
 fn write_compact_models_at(path: &std::path::Path, models: &[String]) -> Result<()> {
     use anyhow::Context;
     if let Some(parent) = path.parent() {
@@ -1230,8 +1277,17 @@ fn write_compact_models_at(path: &std::path::Path, models: &[String]) -> Result<
     let mut in_compact = false;
     let mut compact_found = false;
     let mut replaced = false;
+    // Depth still owed by an old multi-line `models = [` we are replacing. While non-zero we
+    // swallow the continuation lines instead of copying them through: the replacement is a
+    // complete single-line array, so leaving `"haiku",` / `]` behind would strand them after it
+    // and make the file unparseable.
+    let mut pending_array = 0i32;
     let mut out = Vec::new();
     for raw in existing.lines() {
+        if pending_array > 0 {
+            pending_array += bracket_depth_delta(raw);
+            continue;
+        }
         let trimmed = raw.trim();
         let section = trimmed.split('#').next().unwrap_or_default().trim();
         if section.starts_with('[') {
@@ -1250,6 +1306,9 @@ fn write_compact_models_at(path: &std::path::Path, models: &[String]) -> Result<
         {
             out.push(line.clone());
             replaced = true;
+            // Only the value side counts: `models = [` opens an array, `models = ["a"]` doesn't.
+            let value = trimmed.split_once('=').map(|(_, v)| v).unwrap_or_default();
+            pending_array = bracket_depth_delta(value).max(0);
         } else {
             out.push(raw.to_string());
         }
@@ -2056,6 +2115,54 @@ mod tests {
         assert!(text.contains("# keep me"));
         assert!(text.find("models =").unwrap() < text.find("[sub]").unwrap());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Rewriting a *multi-line* `models` array must consume its continuation lines. Replacing
+    /// only the `models = [` line strands `"haiku",` / `]` after the new single-line value and
+    /// produces a config llmtrim can no longer parse — which is how a real install ended up
+    /// with an unreadable file.
+    #[test]
+    fn compact_models_replaces_a_multiline_array_without_stranding_lines() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmtrim-cfg-multiline-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        std::fs::write(
+            &path,
+            "capture_dir = \"/tmp/cap\"\n\n[compact]\nmodels = [\n    \"haiku\",\n    \"sonnet\",\n]\n\n[sub]\nactive = \"off\"\n",
+        )
+        .unwrap();
+        write_compact_models_at(&path, &["haiku".into(), "sonnet".into()]).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        // Parses (the whole point) and holds the new value.
+        let file: toml::Value = toml::from_str(&text)
+            .unwrap_or_else(|e| panic!("rewritten config must parse, got {e}\n---\n{text}"));
+        assert_eq!(resolve_compact_models(Some(&file)), vec!["haiku", "sonnet"]);
+        // The old array's continuation lines are gone, not stranded below the replacement.
+        assert!(!text.contains("    \"haiku\","), "stranded line: {text}");
+        assert!(!text.contains("\n]"), "stranded bracket: {text}");
+        assert_eq!(text.matches("models =").count(), 1);
+        // Neighbouring keys and sections survive the surgical edit.
+        assert!(text.contains("capture_dir = \"/tmp/cap\""));
+        assert!(text.contains("[sub]") && text.contains("active = \"off\""));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bracket_depth_delta_ignores_brackets_in_strings_and_comments() {
+        assert_eq!(bracket_depth_delta("models = ["), 1);
+        assert_eq!(bracket_depth_delta("models = [\"haiku\"]"), 0);
+        assert_eq!(bracket_depth_delta("]"), -1);
+        // Brackets inside strings and comments don't count.
+        assert_eq!(bracket_depth_delta("models = [\"a]b\"]"), 0);
+        assert_eq!(bracket_depth_delta("models = [] # [not an array]"), 0);
+        assert_eq!(bracket_depth_delta("x = 'a]b'"), 0);
+        // Escaped quote doesn't end the string early, so its `]` stays inert.
+        assert_eq!(bracket_depth_delta("x = \"a\\\"]\""), 0);
+        assert_eq!(bracket_depth_delta("nested = [[1], [2]]"), 0);
     }
 
     #[test]


### PR DESCRIPTION
## What & why

llmtrim wrote a `config.toml` it could no longer read. I hit this on a real install: `~/.config/llmtrim/config.toml` failed to parse, which also broke two MCP tests that read the real user config.

`write_compact_models_at` is a line-based TOML editor, chosen so comments and key order survive. It replaced only the line whose key was `models`. When the value was a multi-line array it overwrote `models = [` and left the tail behind:

```toml
[compact]
models = ["haiku", "sonnet"]
    "haiku",      # stranded
    "sonnet",     # stranded
]                 # stranded
```

Now it tracks the array's bracket depth and consumes the continuation lines, with a scanner that ignores brackets inside strings and after `#`.

## Second commit

A review pass found a data-loss path in the first commit. An array left unterminated is already-invalid TOML and never closes by bracket count, because a header like `[sub]` nets to zero depth. The skip ran to EOF and deleted every following section. Reachable, since nothing validates parseability before a rewrite and `llmtrim setup` will happily rewrite an unreadable file.

Fixed by stopping the skip at a table header regardless of depth. Also corrected the `bracket_depth_delta` doc comment, which claimed a multi-line basic string could only strand a stale line when it can also corrupt.

## Scope

Only `write_compact_models_at` had this hazard. `write_sub_mapping_at` goes through a real TOML round-trip, and `save_theme_at` writes a scalar that is never multi-line.

## Deliberately not done

A file already damaged this way is not auto-repaired. There the `models` line is complete, so nothing distinguishes the orphaned tail from real config, and guessing risks deleting keys. Such a file no longer parses, so llmtrim reports it and the user edits it by hand. `compact_models_leaves_an_already_corrupted_tail_alone` pins that it is neither repaired nor silently deleted.

Also pre-existing and out of scope: a top-level dotted `compact.models = [...]` is ignored and a duplicate `[compact]` gets appended. Same behavior on `main`; worth a separate issue.

## How it was verified

`cargo fmt`, `cargo clippy --features intercept --all-targets`, and `cargo nextest run --features intercept` all clean: 1171/1171.

New tests: multi-line array rewrite leaves nothing stranded and still parses; unterminated array stops at the next section with later keys intact; already-corrupted tail left alone; plus unit coverage for `bracket_depth_delta` (strings, comments, escapes, nesting) and `is_section_header` (rejects array element lines like `[1, 2],`).

- [x] `cargo fmt` is clean
- [x] `cargo clippy --features intercept` is clean
- [x] `cargo nextest run --features intercept` passes
- [x] New behavior is covered by a test
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`
- [x] Commits are signed off
