### PR TITLE
fix(sub): NODE_USE_ENV_PROXY so Claude hits the MITM

### DIFF
--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -1255,7 +1255,7 @@ fn set_env_in(env: &winreg::RegKey, proxy: &str, ca: &str) -> Result<()> {
         .context("failed to set NO_PROXY")?;
     env.set_value("NODE_EXTRA_CA_CERTS", &ca)
         .context("failed to set NODE_EXTRA_CA_CERTS")?;
-    env.set_value("NODE_USE_ENV_PROXY", "1")
+    env.set_value("NODE_USE_ENV_PROXY", &"1".to_string())
         .context("failed to set NODE_USE_ENV_PROXY")?;
     Ok(())
 }

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -23,7 +23,7 @@ const END: &str = "# <<< llmtrim <<<";
 /// process can't rewrite its parent shell's environment, so `stop`/`uninstall` print this for
 /// the user to run (or they open a new shell, which self-heals via the daemon-gated block).
 /// Single source of truth for the five managed vars, in both `NO_PROXY` casings.
-pub const UNSET_HINT: &str = "unset HTTPS_PROXY HTTP_PROXY NO_PROXY no_proxy NODE_EXTRA_CA_CERTS SSL_CERT_FILE CURL_CA_BUNDLE";
+pub const UNSET_HINT: &str = "unset HTTPS_PROXY HTTP_PROXY NO_PROXY no_proxy NODE_EXTRA_CA_CERTS SSL_CERT_FILE CURL_CA_BUNDLE NODE_USE_ENV_PROXY";
 
 /// Hosts/ranges that must bypass the interceptor: loopback, link-local, and the private LAN
 /// ranges (RFC-1918 + IPv6 ULA). llmtrim only MITMs a fixed set of public LLM API hosts (the
