### PR TITLE
chore(deps): bump postcss 8.5.15 → 8.5.23 (Dependabot #8)

### DIFF
--- a/crates/llmtrim-tray/package-lock.json
+++ b/crates/llmtrim-tray/package-lock.json
@@ -939,9 +939,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -978,9 +978,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -998,7 +998,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- Bumps transitive `postcss` in `crates/llmtrim-tray/package-lock.json` from **8.5.15 → 8.5.23** to fix [Dependabot alert #8](https://github.com/fkiene/llmtrim/security/dependabot/8) / [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849).
- Vulnerability: path traversal via `/*# sourceMappingURL=... */` auto-loading can disclose arbitrary `.map` files. Fixed in `>= 8.5.18`.
- `postcss` is a **dev-only** transitive dep of `vite` for the Tauri tray UI build — not shipped in the runtime binary, and the tray build never processes untrusted CSS. Practical risk is low; this is lockfile hygiene.

## Changes
- `npm update postcss` in `crates/llmtrim-tray/` (also pulls `nanoid` 3.3.15 → 3.3.16 as a postcss dep).
- `npm audit` now reports **0 vulnerabilities** for the tray UI tree.

## Test plan
- [x] `npm update postcss` resolves to `>= 8.5.18` (landed on 8.5.23)
- [x] `npm audit` clean in `crates/llmtrim-tray`
- [ ] CI green (tray UI build / typecheck if exercised)
- [ ] Confirm Dependabot alert #8 auto-closes after merge