### PR TITLE
Shape tool results before their first cache write

### DIFF
--- a/crates/llmtrim-core/src/cache_zone.rs
+++ b/crates/llmtrim-core/src/cache_zone.rs
@@ -6,8 +6,9 @@
 //! cache, which usually costs *more* than the tokens saved (the "input compression is a
 //! false economy" trap). So content-mutating stages ordinarily compress only the **live zone**:
 //! the segments after the last `cache_control` marker. Tool output has one narrow exception: a
-//! tool result in the final marked message is shaped as that cache entry is first written, then
-//! the turn memo replays the emitted bytes verbatim.
+//! tool result in the final marked message receives terminal-equivalent normalization as that
+//! cache entry is first written, then the turn memo replays the emitted bytes verbatim. Template
+//! folding and lossy windowing remain confined to the live zone.
 //!
 //! No markers ⇒ no known cache ⇒ everything is compressible (behavior unchanged):
 //! determinism keeps an identical prefix cache-stable across calls, and Stage A's OpenAI
@@ -33,12 +34,11 @@ pub fn compressible_pointers(req: &Request, provider: &dyn Provider) -> Vec<Stri
         .collect()
 }
 
-/// Content pointers available to the tool-output write path. In addition to the ordinary live
-/// zone, this includes tool results in the newest cache-marked message: the breakpoint writes the
-/// whole message prefix, including sibling tool results before the marked block, so shaping them
-/// now makes every later cache read cheaper. Earlier messages stay frozen and are replayed
-/// byte-for-byte by the turn memo.
-pub fn tool_result_write_pointers(req: &Request, provider: &dyn Provider) -> Vec<String> {
+/// Tool-result pointers in the final cache-marked message. The breakpoint writes the whole
+/// message prefix, including sibling tool results before the marked block, so terminal-noise
+/// normalization at this boundary makes every later cache read cheaper. These pointers are separate
+/// from [`compressible_pointers`]: lossy live-zone transforms must never run on them.
+pub fn first_arrival_tool_result_pointers(req: &Request, provider: &dyn Provider) -> Vec<String> {
     let raw = req.raw();
     let newest_marked = raw
         .get("messages")
@@ -47,15 +47,10 @@ pub fn tool_result_write_pointers(req: &Request, provider: &dyn Provider) -> Vec
             let i = messages.len().checked_sub(1)?;
             has_cache_control(&messages[i]).then_some(i)
         });