@@ -259,17 +259,21 @@ pub fn heal_managed_env() -> Result<Vec<PathBuf>> {
 /// hermetic. Rewrites the managed block only in profiles that already contain a healable one (see
 /// [`managed_block_needs_heal`]); returns the paths actually rewritten.
 /// Does `s` contain a *well-formed* managed block (`BEGIN`…`END`) that predates the current block
-/// shape and should be rewritten? A block is healable when it lacks either the `NO_PROXY` bypass
-/// or the daemon-liveness gate (`llmtrim _alive`) — both are silent rewrites into the current
-/// form, and the second is what migrates every pre-gate install so `stop` unwires new shells
-/// without the user re-running `setup`. Only a well-formed block qualifies: a malformed
-/// BEGIN-without-END is skipped (rewriting it would stack a duplicate), an already-current block
-/// (both markers present inside it) is skipped, and a `NO_PROXY`/guard the user placed *outside*
-/// the markers does not count — it must be inside the block we manage. Pure/testable.
+/// shape and should be rewritten? A block is healable when it lacks the `NO_PROXY` bypass, the
+/// daemon-liveness gate (`llmtrim _alive`), or `NODE_USE_ENV_PROXY` (Node undici proxy for Claude
+/// Code). Only a well-formed block qualifies: a malformed BEGIN-without-END is skipped (rewriting
+/// it would stack a duplicate), an already-current block is skipped, and a marker the user placed
+/// *outside* the block we manage does not count. Pure/testable.
 #[cfg(not(windows))]
 fn managed_block_needs_heal(s: &str) -> bool {
-    let (mut in_block, mut saw_begin, mut saw_end, mut bypass_in_block, mut gate_in_block) =
-        (false, false, false, false, false);
+    let (
+        mut in_block,
+        mut saw_begin,
+        mut saw_end,
+        mut bypass_in_block,
+        mut gate_in_block,
+        mut node_proxy_in_block,
+    ) = (false, false, false, false, false, false);
     for line in s.lines() {
         match line.trim() {
             BEGIN => {
@@ -284,10 +288,11 @@ fn managed_block_needs_heal(s: &str) -> bool {
             }
             l if in_block && l.contains("llmtrim _alive") => gate_in_block = true,
             l if in_block && l.contains("NO_PROXY") => bypass_in_block = true,
+            l if in_block && l.contains("NODE_USE_ENV_PROXY") => node_proxy_in_block = true,
             _ => {}
         }
     }
-    saw_begin && saw_end && (!bypass_in_block || !gate_in_block)
+    saw_begin && saw_end && (!bypass_in_block || !gate_in_block || !node_proxy_in_block)
 }
 
 #[cfg(not(windows))]
@@ -1145,11 +1150,12 @@ fn profile_has_block_in(base: &std::path::Path) -> bool {
 
 /// The values llmtrim manages in the user environment.
 #[cfg(windows)]
-const ENV_KEYS: [&str; 4] = [
+const ENV_KEYS: [&str; 5] = [
     "HTTPS_PROXY",
     "HTTP_PROXY",
     "NO_PROXY",
     "NODE_EXTRA_CA_CERTS",
+    "NODE_USE_ENV_PROXY",
 ];
 
 /// Open `HKCU\Environment` for read+write (created if somehow absent).
@@ -1249,6 +1255,8 @@ fn set_env_in(env: &winreg::RegKey, proxy: &str, ca: &str) -> Result<()> {
         .context("failed to set NO_PROXY")?;
     env.set_value("NODE_EXTRA_CA_CERTS", &ca)
         .context("failed to set NODE_EXTRA_CA_CERTS")?;
+    env.set_value("NODE_USE_ENV_PROXY", "1")
+        .context("failed to set NODE_USE_ENV_PROXY")?;
     Ok(())
 }
 
@@ -1573,6 +1581,9 @@ fn env_block(proxy: &str, ca: &str, bundle: Option<&str>, syntax: Syntax) -> Str
                 .unwrap_or_default();
             let (proxy, ca, no_proxy) =
                 (posix_quote(proxy), posix_quote(ca), posix_quote(NO_PROXY));
+            // NODE_USE_ENV_PROXY: Node 20.18+/22+ undici fetch ignores HTTPS_PROXY unless set
+            // (Claude Code's Anthropic client). Without it, skip-login's dummy token hits
+            // real Anthropic → 401 Invalid bearer token despite a healthy MITM.
             format!(
                 "{BEGIN}\n\
                  if command -v llmtrim >/dev/null 2>&1 && llmtrim _alive 2>/dev/null; then\n\
@@ -1581,6 +1592,7 @@ fn env_block(proxy: &str, ca: &str, bundle: Option<&str>, syntax: Syntax) -> Str
                  \x20   export NO_PROXY={no_proxy}\n\
                  \x20   export no_proxy={no_proxy}\n\
                  \x20   export NODE_EXTRA_CA_CERTS={ca}\n\
+                 \x20   export NODE_USE_ENV_PROXY=1\n\
                  {native}fi\n\
                  {END}\n"
             )
@@ -1597,6 +1609,7 @@ fn env_block(proxy: &str, ca: &str, bundle: Option<&str>, syntax: Syntax) -> Str
                  $env:HTTP_PROXY = {proxy}\n\
                  $env:NO_PROXY = {no_proxy}\n\
                  $env:NODE_EXTRA_CA_CERTS = {ca}\n\
+                 $env:NODE_USE_ENV_PROXY = '1'\n\
                  {END}\n"
             )
         }
@@ -1638,6 +1651,7 @@ fn manual_env_lines(proxy: &str, ca: &str, bundle: Option<&str>) -> Vec<String> 
             format!("export NO_PROXY={}", q(NO_PROXY)),
             format!("export no_proxy={}", q(NO_PROXY)),
             format!("export NODE_EXTRA_CA_CERTS={}", q(ca)),
+            "export NODE_USE_ENV_PROXY=1".to_string(),
         ];
         if let Some(b) = bundle {
             lines.push(format!("export SSL_CERT_FILE={}", q(b)));
@@ -1653,6 +1667,7 @@ fn manual_env_lines(proxy: &str, ca: &str, bundle: Option<&str>) -> Vec<String> 
             format!("$env:HTTP_PROXY = {}", powershell_quote(proxy)),
             format!("$env:NO_PROXY = {}", powershell_quote(NO_PROXY)),
             format!("$env:NODE_EXTRA_CA_CERTS = {}", powershell_quote(ca)),
+            "$env:NODE_USE_ENV_PROXY = '1'".to_string(),
         ]
     }
 }
