### PR TITLE
feat(sub): skip Anthropic /login under always-sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,26 @@ This window only (installed with ensure; includes subagents; survives `/clear`):
 
 Tokens: `~/.llmtrim/<provider>/auth.json` (mode 0600). Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_SUB_CHAIN`.
 
+**Anthropic `/login` vs claude.ai connectors:** with global `sub` in `always` mode, by
+default llmtrim writes a dummy `ANTHROPIC_AUTH_TOKEN` into `~/.claude/settings.json` (same
+idea as [claude-code-proxy](https://github.com/raine/claude-code-proxy)'s
+`ANTHROPIC_AUTH_TOKEN=unused`) so Claude Code does not need a live Anthropic OAuth session.
+The MITM strips that dummy token and injects the real Grok/Codex/Kimi credential; non-messages
+Anthropic probes are answered locally so they never return `401 Invalid bearer token`.
+
+Claude Code treats any API-key auth as overriding claude.ai login, so **claude.ai connectors
+are disabled** while the dummy token is set. That is expected. To keep connectors (and accept
+Anthropic `/login` when the session expires):
+
+```bash
+llmtrim sub anthropic-login keep   # connectors OK; Anthropic login required
+llmtrim sub anthropic-login skip   # default: no Anthropic /login; connectors off
+```
+
+Restart Claude Code after `sub on` / `sub off` / `sub mode` / `sub anthropic-login` for the
+settings change to take effect. `sub mode fallback` always needs a real Anthropic login (the
+primary path is Anthropic).
+
 </details>
 
 ---

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -413,6 +413,52 @@ pub fn apply(opts: Options) -> Result<Report> {
             .push((ui::OK, "Compact".into(), "configured".into()));
     }
 
+    // Always-sub skip-login: keep Claude Code's dummy Anthropic auth in sync.
+    if claude {
+        let want = llmtrim_core::config::sub_skip_anthropic_login();
+        match crate::statusline::sync_sub_auth_env(want) {
+            Ok(crate::statusline::SubAuthEnvChange::Injected) => {
+                report.applied.push("sub_auth_env");
+                report.rows.push((
+                    ui::OK,
+                    "Claude auth".into(),
+                    "dummy token set · no Anthropic /login · connectors disabled".into(),
+                ));
+            }
+            Ok(crate::statusline::SubAuthEnvChange::Removed) => {
+                report.applied.push("sub_auth_env");
+                report.rows.push((
+                    ui::OK,
+                    "Claude auth".into(),
+                    "dummy ANTHROPIC_AUTH_TOKEN removed".into(),
+                ));
+            }
+            Ok(crate::statusline::SubAuthEnvChange::Unchanged) if want => {
+                use crate::statusline::SubAuthEnvPresence;
+                let detail = match crate::statusline::sub_auth_env_presence() {
+                    SubAuthEnvPresence::Ours => {
+                        "skip-login active · connectors disabled".to_string()
+                    }
+                    SubAuthEnvPresence::Foreign => {
+                        "skip-login wanted, foreign ANTHROPIC_AUTH_TOKEN left alone".to_string()
+                    }
+                    SubAuthEnvPresence::Absent | SubAuthEnvPresence::Unknown => {
+                        "skip-login wanted, dummy token not in settings yet".to_string()
+                    }
+                };
+                report
+                    .rows
+                    .push((ui::OK, "Claude auth".into(), detail));
+            }
+            Ok(_) => {}
+            Err(e) => report.rows.push((
+                ui::WARN,
+                "Claude auth".into(),
+                format!("could not update settings: {e:#}"),
+            )),
+        }
+    }
+
     // Tray autostart when binary is present (explicit ensure/setup only).
     if opts.install_missing && crate::tray::tray_binary().is_some() && !state.opt_out.tray_autostart
     {

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -446,9 +446,7 @@ pub fn apply(opts: Options) -> Result<Report> {
                         "skip-login wanted, dummy token not in settings yet".to_string()
                     }
                 };
-                report
-                    .rows
-                    .push((ui::OK, "Claude auth".into(), detail));
+                report.rows.push((ui::OK, "Claude auth".into(), detail));
             }
             Ok(_) => {}
             Err(e) => report.rows.push((

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -540,6 +540,15 @@ enum SubCmd {
         #[command(subcommand)]
         action: AuthAction,
     },
+    /// Whether always-sub injects a dummy Anthropic token so Claude Code skips `/login`.
+    ///
+    /// `skip` (default): no Anthropic OAuth required; claude.ai connectors are disabled.
+    /// `keep`: leave Claude on its claude.ai login (connectors work; Anthropic /login still required).
+    #[command(name = "anthropic-login")]
+    AnthropicLogin {
+        /// `skip` or `keep`.
+        mode: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -974,12 +983,48 @@ fn print_reroute_enabled(p: llmtrim::reroute::SubProvider) -> bool {
     logged_in
 }
 
+/// Reconcile Claude Code's dummy Anthropic auth with `sub_skip_anthropic_login()`.
+/// When always-sub and anthropic-login=skip, inject `ANTHROPIC_AUTH_TOKEN=llmtrim-sub` into
+/// `~/.claude/settings.json` so Claude Code skips Anthropic OAuth (same trick as
+/// claude-code-proxy). Off / fallback / keep removes only our sentinel.
+///
+/// Note: a dummy token disables claude.ai connectors (Claude Code prefers any API-key source
+/// over claude.ai login). Use `llmtrim sub anthropic-login keep` to restore connectors.
+#[cfg(feature = "intercept")]
+fn sync_claude_sub_auth() {
+    let want = llmtrim_core::config::sub_skip_anthropic_login();
+    match llmtrim::statusline::sync_sub_auth_env(want) {
+        Ok(llmtrim::statusline::SubAuthEnvChange::Injected) => {
+            println!(
+                "Claude Code: set env.ANTHROPIC_AUTH_TOKEN so Anthropic /login is not required \
+                 while sub is always-on.\n\
+                 Note: claude.ai connectors are disabled while this is set (Claude Code treats \
+                 any API-key auth as overriding claude.ai login).\n\
+                 Keep connectors: `llmtrim sub anthropic-login keep` (Anthropic /login required).\n\
+                 Restart Claude Code to pick this up."
+            );
+        }
+        Ok(llmtrim::statusline::SubAuthEnvChange::Removed) => {
+            println!(
+                "Claude Code: removed dummy ANTHROPIC_AUTH_TOKEN (Anthropic OAuth / API key \
+                 required again; claude.ai connectors can work again).\n\
+                 Restart Claude Code to pick this up."
+            );
+        }
+        Ok(llmtrim::statusline::SubAuthEnvChange::Unchanged) => {}
+        Err(e) => eprintln!("llmtrim: could not update Claude Code auth env: {e:#}"),
+    }
+}
+
 /// Apply a `sub` config change to the interceptor. The daemon reads its config once at boot
 /// (`RuntimeConfig` is a `OnceLock`), so a running one keeps the old routing until restarted.
 /// Restarts it in place unless `no_restart` is set or nothing is running (the next `start` picks
-/// up the new config on its own).
+/// up the new config on its own). Also reconciles the Claude Code dummy-auth env for always-on sub.
 #[cfg(feature = "intercept")]
 fn apply_sub_change(no_restart: bool) {
+    // Always reconcile Claude settings, even when the daemon isn't running / no_restart —
+    // the auth env is independent of the interceptor process.
+    sync_claude_sub_auth();
     let Some(state) = llmtrim::daemon::running() else {
         return;
     };
@@ -1157,15 +1202,19 @@ fn run_sub(action: SubCmd) -> Result<()> {
                     print_reroute_enabled(p)
                 }
             };
-            // Skip the restart when signed out: routing can't work until sign-in anyway.
+            // Claude auth-env sync always runs (independent of provider login). Daemon restart
+            // is still skipped when signed out — routing can't work until sign-in anyway.
             if logged_in {
                 apply_sub_change(no_restart);
+            } else {
+                sync_claude_sub_auth();
             }
             Ok(())
         }
         SubCmd::Off { no_restart } => {
             llmtrim_core::config::disable_sub()?;
             println!("Reroute disabled — traffic goes to Anthropic (compression only).");
+            // Always sync Claude auth env even if not logged in earlier paths skipped restart.
             apply_sub_change(no_restart);
             Ok(())
         }
@@ -1303,11 +1352,20 @@ fn run_sub(action: SubCmd) -> Result<()> {
                 for (k, v) in &cfg.sub_tiers {
                     mapping.insert(k.clone(), v.clone());
                 }
+                let skip_login = llmtrim_core::config::sub_skip_anthropic_login();
+                let claude_auth = match llmtrim::statusline::sub_auth_env_presence() {
+                    llmtrim::statusline::SubAuthEnvPresence::Ours => "dummy",
+                    llmtrim::statusline::SubAuthEnvPresence::Foreign => "foreign",
+                    llmtrim::statusline::SubAuthEnvPresence::Absent => "absent",
+                    llmtrim::statusline::SubAuthEnvPresence::Unknown => "unknown",
+                };
                 let out = serde_json::json!({
                     "provider": active.map(|p| p.as_str()),
                     "mode": if cfg.sub_fallback { "fallback" } else { "always" },
                     "chain": cfg.sub_chain,
                     "effort": cfg.sub_effort,
+                    "anthropic_login": if skip_login { "skip" } else { "keep" },
+                    "claude_auth_token": claude_auth,
                     "mapping": mapping,
                     "auth": {
                         "codex": llmtrim::reroute::auth::auth_status_json(SubProvider::Codex),
@@ -1392,11 +1450,66 @@ fn run_sub(action: SubCmd) -> Result<()> {
                             p.as_str()
                         );
                     }
+                    // Report what is actually in Claude settings, not just the intended mode.
+                    use llmtrim::statusline::SubAuthEnvPresence;
+                    let skip = llmtrim_core::config::sub_skip_anthropic_login();
+                    match (
+                        cfg.sub_fallback,
+                        skip,
+                        llmtrim::statusline::sub_auth_env_presence(),
+                    ) {
+                        (true, _, _) => println!(
+                            "  claude: fallback mode needs a live Anthropic login \
+                             (primary path is Anthropic; connectors OK)"
+                        ),
+                        (false, true, SubAuthEnvPresence::Ours) => println!(
+                            "  claude: Anthropic /login not required (dummy token set); \
+                             claude.ai connectors disabled — `llmtrim sub anthropic-login keep` \
+                             to restore connectors"
+                        ),
+                        (false, true, SubAuthEnvPresence::Foreign) => println!(
+                            "  claude: skip-login wanted, but a foreign ANTHROPIC_AUTH_TOKEN is \
+                             already in settings — left alone (connectors may still be disabled)"
+                        ),
+                        (false, true, SubAuthEnvPresence::Absent | SubAuthEnvPresence::Unknown) => {
+                            println!(
+                                "  claude: skip-login wanted, but dummy token is not in settings \
+                                 yet — run `llmtrim sub mode always` or `llmtrim ensure`, then \
+                                 restart Claude Code"
+                            );
+                        }
+                        (false, false, _) => println!(
+                            "  claude: anthropic-login=keep — stay logged in to Anthropic \
+                             (claude.ai connectors OK)"
+                        ),
+                    }
                 }
             }
             Ok(())
         }
         SubCmd::Auth { provider, action } => run_auth(&provider, action),
+        SubCmd::AnthropicLogin { mode } => {
+            let skip = match mode.trim().to_ascii_lowercase().as_str() {
+                "skip" | "dummy" | "none" => true,
+                "keep" | "oauth" | "claude" | "connectors" => false,
+                other => anyhow::bail!("unknown anthropic-login mode '{other}' (skip|keep)"),
+            };
+            llmtrim_core::config::write_sub_anthropic_login(skip)?;
+            if skip {
+                println!(
+                    "anthropic-login: skip — always-sub injects a dummy token (no Anthropic \
+                     /login; claude.ai connectors disabled)."
+                );
+            } else {
+                println!(
+                    "anthropic-login: keep — Claude stays on claude.ai OAuth (connectors work; \
+                     Anthropic /login still required when the session expires)."
+                );
+            }
+            // Reconcile settings immediately (no daemon restart needed for settings env).
+            sync_claude_sub_auth();
+            Ok(())
+        }
     }
 }
 

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -6488,12 +6488,7 @@ mod imp {
         }
 
         async fn response_body_string(res: Response<Body>) -> String {
-            let bytes = res
-                .into_body()
-                .collect()
-                .await
-                .expect("body")
-                .to_bytes();
+            let bytes = res.into_body().collect().await.expect("body").to_bytes();
             String::from_utf8_lossy(&bytes).into_owned()
         }
 
@@ -6848,10 +6843,7 @@ mod imp {
             };
             assert_eq!(res.status().as_u16(), 200);
             let body = response_body_string(res).await;
-            assert!(
-                body.contains("claude-opus-4"),
-                "stub model list: {body}"
-            );
+            assert!(body.contains("claude-opus-4"), "stub model list: {body}");
         }
 
         #[tokio::test]
@@ -6894,14 +6886,21 @@ mod imp {
             let (mut handler, _rx) = make_interceptor();
             handler.sub = None;
             let body = r#"{"model":"claude-opus-4","messages":[{"role":"user","content":"hi"}],"max_tokens":16}"#;
-            let req =
-                post_request_bearer("https://api.anthropic.com/v1/messages/", body, "llmtrim-sub");
+            let req = post_request_bearer(
+                "https://api.anthropic.com/v1/messages/",
+                body,
+                "llmtrim-sub",
+            );
             let result = handler.handle_request_inner(req).await;
             let RequestOrResponse::Response(res) = result else {
                 panic!("trailing-slash messages must still be classified as messages");
             };
             assert_eq!(res.status().as_u16(), 400);
-            assert!(response_body_string(res).await.contains("dummy Anthropic auth"));
+            assert!(
+                response_body_string(res)
+                    .await
+                    .contains("dummy Anthropic auth")
+            );
         }
 
         #[tokio::test]

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -647,6 +647,103 @@ mod imp {
             .unwrap_or_else(|_| Response::new(Body::empty()))
     }
 
+    /// Sentinel values Claude Code may send as Anthropic credentials when always-sub skips OAuth.
+    /// Includes our settings.json value and the claude-code-proxy placeholders.
+    fn is_dummy_anthropic_credential(raw: &str) -> bool {
+        let s = raw.trim();
+        let s = s
+            .strip_prefix("Bearer ")
+            .or_else(|| s.strip_prefix("bearer "))
+            .unwrap_or(s)
+            .trim();
+        matches!(s, "llmtrim-sub" | "unused" | "anything")
+    }
+
+    /// True when the request carries only a dummy Anthropic credential (settings/wrap inject
+    /// `llmtrim-sub`; users/CCP may use `unused`/`anything`). Real OAuth/API keys pass through.
+    fn has_dummy_anthropic_auth(headers: &header::HeaderMap) -> bool {
+        let auth = headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let xkey = headers
+            .get("x-api-key")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        is_dummy_anthropic_credential(auth) || is_dummy_anthropic_credential(xkey)
+    }
+
+    /// Classify Anthropic API paths we care about for sub reroute / dummy-auth handling.
+    /// Trailing slashes are ignored so `/v1/messages/` still counts as messages.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum AnthropicApiPath {
+        Messages,
+        CountTokens,
+        Other,
+    }
+
+    fn classify_anthropic_api_path(path: &str) -> AnthropicApiPath {
+        // Trim trailing slashes only; keep internal structure so count_tokens stays distinct.
+        let p = path.trim_end_matches('/');
+        if p.ends_with("/v1/messages/count_tokens") {
+            AnthropicApiPath::CountTokens
+        } else if p.ends_with("/v1/messages") {
+            AnthropicApiPath::Messages
+        } else {
+            AnthropicApiPath::Other
+        }
+    }
+
+    /// Local answer for Anthropic traffic that is not `/v1/messages` when the client presented a
+    /// dummy Anthropic credential (always-sub skip-login).
+    ///
+    /// Anything we still forward to Anthropic with that credential comes back as
+    /// `401 Invalid bearer token` and Claude Code renders "Please run /login". Stub known probes;
+    /// unknown paths get an empty 200 so the client continues.
+    ///
+    /// **Must drain the request body** before answering: returning a response while the client is
+    /// still writing a POST body breaks HTTP keep-alive and surfaces as `ECONNRESET` in Claude Code.
+    async fn anthropic_sub_passthrough_stub(req: Request<Body>) -> Response<Body> {
+        let method = req.method().clone();
+        let path = req.uri().path().to_string();
+        // Drop the body fully so the client→proxy half of the connection is clean.
+        let _ = req.into_body().collect().await;
+        let path_for_models = path.trim_end_matches('/');
+        if method == Method::GET && path_for_models.ends_with("/v1/models") {
+            // Anthropic-shaped model list. Claude Code's gateway discovery only surfaces ids that
+            // start with `claude`/`anthropic`; keep a small stable set so /model still works.
+            let body = serde_json::json!({
+                "data": [
+                    { "type": "model", "id": "claude-opus-4-20250514", "display_name": "Opus (sub)" },
+                    { "type": "model", "id": "claude-sonnet-4-20250514", "display_name": "Sonnet (sub)" },
+                    { "type": "model", "id": "claude-haiku-4-20250414", "display_name": "Haiku (sub)" },
+                ],
+                "has_more": false,
+                "first_id": "claude-opus-4-20250514",
+                "last_id": "claude-haiku-4-20250414",
+            })
+            .to_string();
+            return json_response(200, &body);
+        }
+        // Soft no-op: empty JSON object. Prefer this over a 401 that triggers /login.
+        json_response(200, "{}")
+    }
+
+    /// Clear error when dummy Anthropic auth is active but this request will not be rerouted
+    /// (window `/sub off`, sub disabled, etc.). Forwarding would 401 at Anthropic and surface as
+    /// "Please run /login".
+    ///
+    /// Drains the request body first — same keep-alive hazard as [`anthropic_sub_passthrough_stub`].
+    async fn dummy_auth_not_rerouted_error(req: Request<Body>) -> Response<Body> {
+        let _ = req.into_body().collect().await;
+        anthropic_error(
+            400,
+            "llmtrim: dummy Anthropic auth is active (sub anthropic-login=skip) but this request \
+             is not routing to a subscription. Run `/sub on`, or `llmtrim sub anthropic-login keep` \
+             and Anthropic /login if you want real Anthropic in this window.",
+        )
+    }
+
     /// A single-frame Anthropic SSE response (used for reroute error/short-circuit replies).
     fn sse_response(body: String) -> Response<Body> {
         Response::builder()
@@ -1666,9 +1763,14 @@ mod imp {
             // Fallback mode arms a fallback instead of rerouting up front: the turn goes to
             // Anthropic normally, and only replays to the sub provider if Anthropic fails (handled
             // in the response phase). Captured here so we can read the session header and body.
+            //
+            // Dummy Anthropic auth (always-sub + anthropic-login=skip): Claude Code may send
+            // `ANTHROPIC_AUTH_TOKEN=llmtrim-sub`. Non-messages probes must not reach Anthropic
+            // (401 → "Please run /login"). Messages that aren't rerouted (e.g. window `/sub off`)
+            // must not reach Anthropic either — return a clear llmtrim error instead.
             let mut fallback_arm: Option<(Vec<crate::reroute::SubProvider>, Option<String>)> = None;
-            if matches!(provider, Some(ProviderKind::Anthropic)) && req.method() == Method::POST {
-                let path = req.uri().path();
+            if matches!(provider, Some(ProviderKind::Anthropic)) {
+                let path_kind = classify_anthropic_api_path(req.uri().path());
                 // The filesystem registry is consulted per request, keyed by Claude Code's
                 // inbound session header.  A local `off` is authoritative and suppresses both
                 // direct reroute and global fallback; an absent/expired record follows global.
@@ -1687,14 +1789,19 @@ mod imp {
                     matches!(window_intent, Some(crate::window_sub::Intent::Disabled));
                 if !window_disabled && (!self.sub_fallback || window_sub.is_some()) {
                     if let Some(sub) = window_sub.or(self.sub) {
-                        if path.ends_with("/v1/messages/count_tokens") {
+                        if req.method() == Method::POST
+                            && path_kind == AnthropicApiPath::CountTokens
+                        {
                             return self.reroute_count_tokens(req).await;
                         }
-                        if path.ends_with("/v1/messages") {
+                        if req.method() == Method::POST && path_kind == AnthropicApiPath::Messages {
                             return self.reroute_messages(req, sub).await;
                         }
                     }
-                } else if !window_disabled && path.ends_with("/v1/messages") {
+                } else if !window_disabled
+                    && req.method() == Method::POST
+                    && path_kind == AnthropicApiPath::Messages
+                {
                     // A chain is enough to arm the fallback: `sub` selects who serves *every* turn
                     // in `always` mode, but in fallback mode the chain is the whole answer, so
                     // `sub = off` + a chain is a valid configuration.
@@ -1710,6 +1817,24 @@ mod imp {
                             .map(str::to_string);
                         fallback_arm = Some((providers, session_id));
                     }
+                }
+                // Dummy credential handling (token is global in settings.json, so it still
+                // arrives after window `/sub off`). If we already returned from reroute_* above,
+                // we never reach here for a successfully rerouted messages turn.
+                if has_dummy_anthropic_auth(req.headers()) {
+                    let is_messages_post = req.method() == Method::POST
+                        && matches!(
+                            path_kind,
+                            AnthropicApiPath::Messages | AnthropicApiPath::CountTokens
+                        );
+                    if is_messages_post {
+                        // Not rerouted (window off / no sub / fallback-first). Dummy cannot hit
+                        // Anthropic — refuse with a clear error instead of a bare 401.
+                        // Drain body inside the helper (large messages POSTs).
+                        return dummy_auth_not_rerouted_error(req).await.into();
+                    }
+                    // Non-messages: stub (drain body). Do not forward dummy creds to Anthropic.
+                    return anthropic_sub_passthrough_stub(req).await.into();
                 }
             }
             // Only compress POST bodies to a known provider; pass everything else through.
@@ -5875,6 +6000,88 @@ mod imp {
         }
 
         #[test]
+        fn dummy_anthropic_credential_detects_sentinel_and_ccp_placeholders() {
+            assert!(is_dummy_anthropic_credential("llmtrim-sub"));
+            assert!(is_dummy_anthropic_credential("Bearer llmtrim-sub"));
+            assert!(is_dummy_anthropic_credential("unused"));
+            assert!(is_dummy_anthropic_credential("Bearer anything"));
+            assert!(!is_dummy_anthropic_credential("sk-ant-real"));
+            assert!(!is_dummy_anthropic_credential("Bearer sk-ant-real"));
+        }
+
+        #[test]
+        fn classify_anthropic_api_path_trims_trailing_slash() {
+            assert_eq!(
+                classify_anthropic_api_path("/v1/messages"),
+                AnthropicApiPath::Messages
+            );
+            assert_eq!(
+                classify_anthropic_api_path("/v1/messages/"),
+                AnthropicApiPath::Messages
+            );
+            assert_eq!(
+                classify_anthropic_api_path("/v1/messages/count_tokens"),
+                AnthropicApiPath::CountTokens
+            );
+            assert_eq!(
+                classify_anthropic_api_path("/v1/messages/count_tokens/"),
+                AnthropicApiPath::CountTokens
+            );
+            assert_eq!(
+                classify_anthropic_api_path("/v1/models"),
+                AnthropicApiPath::Other
+            );
+        }
+
+        #[tokio::test]
+        async fn always_sub_stub_answers_models_and_soft_noops_the_rest() {
+            let models_req = Request::builder()
+                .method(Method::GET)
+                .uri("https://api.anthropic.com/v1/models")
+                .body(Body::empty())
+                .unwrap();
+            let models = anthropic_sub_passthrough_stub(models_req).await;
+            assert_eq!(models.status().as_u16(), 200);
+
+            let other_req = Request::builder()
+                .method(Method::POST)
+                .uri("https://api.anthropic.com/v1/complete")
+                .body(Body::from(Full::new(Bytes::from_static(b"{\"x\":1}"))))
+                .unwrap();
+            let other = anthropic_sub_passthrough_stub(other_req).await;
+            assert_eq!(other.status().as_u16(), 200);
+        }
+
+        #[tokio::test]
+        async fn dummy_auth_not_rerouted_error_drains_body_and_returns_400() {
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri("https://api.anthropic.com/v1/messages")
+                .body(Body::from(Full::new(Bytes::from_static(
+                    b"{\"model\":\"x\",\"messages\":[]}",
+                ))))
+                .unwrap();
+            let res = dummy_auth_not_rerouted_error(req).await;
+            assert_eq!(res.status().as_u16(), 400);
+        }
+
+        #[test]
+        fn has_dummy_anthropic_auth_reads_authorization_and_x_api_key() {
+            let mut headers = header::HeaderMap::new();
+            assert!(!has_dummy_anthropic_auth(&headers));
+            headers.insert(
+                header::AUTHORIZATION,
+                header::HeaderValue::from_static("Bearer llmtrim-sub"),
+            );
+            assert!(has_dummy_anthropic_auth(&headers));
+            headers.clear();
+            headers.insert("x-api-key", header::HeaderValue::from_static("sk-ant-real"));
+            assert!(!has_dummy_anthropic_auth(&headers));
+            headers.insert("x-api-key", header::HeaderValue::from_static("unused"));
+            assert!(has_dummy_anthropic_auth(&headers));
+        }
+
+        #[test]
         fn ca_is_current_only_when_present_and_sidecar_matches() {
             let want = vec!["a.com".to_string(), "b.com".to_string()];
             assert!(ca_is_current(true, Some(&want), &want));
@@ -6260,6 +6467,36 @@ mod imp {
                 .expect("valid request")
         }
 
+        /// POST with `Authorization: Bearer <token>` (for dummy-auth gate tests).
+        fn post_request_bearer(uri: &str, body: &str, token: &str) -> Request<Body> {
+            Request::builder()
+                .method(Method::POST)
+                .uri(uri)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .expect("valid request")
+        }
+
+        fn get_request_bearer(uri: &str, token: &str) -> Request<Body> {
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .expect("valid request")
+        }
+
+        async fn response_body_string(res: Response<Body>) -> String {
+            let bytes = res
+                .into_body()
+                .collect()
+                .await
+                .expect("body")
+                .to_bytes();
+            String::from_utf8_lossy(&bytes).into_owned()
+        }
+
         /// Spin up a stub HTTP/1.1 server on an ephemeral loopback port. It accepts
         /// exactly one connection, reads (discards) the request, then writes the given
         /// status line and response body. Returns the bound port immediately.
@@ -6596,6 +6833,115 @@ mod imp {
                 "mixed-case host must still be excluded"
             );
             assert_eq!(drain_body(out_req.into_body()).await, body.as_bytes());
+        }
+
+        // ── dummy Anthropic auth gate (always-sub skip-login) ────────────────
+
+        #[tokio::test]
+        async fn handle_request_inner_stubs_models_when_dummy_auth() {
+            let (mut handler, _rx) = make_interceptor();
+            // No sub required for non-messages stubs — dummy alone is enough.
+            let req = get_request_bearer("https://api.anthropic.com/v1/models", "llmtrim-sub");
+            let result = handler.handle_request_inner(req).await;
+            let RequestOrResponse::Response(res) = result else {
+                panic!("dummy auth on /v1/models must short-circuit, not forward");
+            };
+            assert_eq!(res.status().as_u16(), 200);
+            let body = response_body_string(res).await;
+            assert!(
+                body.contains("claude-opus-4"),
+                "stub model list: {body}"
+            );
+        }
+
+        #[tokio::test]
+        async fn handle_request_inner_stubs_non_messages_post_when_dummy_auth() {
+            let (mut handler, _rx) = make_interceptor();
+            let req = post_request_bearer(
+                "https://api.anthropic.com/v1/complete",
+                r#"{"prompt":"hi"}"#,
+                "llmtrim-sub",
+            );
+            let result = handler.handle_request_inner(req).await;
+            let RequestOrResponse::Response(res) = result else {
+                panic!("dummy auth non-messages must short-circuit");
+            };
+            assert_eq!(res.status().as_u16(), 200);
+            assert_eq!(response_body_string(res).await, "{}");
+        }
+
+        #[tokio::test]
+        async fn handle_request_inner_dummy_messages_without_sub_returns_clear_400() {
+            let (mut handler, _rx) = make_interceptor();
+            handler.sub = None;
+            let body = r#"{"model":"claude-opus-4","messages":[{"role":"user","content":"hi"}],"max_tokens":16}"#;
+            let req =
+                post_request_bearer("https://api.anthropic.com/v1/messages", body, "llmtrim-sub");
+            let result = handler.handle_request_inner(req).await;
+            let RequestOrResponse::Response(res) = result else {
+                panic!("dummy + no sub must not forward to Anthropic");
+            };
+            assert_eq!(res.status().as_u16(), 400);
+            let text = response_body_string(res).await;
+            assert!(
+                text.contains("dummy Anthropic auth"),
+                "expected clear llmtrim error, got {text}"
+            );
+        }
+
+        #[tokio::test]
+        async fn handle_request_inner_dummy_messages_trailing_slash_still_gated() {
+            let (mut handler, _rx) = make_interceptor();
+            handler.sub = None;
+            let body = r#"{"model":"claude-opus-4","messages":[{"role":"user","content":"hi"}],"max_tokens":16}"#;
+            let req =
+                post_request_bearer("https://api.anthropic.com/v1/messages/", body, "llmtrim-sub");
+            let result = handler.handle_request_inner(req).await;
+            let RequestOrResponse::Response(res) = result else {
+                panic!("trailing-slash messages must still be classified as messages");
+            };
+            assert_eq!(res.status().as_u16(), 400);
+            assert!(response_body_string(res).await.contains("dummy Anthropic auth"));
+        }
+
+        #[tokio::test]
+        async fn handle_request_inner_dummy_messages_with_sub_enters_reroute_not_stub() {
+            // With sub set, messages take the reroute path (auth may fail without credentials,
+            // but must NOT return the non-messages stub `{}` or the "not routing" 400).
+            let (mut handler, _rx) = make_interceptor();
+            handler.sub = Some(crate::reroute::SubProvider::Grok);
+            handler.sub_fallback = false;
+            let body = r#"{"model":"claude-opus-4","messages":[{"role":"user","content":"hi"}],"max_tokens":16}"#;
+            let req =
+                post_request_bearer("https://api.anthropic.com/v1/messages", body, "llmtrim-sub");
+            let result = handler.handle_request_inner(req).await;
+            let RequestOrResponse::Response(res) = result else {
+                // A rewritten Request to Grok is also fine (would mean auth succeeded in test env).
+                return;
+            };
+            let status = res.status().as_u16();
+            let text = response_body_string(res).await;
+            assert_ne!(status, 200, "must not be the soft non-messages stub");
+            assert!(
+                !text.contains("not routing to a subscription"),
+                "must enter reroute, not the window-off error: {text}"
+            );
+            // Without stored Grok creds, get_token fails with 401 + not authenticated.
+            assert!(
+                status == 401 || text.contains("not authenticated") || text.contains("llmtrim"),
+                "expected reroute preflight error, got status={status} body={text}"
+            );
+        }
+
+        #[tokio::test]
+        async fn handle_request_inner_real_auth_does_not_stub_models() {
+            let (mut handler, _rx) = make_interceptor();
+            let req = get_request_bearer("https://api.anthropic.com/v1/models", "sk-ant-real-key");
+            let result = handler.handle_request_inner(req).await;
+            // Real credential: forward (Request), do not short-circuit with our stub list.
+            let RequestOrResponse::Request(_) = result else {
+                panic!("real API key on /v1/models must forward, not stub");
+            };
         }
 
         // Test 3: replay on 400 ───────────────────────────────────────────────

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -774,6 +774,21 @@ pub fn uninstall(purge: bool, keep_binary: bool) -> Result<()> {
         Err(e) => rows.push((ui::WARN, "Window /sub".into(), format!("not removed: {e}"))),
     }
 
+    // 2c2. Drop the dummy Anthropic auth env we inject while always-sub is on.
+    match crate::statusline::clear_sub_auth_env() {
+        Ok(crate::statusline::SubAuthEnvChange::Removed) => rows.push((
+            ui::OK,
+            "Claude auth".into(),
+            "removed dummy ANTHROPIC_AUTH_TOKEN from settings".into(),
+        )),
+        Ok(_) => {}
+        Err(e) => rows.push((
+            ui::WARN,
+            "Claude auth".into(),
+            format!("not cleaned: {e}"),
+        )),
+    }
+
     // 2d. Unwire the Claude Code guard hook, leaving the user's other hooks in place.
     match crate::guard::unwire() {
         Ok(true) => rows.push((

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -782,11 +782,7 @@ pub fn uninstall(purge: bool, keep_binary: bool) -> Result<()> {
             "removed dummy ANTHROPIC_AUTH_TOKEN from settings".into(),
         )),
         Ok(_) => {}
-        Err(e) => rows.push((
-            ui::WARN,
-            "Claude auth".into(),
-            format!("not cleaned: {e}"),
-        )),
+        Err(e) => rows.push((ui::WARN, "Claude auth".into(), format!("not cleaned: {e}"))),
     }
 
     // 2d. Unwire the Claude Code guard hook, leaving the user's other hooks in place.

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -2173,8 +2173,7 @@ mod tests {
             SubAuthEnvChange::Unchanged
         );
         assert_eq!(
-            settings["env"]["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"],
-            "1",
+            settings["env"]["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"], "1",
             "user-only flag left alone when our token is absent"
         );
     }

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -1248,6 +1248,169 @@ pub fn uninstall() -> Result<()> {
     Ok(())
 }
 
+// ── sub always-on: skip Claude Code's Anthropic OAuth ─────────────────────────
+//
+// Claude Code gates every turn (including `/compact`) on a live Anthropic OAuth session even
+// when llmtrim rewrites the request to Grok/Codex/Kimi. claude-code-proxy avoids that by
+// launching Claude with `ANTHROPIC_AUTH_TOKEN=unused`. We do the same via Claude's own
+// `settings.json` `env` block when global `sub` is always-on *and* `sub.anthropic_login = skip`
+// (the default) — Claude never starts the OAuth flow, and the MITM still strips the dummy token
+// and injects the real provider token.
+//
+// Trade-off: Claude Code treats any ANTHROPIC_AUTH_TOKEN / API key as taking precedence over
+// claude.ai login, so **claude.ai connectors are disabled** while our dummy is set. Users who
+// need connectors run `llmtrim sub anthropic-login keep` (and stay logged in to Anthropic).
+//
+// Ownership: only touch the key when missing or already set to our sentinel value. Never
+// overwrite a real API key the user put there, and never remove a foreign value on `sub off`.
+// We deliberately do *not* manage CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC — that flag is a
+// boolean `"1"` we cannot own without risking a user's pre-existing preference.
+
+/// Sentinel written to `settings.json` → `env.ANTHROPIC_AUTH_TOKEN` while always-sub skips login.
+/// Distinctive so we can remove it later without clobbering a user's real key.
+pub const SUB_AUTH_TOKEN_VALUE: &str = "llmtrim-sub";
+
+const SUB_AUTH_TOKEN_KEY: &str = "ANTHROPIC_AUTH_TOKEN";
+
+/// Result of reconciling the Claude Code dummy-auth env with the current sub mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubAuthEnvChange {
+    /// Wrote our sentinel into `env.ANTHROPIC_AUTH_TOKEN`.
+    Injected,
+    /// Removed our sentinel (sub off / fallback / keep-login / uninstall).
+    Removed,
+    /// Already correct, or a foreign value we refuse to touch, or no Claude settings to edit.
+    Unchanged,
+}
+
+/// What is currently in Claude settings regarding our dummy auth (for status output).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubAuthEnvPresence {
+    /// Our sentinel is set — Claude Code skips Anthropic OAuth; connectors disabled.
+    Ours,
+    /// A non-sentinel ANTHROPIC_AUTH_TOKEN is set — we left it alone.
+    Foreign,
+    /// No ANTHROPIC_AUTH_TOKEN in settings env.
+    Absent,
+    /// Settings file missing / unreadable / not an object.
+    Unknown,
+}
+
+/// Pure mutation of a parsed Claude settings object.
+///
+/// - `want = true`: set `env.ANTHROPIC_AUTH_TOKEN` to [`SUB_AUTH_TOKEN_VALUE`] unless a foreign
+///   (non-sentinel) value is already there.
+/// - `want = false`: remove the key only when it holds our sentinel.
+pub fn apply_sub_auth_env(settings: &mut Value, want: bool) -> Result<SubAuthEnvChange> {
+    let root = settings
+        .as_object_mut()
+        .context("Claude settings root must be an object")?;
+
+    let current = root
+        .get("env")
+        .and_then(Value::as_object)
+        .and_then(|e| e.get(SUB_AUTH_TOKEN_KEY))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    if want {
+        match current.as_deref() {
+            Some(SUB_AUTH_TOKEN_VALUE) => return Ok(SubAuthEnvChange::Unchanged),
+            Some(_) => return Ok(SubAuthEnvChange::Unchanged), // foreign — leave alone
+            None => {
+                let env = root
+                    .entry("env")
+                    .or_insert_with(|| Value::Object(Default::default()));
+                let env_obj = env
+                    .as_object_mut()
+                    .context("Claude settings env must be an object")?;
+                env_obj.insert(
+                    SUB_AUTH_TOKEN_KEY.to_string(),
+                    Value::String(SUB_AUTH_TOKEN_VALUE.to_string()),
+                );
+                return Ok(SubAuthEnvChange::Injected);
+            }
+        }
+    }
+
+    // want = false: remove only our sentinel.
+    if current.as_deref() != Some(SUB_AUTH_TOKEN_VALUE) {
+        return Ok(SubAuthEnvChange::Unchanged);
+    }
+    let Some(env) = root.get_mut("env") else {
+        return Ok(SubAuthEnvChange::Unchanged);
+    };
+    let Some(env_obj) = env.as_object_mut() else {
+        return Ok(SubAuthEnvChange::Unchanged);
+    };
+    env_obj.remove(SUB_AUTH_TOKEN_KEY);
+    // Legacy cleanup: early 0.11.8-dev also wrote CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+    // alongside our sentinel. We no longer set that flag (cannot own a bare "1"), but drop it
+    // when tearing down our package so an orphan key does not linger after anthropic-login keep
+    // / sub off. Only remove the exact value we used to write.
+    const LEGACY_NONESSENTIAL_KEY: &str = "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC";
+    if env_obj.get(LEGACY_NONESSENTIAL_KEY).and_then(Value::as_str) == Some("1") {
+        env_obj.remove(LEGACY_NONESSENTIAL_KEY);
+    }
+    if env_obj.is_empty() {
+        root.remove("env");
+    }
+    Ok(SubAuthEnvChange::Removed)
+}
+
+/// Reconcile `~/.claude/settings.json` with whether we should skip Anthropic login.
+/// No-op when Claude Code isn't installed or the settings file is missing and we don't need to inject.
+pub fn sync_sub_auth_env(want: bool) -> Result<SubAuthEnvChange> {
+    let path = claude_settings_path()?;
+    let existing = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) if !want => return Ok(SubAuthEnvChange::Unchanged),
+        Err(_) => String::from("{}"),
+    };
+    let mut settings: Value = if existing.trim().is_empty() {
+        Value::Object(Default::default())
+    } else {
+        serde_json::from_str(&existing)
+            .with_context(|| format!("{} is not valid JSON", path.display()))?
+    };
+    let change = apply_sub_auth_env(&mut settings, want)?;
+    if matches!(
+        change,
+        SubAuthEnvChange::Injected | SubAuthEnvChange::Removed
+    ) {
+        write_settings(&path, &settings)?;
+    }
+    Ok(change)
+}
+
+/// Drop our sentinel from Claude settings (uninstall / teardown). Idempotent.
+pub fn clear_sub_auth_env() -> Result<SubAuthEnvChange> {
+    sync_sub_auth_env(false)
+}
+
+/// Read-only: is our dummy token (or a foreign one) present in Claude settings?
+pub fn sub_auth_env_presence() -> SubAuthEnvPresence {
+    let Ok(path) = claude_settings_path() else {
+        return SubAuthEnvPresence::Unknown;
+    };
+    let Ok(s) = std::fs::read_to_string(&path) else {
+        return SubAuthEnvPresence::Absent;
+    };
+    let Ok(settings) = serde_json::from_str::<Value>(&s) else {
+        return SubAuthEnvPresence::Unknown;
+    };
+    match settings
+        .get("env")
+        .and_then(Value::as_object)
+        .and_then(|e| e.get(SUB_AUTH_TOKEN_KEY))
+        .and_then(Value::as_str)
+    {
+        Some(SUB_AUTH_TOKEN_VALUE) => SubAuthEnvPresence::Ours,
+        Some(_) => SubAuthEnvPresence::Foreign,
+        None => SubAuthEnvPresence::Absent,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1914,6 +2077,106 @@ mod tests {
         let mut settings = serde_json::json!([1, 2, 3]);
         assert!(set_statusline(&mut settings, p).is_err());
         assert!(clear_statusline(&mut settings, p).is_err());
+    }
+
+    #[test]
+    fn sub_auth_env_injects_sentinel_and_removes_only_ours() {
+        let mut settings = serde_json::json!({ "theme": "dark" });
+        assert_eq!(
+            apply_sub_auth_env(&mut settings, true).unwrap(),
+            SubAuthEnvChange::Injected
+        );
+        assert_eq!(
+            settings["env"]["ANTHROPIC_AUTH_TOKEN"],
+            SUB_AUTH_TOKEN_VALUE
+        );
+        // Idempotent when already ours.
+        assert_eq!(
+            apply_sub_auth_env(&mut settings, true).unwrap(),
+            SubAuthEnvChange::Unchanged
+        );
+        // Remove on want=false.
+        assert_eq!(
+            apply_sub_auth_env(&mut settings, false).unwrap(),
+            SubAuthEnvChange::Removed
+        );
+        assert!(settings.get("env").is_none(), "empty env object dropped");
+        assert_eq!(settings["theme"], "dark");
+    }
+
+    #[test]
+    fn sub_auth_env_never_overwrites_or_removes_a_foreign_token() {
+        let mut settings = serde_json::json!({
+            "env": { "ANTHROPIC_AUTH_TOKEN": "sk-ant-real", "OTHER": "keep" }
+        });
+        assert_eq!(
+            apply_sub_auth_env(&mut settings, true).unwrap(),
+            SubAuthEnvChange::Unchanged
+        );
+        assert_eq!(settings["env"]["ANTHROPIC_AUTH_TOKEN"], "sk-ant-real");
+        assert_eq!(
+            apply_sub_auth_env(&mut settings, false).unwrap(),
+            SubAuthEnvChange::Unchanged
+        );
+        assert_eq!(settings["env"]["ANTHROPIC_AUTH_TOKEN"], "sk-ant-real");
+        assert_eq!(settings["env"]["OTHER"], "keep");
+    }
+
+    #[test]
+    fn sub_auth_env_preserves_sibling_env_keys_when_removing_ours() {
+        let mut settings = serde_json::json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": SUB_AUTH_TOKEN_VALUE,
+                "CLAUDE_CODE_EFFORT_LEVEL": "low"
+            }
+        });
+        assert_eq!(
+            apply_sub_auth_env(&mut settings, false).unwrap(),
+            SubAuthEnvChange::Removed
+        );
+        assert!(settings["env"].get("ANTHROPIC_AUTH_TOKEN").is_none());
+        assert_eq!(settings["env"]["CLAUDE_CODE_EFFORT_LEVEL"], "low");
+    }
+
+    #[test]
+    fn sub_auth_env_cleans_legacy_nonessential_flag_with_our_token() {
+        let mut settings = serde_json::json!({
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": SUB_AUTH_TOKEN_VALUE,
+                "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+                "CLAUDE_CODE_EFFORT_LEVEL": "low"
+            }
+        });
+        assert_eq!(
+            apply_sub_auth_env(&mut settings, false).unwrap(),
+            SubAuthEnvChange::Removed
+        );
+        assert!(settings["env"].get("ANTHROPIC_AUTH_TOKEN").is_none());
+        assert!(
+            settings["env"]
+                .get("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC")
+                .is_none(),
+            "legacy package flag cleaned with our token"
+        );
+        assert_eq!(settings["env"]["CLAUDE_CODE_EFFORT_LEVEL"], "low");
+    }
+
+    #[test]
+    fn sub_auth_env_does_not_touch_nonessential_without_our_token() {
+        let mut settings = serde_json::json!({
+            "env": {
+                "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+            }
+        });
+        assert_eq!(
+            apply_sub_auth_env(&mut settings, false).unwrap(),
+            SubAuthEnvChange::Unchanged
+        );
+        assert_eq!(
+            settings["env"]["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"],
+            "1",
+            "user-only flag left alone when our token is absent"
+        );
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/wrap.rs
+++ b/crates/llmtrim-cli/src/wrap.rs
@@ -128,8 +128,9 @@ pub fn run(raw: Vec<String>) -> Result<()> {
     }
 
     // The child inherits our environment as-is: post-setup that already contains
-    // HTTPS_PROXY + the CA trust vars, which is the entire interception mechanism. We add
-    // nothing agent-specific.
+    // HTTPS_PROXY + the CA trust vars, which is the entire interception mechanism.
+    // When global sub is always-on, also inject a dummy Anthropic auth token so Claude
+    // Code skips OAuth (same idea as claude-code-proxy's ANTHROPIC_AUTH_TOKEN=unused).
     eprintln!(
         "{}",
         ui::paint(color, Tone::Dim, &format!("llmtrim wrap → {}", inv.agent))
@@ -138,28 +139,48 @@ pub fn run(raw: Vec<String>) -> Result<()> {
     exec_agent(&inv)
 }
 
+/// True when the agent binary looks like Claude Code (not Codex/Gemini/etc.).
+fn agent_is_claude(agent: &str) -> bool {
+    let base = agent
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(agent)
+        .to_ascii_lowercase();
+    base == "claude" || base.starts_with("claude-") || base == "claude.exe"
+}
+
 /// Launch the agent and propagate its exit code. This is the real-IO entrypoint (it spawns
 /// a subprocess), so it is left uncovered by unit tests — the testable logic lives in
 /// `parse_invocation` / `readiness`, which are tested below.
 fn exec_agent(inv: &WrapInvocation) -> Result<()> {
-    let status = std::process::Command::new(&inv.agent)
-        .args(&inv.args)
-        .status()
-        .with_context(|| {
-            if KNOWN_AGENTS.contains(&inv.agent.as_str()) {
-                format!(
-                    "failed to launch `{}`: is it installed and on your PATH?",
-                    inv.agent
-                )
-            } else {
-                format!(
-                    "failed to launch `{}`: not found on PATH (pass an installed binary, \
-                     e.g. one of: {})",
-                    inv.agent,
-                    KNOWN_AGENTS.join(", ")
-                )
-            }
-        })?;
+    let mut cmd = std::process::Command::new(&inv.agent);
+    cmd.args(&inv.args);
+    // Always-sub skip-login: Claude Code must not require a live Anthropic OAuth session.
+    // Only inject for Claude-ish binaries — never pollute codex/gemini/etc.
+    // Prefer an already-set user value; only inject when missing so a real key still wins.
+    if llmtrim_core::config::sub_skip_anthropic_login() && agent_is_claude(&inv.agent) {
+        if std::env::var_os("ANTHROPIC_AUTH_TOKEN").is_none() {
+            cmd.env(
+                "ANTHROPIC_AUTH_TOKEN",
+                crate::statusline::SUB_AUTH_TOKEN_VALUE,
+            );
+        }
+    }
+    let status = cmd.status().with_context(|| {
+        if KNOWN_AGENTS.contains(&inv.agent.as_str()) {
+            format!(
+                "failed to launch `{}`: is it installed and on your PATH?",
+                inv.agent
+            )
+        } else {
+            format!(
+                "failed to launch `{}`: not found on PATH (pass an installed binary, \
+                 e.g. one of: {})",
+                inv.agent,
+                KNOWN_AGENTS.join(", ")
+            )
+        }
+    })?;
 
     // Per the repo's exit-code rule: mirror the child's status so CI/scripts see the truth.
     std::process::exit(status.code().unwrap_or(1));
@@ -225,5 +246,16 @@ mod tests {
     fn readiness_env_unwired_takes_precedence() {
         assert_eq!(readiness(false, false), Readiness::EnvUnwired);
         assert_eq!(readiness(true, false), Readiness::EnvUnwired);
+    }
+
+    #[test]
+    fn agent_is_claude_matches_claude_binaries_only() {
+        assert!(agent_is_claude("claude"));
+        assert!(agent_is_claude("/usr/bin/claude"));
+        assert!(agent_is_claude("claude-2"));
+        assert!(agent_is_claude(r"C:\Tools\claude.exe"));
+        assert!(!agent_is_claude("codex"));
+        assert!(!agent_is_claude("gemini"));
+        assert!(!agent_is_claude("/usr/bin/aider"));
     }
 }

--- a/crates/llmtrim-cli/src/wrap.rs
+++ b/crates/llmtrim-cli/src/wrap.rs
@@ -158,13 +158,14 @@ fn exec_agent(inv: &WrapInvocation) -> Result<()> {
     // Always-sub skip-login: Claude Code must not require a live Anthropic OAuth session.
     // Only inject for Claude-ish binaries — never pollute codex/gemini/etc.
     // Prefer an already-set user value; only inject when missing so a real key still wins.
-    if llmtrim_core::config::sub_skip_anthropic_login() && agent_is_claude(&inv.agent) {
-        if std::env::var_os("ANTHROPIC_AUTH_TOKEN").is_none() {
-            cmd.env(
-                "ANTHROPIC_AUTH_TOKEN",
-                crate::statusline::SUB_AUTH_TOKEN_VALUE,
-            );
-        }
+    if llmtrim_core::config::sub_skip_anthropic_login()
+        && agent_is_claude(&inv.agent)
+        && std::env::var_os("ANTHROPIC_AUTH_TOKEN").is_none()
+    {
+        cmd.env(
+            "ANTHROPIC_AUTH_TOKEN",
+            crate::statusline::SUB_AUTH_TOKEN_VALUE,
+        );
     }
     let status = cmd.status().with_context(|| {
         if KNOWN_AGENTS.contains(&inv.agent.as_str()) {

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1151,6 +1151,69 @@ fn resolve_sub_fallback(env: &impl Fn(&str) -> Option<String>, file: Option<&tom
         .unwrap_or(false)
 }
 
+/// Whether global sub is active in `always` mode (provider set, mode not `fallback`).
+///
+/// Reads the config file **fresh from disk** so a CLI that just ran `write_sub_*` in this process
+/// sees the new state. Prefer this over [`RuntimeConfig::get`] for post-write decisions —
+/// `RuntimeConfig` is process-cached and stays on the pre-write snapshot.
+pub fn sub_always_on() -> bool {
+    let file = load_config_file();
+    let env = |k: &str| std::env::var(k).ok();
+    resolve_sub_provider(&env, file.as_ref()).is_some() && !resolve_sub_fallback(&env, file.as_ref())
+}
+
+/// Whether always-sub should inject a dummy `ANTHROPIC_AUTH_TOKEN` so Claude Code skips Anthropic
+/// OAuth / `/login`.
+///
+/// Default **true** when [`sub_always_on`] (skip login). Set `sub.anthropic_login = "keep"` or
+/// `LLMTRIM_SUB_ANTHROPIC_LOGIN=keep` to leave Claude on its claude.ai OAuth session — required for
+/// claude.ai connectors, but then a live Anthropic login is mandatory again.
+///
+/// Fresh-from-disk like [`sub_always_on`]. False when sub is off or in fallback mode.
+pub fn sub_skip_anthropic_login() -> bool {
+    if !sub_always_on() {
+        return false;
+    }
+    let file = load_config_file();
+    let env = |k: &str| std::env::var(k).ok();
+    resolve_sub_skip_anthropic_login(&env, file.as_ref())
+}
+
+fn resolve_sub_skip_anthropic_login(
+    env: &impl Fn(&str) -> Option<String>,
+    file: Option<&toml::Value>,
+) -> bool {
+    // `skip` = inject dummy (default). `keep` = leave Anthropic OAuth alone (connectors work).
+    let parse = |raw: &str| match raw.trim().to_ascii_lowercase().as_str() {
+        "keep" | "oauth" | "claude" | "connectors" => false,
+        "skip" | "dummy" | "none" => true,
+        other => {
+            eprintln!(
+                "llmtrim: unknown sub.anthropic_login '{other}' — using 'skip' (expected skip|keep)"
+            );
+            true
+        }
+    };
+    if let Some(v) = env("LLMTRIM_SUB_ANTHROPIC_LOGIN").filter(|s| !s.is_empty()) {
+        return parse(&v);
+    }
+    file.and_then(|v| v.get("sub"))
+        .and_then(|v| v.get("anthropic_login"))
+        .and_then(toml::Value::as_str)
+        .map(parse)
+        .unwrap_or(true) // default: skip Anthropic login while always-sub
+}
+
+/// Persist `sub.anthropic_login`: `skip` (dummy token, no Anthropic /login) or `keep` (claude.ai
+/// OAuth for connectors; Anthropic login still required).
+pub fn write_sub_anthropic_login(skip: bool) -> Result<()> {
+    let path = config_path().ok_or_else(|| anyhow::anyhow!("no config path (HOME/XDG unset)"))?;
+    let value = if skip { "skip" } else { "keep" };
+    edit_sub_table_at(&path, |t| {
+        t["anthropic_login"] = toml_edit::value(value);
+    })
+}
+
 /// Ordered fallback providers from env or `[sub] chain`. Unknown entries are retained so the
 /// serve layer can report them clearly; an empty/missing chain falls back to the active provider.
 fn resolve_sub_chain(
@@ -1756,6 +1819,40 @@ mod tests {
         }
         let env = |k: &str| (k == "LLMTRIM_SUB_MODE").then(|| "on-error".to_string());
         assert!(resolve_sub_fallback(&env, None));
+    }
+
+    #[test]
+    fn sub_skip_anthropic_login_defaults_skip_and_honors_keep() {
+        let no_env = |_: &str| None;
+        // Default while always-sub: skip (inject dummy).
+        let always: toml::Value =
+            toml::from_str("[sub]\nactive = \"grok\"\nmode = \"always\"\n").unwrap();
+        assert!(resolve_sub_skip_anthropic_login(&no_env, Some(&always)));
+        // Explicit keep.
+        let keep: toml::Value = toml::from_str(
+            "[sub]\nactive = \"grok\"\nmode = \"always\"\nanthropic_login = \"keep\"\n",
+        )
+        .unwrap();
+        assert!(!resolve_sub_skip_anthropic_login(&no_env, Some(&keep)));
+        // Explicit skip.
+        let skip: toml::Value = toml::from_str(
+            "[sub]\nactive = \"grok\"\nmode = \"always\"\nanthropic_login = \"skip\"\n",
+        )
+        .unwrap();
+        assert!(resolve_sub_skip_anthropic_login(&no_env, Some(&skip)));
+        // Env wins over file keep.
+        let env_skip =
+            |k: &str| (k == "LLMTRIM_SUB_ANTHROPIC_LOGIN").then(|| "skip".to_string());
+        assert!(resolve_sub_skip_anthropic_login(&env_skip, Some(&keep)));
+        let env_keep =
+            |k: &str| (k == "LLMTRIM_SUB_ANTHROPIC_LOGIN").then(|| "keep".to_string());
+        assert!(!resolve_sub_skip_anthropic_login(&env_keep, Some(&always)));
+        // Connectors alias for keep.
+        let connectors: toml::Value = toml::from_str(
+            "[sub]\nactive = \"grok\"\nmode = \"always\"\nanthropic_login = \"connectors\"\n",
+        )
+        .unwrap();
+        assert!(!resolve_sub_skip_anthropic_login(&no_env, Some(&connectors)));
     }
 
     #[test]

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1159,7 +1159,8 @@ fn resolve_sub_fallback(env: &impl Fn(&str) -> Option<String>, file: Option<&tom
 pub fn sub_always_on() -> bool {
     let file = load_config_file();
     let env = |k: &str| std::env::var(k).ok();
-    resolve_sub_provider(&env, file.as_ref()).is_some() && !resolve_sub_fallback(&env, file.as_ref())
+    resolve_sub_provider(&env, file.as_ref()).is_some()
+        && !resolve_sub_fallback(&env, file.as_ref())
 }
 
 /// Whether always-sub should inject a dummy `ANTHROPIC_AUTH_TOKEN` so Claude Code skips Anthropic
@@ -1841,18 +1842,19 @@ mod tests {
         .unwrap();
         assert!(resolve_sub_skip_anthropic_login(&no_env, Some(&skip)));
         // Env wins over file keep.
-        let env_skip =
-            |k: &str| (k == "LLMTRIM_SUB_ANTHROPIC_LOGIN").then(|| "skip".to_string());
+        let env_skip = |k: &str| (k == "LLMTRIM_SUB_ANTHROPIC_LOGIN").then(|| "skip".to_string());
         assert!(resolve_sub_skip_anthropic_login(&env_skip, Some(&keep)));
-        let env_keep =
-            |k: &str| (k == "LLMTRIM_SUB_ANTHROPIC_LOGIN").then(|| "keep".to_string());
+        let env_keep = |k: &str| (k == "LLMTRIM_SUB_ANTHROPIC_LOGIN").then(|| "keep".to_string());
         assert!(!resolve_sub_skip_anthropic_login(&env_keep, Some(&always)));
         // Connectors alias for keep.
         let connectors: toml::Value = toml::from_str(
             "[sub]\nactive = \"grok\"\nmode = \"always\"\nanthropic_login = \"connectors\"\n",
         )
         .unwrap();
-        assert!(!resolve_sub_skip_anthropic_login(&no_env, Some(&connectors)));
+        assert!(!resolve_sub_skip_anthropic_login(
+            &no_env,
+            Some(&connectors)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Always-sub still forced Claude Code through Anthropic OAuth even when every `/v1/messages` turn was rewritten to Grok/Codex/Kimi. After OAuth expiry, the client blocked with "Please run /login" before the MITM ever saw the request — including `/compact`.

This mirrors [claude-code-proxy](https://github.com/raine/claude-code-proxy): under global `sub` always-on, inject a dummy `ANTHROPIC_AUTH_TOKEN` into `~/.claude/settings.json` so Claude Code leaves OAuth mode. The proxy strips that credential, injects the real subscription token, and answers non-messages Anthropic probes locally.

### Trade-off (intentional)

Claude Code disables **claude.ai connectors** while any API-key auth is set. Documented and reversible:

```bash
llmtrim sub anthropic-login skip   # default: no Anthropic /login; connectors off
llmtrim sub anthropic-login keep   # connectors OK; Anthropic /login still required
```

### Also includes

- Clear 400 when dummy auth is present but the turn is not rerouted (window `/sub off`)
- Body drain on stub **and** error paths (missing drain caused `ECONNRESET`)
- Trailing-slash-safe `/v1/messages` classification
- `wrap` injects only for Claude binaries
- `ensure` / `sub status` report actual settings presence
- Legacy `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` cleaned when removing our sentinel
- Integration tests for the dummy-auth `handle_request_inner` gates

## Test plan

- [x] Unit tests: dummy credential detection, path classify, settings ownership, anthropic_login resolver, wrap agent filter
- [x] Integration: dummy + models → stub; dummy + messages no sub → 400; dummy + messages + sub → reroute path; real key → no stub
- [x] Live probe: `GET /v1/models` + dummy → 200 stub; `POST /v1/messages` + dummy + grok sub → SSE from Grok
- [x] `llmtrim sub anthropic-login keep|skip` updates settings; restart Claude Code required
- [ ] CI green
- [ ] Manual: always-sub skip-login session survives without Anthropic `/login`; connectors warning expected under skip