### PR TITLE
docs(config): state the toml/toml_edit read-write split

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,15 @@ Stages implement the `Transform` trait (`src/gate.rs`) and are assembled in
 
 Lossy stages stay **off by default** and are quality-checked offline (see README §6).
 
+## Editing the user's config file
+
+Read with `toml`, write with `toml_edit`, and never write back a parsed `toml::Value`.
+
+`config.toml` is hand-edited, so it carries comments, key order, and spacing that belong to
+the user. `toml_edit` edits the document in place and keeps them; parsing to `toml::Value` and
+re-serializing throws them away. That failure is silent, since the output is valid TOML that
+round-trips cleanly, so tests pass while the user's comments disappear.
+
 ## Before a large change
 
 Open an issue first for anything beyond a small fix. Describe the problem and the approach

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -3,6 +3,20 @@
 //! Config resolves from `LLMTRIM_PRESET` / a `preset = "<name>"` key (a named profile) or the
 //! per-stage flags in a TOML file (`LLMTRIM_CONFIG` or the platform config dir); with neither,
 //! the default is `auto` (shape-routing). See [`DenseConfig::load`].
+//!
+//! # Two TOML crates, on purpose
+//!
+//! **Read with `toml`. Write with `toml_edit`. Never write back a parsed `toml::Value`.**
+//!
+//! Reads use `toml`, which has serde integration and an ergonomic `Value` API. Writes go
+//! through `toml_edit`, which edits a document in place and so preserves the comments, key
+//! order, and spacing a hand-edited config file carries.
+//!
+//! The rule exists because breaking it is silent. Parsing to `toml::Value` and re-serializing
+//! with `to_string_pretty` produces valid TOML and passes any round-trip test, while deleting
+//! every comment the user wrote. `edit_sub_table_at` did exactly that on every `llmtrim sub`
+//! invocation until #200, and its own doc comment recorded the loss as if it were a design
+//! choice. A new writer that copies the surrounding read code will reintroduce it.
 
 use std::path::PathBuf;
 use std::str::FromStr;


### PR DESCRIPTION
## What & why

Closes #201.

`config.rs` uses two TOML crates: `toml` for every read (~85 references), `toml_edit` for every write (~47). The split is deliberate and worth keeping. `toml` has serde integration and an ergonomic `Value` API; `toml_edit` edits in place and preserves the comments, key order, and spacing a hand-edited config carries.

Nothing said so. That matters because breaking the rule fails silently: parsing to `toml::Value` and re-serializing produces valid TOML that round-trips cleanly, while deleting every comment the user wrote. Tests pass, the user's file is quietly stripped.

That is not hypothetical. `edit_sub_table_at` did exactly this on every `llmtrim sub` invocation until #200, and its own doc comment recorded the loss as though it were a design choice. A contributor adding a fourth writer would reach for the `toml::Value` idiom the surrounding read code uses and reintroduce it.

## What changed

Docs only, no code.

- A `# Two TOML crates, on purpose` section in the `config.rs` module header, stating the rule and why it is silent when broken.
- A matching `## Editing the user's config file` section in CONTRIBUTING.md, since a first-time contributor reads that before the module docs.

## How it was verified

`cargo fmt` clean, and `RUSTDOCFLAGS="-D warnings" cargo doc -p llmtrim-core --no-deps` builds clean so the new module docs render without warnings. No code changed, so no test impact.

- [x] `cargo fmt` is clean
- [x] `cargo clippy --features intercept` is clean (no code change)
- [x] `cargo nextest run --features intercept` passes (no code change)
- [x] New behavior is covered by a test (n/a — docs only)
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]` (n/a — invisible to users)
- [x] Commits are signed off