-    let frozen = frozen_pointers(req, provider);
-
     provider
         .content_text_pointers(req)
         .into_iter()
         .filter(|pointer| {
-            if !frozen.contains(pointer) {
-                return !is_instruction(req, provider, pointer);
-            }
             newest_marked.is_some_and(|i| {
                 pointer.starts_with(&format!("/messages/{i}/"))
                     && crate::provider::is_tool_result_ptr(req, pointer)
@@ -251,7 +246,7 @@ mod tests {
 
         assert!(compressible_pointers(&r, p.as_ref()).is_empty());
         assert_eq!(
-            tool_result_write_pointers(&r, p.as_ref()),
+            first_arrival_tool_result_pointers(&r, p.as_ref()),
             vec![
                 "/messages/2/content/0/content".to_string(),
                 "/messages/2/content/1/content".to_string(),
@@ -269,7 +264,7 @@ mod tests {
         }));
         let p = for_kind(ProviderKind::Anthropic);
 
-        assert!(tool_result_write_pointers(&r, p.as_ref()).is_empty());
+        assert!(first_arrival_tool_result_pointers(&r, p.as_ref()).is_empty());
     }
 
     #[test]

--- a/crates/llmtrim-core/src/cache_zone.rs
+++ b/crates/llmtrim-core/src/cache_zone.rs
@@ -34,27 +34,28 @@ pub fn compressible_pointers(req: &Request, provider: &dyn Provider) -> Vec<Stri
         .collect()
 }
 
-/// Tool-result pointers in the final cache-marked message. The breakpoint writes the whole
-/// message prefix, including sibling tool results before the marked block, so terminal-noise
-/// normalization at this boundary makes every later cache read cheaper. These pointers are separate
-/// from [`compressible_pointers`]: lossy live-zone transforms must never run on them.
+/// Tool-result pointers entering the cache at the final breakpoint. Claude Code may append a
+/// system reminder carrying the marker after the result, so skip those trailing system messages
+/// and select the adjacent tool-result message. Lossy transforms remain confined to the live zone.
 pub fn first_arrival_tool_result_pointers(req: &Request, provider: &dyn Provider) -> Vec<String> {
-    let raw = req.raw();
-    let newest_marked = raw
-        .get("messages")
-        .and_then(Value::as_array)
-        .and_then(|messages| {
-            let i = messages.len().checked_sub(1)?;
-            has_cache_control(&messages[i]).then_some(i)
-        });
+    let Some(messages) = req.raw().get("messages").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let Some(mut boundary) = messages.len().checked_sub(1) else {
+        return Vec::new();
+    };
+    if !has_cache_control(&messages[boundary]) {
+        return Vec::new();
+    }
+    while boundary > 0 && messages[boundary].get("role").and_then(Value::as_str) == Some("system") {
+        boundary -= 1;
+    }
+    let prefix = format!("/messages/{boundary}/");
     provider
         .content_text_pointers(req)
         .into_iter()
         .filter(|pointer| {
-            newest_marked.is_some_and(|i| {
-                pointer.starts_with(&format!("/messages/{i}/"))
-                    && crate::provider::is_tool_result_ptr(req, pointer)
-            })
+            pointer.starts_with(&prefix) && crate::provider::is_tool_result_ptr(req, pointer)
         })
         .collect()
 }
@@ -252,6 +253,30 @@ mod tests {
                 "/messages/2/content/1/content".to_string(),
             ],
             "the breakpoint writes the whole final message, including sibling results"
+        );
+    }
+
+    #[test]
+    fn trailing_marked_system_reminder_caches_preceding_tool_result() {
+        let r = req(json!({
+            "messages": [
+                {"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "new", "name": "shell", "input": {}}
+                ]},
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "new", "content": "new output"}
+                ]},
+                {"role": "system", "content": [
+                    {"type": "text", "text": "budget reminder",
+                     "cache_control": {"type": "ephemeral"}}
+                ]},
+            ]
+        }));
+        let p = for_kind(ProviderKind::Anthropic);
+
+        assert_eq!(
+            first_arrival_tool_result_pointers(&r, p.as_ref()),
+            vec!["/messages/1/content/0/content".to_string()]
         );
     }
 

--- a/crates/llmtrim-core/src/cache_zone.rs
+++ b/crates/llmtrim-core/src/cache_zone.rs
@@ -4,9 +4,10 @@
 //! prefix), the provider caches everything up to the last marker and bills it at ~0.1×.
 //! Rewriting that content — even to save tokens — changes the cached bytes and busts the
 //! cache, which usually costs *more* than the tokens saved (the "input compression is a
-//! false economy" trap). So the content-mutating stages compress only the **live zone**:
-//! the segments after the last `cache_control` marker. Each new tool result is therefore
-//! compressed exactly once — when it first arrives in the live zone — then frozen.
+//! false economy" trap). So content-mutating stages ordinarily compress only the **live zone**:
+//! the segments after the last `cache_control` marker. Tool output has one narrow exception: a
+//! tool result in the final marked message is shaped as that cache entry is first written, then
+//! the turn memo replays the emitted bytes verbatim.
 //!
 //! No markers ⇒ no known cache ⇒ everything is compressible (behavior unchanged):
 //! determinism keeps an identical prefix cache-stable across calls, and Stage A's OpenAI
@@ -29,6 +30,37 @@ pub fn compressible_pointers(req: &Request, provider: &dyn Provider) -> Vec<Stri
         .content_text_pointers(req)
         .into_iter()
         .filter(|p| !frozen.contains(p) && !is_instruction(req, provider, p))
