### PR TITLE
fix(ensure): stop re-asking cheaper /compact models when already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`llmtrim ensure` no longer re-asks about cheaper `/compact` models after they are configured.**
+  `compact_models_configured()` used `str::parse::<toml::Value>()`, which in toml 1.x only accepts
+  a single value — a real multi-key `config.toml` failed the parse, the error was swallowed, and
+  ensure/doctor always reported compact as missing. It now uses `toml::from_str` like every other
+  config reader.
+
 - **Cold-cache guard shows the blocked draft on the TTY again.** `suppressOriginalPrompt` stopped
   Claude Code nesting `Original prompt:` into the warning, but also hid the draft entirely once
   the input box was cleared — next-turn `additionalContext` only helped if you typed something

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1333,7 +1333,18 @@ pub fn compact_models_configured() -> bool {
     };
     std::fs::read_to_string(path)
         .ok()
-        .and_then(|text| text.parse::<toml::Value>().ok())
+        .is_some_and(|text| compact_models_present_in(&text))
+}
+
+/// True when `text` is a TOML document that defines `[compact].models` (any value, including `[]`).
+///
+/// Uses `toml::from_str` (document deserialize), not `str::parse` / `Value::from_str`. In toml 1.x,
+/// `Value: FromStr` is a single-value parser — a multi-key document like `capture_dir = "…"` fails
+/// with "unexpected content, expected nothing". Swallowing that error made ensure re-prompt forever
+/// even when `[compact].models` was already set.
+fn compact_models_present_in(text: &str) -> bool {
+    toml::from_str::<toml::Value>(text)
+        .ok()
         .and_then(|doc| doc.get("compact").cloned())
         .and_then(|compact| compact.get("models").cloned())
         .is_some()
@@ -2226,6 +2237,22 @@ mod tests {
     fn compact_models_preserve_order_and_deduplicate() {
         let c = resolve_file("[compact]\nmodels = [\"haiku\", \"sonnet\", \"haiku\", \"\"]\n");
         assert_eq!(c.compact_models, vec!["haiku", "sonnet"]);
+    }
+
+    /// Regression: a real config always has other top-level keys (`capture_dir`, `theme`, …).
+    /// `str::parse::<toml::Value>` rejects that shape in toml 1.x, so ensure kept re-prompting.
+    #[test]
+    fn compact_models_present_in_multi_key_document() {
+        let text = "capture_dir = \"/tmp/cap\"\ntheme = \"macchiato\"\n\n[compact]\nmodels = [\"haiku\", \"sonnet\"]\n\n[sub]\nactive = \"off\"\n";
+        assert!(compact_models_present_in(text));
+        assert!(compact_models_present_in("[compact]\nmodels = []\n"));
+        assert!(!compact_models_present_in("[compact]\n# models omitted\n"));
+        assert!(!compact_models_present_in("capture_dir = \"/tmp/cap\"\n"));
+        // The wrong API: documents are not single values.
+        assert!(
+            text.parse::<toml::Value>().is_err(),
+            "toml 1.x Value::from_str must not silently accept multi-key documents (that was the bug)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `compact_models_configured()` always returned `false` on a real `config.toml` because it used `str::parse::<toml::Value>()`. In toml 1.x that is a single-value parser; multi-key documents fail with "unexpected content, expected nothing", and `.ok()` swallowed the error.
- `llmtrim ensure` / `doctor` therefore always thought `[compact].models` was missing and re-prompted `Use cheaper models for Claude Code /compact (Haiku → Sonnet)?` even when it was already configured. `compact status` and the proxy were fine — they already used `toml::from_str`.
- Parse with `toml::from_str` (same as every other config reader), extract a pure helper for the check, and add a regression test that includes a multi-key document.

## Test plan

- [x] `cargo test -p llmtrim-core --lib compact_models` (8 passed, including new multi-key regression)
- [ ] After merge/install: `llmtrim doctor` no longer warns about compact when `~/.config/llmtrim/config.toml` has `[compact] models = [...]`
- [ ] `llmtrim ensure` does not re-prompt the cheaper `/compact` models question when already configured