### PR TITLE
fix(proxy): harden upstream transport resets

### DIFF
--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -1434,6 +1434,7 @@ fn run() -> Result<()> {
                     cache_write_tokens: None,
                     output_shaped: Some(result.output_shaped),
                     frozen_input_tokens: Some(result.frozen_input_tokens.0 as i64),
+                    outcome: None,
                 });
             }
 
@@ -1478,6 +1479,7 @@ fn run() -> Result<()> {
                         cache_write_tokens: None,
                         output_shaped: Some(result.output_shaped),
                         frozen_input_tokens: Some(result.frozen_input_tokens.0 as i64),
+                        outcome: None,
                     });
                 }
             }

--- a/crates/llmtrim-cli/src/mcp.rs
+++ b/crates/llmtrim-cli/src/mcp.rs
@@ -239,6 +239,7 @@ mod imp {
             cache_write_tokens: None,
             output_shaped: Some(false),
             frozen_input_tokens: Some(0),
+            outcome: None,
         }
     }
 
@@ -327,6 +328,7 @@ mod imp {
             cache_write_tokens: None,
             output_shaped: Some(result.output_shaped),
             frozen_input_tokens: Some(result.frozen_input_tokens.0 as i64),
+            outcome: None,
         }
     }
 

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -1738,6 +1738,7 @@ mod tests {
                     cache_write_tokens: None,
                     output_shaped: Some(false),
                     frozen_input_tokens: Some(0),
+                    outcome: None,
                 })
                 .unwrap();
         }
@@ -1827,6 +1828,7 @@ mod tests {
             cache_write_tokens: None,
             output_shaped: Some(false),
             frozen_input_tokens: Some(0),
+            outcome: None,
         })
         .unwrap();
         let v2: serde_json::Value = serde_json::from_str(&stats_json(&t2, None).unwrap()).unwrap();