+        .collect()
+}
+
+/// Content pointers available to the tool-output write path. In addition to the ordinary live
+/// zone, this includes tool results in the newest cache-marked message: the breakpoint writes the
+/// whole message prefix, including sibling tool results before the marked block, so shaping them
+/// now makes every later cache read cheaper. Earlier messages stay frozen and are replayed
+/// byte-for-byte by the turn memo.
+pub fn tool_result_write_pointers(req: &Request, provider: &dyn Provider) -> Vec<String> {
+    let raw = req.raw();
+    let newest_marked = raw
+        .get("messages")
+        .and_then(Value::as_array)
+        .and_then(|messages| {
+            let i = messages.len().checked_sub(1)?;
+            has_cache_control(&messages[i]).then_some(i)
+        });
+    let frozen = frozen_pointers(req, provider);
+
+    provider
+        .content_text_pointers(req)
+        .into_iter()
+        .filter(|pointer| {
+            if !frozen.contains(pointer) {
+                return !is_instruction(req, provider, pointer);
+            }
+            newest_marked.is_some_and(|i| {
+                pointer.starts_with(&format!("/messages/{i}/"))
+                    && crate::provider::is_tool_result_ptr(req, pointer)
+            })
+        })
         .collect()
 }
 
@@ -195,6 +227,49 @@ mod tests {
         let frozen = frozen_pointers(&r, p.as_ref());
         assert!(frozen.contains("/messages/0/content/0/text"));
         assert!(frozen.contains("/messages/1/content/0/text"));
+    }
+
+    #[test]
+    fn newest_marked_tool_result_is_available_only_to_write_path() {
+        let r = req(json!({
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "old", "content": "old cached output",
+                     "cache_control": {"type": "ephemeral"}}
+                ]},
+                {"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "new", "name": "shell", "input": {}}
+                ]},
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "new-a", "content": "new output A"},
+                    {"type": "tool_result", "tool_use_id": "new-b", "content": "new output B",
+                     "cache_control": {"type": "ephemeral"}}
+                ]},
+            ]
+        }));
+        let p = for_kind(ProviderKind::Anthropic);
+
+        assert!(compressible_pointers(&r, p.as_ref()).is_empty());
+        assert_eq!(
+            tool_result_write_pointers(&r, p.as_ref()),
+            vec![
+                "/messages/2/content/0/content".to_string(),
+                "/messages/2/content/1/content".to_string(),
+            ],
+            "the breakpoint writes the whole final message, including sibling results"
+        );
+    }
+
+    #[test]
+    fn marked_non_tool_content_stays_frozen_on_write_path() {
+        let r = req(json!({
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "do not reshape", "cache_control": {"type": "ephemeral"}}
+            ]}]
+        }));
+        let p = for_kind(ProviderKind::Anthropic);
+
+        assert!(tool_result_write_pointers(&r, p.as_ref()).is_empty());
     }
 
     #[test]

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -577,7 +577,10 @@ mod tests {
                     {"type": "tool_use", "id": "new", "name": "shell", "input": {}}
                 ]},
                 {"role": "user", "content": [
-                    {"type": "tool_result", "tool_use_id": "new", "content": arriving_log,
+                    {"type": "tool_result", "tool_use_id": "new", "content": arriving_log}
+                ]},
+                {"role": "system", "content": [
+                    {"type": "text", "text": "budget reminder",
                      "cache_control": {"type": "ephemeral"}}
                 ]},
             ],
@@ -614,6 +617,14 @@ mod tests {
         assert!(
             !shaped.contains("omitted"),
             "cache-boundary shaping must never emit a lossy omission marker: {shaped}"
+        );
+        let counter =
+            tokenizer::counter_for(ProviderKind::Anthropic, result.model.as_deref()).unwrap();
+        let expected_frozen =
+            counter.count(&cached_log) + counter.count(shaped) + counter.count("budget reminder");
+        assert_eq!(
+            result.frozen_input_tokens.0, expected_frozen,
+            "the frozen-zone meter must describe the normalized bytes actually forwarded"
         );
     }
 

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -561,9 +561,10 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         let arriving_log = (0..80)
-            .map(|i| format!("DEBUG new worker {i} idle waiting for work"))
+            .map(|i| format!("\x1b[90mDEBUG new worker {i} idle waiting for work\x1b[0m"))
             .collect::<Vec<_>>()
             .join("\n")
