### PR TITLE
docs: align issue/PR templates with the current CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,39 +8,43 @@ assignees: ""
 
 ## What happened
 
-<!-- A clear description of the bug. -->
+<!-- What went wrong, in plain terms. -->
 
 ## How are you running llmtrim?
 
-- [ ] Proxy (`llmtrim setup` / `serve`) — intercepting a tool's traffic
-- [ ] CLI (`llmtrim compress` / `send` / `batch`)
+- [ ] Proxy / daemon (`llmtrim setup` / `start` / `serve` / `wrap`): intercepting a tool's traffic
+- [ ] CLI (`llmtrim compress` / `send`)
+- [ ] Subscription reroute (`llmtrim sub` → codex | kimi | grok)
+- [ ] MCP (`llmtrim mcp`)
 
 - Tool / client (proxy path): <!-- e.g. Claude Code, Cursor, Codex, a Node app -->
-- Provider: <!-- openai | anthropic | gemini | … -->
-- Preset / config: <!-- auto (default), rag, code, … — paste your config.toml if custom -->
+- Provider: <!-- openai | anthropic | google (`gemini` is an alias for google) -->
+- Preset / config: <!-- auto (default), safe, agent, code, rag, aggressive, cache, reasoning, frugal; or paste ~/.config/llmtrim/config.toml if custom -->
 
 ## Reproduce
 
 ```bash
 # Proxy: the steps + the tool action that triggers it.
-# CLI:  the command + a MINIMAL request body, e.g.
+# For mangled requests, set LLMTRIM_CAPTURE_DIR=~/llmtrim-capture and re-run, then attach the before/after pair.
+# CLI: the command + a MINIMAL request body, e.g.
 echo '<request json>' | llmtrim compress --provider openai
 ```
 
-> ⚠️ **Redact secrets first** — strip API keys, `authorization` headers, and private prompt
-> content. llmtrim never needs them to reproduce a compression bug. (Security *vulnerabilities*
-> go through the private advisory link, not a public issue — see SECURITY.md.)
+> ⚠️ **Redact secrets first.** Strip API keys, `authorization` headers, and private prompt
+> content. llmtrim never needs them to reproduce a compression bug. Security *vulnerabilities*
+> go through the private advisory link, not a public issue (see SECURITY.md).
 
 ## Expected vs actual
 
 - Expected:
 - Actual:
 
-<!-- Paste any error output / proxy log (run `llmtrim serve` in the foreground) here. -->
+<!-- Paste error output or proxy log here. Daemon log is usually ~/.llmtrim/serve.log; or run `llmtrim serve` in the foreground. -->
 
 ## Environment
 
 - `llmtrim --version`:
-- `llmtrim status` (daemon + CA + savings state):
-- Install method: <!-- prebuilt binary | cargo install | homebrew | source -->
+- `llmtrim status` (daemon + CA + savings):
+- `llmtrim doctor` (paste failing checks only):
+- Install method: <!-- npm | curl installer | homebrew | scoop | cargo install | docker | source -->
 - OS / arch:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
     url: https://github.com/fkiene/llmtrim/security/advisories/new
-    about: Please report security issues privately — see SECURITY.md, do not open a public issue.
+    about: Please report security issues privately. See SECURITY.md; do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,12 +17,12 @@ assignees: ""
 ## Token / quality impact
 
 <!-- If it's a compression stage: roughly what does it save, and what's the quality risk?
-     llmtrim stages are token-gated and quality-checked offline (see README §6). -->
+     Lossy stages stay off by default and are quality-checked offline
+     (see README → Configuration and The numbers). -->
 
 ## Are you willing to contribute this?
 
-<!-- No obligation either way. This just tells us whether to leave it for you
-     or pick it up ourselves. -->
+<!-- No obligation. Say whether you plan to open a PR or only want the idea on record. -->
 
 - [ ] I'd like to implement this myself and open a PR
 - [ ] I'm reporting the idea; happy for a maintainer or someone else to build it

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Thanks for contributing to llmtrim! -->
+<!-- Thanks for contributing to llmtrim. -->
 
 ## What & why
 
@@ -12,15 +12,15 @@ Closes #
 
 ## How it was verified
 
-<!-- Tests added/updated? Did the check loop pass? -->
+<!-- Tests added or updated? Did the check loop pass? -->
 
 - [ ] `cargo fmt` is clean
-- [ ] `cargo clippy --features intercept` is clean
-- [ ] `cargo nextest run --features intercept` passes
+- [ ] `cargo clippy --all-targets` is clean
+- [ ] `cargo nextest run --profile ci` passes
 - [ ] New behavior is covered by a test
 - [ ] `CHANGELOG.md` has an entry under `## [Unreleased]` (or the change is invisible to users)
 - [ ] Commits are signed off (`git commit -s`, DCO, see CONTRIBUTING.md)
 
 ## Notes
 
