### PR TITLE
test(mcp): make the MCP tests independent of the real config file

### DIFF
--- a/crates/llmtrim-cli/src/mcp.rs
+++ b/crates/llmtrim-cli/src/mcp.rs
@@ -23,12 +23,17 @@ pub use imp::{install, run};
 
 /// The MCP handler the `mcp` command serves, for protocol-level tests that drive it over
 /// an in-memory transport instead of stdio. `db` is an isolated ledger path so the test
-/// never writes to the user's real savings DB. Not a stable API: it exists only for the
-/// `tests/mcp_protocol.rs` integration test (which can't reach the private `mod imp`).
+/// never writes to the user's real savings DB, and `config` is a fixed compression config so
+/// the test never reads the developer's `~/.llmtrim` (a malformed one used to fail it). Not a
+/// stable API: it exists only for the `tests/mcp_protocol.rs` integration test (which can't
+/// reach the private `mod imp`).
 #[doc(hidden)]
 #[cfg(feature = "mcp")]
-pub fn test_server(db: std::path::PathBuf) -> impl rmcp::ServerHandler + Clone {
-    imp::server_at(db)
+pub fn test_server(
+    db: std::path::PathBuf,
+    config: llmtrim_core::config::DenseConfig,
+) -> impl rmcp::ServerHandler + Clone {
+    imp::server_at(db, config)
 }
 
 #[cfg(feature = "mcp")]
@@ -104,17 +109,35 @@ mod imp {
     #[derive(Clone)]
     pub(super) struct LlmtrimServer {
         db: Option<PathBuf>,
+        /// The compression config: `None` is the real one (`DenseConfig::load`, honoring
+        /// `~/.llmtrim` like every other front-end); `Some(c)` is a fixed config for tests,
+        /// so the protocol test never depends on the developer's config file.
+        config: Option<DenseConfig>,
     }
 
     pub(super) fn server() -> LlmtrimServer {
-        LlmtrimServer { db: None }
+        LlmtrimServer {
+            db: None,
+            config: None,
+        }
     }
 
-    pub(super) fn server_at(db: PathBuf) -> LlmtrimServer {
-        LlmtrimServer { db: Some(db) }
+    pub(super) fn server_at(db: PathBuf, config: DenseConfig) -> LlmtrimServer {
+        LlmtrimServer {
+            db: Some(db),
+            config: Some(config),
+        }
     }
 
     impl LlmtrimServer {
+        /// The config to compress under: the injected one, else the on-disk one.
+        fn config(&self) -> Result<DenseConfig, McpError> {
+            match &self.config {
+                Some(c) => Ok(c.clone()),
+                None => DenseConfig::load().map_err(internal),
+            }
+        }
+
         fn tracker(&self) -> Result<Tracker> {
             match &self.db {
                 Some(p) => Tracker::open_at(p),
@@ -139,7 +162,11 @@ mod imp {
             &self,
             Parameters(args): Parameters<CompressArgs>,
         ) -> Result<CallToolResult, McpError> {
-            let result = compress(&args.request.into_body(), args.provider.as_deref())?;
+            let result = compress_with(
+                &args.request.into_body(),
+                args.provider.as_deref(),
+                &self.config()?,
+            )?;
             self.record(&ledger_record(&result));
             ok_json(&compress_payload(&result))
         }
@@ -175,16 +202,21 @@ mod imp {
     )]
     impl ServerHandler for LlmtrimServer {}
 
-    /// Run the engine once, honoring `~/.llmtrim` config like the proxy and CLI. Pure: the
-    /// caller records the savings. A bad provider hint or malformed request comes back as a
+    /// Run the engine once against an explicit config. The seam the config-independent
+    /// callers use: no file is read, so a caller that already has a config (or a test that
+    /// wants a fixed one) never depends on the machine's `~/.llmtrim`. Pure: the caller
+    /// records the savings. A bad provider hint or malformed request comes back as a
     /// JSON-RPC error, never a panic.
-    fn compress(request: &str, provider: Option<&str>) -> Result<CompressResult, McpError> {
+    fn compress_with(
+        request: &str,
+        provider: Option<&str>,
+        config: &DenseConfig,
+    ) -> Result<CompressResult, McpError> {
         let kind = provider
             .map(ProviderKind::from_str)
             .transpose()
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-        let config = DenseConfig::load().map_err(internal)?;
-        llmtrim_core::compress_with_config(request, kind, &config)
+        llmtrim_core::compress_with_config(request, kind, config)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))
     }
 
@@ -543,13 +575,17 @@ mod imp {
 
         #[test]
         fn bad_provider_is_invalid_params_not_panic() {
-            let err = compress(&req(), Some("not-a-provider")).unwrap_err();
+            let config = DenseConfig::preset("auto").expect("built-in preset");
+            let err = compress_with(&req(), Some("not-a-provider"), &config).unwrap_err();
             assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
         }
 
         #[test]
         fn malformed_request_is_an_error() {
-            let err = compress("{ not json", None).unwrap_err();
+            // A fixed config, not `DenseConfig::load()`: this test is about malformed JSON,
+            // not config loading, so it must not read (or fail on) the machine's config file.
+            let config = DenseConfig::preset("auto").expect("built-in preset");
+            let err = compress_with("{ not json", None, &config).unwrap_err();
             assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
         }
 

--- a/crates/llmtrim-cli/tests/mcp_protocol.rs
+++ b/crates/llmtrim-cli/tests/mcp_protocol.rs
@@ -17,8 +17,13 @@ async fn initialize_list_and_call_over_jsonrpc() {
 
     // The server side: spawn the real handler the `llmtrim mcp` command serves. We start
     // it through the same public entry the binary uses, over the duplex instead of stdio.
+    // Isolate the config too: a fixed built-in preset, so the test never reads (or fails on)
+    // the developer's `~/.llmtrim` config file. CI has no such file; a malformed local one
+    // used to fail this test while CI stayed green.
+    let config = llmtrim_core::config::DenseConfig::preset("auto").expect("built-in preset");
+
     let server = tokio::spawn(async move {
-        let service = llmtrim::mcp::test_server(db)
+        let service = llmtrim::mcp::test_server(db, config)
             .serve(server_transport)
             .await
             .expect("server handshake");
@@ -69,8 +74,8 @@ async fn initialize_list_and_call_over_jsonrpc() {
     }
 
     // llmtrim_compress: a real-shaped request comes back compressed with token deltas. We
-    // don't assert the input shrinks (the server honors ~/.llmtrim config, whose `auto`
-    // default may add an output-shaping instruction); the deterministic mapping is unit-tested.
+    // don't assert the input shrinks (the `auto` config may add an output-shaping
+    // instruction); the deterministic mapping is unit-tested.
     let request_body = json!({
         "model": "gpt-4o",
         "messages": [


### PR DESCRIPTION
## What & why

Two MCP tests read the developer's real `~/.config/llmtrim/config.toml`:

- `mcp::imp::tests::malformed_request_is_an_error`
- `mcp_protocol::initialize_list_and_call_over_jsonrpc`

Neither is about config loading. Both call `compress()`, which called `DenseConfig::load()`, which reads the file. A malformed config therefore failed both with `failed to parse …/config.toml`, while CI stayed green because CI has no user config. That happened for real this week: a config corrupted by the bug fixed in #198 broke both tests locally with nothing to point at the cause.

A third test in the same file, `bad_provider_is_invalid_params_not_panic`, had the identical dependency and is fixed here too.

## Mechanism

Dependency injection, reusing the pattern already in this file. `LlmtrimServer` had a `db: Option<PathBuf>` field so tests avoid the user's real ledger; this adds `config: Option<DenseConfig>` alongside it, on the same principle.

- `compress(request, provider)` becomes `compress_with(request, provider, &DenseConfig)`.
- `fn config()` returns the injected config, or `DenseConfig::load()` on the `None` arm.
- `server()` (production) passes `None`, so behavior is byte-identical.
- `server_at()` / `test_server()` take a config; the protocol test passes `DenseConfig::preset("auto")`.

`preset("auto")` and the `auto()` that `load()` falls back to when no file exists are the same value (`lossless()` with `auto = true`), so the tests now assert against exactly what CI was implicitly exercising.

Rejected: setting `LLMTRIM_PRESET`, or redirecting `XDG_CONFIG_HOME`/`HOME` per test. `std::env::set_var` is process-global, which is safe under nextest (process per test) but races under `cargo test`, and contributors do run `cargo test`.

## How it was verified

`cargo fmt`, `cargo clippy --features intercept --all-targets`, `cargo nextest run --features intercept` all clean: 1171/1171.

Hermeticity proven against a deliberately malformed config in a redirected home (the real config was never touched):

```
XDG_CONFIG_HOME=$FAKE/.config HOME=$FAKE cargo nextest run --features intercept \
  -E 'test(malformed_request_is_an_error) or test(initialize_list_and_call_over_jsonrpc) or test(bad_provider_is_invalid_params_not_panic)'
-> 3 passed
```

Control, same malformed config against unmodified `main`:

```
-> 2 tests run: 0 passed, 2 failed
   panicked: McpError(-32603, "failed to parse .../config.toml")
```

So the fixture reproduces the reported failure and the change removes it.

## No CHANGELOG entry

Test-only. `compress_with` is private in a private module, `test_server` is `#[doc(hidden)]` and documented as unstable, and the `None` arm preserves production behavior exactly. The PR checklist allows omitting when the change is invisible to users.

## Deliberately not changed

`llmtrim_core::compress()` (`crates/llmtrim-core/src/lib.rs:265`) also calls `DenseConfig::load()`, but degrades gracefully: on a parse error it warns and falls back to `DenseConfig::default()`, so no test can fail through it. Changing it would be a production behavior change outside this scope.

- [x] `cargo fmt` is clean
- [x] `cargo clippy --features intercept` is clean
- [x] `cargo nextest run --features intercept` passes
- [x] New behavior is covered by a test
- [x] `CHANGELOG.md` entry (n/a — invisible to users, see above)
- [x] Commits are signed off