@@ -1860,6 +1862,7 @@ mod tests {
                 cache_write_tokens: None,
                 output_shaped: Some(false),
                 frozen_input_tokens: Some(600),
+                outcome: None,
             })
             .unwrap();
         let ov = overview_data(&tracker, |_, _| {
@@ -1903,6 +1906,7 @@ mod tests {
             cache_write_tokens: None,
             output_shaped: Some(false),
             frozen_input_tokens: frozen,
+            outcome: None,
         };
         let tracker = Tracker::open_in_memory().unwrap();
         // Metered row: 100 frozen, no saving on its 300-token surface.

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1045,14 +1045,11 @@ mod imp {
         let model = pending.and_then(|p| p.model.as_deref()).unwrap_or("?");
         let sub = pending
             .and_then(|p| {
-                p.reroute
-                    .as_ref()
-                    .map(|r| r.provider.as_str())
-                    .or_else(|| {
-                        p.fallback
-                            .as_ref()
-                            .and_then(|f| f.providers.first().map(|p| p.as_str()))
-                    })
+                p.reroute.as_ref().map(|r| r.provider.as_str()).or_else(|| {
+                    p.fallback
+                        .as_ref()
+                        .and_then(|f| f.providers.first().map(|p| p.as_str()))
+                })
             })
             .unwrap_or("-");
         let session = pending
@@ -1060,11 +1057,7 @@ mod imp {
                 p.reroute
                     .as_ref()
                     .and_then(|r| r.session_id.as_deref())
-                    .or_else(|| {
-                        p.fallback
-                            .as_ref()
-                            .and_then(|f| f.session_id.as_deref())
-                    })
+                    .or_else(|| p.fallback.as_ref().and_then(|f| f.session_id.as_deref()))
                     .or_else(|| {
                         p.breakdown
                             .as_ref()
@@ -1472,8 +1465,7 @@ mod imp {
                         // Non-2xx after a successful transport: surface as a typed Anthropic
                         // error (same shape as the live reroute failure path), not another
                         // transport error — we got a real response this time.
-                        let message =
-                            reroute_upstream_error_message(info.provider, status, &raw);
+                        let message = reroute_upstream_error_message(info.provider, status, &raw);
                         let acc = Arc::new(Mutex::new(message.clone().into_bytes()));
                         let _finalize = Finalize {
                             acc,
@@ -1488,11 +1480,7 @@ mod imp {
                             None,
                         );
                     }
-                    log_upstream_transport_failure(
-                        self.pending.as_ref(),
-                        &cause,
-                        "retry-failed",
-                    );
+                    log_upstream_transport_failure(self.pending.as_ref(), &cause, "retry-failed");
                 } else if let Some(original) = pending.original.clone() {
                     log_upstream_transport_failure(self.pending.as_ref(), &cause, "retry");
                     let proxy = self.upstream_proxy.clone();
@@ -1521,11 +1509,7 @@ mod imp {
                         };
                         return buffered_response(status, content_type, body);
                     }
-                    log_upstream_transport_failure(
-                        self.pending.as_ref(),
-                        &cause,
-                        "retry-failed",
-                    );
+                    log_upstream_transport_failure(self.pending.as_ref(), &cause, "retry-failed");
                 }
             }
 
@@ -4935,9 +4919,7 @@ mod imp {
             assert!(is_transient_transport_error("broken pipe"));
             assert!(is_transient_transport_error("operation timed out"));
             // Validation / auth failures must never re-fire a body.
-            assert!(!is_transient_transport_error(
-                "invalid_request: bad schema"
-            ));
+            assert!(!is_transient_transport_error("invalid_request: bad schema"));
             assert!(!is_transient_transport_error(
                 "authentication_error: invalid x-api-key"
             ));

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1088,6 +1088,9 @@ mod imp {
         client
             .http1_title_case_headers(true)
             .http1_preserve_header_case(true)
+            // Required for `pool_idle_timeout` to actually fire (hyper-util no-ops the
+            // timeout when no timer is installed).
+            .pool_timer(hyper_util::rt::TokioTimer::new())
             // Stale keep-alives to subscription backends (esp. Grok) show up as
             // `SendRequest: connection reset` after idle. Keep the pool for burst reuse
             // but expire idle sockets quickly so we almost never re-use a half-closed one.

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1011,7 +1011,89 @@ mod imp {
             cache_write_tokens: usage.cache_write,
             output_shaped: Some(p.output_shaped),
             frozen_input_tokens: p.frozen_input_tokens,
+            outcome: None,
         }
+    }
+
+    /// Ledger row for a transport failure that never produced a response: input savings still
+    /// count, but `outcome=transport_reset` marks it so status doesn't treat the zero output as
+    /// a real completion.
+    fn record_transport_reset(p: Pending) -> Record {
+        let mut r = record_from(p, ResponseUsage::default());
+        r.outcome = Some("transport_reset".into());
+        r
+    }
+
+    /// True for the hyper/hudsucker failures that a one-shot re-issue usually fixes: a pooled
+    /// keep-alive the server already closed, a brief connect blip, a SendRequest reset. Leave
+    /// validation/auth strings alone so we never re-fire a bad body.
+    fn is_transient_transport_error(cause: &str) -> bool {
+        let c = cause.to_ascii_lowercase();
+        c.contains("connection reset")
+            || c.contains("connection closed")
+            || c.contains("broken pipe")
+            || c.contains("connection refused")
+            || c.contains("sendrequest")
+            || c.contains("timed out")
+            || c.contains("timeout")
+            || c.contains("connection error")
+    }
+
+    /// Stderr line for a transport failure: always names session + model so a Grok/sub reset is
+    /// greppable without reconstructing the turn from the ledger.
+    fn log_upstream_transport_failure(pending: Option<&Pending>, cause: &str, attempt: &str) {
+        let model = pending.and_then(|p| p.model.as_deref()).unwrap_or("?");
+        let sub = pending
+            .and_then(|p| {
+                p.reroute
+                    .as_ref()
+                    .map(|r| r.provider.as_str())
+                    .or_else(|| {
+                        p.fallback
+                            .as_ref()
+                            .and_then(|f| f.providers.first().map(|p| p.as_str()))
+                    })
+            })
+            .unwrap_or("-");
+        let session = pending
+            .and_then(|p| {
+                p.reroute
+                    .as_ref()
+                    .and_then(|r| r.session_id.as_deref())
+                    .or_else(|| {
+                        p.fallback
+                            .as_ref()
+                            .and_then(|f| f.session_id.as_deref())
+                    })
+                    .or_else(|| {
+                        p.breakdown
+                            .as_ref()
+                            .and_then(|b| b.cc_session_id.as_deref())
+                    })
+            })
+            .unwrap_or("-");
+        eprintln!(
+            "llmtrim: upstream transport {attempt} model={model} sub={sub} session={session}: {cause}"
+        );
+        let _ = std::io::Write::flush(&mut std::io::stderr());
+    }
+
+    /// Short-idle hyper client for the MITM outbound pool. Stale keep-alives to subscription
+    /// backends (esp. Grok) surface as `SendRequest: connection reset` after idle; expire them
+    /// quickly so we almost never re-use a half-closed socket. Title/preserve flags match
+    /// hudsucker's default client so header casing stays wire-compatible.
+    fn outbound_client_builder() -> hyper_util::client::legacy::Builder {
+        let mut client =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());
+        client
+            .http1_title_case_headers(true)
+            .http1_preserve_header_case(true)
+            // Stale keep-alives to subscription backends (esp. Grok) show up as
+            // `SendRequest: connection reset` after idle. Keep the pool for burst reuse
+            // but expire idle sockets quickly so we almost never re-use a half-closed one.
+            .pool_idle_timeout(std::time::Duration::from_secs(5))
+            .pool_max_idle_per_host(2);
+        client
     }
 
     /// Per-source attribution attached to a `Pending` for the breakdown view: the parsed
@@ -1346,9 +1428,9 @@ mod imp {
         /// through `tracing`, which llmtrim does not subscribe to: the user sees a dropped
         /// connection with no cause, and the SDK sees an error it cannot parse (issue #157).
         ///
-        /// Report it instead: name the cause on stderr (where the rest of llmtrim's proxy
-        /// diagnostics go, so `llmtrim serve` in the foreground shows it) and answer in the
-        /// client's own error shape so it can back off and retry rather than fail the turn.
+        /// Report it instead: name the cause (with session/model) on stderr, try one replay when
+        /// the body is still available, and answer in the client's own error shape so it can
+        /// back off and retry rather than fail the turn.
         async fn handle_error(
             &mut self,
             _ctx: &HttpContext,
@@ -1364,9 +1446,97 @@ mod imp {
                 cause.push_str(&e.to_string());
                 src = std::error::Error::source(e);
             }
+
+            log_upstream_transport_failure(self.pending.as_ref(), &cause, "failed");
+
+            // One re-issue on a transient reset when we still hold a replayable body. Prefer the
+            // rewritten subscription body (Grok/sub path); otherwise the original Anthropic body.
+            if is_transient_transport_error(&cause)
+                && let Some(pending) = self.pending.as_ref()
+            {
+                if let Some(info) = pending.reroute.clone()
+                    && let Some(replay) = info.replay.clone()
+                {
+                    log_upstream_transport_failure(self.pending.as_ref(), &cause, "retry");
+                    if let Some((status, raw, _ra)) = self
+                        .reissue_reroute(&replay.url, replay.headers.clone(), replay.body)
+                        .await
+                    {
+                        let pending = self.pending.take().expect("pending present above");
+                        if (200..300).contains(&status) {
+                            return self.finish_buffered_reroute(pending, &info, raw);
+                        }
+                        // Non-2xx after a successful transport: surface as a typed Anthropic
+                        // error (same shape as the live reroute failure path), not another
+                        // transport error — we got a real response this time.
+                        let message =
+                            reroute_upstream_error_message(info.provider, status, &raw);
+                        let acc = Arc::new(Mutex::new(message.clone().into_bytes()));
+                        let _finalize = Finalize {
+                            acc,
+                            pending: Some(pending),
+                            ledger: self.ledger.clone(),
+                            breakdown_ledger: self.breakdown_ledger.clone(),
+                        };
+                        return anthropic_error_typed(
+                            status,
+                            reroute_error_kind(status),
+                            &message,
+                            None,
+                        );
+                    }
+                    log_upstream_transport_failure(
+                        self.pending.as_ref(),
+                        &cause,
+                        "retry-failed",
+                    );
+                } else if let Some(original) = pending.original.clone() {
+                    log_upstream_transport_failure(self.pending.as_ref(), &cause, "retry");
+                    let proxy = self.upstream_proxy.clone();
+                    let fetched = tokio::task::spawn_blocking(move || {
+                        fetch_original(&original, proxy.as_deref())
+                    })
+                    .await;
+                    if let Ok(Some((status, content_type, body))) = fetched {
+                        let pending = self.pending.take().expect("pending present above");
+                        if (200..300).contains(&status) {
+                            note_session_accepted(&pending);
+                            let _finalize = Finalize {
+                                acc: Arc::new(Mutex::new(body.clone())),
+                                pending: Some(pending),
+                                ledger: self.ledger.clone(),
+                                breakdown_ledger: self.breakdown_ledger.clone(),
+                            };
+                            return buffered_response(status, content_type, body);
+                        }
+                        // Got a real non-2xx: record via Finalize (output unknown) and relay.
+                        let _finalize = Finalize {
+                            acc: Arc::new(Mutex::new(body.clone())),
+                            pending: Some(pending),
+                            ledger: self.ledger.clone(),
+                            breakdown_ledger: self.breakdown_ledger.clone(),
+                        };
+                        return buffered_response(status, content_type, body);
+                    }
+                    log_upstream_transport_failure(
+                        self.pending.as_ref(),
+                        &cause,
+                        "retry-failed",
+                    );
+                }
+            }
+
+            // Final surface: take pending so Drop does not double-record, mark transport_reset.
+            if let Some(p) = self.pending.take() {
+                if let Some(x) = build_breakdown(&p, &ResponseUsage::default()) {
+                    let _ = self.breakdown_ledger.send(x);
+                }
+                let _ = self.ledger.send(record_transport_reset(p));
+            }
             eprintln!(
                 "llmtrim: upstream request failed ({cause}) — reported to the client as a retryable error"
             );
+            let _ = std::io::Write::flush(&mut std::io::stderr());
             upstream_transport_error(self.streaming, &format!("upstream request failed: {cause}"))
         }
 
@@ -4180,6 +4350,7 @@ mod imp {
                 .with_addr(addr)
                 .with_ca(ca)
                 .with_http_connector(proxy_connector)
+                .with_client(outbound_client_builder())
                 .with_http_handler(handler)
                 .with_graceful_shutdown(async {
                     let _ = tokio::signal::ctrl_c().await;
@@ -4194,6 +4365,7 @@ mod imp {
                 .with_addr(addr)
                 .with_ca(ca)
                 .with_rustls_connector(aws_lc_rs::default_provider())
+                .with_client(outbound_client_builder())
                 .with_http_handler(handler)
                 .with_graceful_shutdown(async {
                     let _ = tokio::signal::ctrl_c().await;
@@ -4746,6 +4918,26 @@ mod imp {
                     .unwrap()
                     .contains("tls handshake eof")
             );
+        }
+
+        #[test]
+        fn is_transient_transport_error_matches_real_hyper_reset() {
+            // The exact cause string hyper/hudsucker surfaces for a stale keep-alive to Grok.
+            assert!(is_transient_transport_error(
+                "client error (SendRequest): connection error: connection reset"
+            ));
+            assert!(is_transient_transport_error(
+                "connection closed before message completed"
+            ));
+            assert!(is_transient_transport_error("broken pipe"));
+            assert!(is_transient_transport_error("operation timed out"));
+            // Validation / auth failures must never re-fire a body.
+            assert!(!is_transient_transport_error(
+                "invalid_request: bad schema"
+            ));
+            assert!(!is_transient_transport_error(
+                "authentication_error: invalid x-api-key"
+            ));
         }
 
         #[test]

--- a/crates/llmtrim-ledger/src/money.rs
+++ b/crates/llmtrim-ledger/src/money.rs
@@ -827,6 +827,7 @@ mod tests {
             cache_write_tokens: None,
             output_shaped: Some(false),
             frozen_input_tokens: Some(0),
+            outcome: None,
         })
         .unwrap();
         let cov = money_coverage(t.connection()).unwrap();

--- a/crates/llmtrim-ledger/src/tracking.rs
+++ b/crates/llmtrim-ledger/src/tracking.rs
@@ -44,6 +44,10 @@ pub struct Record {
     /// discipline. `input_before − frozen` is the compressible surface — the honest
     /// denominator for the "saved on new content" figure. `None` on pre-meter rows.
     pub frozen_input_tokens: Option<i64>,
+    /// Explicit non-success outcome for a turn that never produced measurable output, e.g.
+    /// `transport_reset` when the upstream keep-alive died before any response. `None` on
+    /// ordinary rows (including pre-column ledgers) so old readers stay valid.
+    pub outcome: Option<String>,
 }
 
 /// One attributed proxy turn for the breakdown view: identity + provider-reported usage +
@@ -371,7 +375,8 @@ impl Tracker {
                     fresh_input_tokens INTEGER,
                     cache_write_tokens INTEGER,
                     output_shaped INTEGER,
-                    frozen_input_tokens INTEGER
+                    frozen_input_tokens INTEGER,
+                    outcome TEXT
                 );
                 CREATE TABLE IF NOT EXISTS breakdown_turns (
                     id            INTEGER PRIMARY KEY,
@@ -466,6 +471,15 @@ impl Tracker {
                 return Err(e).with_context(|| format!("failed to add breakdown column {col}"));
             }
         }
+        for col in ["outcome"] {
+            if let Err(e) = self.conn.execute(
+                &format!("ALTER TABLE compressions ADD COLUMN {col} TEXT"),
+                [],
+            ) && !is_duplicate_column(&e)
+            {
+                return Err(e).with_context(|| format!("failed to add ledger column {col}"));
+            }
+        }
         Ok(())
     }
 
@@ -526,8 +540,9 @@ impl Tracker {
                 "INSERT INTO compressions
                     (ts, provider, model, tokenizer, exact, input_before, input_after,
                      output_before, output_after, compress_micros, cache_read_tokens,
-                     fresh_input_tokens, cache_write_tokens, output_shaped, frozen_input_tokens)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                     fresh_input_tokens, cache_write_tokens, output_shaped, frozen_input_tokens,
+                     outcome)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
                 params![
                     ts,
                     r.provider,
@@ -544,6 +559,7 @@ impl Tracker {
                     r.cache_write_tokens,
                     r.output_shaped.map(i64::from),
                     r.frozen_input_tokens,
+                    r.outcome,
                 ],
             )
             .context("failed to record compression")?;
@@ -717,8 +733,9 @@ impl Tracker {
                 "INSERT INTO compressions
                     (ts, provider, model, tokenizer, exact, input_before, input_after,
                      output_before, output_after, compress_micros, cache_read_tokens,
-                     fresh_input_tokens, cache_write_tokens, output_shaped, frozen_input_tokens)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                     fresh_input_tokens, cache_write_tokens, output_shaped, frozen_input_tokens,
+                     outcome)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
                 params![
                     ts,
                     r.provider,
@@ -735,6 +752,7 @@ impl Tracker {
                     r.cache_write_tokens,
                     r.output_shaped.map(i64::from),
                     r.frozen_input_tokens,
+                    r.outcome,
                 ],
             )
             .context("failed to record compression (test)")?;
@@ -994,6 +1012,7 @@ mod tests {
             cache_write_tokens: None,
             output_shaped: None,
             frozen_input_tokens: None,
+            outcome: None,
         }
     }
 
@@ -1184,6 +1203,7 @@ mod tests {
             cache_write_tokens: Some(12),
             output_shaped: Some(true),
             frozen_input_tokens: None,
+            outcome: None,
         })
         .unwrap();
 
@@ -1203,6 +1223,7 @@ mod tests {
             cache_write_tokens: None,
             output_shaped: Some(false),
             frozen_input_tokens: None,
+            outcome: None,
         })
         .unwrap();
 
@@ -1334,6 +1355,29 @@ mod tests {
             .expect("second migrate swallows duplicate-column ALTERs");
         t.record(&rec("openai", true, 10, 5)).unwrap();
         assert_eq!(t.summary().unwrap().events, 1);
+    }
+
+    #[test]
+    fn transport_reset_outcome_round_trips() {
+        // Transport failures used to look like anonymous out=0 rows. The outcome column
+        // lets status/monitor distinguish a reset from a real zero-output completion.
+        let t = Tracker::open_in_memory().unwrap();
+        let mut r = rec("anthropic", true, 100, 80);
+        r.outcome = Some("transport_reset".into());
+        t.record(&r).unwrap();
+        let outcome: Option<String> = t
+            .conn
+            .query_row(
+                "SELECT outcome FROM compressions WHERE provider = 'anthropic'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(outcome.as_deref(), Some("transport_reset"));
+        // Re-migrate must keep the column and not reject a second insert.
+        t.migrate().expect("outcome ALTER is idempotent");
+        t.record(&rec("openai", true, 10, 5)).unwrap();
+        assert_eq!(t.summary().unwrap().events, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stale keep-alive connections to subscription backends (especially Grok) surface as hyper `SendRequest: connection reset` and become anonymous `out=0` ledger rows. Live watch on grok-always sub mode hit this as a ~604s hang followed by a ghost turn (`fresh=0` / `cr=0` / `out=0`) while the client saw:

```text
llmtrim: upstream request failed (client error (SendRequest): connection error: connection reset)
```

This PR:

1. **Expires idle outbound sockets quickly** (5s idle timeout, max 2 idle/host) on the hudsucker MITM client, with `pool_timer` installed so hyper-util actually applies the timeout.
2. **Retries once** on transient transport failures (`connection reset` / `SendRequest` / closed / broken pipe / timeout) when a replay body is still available (`reroute.replay` or `original`).
3. **Logs session + model** on every transport failure attempt (`failed` / `retry` / `retry-failed`) with stderr flush.
4. **Records `outcome=transport_reset`** on final failure instead of an anonymous zero-output compressions row (additive ledger column; old readers stay valid).

Successful retries reuse the existing buffered reroute path (`reissue_reroute` + `finish_buffered_reroute`) so Grok Responses SSE is still translated to Anthropic shape for Claude Code.

## Test plan

- [x] `is_transient_transport_error` matches the real hyper reset string; rejects validation/auth
- [x] Existing `upstream_transport_error` SSE/JSON shape tests still pass
- [x] Ledger `transport_reset` outcome round-trips (migrate + insert)
- [x] Clippy clean on intercept lib
- [ ] CI green
- [ ] After merge: install/restart daemon and confirm `serve.log` / ledger show `transport_reset` (or silent recovery) instead of bare `out=0` ghosts under grok sub load