-<!-- Anything reviewers should know: tradeoffs, follow-ups, breaking changes. -->
+<!-- Tradeoffs, follow-ups, or breaking changes reviewers should know about. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,16 +21,19 @@ The standard check loop (run all three before pushing):
 
 ```bash
 cargo fmt
-cargo clippy --features intercept
-cargo nextest run --features intercept
+cargo clippy --all-targets
+cargo nextest run --profile ci
 ```
 
 Notes:
 
 - Use `cargo nextest run`, not `cargo test`: it runs in parallel and prints compact output.
-- Do not pass `-- -D warnings` to clippy. `warnings = "deny"` is already set in the
+  `--profile ci` matches the GitHub Actions job (see `.config/nextest.toml`).
+- Do not pass `-- -D warnings` to clippy locally. `warnings = "deny"` is already set in the
   workspace `[lints.rust]`, and adding the flag forks the build cache between clippy and test.
-- Keep `--features intercept` consistent across commands so the incremental cache is reused.
+  CI still runs clippy with `-D warnings`.
+- Default features already include `intercept` and `mcp`. Pass feature flags only when you
+  intentionally change that set (e.g. `--features live` for the bench network path).
 
 The suite is deterministic and hits no network. `cargo build --features live` builds the
 optional bench network path (async-openai + tokio); async is confined to that path and is
@@ -39,7 +42,7 @@ not allowed in the core compression stages.
 Before the first push that opens a PR, also check coverage of the files you changed:
 
 ```bash
-cargo llvm-cov --features intercept,mcp --summary-only
+cargo llvm-cov nextest --features intercept,mcp --summary-only
 ```
 
 CI runs fmt, clippy, and the test suite on Linux, macOS, and Windows. Keep all three green.
@@ -52,17 +55,18 @@ git config core.hooksPath .githooks
 
 ## Adding a compression stage
 
-Stages implement the `Transform` trait (`src/gate.rs`) and are assembled in
-`stages_for` (`src/lib.rs`). A stage:
+Stages implement the `Transform` trait (`crates/llmtrim-core/src/gate.rs`) and are assembled in
+`stages_for` (`crates/llmtrim-core/src/lib.rs`). A stage:
 
 1. Declares a `GateKind`: `InputTokens` (reverted if it doesn't reduce tokens),
    `OutputShaping`, or `Structural`.
 2. Mutates the JSON-backed `Request` at JSON-pointer addresses (lossless by construction
    for any field it doesn't touch).
-3. Adds a config flag in `DenseConfig` (`src/config.rs`) and is wired into a preset.
+3. Adds a config flag in `DenseConfig` (`crates/llmtrim-core/src/config.rs`) and is wired into a preset.
 4. Ships with unit tests proving the token win and quality behavior.
 
-Lossy stages stay **off by default** and are quality-checked offline (see README §6).
+Lossy stages stay **off by default** and are quality-checked offline (see README → Configuration
+and The numbers).
 
 ## Editing the user's config file
 


### PR DESCRIPTION
## Summary

The bug-report template still listed `llmtrim batch` (removed in 546358c) and under-described how people actually run llmtrim. This brings the GitHub templates and CONTRIBUTING check loop in line with the shipping CLI.

### Bug report
- Drop dead `batch`; list proxy/`start`/`serve`/`wrap`, CLI `compress`/`send`, `sub`, and `mcp`
- Providers: `openai | anthropic | google` (`gemini` is an alias)
- Full preset list + real config path
- Capture repro (`LLMTRIM_CAPTURE_DIR`), daemon log path, `llmtrim doctor`
- Install methods: npm, curl, homebrew, scoop, cargo, docker, source

### Feature request / config
- Replace dead `README §6` pointer with Configuration / The numbers
- Drop "we" wording in the contribute checkbox comment
- Em-dash out of the security contact blurb

### PR template + CONTRIBUTING
- Check loop matches CI: `clippy --all-targets`, `nextest --profile ci`
- Stage paths updated to `crates/llmtrim-core/src/...`
- `llvm-cov nextest` form matches the coverage job

## Test plan

- [x] Diffed templates against `llmtrim --help` and `DenseConfig::preset`
- [x] Confirmed `batch` is unrecognized on 0.11.11
- [x] Confirmed CI uses `cargo clippy --all-targets` and `cargo nextest run --profile ci`
- [ ] CI green on this PR