### PR TITLE
feat: add per-model pricing overrides via config TOML and LLMTRIM_PRICING env

### DIFF
--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -1025,16 +1025,25 @@ pub(crate) struct BreakdownRates {
     pub cache_write: f64,
 }
 
-/// Resolve the frozen rates for a (provider, model) pair. Unknown models price at 0
-/// (the TUI then shows a blank cost cell rather than a misleading $0.00).
+/// Resolve the frozen rates for a (provider, model) pair. Pricing overrides from
+/// config take precedence over the built-in provider data.
 #[cfg(feature = "intercept")]
 pub(crate) fn rates_for(provider: &str, model: Option<&str>) -> BreakdownRates {
-    let (input, output) = model.and_then(llm_prices).unwrap_or((0.0, 0.0));
+    let (input, output, cache_override) = model
+        .and_then(|m| {
+            // Check pricing overrides first
+            let config = llmtrim_core::config::RuntimeConfig::get();
+            config.pricing_overrides.get(m).map(|ov| (ov.input, ov.output, ov.cache_read))
+        })
+        .or_else(|| {
+            model.and_then(llm_prices).map(|(i, o)| (i, o, -1.0))
+        })
+        .unwrap_or((0.0, 0.0, -1.0));
     let (read_mult, write_mult) = cache_multipliers(provider);
     BreakdownRates {
         input,
         output,
-        cache_read: input * read_mult,
+        cache_read: if cache_override > 0.0 { cache_override } else { input * read_mult },
         cache_write: input * write_mult,
     }
 }
@@ -1228,12 +1237,19 @@ pub fn overview_data(
 /// upstream brand), then the embedded models.dev snapshot for models the registry hasn't
 /// shipped yet (e.g. day-one releases like claude-fable-5 on 0.14.3).
 pub(crate) fn llm_prices(model_id: &str) -> Option<(f64, f64)> {
+    // 1. Check user-configured pricing overrides first (LLMTRIM_PRICING env / TOML [pricing])
+    let config = llmtrim_core::config::RuntimeConfig::get();
+    if let Some(ov) = config.pricing_overrides.get(model_id) {
+        return Some((ov.input, ov.output));
+    }
+    // 2. Check live provider data
     #[cfg(feature = "intercept")]
     for &provider_id in llm_providers::get_providers_data().keys() {
         if let Some(model) = llm_providers::get_model_ref(provider_id, model_id) {
             return Some((model.input_price, model.output_price));
         }
     }
+    // 3. Fall back to compiled-in pricing.json snapshot
     snapshot_prices(model_id)
 }
 

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -24,6 +24,15 @@ use std::str::FromStr;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+/// Per-model pricing override, USD per 1M tokens. Used in [`RuntimeConfig::pricing_overrides`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PricingOverride {
+    pub input: f64,
+    pub output: f64,
+    #[serde(default)]
+    pub cache_read: f64,
+}
+
 /// The Stage D format legend, embedded at build time and injected into the prompt
 /// so the model can read the columnar encoding (always include a legend).
 /// Validated non-empty by `build.rs`.