@@ -2107,6 +2122,8 @@ mod tests {
         );
         assert!(b.contains("export HTTPS_PROXY='http://127.0.0.1:8787'"));
         assert!(b.contains("export NODE_EXTRA_CA_CERTS='/home/u/ca.pem'"));
+        // Node undici needs this to honor HTTPS_PROXY (Claude Code).
+        assert!(b.contains("export NODE_USE_ENV_PROXY=1"));
         // LAN/local bypass travels with the proxy, in both casings tools read.
         assert!(b.contains(&format!("export NO_PROXY='{NO_PROXY}'")));
         assert!(b.contains(&format!("export no_proxy='{NO_PROXY}'")));
@@ -2140,6 +2157,7 @@ mod tests {
         assert!(lines.contains(&format!("export NO_PROXY='{NO_PROXY}'")));
         assert!(lines.contains(&format!("export no_proxy='{NO_PROXY}'")));
         assert!(lines.contains(&"export NODE_EXTRA_CA_CERTS='/home/u/ca.pem'".to_string()));
+        assert!(lines.contains(&"export NODE_USE_ENV_PROXY=1".to_string()));
         assert!(!lines.iter().any(|l| l.contains("SSL_CERT_FILE")));
         assert!(!lines.iter().any(|l| l.contains("CURL_CA_BUNDLE")));
         // Unlike env_block, this is a standalone eval-able snippet: no BEGIN/END markers,

--- a/crates/llmtrim-cli/src/setup.rs
+++ b/crates/llmtrim-cli/src/setup.rs
@@ -1592,7 +1592,7 @@ fn env_block(proxy: &str, ca: &str, bundle: Option<&str>, syntax: Syntax) -> Str
                  \x20   export NO_PROXY={no_proxy}\n\
                  \x20   export no_proxy={no_proxy}\n\
                  \x20   export NODE_EXTRA_CA_CERTS={ca}\n\
-                 \x20   export NODE_USE_ENV_PROXY=1\n\
+                 \x20   export NODE_USE_ENV_PROXY='1'\n\
                  {native}fi\n\
                  {END}\n"
             )
@@ -1651,7 +1651,7 @@ fn manual_env_lines(proxy: &str, ca: &str, bundle: Option<&str>) -> Vec<String> 
             format!("export NO_PROXY={}", q(NO_PROXY)),
             format!("export no_proxy={}", q(NO_PROXY)),
             format!("export NODE_EXTRA_CA_CERTS={}", q(ca)),