+            + "\nordinary future-critical detail sentinel_delta_47"
             + "\nERROR failure in the arriving result";
         let input = serde_json::json!({
             "model": "claude-3-5-sonnet-20241022",
@@ -604,6 +605,15 @@ mod tests {
             "the arriving result was shaped before its cache write ({} -> {})",
             arriving_log.len(),
             shaped.len()
+        );
+        assert!(
+            shaped.contains("sentinel_delta_47")
+                && shaped.contains("DEBUG new worker 47 idle waiting for work"),
+            "ordinary details and literal template values must survive boundary shaping: {shaped}"
+        );
+        assert!(
+            !shaped.contains("omitted"),
+            "cache-boundary shaping must never emit a lossy omission marker: {shaped}"
         );
     }
 

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -555,6 +555,59 @@ mod tests {
     }
 
     #[test]
+    fn agent_preset_shapes_tool_result_at_cache_write_boundary() {
+        let cached_log = (0..80)
+            .map(|i| format!("INFO old step {i} routine nominal pass"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let arriving_log = (0..80)
+            .map(|i| format!("DEBUG new worker {i} idle waiting for work"))
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\nERROR failure in the arriving result";
+        let input = serde_json::json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "old", "content": cached_log,
+                     "cache_control": {"type": "ephemeral"}}
+                ]},
+                {"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "new", "name": "shell", "input": {}}
+                ]},
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "new", "content": arriving_log,
+                     "cache_control": {"type": "ephemeral"}}
+                ]},
+            ],
+            "max_tokens": 1024,
+        })
+        .to_string();
+
+        let cfg = config::DenseConfig::preset("agent").expect("agent preset");
+        let result =
+            compress_with_config(&input, Some(ProviderKind::Anthropic), &cfg).expect("compress");
+        let body: Value = serde_json::from_str(&result.request_json).unwrap();
+
+        assert_eq!(
+            body.pointer("/messages/0/content/0/content")
+                .and_then(Value::as_str),
+            Some(cached_log.as_str()),
+            "an older cache entry stays byte-identical"
+        );
+        let shaped = body
+            .pointer("/messages/2/content/0/content")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(
+            shaped.len() < arriving_log.len(),
+            "the arriving result was shaped before its cache write ({} -> {})",
+            arriving_log.len(),
+            shaped.len()
+        );
+    }
+
+    #[test]
     fn frozen_prefix_untouched_while_live_zone_compresses() {
         // message 0 is the cached prefix (`cache_control`) holding a big log; message 1 is
         // the live user turn with another big log. The agent preset must compress the live

--- a/crates/llmtrim-core/src/pipeline.rs
+++ b/crates/llmtrim-core/src/pipeline.rs
@@ -154,20 +154,6 @@ pub fn run_gated(
     let mut content = count_content_cached(req, provider, counter, &mut seg_cache);
     let mut tools = count_tools(req, counter);
     let input_tokens_before = content + tools;
-    // Frozen-zone meter: size of the cache-controlled prefix the stages will skip. Counted
-    // once up front (the zone is immutable by discipline); `seg_cache` is already warm from
-    // the full content count, so this is hash lookups, not a second BPE pass.
-    let frozen_input_tokens: usize = crate::cache_zone::frozen_pointers(req, provider)
-        .iter()
-        .filter_map(|p| req.get_str(p))
-        .map(|s| {
-            seg_cache
-                .get(s)
-                .copied()
-                .unwrap_or_else(|| counter.count(s))
-        })
-        .sum();
-
     for stage in stages {
         let scope = stage.scope();
         let before = content + tools;
@@ -275,6 +261,19 @@ pub fn run_gated(
     }
 
     let input_tokens_after = content + tools;
+    // Measure the prefix bytes that will actually be cached. Toolout may apply lossless
+    // terminal normalization to a newly marked boundary, so the frozen zone is immutable only
+    // after the pipeline has finished. The segment cache keeps unchanged entries cheap.
+    let frozen_input_tokens: usize = crate::cache_zone::frozen_pointers(req, provider)
+        .iter()
+        .filter_map(|p| req.get_str(p))
+        .map(|s| {
+            seg_cache
+                .get(s)
+                .copied()
+                .unwrap_or_else(|| counter.count(s))
+        })
+        .sum();
     PipelineOutcome {
         stages: reports,
         plan,

--- a/crates/llmtrim-core/src/stages/toolout/mod.rs
+++ b/crates/llmtrim-core/src/stages/toolout/mod.rs
@@ -34,8 +34,10 @@
 //! 3. **Never inflate** (`elide_into`): an elision marker is emitted only when it is
 //!    shorter than the lines it hides; a lone `--` separator survives as itself.
 //!
-//! Lossy, `InputTokens`-gated (reverts if it doesn't cut tokens), `Content`-scoped.
-//! Zero model calls.
+//! Live-zone windowing is lossy. First-arrival cache-boundary results receive only terminal-
+//! equivalent normalization; even template folding stays live-zone-only because it rewrites
+//! literal values into compact notation. The combined stage is `InputTokens`-gated (reverts if it
+//! doesn't cut tokens), `Content`-scoped, and uses zero model calls.
 //!
 //! Note on universality: the level/failure keywords scored below are tokens
 //! *machine-emitted* by runtimes and build tools (`ERROR`, `FATAL`, `Traceback`,
@@ -169,7 +171,19 @@ impl Transform for ToolOutputStage {
         provider: &dyn Provider,
         _plan: &mut Vec<PlanEntry>,
     ) -> Result<()> {
-        let pointers = crate::cache_zone::tool_result_write_pointers(req, provider);
+        let first_arrival = crate::cache_zone::first_arrival_tool_result_pointers(req, provider);
+        for pointer in first_arrival {
+            let Some(raw) = req.get_str(&pointer) else {
+                continue;
+            };
+            let (shaped, changed) = normalize::normalize(raw);
+            if changed {
+                req.set(&pointer, Value::String(shaped));
+            }
+        }
+
+        // Lossy classification and windowing remain restricted to the ordinary live zone.
+        let pointers = crate::cache_zone::compressible_pointers(req, provider);
 
         // Pre-pass (feature #6): strip ANSI escapes and collapse carriage-return progress
         // on each candidate *before* detection. This is lossless for the model and lets

--- a/crates/llmtrim-core/src/stages/toolout/mod.rs
+++ b/crates/llmtrim-core/src/stages/toolout/mod.rs
@@ -169,7 +169,7 @@ impl Transform for ToolOutputStage {
         provider: &dyn Provider,
         _plan: &mut Vec<PlanEntry>,
     ) -> Result<()> {
-        let pointers = crate::cache_zone::compressible_pointers(req, provider);
+        let pointers = crate::cache_zone::tool_result_write_pointers(req, provider);
 
         // Pre-pass (feature #6): strip ANSI escapes and collapse carriage-return progress
         // on each candidate *before* detection. This is lossless for the model and lets


### PR DESCRIPTION
## Summary

- normalize newly arriving tool results before Claude Code writes them into the cached prefix
- keep cache-boundary shaping lossless while preserving the existing lossy pipeline for uncached tool output
- handle Claude Code's trailing cache-marked system reminder and meter the exact normalized frozen bytes

## Validation

- [x] `cargo test -p llmtrim-core --lib` (514 passed)
- [x] `cargo test -p llmtrim-core --doc`
- [x] `cargo clippy -p llmtrim-core --all-targets -- -D warnings`
- [x] live Claude Code tool loop through an isolated branch proxy
- [x] verified all semantic output survived while 160 ANSI escapes and 40 carriage returns were removed
- [x] three independent code reviews completed with no outstanding findings