@@ -867,6 +876,11 @@ pub struct RuntimeConfig {
     /// Capture corpus size ceiling in MB (env `LLMTRIM_CAPTURE_MAX_MB` / file
     /// `capture_max_mb`); `Some(0)` disables the cap, `None` means use the default.
     pub capture_max_mb: Option<u64>,
+    /// Per-model pricing overrides, USD per 1M tokens (env `LLMTRIM_PRICING` as JSON,
+    /// or file `[pricing."model-id"]` table). Each entry maps `input`, `output`,
+    /// and optional `cache_read` rates. When set, these override the built-in
+    /// provider pricing for the matched model ids.
+    pub pricing_overrides: std::collections::HashMap<String, PricingOverride>,
     /// Context-window override for the cost breakdown (env `LLMTRIM_BREAKDOWN_WINDOW` / file
     /// `breakdown_window`); positive only.
     pub breakdown_window: Option<i64>,
@@ -981,6 +995,7 @@ impl RuntimeConfig {
             capture_max_mb: env_set("LLMTRIM_CAPTURE_MAX_MB")
                 .and_then(|s| s.trim().parse::<u64>().ok())
                 .or_else(|| fint("capture_max_mb").and_then(|n| u64::try_from(n).ok())),
+            pricing_overrides: resolve_pricing_overrides(&env, file),
             breakdown_window: positive(
                 env_set("LLMTRIM_BREAKDOWN_WINDOW")
                     .and_then(|s| s.trim().parse::<i64>().ok())
@@ -1610,6 +1625,52 @@ pub fn max_rows() -> Option<i64> {
 /// Configured breakdown retention cap (in turns), or `None` to fall back to the built-in default.
 pub fn max_breakdown_turns() -> Option<i64> {
     RuntimeConfig::get().max_breakdown_turns
+}
+
+/// Parse pricing overrides from the `LLMTRIM_PRICING` env var (JSON) or the
+/// `[pricing."model-id"]` TOML section. Returns a map of model id → PricingOverride.
+fn resolve_pricing_overrides(
+    env: &impl Fn(&str) -> Option<String>,
+    file: Option<&toml::Value>,
+) -> std::collections::HashMap<String, PricingOverride> {
+    // Env var: LLMTRIM_PRICING as JSON
+    if let Some(json_str) = env("LLMTRIM_PRICING").filter(|s| !s.is_empty()) {
+        if let Ok(map) =
+            serde_json::from_str::<std::collections::HashMap<String, PricingOverride>>(&json_str)
+        {
+            return map;
+        }
+    }
+    // TOML file: [pricing."model-id"]
+    if let Some(pricing) =
+        file.and_then(|v| v.get("pricing"))
+            .and_then(toml::Value::as_table)
+    {
+        let mut map = std::collections::HashMap::new();
+        for (key, val) in pricing {
+            if let Some(ov) = parse_pricing_override(val) {
+                map.insert(key.clone(), ov);
+            }
+        }
+        if !map.is_empty() {
+            return map;
+        }
+    }
+    std::collections::HashMap::new()
+}
+
+fn parse_pricing_override(val: &toml::Value) -> Option<PricingOverride> {
+    let table = val.as_table()?;
+    let input = table.get("input").and_then(toml::Value::as_float)?;
+    let output = table.get("output").and_then(toml::Value::as_float)?;
+    let cache_read = table
+        .get("cache_read")
+        .and_then(toml::Value::as_float)
+        .unwrap_or(0.0);
+    if input <= 0.0 || output <= 0.0 {
+        return None;
+    }
+    Some(PricingOverride { input, output, cache_read })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Adds per-model pricing overrides via `LLMTRIM_PRICING` env var or `[pricing]` TOML config section, allowing users to override incorrect built-in pricing for specific model IDs.

## Problem

The `llm_providers` external crate (v0.14.3) returns incorrect pricing rates for several models. For example, `deepseek-v4-pro` is priced at ~$12.00/M input / $24.00/M output by `llm_providers`, while the actual DeepSeek API price (after the permanent 75% reduction in May 2026) is $0.435/M input / $0.87/M output — a **27x discrepancy**. This makes the cost dashboard (`llmtrim status`) show wildly inflated dollar figures.

The compiled-in `bench/pricing.json` has correct pricing, but it is only used as a fallback — `llm_prices()` checks `llm_providers` first and never reaches the fallback for models the registry covers.

## Solution

Add a user-configurable pricing override mechanism with two forms:

### TOML config (`[pricing."model-id"]`)

```toml
[pricing."deepseek-v4-pro"]
input = 0.435
output = 0.87
cache_read = 0.003625

[pricing."deepseek-v4-flash"]
input = 0.14
output = 0.28
cache_read = 0.0028
```

### Environment variable (`LLMTRIM_PRICING`)

```bash
export LLMTRIM_PRICING='{"deepseek-v4-pro":{"input":0.435,"output":0.87,"cache_read":0.003625}}'
```

The env var takes precedence over the TOML file when both are set.

### Resolution order

1. **Pricing overrides** (env `LLMTRIM_PRICING` → TOML `[pricing]`) — user-configured
2. **Live provider data** (`llm_providers` crate) — existing behavior
3. **Snapshot fallback** (`bench/pricing.json`) — existing behavior

## Changes

- `crates/llmtrim-core/src/config.rs`: Added `PricingOverride` struct and `pricing_overrides` field
- `crates/llmtrim-cli/src/monitor.rs`: Updated `llm_prices()` and `rates_for()` to check overrides first

## Backwards Compatibility

Fully backwards-compatible. Without overrides, behavior is identical to current release.