-            "export NODE_USE_ENV_PROXY=1".to_string(),
+            "export NODE_USE_ENV_PROXY='1'".to_string(),
         ];
         if let Some(b) = bundle {
             lines.push(format!("export SSL_CERT_FILE={}", q(b)));
@@ -2123,7 +2123,7 @@ mod tests {
         assert!(b.contains("export HTTPS_PROXY='http://127.0.0.1:8787'"));
         assert!(b.contains("export NODE_EXTRA_CA_CERTS='/home/u/ca.pem'"));
         // Node undici needs this to honor HTTPS_PROXY (Claude Code).
-        assert!(b.contains("export NODE_USE_ENV_PROXY=1"));
+        assert!(b.contains("export NODE_USE_ENV_PROXY='1'"));
         // LAN/local bypass travels with the proxy, in both casings tools read.
         assert!(b.contains(&format!("export NO_PROXY='{NO_PROXY}'")));
         assert!(b.contains(&format!("export no_proxy='{NO_PROXY}'")));
@@ -2157,7 +2157,7 @@ mod tests {
         assert!(lines.contains(&format!("export NO_PROXY='{NO_PROXY}'")));
         assert!(lines.contains(&format!("export no_proxy='{NO_PROXY}'")));
         assert!(lines.contains(&"export NODE_EXTRA_CA_CERTS='/home/u/ca.pem'".to_string()));
-        assert!(lines.contains(&"export NODE_USE_ENV_PROXY=1".to_string()));
+        assert!(lines.contains(&"export NODE_USE_ENV_PROXY='1'".to_string()));
         assert!(!lines.iter().any(|l| l.contains("SSL_CERT_FILE")));
         assert!(!lines.iter().any(|l| l.contains("CURL_CA_BUNDLE")));
         // Unlike env_block, this is a standalone eval-able snippet: no BEGIN/END markers,

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -1296,11 +1296,17 @@ pub enum SubAuthEnvPresence {
     Unknown,
 }
 
+/// Node 20.18+/22+ undici `fetch` ignores `HTTPS_PROXY` unless this is set. Claude Code uses
+/// that stack, so without it skip-login's dummy token hits real Anthropic → `401 Invalid bearer
+/// token` even when the shell has `HTTPS_PROXY` and the MITM is healthy.
+const NODE_USE_ENV_PROXY_KEY: &str = "NODE_USE_ENV_PROXY";
+const NODE_USE_ENV_PROXY_VALUE: &str = "1";
+
 /// Pure mutation of a parsed Claude settings object.
 ///
-/// - `want = true`: set `env.ANTHROPIC_AUTH_TOKEN` to [`SUB_AUTH_TOKEN_VALUE`] unless a foreign
-///   (non-sentinel) value is already there.
-/// - `want = false`: remove the key only when it holds our sentinel.
+/// - `want = true`: set `env.ANTHROPIC_AUTH_TOKEN` to [`SUB_AUTH_TOKEN_VALUE`] (and
+///   `NODE_USE_ENV_PROXY=1`) unless a foreign (non-sentinel) token is already there.
+/// - `want = false`: remove those keys only when the token holds our sentinel.
 pub fn apply_sub_auth_env(settings: &mut Value, want: bool) -> Result<SubAuthEnvChange> {
     let root = settings
         .as_object_mut()
@@ -1315,7 +1321,26 @@ pub fn apply_sub_auth_env(settings: &mut Value, want: bool) -> Result<SubAuthEnv
 
     if want {
         match current.as_deref() {
-            Some(SUB_AUTH_TOKEN_VALUE) => return Ok(SubAuthEnvChange::Unchanged),
+            Some(SUB_AUTH_TOKEN_VALUE) => {
+                // Ours already — still ensure Node honors HTTPS_PROXY (upgrade path for
+                // installs that got the dummy token before NODE_USE_ENV_PROXY was added).
+                let env = root
+                    .entry("env")
+                    .or_insert_with(|| Value::Object(Default::default()));
+                let env_obj = env
+                    .as_object_mut()
+                    .context("Claude settings env must be an object")?;
+                let proxy_ok = env_obj.get(NODE_USE_ENV_PROXY_KEY).and_then(Value::as_str)
+                    == Some(NODE_USE_ENV_PROXY_VALUE);
+                if proxy_ok {
+                    return Ok(SubAuthEnvChange::Unchanged);
+                }
+                env_obj.insert(
+                    NODE_USE_ENV_PROXY_KEY.to_string(),
+                    Value::String(NODE_USE_ENV_PROXY_VALUE.to_string()),
+                );
+                return Ok(SubAuthEnvChange::Injected);
+            }
             Some(_) => return Ok(SubAuthEnvChange::Unchanged), // foreign — leave alone
             None => {
                 let env = root
@@ -1328,12 +1353,16 @@ pub fn apply_sub_auth_env(settings: &mut Value, want: bool) -> Result<SubAuthEnv
                     SUB_AUTH_TOKEN_KEY.to_string(),
                     Value::String(SUB_AUTH_TOKEN_VALUE.to_string()),
                 );
+                env_obj.insert(
+                    NODE_USE_ENV_PROXY_KEY.to_string(),
+                    Value::String(NODE_USE_ENV_PROXY_VALUE.to_string()),
+                );
                 return Ok(SubAuthEnvChange::Injected);
             }
         }
     }
 
-    // want = false: remove only our sentinel.
+    // want = false: remove only our package.
     if current.as_deref() != Some(SUB_AUTH_TOKEN_VALUE) {
         return Ok(SubAuthEnvChange::Unchanged);
     }
@@ -1344,10 +1373,13 @@ pub fn apply_sub_auth_env(settings: &mut Value, want: bool) -> Result<SubAuthEnv
         return Ok(SubAuthEnvChange::Unchanged);
     };
     env_obj.remove(SUB_AUTH_TOKEN_KEY);
+    if env_obj.get(NODE_USE_ENV_PROXY_KEY).and_then(Value::as_str)
+        == Some(NODE_USE_ENV_PROXY_VALUE)
+    {
+        env_obj.remove(NODE_USE_ENV_PROXY_KEY);
+    }
     // Legacy cleanup: early 0.11.8-dev also wrote CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
-    // alongside our sentinel. We no longer set that flag (cannot own a bare "1"), but drop it
-    // when tearing down our package so an orphan key does not linger after anthropic-login keep
-    // / sub off. Only remove the exact value we used to write.
+    // alongside our sentinel. Drop it when tearing down our package.
     const LEGACY_NONESSENTIAL_KEY: &str = "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC";
     if env_obj.get(LEGACY_NONESSENTIAL_KEY).and_then(Value::as_str) == Some("1") {
         env_obj.remove(LEGACY_NONESSENTIAL_KEY);
@@ -2090,7 +2122,8 @@ mod tests {
             settings["env"]["ANTHROPIC_AUTH_TOKEN"],
             SUB_AUTH_TOKEN_VALUE
         );
-        // Idempotent when already ours.
+        assert_eq!(settings["env"]["NODE_USE_ENV_PROXY"], "1");
+        // Idempotent when already ours (token + proxy flag).
         assert_eq!(
             apply_sub_auth_env(&mut settings, true).unwrap(),
             SubAuthEnvChange::Unchanged
@@ -2143,6 +2176,7 @@ mod tests {
         let mut settings = serde_json::json!({
             "env": {
                 "ANTHROPIC_AUTH_TOKEN": SUB_AUTH_TOKEN_VALUE,
+                "NODE_USE_ENV_PROXY": "1",
                 "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
                 "CLAUDE_CODE_EFFORT_LEVEL": "low"
             }
@@ -2152,6 +2186,7 @@ mod tests {
             SubAuthEnvChange::Removed
         );
         assert!(settings["env"].get("ANTHROPIC_AUTH_TOKEN").is_none());
+        assert!(settings["env"].get("NODE_USE_ENV_PROXY").is_none());
         assert!(
             settings["env"]
                 .get("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC")
@@ -2159,6 +2194,18 @@ mod tests {
             "legacy package flag cleaned with our token"
         );
         assert_eq!(settings["env"]["CLAUDE_CODE_EFFORT_LEVEL"], "low");
+    }
+
+    #[test]
+    fn sub_auth_env_upgrades_existing_token_with_node_proxy_flag() {
+        let mut settings = serde_json::json!({
+            "env": { "ANTHROPIC_AUTH_TOKEN": SUB_AUTH_TOKEN_VALUE }
+        });
+        assert_eq!(
+            apply_sub_auth_env(&mut settings, true).unwrap(),
+            SubAuthEnvChange::Injected
+        );
+        assert_eq!(settings["env"]["NODE_USE_ENV_PROXY"], "1");
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -1373,8 +1373,7 @@ pub fn apply_sub_auth_env(settings: &mut Value, want: bool) -> Result<SubAuthEnv
         return Ok(SubAuthEnvChange::Unchanged);
     };
     env_obj.remove(SUB_AUTH_TOKEN_KEY);
-    if env_obj.get(NODE_USE_ENV_PROXY_KEY).and_then(Value::as_str)
-        == Some(NODE_USE_ENV_PROXY_VALUE)
+    if env_obj.get(NODE_USE_ENV_PROXY_KEY).and_then(Value::as_str) == Some(NODE_USE_ENV_PROXY_VALUE)
     {
         env_obj.remove(NODE_USE_ENV_PROXY_KEY);
     }


### PR DESCRIPTION
## Summary

With `sub anthropic-login skip`, Claude Code uses a dummy `ANTHROPIC_AUTH_TOKEN`. On Node 20.18+/22, undici `fetch` **ignores `HTTPS_PROXY`** unless `NODE_USE_ENV_PROXY=1`, so the dummy key goes straight to Anthropic → `401 Invalid bearer token` even when llmtrim doctor is green and Grok is logged in.

## Fix

- Write `NODE_USE_ENV_PROXY=1` into Claude settings next to the dummy token (and upgrade existing installs that only have the token)
- Export it from setup's managed profile / `setup --env` / Windows env
- Heal old profile blocks missing the flag

## Test plan

- [x] Unit tests for settings inject/upgrade/remove and setup env block
- [ ] On a machine that repros 401 with skip-login: after upgrade, restart Claude → Grok serves
- [ ] CI green