### PR TITLE
fix(guard): pass local-only /sub through cold-cache block

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Owned settings rewrite themselves when the binary path or payload changes. To op
 
 Resuming a large session after the prompt-cache TTL rewrites the whole context at cache-write rates (often a few dollars) with no warning at the prompt.
 
-Guard is a free `UserPromptSubmit` hook. It blocks one turn, prints idle time, context size, estimated cost, and the draft you typed (Claude Code clears the input box and would otherwise drop it), then lets a resend through. If you type something else next, the blocked text is also reinjected as model context. `/compact` pays that cold write too, because it has to read the full context to summarize.
+Guard is a free `UserPromptSubmit` hook. It blocks one turn, prints idle time, context size, estimated cost, and the draft you typed (Claude Code clears the input box and would otherwise drop it), then lets a resend through. If you type something else next, the blocked text is also reinjected as model context. `/compact` pays that cold write too, because it has to read the full context to summarize. Local-only slash commands that never hit the model (today: `/sub`) pass through without acking the gap, so the next real prompt still warns.
 
 Opt out: `llmtrim guard uninstall`. `ensure` remembers that choice.
 

--- a/crates/llmtrim-cli/src/guard.rs
+++ b/crates/llmtrim-cli/src/guard.rs
@@ -5,7 +5,9 @@
 //! a resumed session re-writes its whole context on the next request, billed at the cache-write
 //! rate. Nothing at the prompt says so. So on the first submit after a long idle gap on a big
 //! context, emit a JSON block decision and exit 2 — Claude Code blocks the prompt with no API
-//! call, and a resend goes straight through.
+//! call, and a resend goes straight through. Local-only slash commands that never reach the
+//! model (today: `/sub`) pass through without acking the gap, so the next real prompt still
+//! warns.
 //!
 //! The block response sets `suppressOriginalPrompt` so Claude Code does not append the blocked
 //! text as `Original prompt:` (that echo nested the warning inside itself on every resend). The
@@ -136,6 +138,25 @@ fn scan(reader: impl BufRead) -> Option<Scan> {
 /// context big enough that re-writing it costs real money.
 fn should_warn(idle_secs: i64, tokens: i64) -> bool {
     idle_secs >= CACHE_TTL_SECS && tokens >= MIN_TOKENS
+}
+
+/// Slash command names (no leading `/`) that never hit the model. Owned by the modules that
+/// install them — add a new entry when a new bang-only / `disable-model-invocation` skill lands.
+/// `/compact` is deliberately *not* here; it re-sends the whole context.
+const LOCAL_ONLY_SLASH_COMMANDS: &[&str] = &[crate::window_sub::COMMAND_NAME];
+
+/// Prompts that never reach the model — no cold-cache rewrite, so the guard has nothing to warn
+/// about. Match each name as a whole slash word so prose like `/subscribe` still warns. Does not
+/// ack the gap: the next real chat prompt after a local command must still warn.
+fn is_local_only_prompt(prompt: &str) -> bool {
+    let trimmed = prompt.trim_start();
+    let Some(body) = trimmed.strip_prefix('/') else {
+        return false;
+    };
+    LOCAL_ONLY_SLASH_COMMANDS.iter().any(|name| {
+        body.strip_prefix(name)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with(char::is_whitespace))
+    })
 }
 
 // ── the once-per-gap marker ──────────────────────────────────────────────────────
@@ -341,6 +362,11 @@ fn decide_in(input: &str, now: DateTime<Utc>, dir: &Path) -> Verdict {
     let Some(hook) = parse_hook(input) else {
         return Verdict::Pass;
     };
+    // Local-only slash commands never hit the API. Pass without acking the gap and without
+    // consuming a stashed draft — the next real prompt still owns the cold-cache decision.
+    if is_local_only_prompt(&hook.prompt) {
+        return Verdict::Pass;
+    }
     let Ok(file) = std::fs::File::open(&hook.transcript_path) else {
         return Verdict::Pass;
     };
@@ -698,6 +724,49 @@ mod tests {
     fn cold_and_big_blocks() {
         let (payload, dir) = fixture(&[entry(&ago(7200), 150_000, false)]);
         assert_eq!(verdict(&payload, &dir), BLOCK);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn local_only_prompt_recognises_sub_as_a_whole_word() {
+        let slash = format!("/{}", crate::window_sub::COMMAND_NAME);
+        assert!(is_local_only_prompt(&slash));
+        assert!(is_local_only_prompt(&format!("{slash} on codex")));
+        assert!(is_local_only_prompt(&format!("  {slash} off")));
+        assert!(is_local_only_prompt(&format!("{slash}\ton")));
+        assert!(!is_local_only_prompt(&format!(
+            "/{}scribe",
+            crate::window_sub::COMMAND_NAME
+        )));
+        assert!(!is_local_only_prompt("/compact"));
+        assert!(!is_local_only_prompt(&format!("please {slash} on codex")));
+        assert!(!is_local_only_prompt("carry on"));
+    }
+
+    #[test]
+    fn cold_sub_slash_command_passes_without_acking() {
+        // `/sub` is bang-shell only — no cold rewrite. Must not consume the gap, so the next
+        // real prompt still gets the warning.
+        let (payload, dir) = fixture(&[entry(&ago(7200), 150_000, false)]);
+        let mut v: Value = serde_json::from_str(&payload).unwrap();
+        v["prompt"] = Value::String(format!("/{} on codex", crate::window_sub::COMMAND_NAME));
+        assert_eq!(
+            decide_verdict(&v.to_string(), &dir),
+            Verdict::Pass,
+            "/sub must not be blocked"
+        );
+        let session = v["session_id"].as_str().unwrap();
+        assert!(
+            !marker_path(&dir, session).exists(),
+            "local command must not ack the gap"
+        );
+        // Real chat after /sub still warns.
+        v["prompt"] = Value::String("carry on".into());
+        assert_eq!(
+            verdict(&v.to_string(), &dir),
+            BLOCK,
+            "next real prompt still sees the cold gap"
+        );
         std::fs::remove_dir_all(dir).unwrap();
     }
 

--- a/crates/llmtrim-cli/src/window_sub.rs
+++ b/crates/llmtrim-cli/src/window_sub.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 
 const TTL: Duration = Duration::from_secs(30 * 60);
 const TOUCH: Duration = Duration::from_secs(60);
-const COMMAND_NAME: &str = "sub";
+/// Claude Code skill / slash name (`/sub`). Shared with [`crate::guard`] so the cold-cache
+/// hook exempts the same command this module installs.
+pub(crate) const COMMAND_NAME: &str = "sub";
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 struct Registry {


### PR DESCRIPTION
## Summary

- Cold-cache `UserPromptSubmit` guard no longer blocks `/sub` (and future local-only slash skills on the shared list)
- `/sub` is bang-shell + `disable-model-invocation` — it never rewrites the prompt cache, so the warning was a false positive
- Exemption does **not** ack the idle gap, so the next real chat prompt still gets the cost warning
- Slash name is shared via `window_sub::COMMAND_NAME` (`pub(crate)`); `/compact` stays guarded on purpose

## Test plan

- [x] `cargo test -p llmtrim --lib guard::` (30 passed)
- [ ] Install/rebuild the hook binary Claude Code invokes
- [ ] On a large session idle >1h, run `/sub on codex` — should execute, not block
- [ ] Immediately after, send a normal prompt — should still get the cold-cache warning once