### PR TITLE
feat(sub): route named Claude subagents per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,18 @@ llmtrim sub chain codex,kimi,grok
 llmtrim sub off
 ```
 
+Route only a delegated Claude Code subagent while leaving the parent window unchanged:
+
+```bash
+llmtrim agents install          # also installed/refreshed by setup, update, and ensure
+```
+
+Then ask naturally: `Implement it using a Grok subagent`, `use Terra`, or `review this with GPT Terra`.
+Provider-only agents preserve the child request's Claude tier through the configured mapping; an
+explicit model agent pins that provider model. Request-local agents override the window `/sub` and
+global policy only for their own requests. `llmtrim agents uninstall` removes only llmtrim-owned
+agent files and records an opt-out so `ensure` leaves them removed.
+
 This window only (installed with ensure; includes subagents; survives `/clear`):
 
 ```text

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -14,6 +14,9 @@ use crate::ui;
 
 const CURRENT: &str = env!("CARGO_PKG_VERSION");
 const STATE_FILE: &str = "integrations.json";
+/// Sidecar opt-out for routed subagents. Kept out of [`OptOut`] so adding the feature does not
+/// change that constructible public struct (cargo-semver-checks / 0.11.x patch).
+const ROUTE_AGENTS_OPT_OUT: &str = "route-agents.opt-out";
 
 /// User opt-outs, remembered forever so ensure never re-prompts after an explicit no.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -22,13 +25,41 @@ pub struct OptOut {
     pub statusline: bool,
     pub guard: bool,
     pub window_sub: bool,
-    pub route_agents: bool,
     pub compact: bool,
     pub tray_autostart: bool,
     /// User declined the optional Linux tray download.
     pub tray_download: bool,
     /// User dismissed the one-time subscription onboarding nudge.
     pub sub_nudge: bool,
+}
+
+fn route_agents_opted_out_at(home: &Path) -> bool {
+    home.join(ROUTE_AGENTS_OPT_OUT).is_file()
+}
+
+fn set_route_agents_opt_out_at(home: &Path, value: bool) -> Result<()> {
+    let path = home.join(ROUTE_AGENTS_OPT_OUT);
+    if value {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        std::fs::write(&path, b"").with_context(|| format!("write {}", path.display()))?;
+    } else if path.exists() {
+        std::fs::remove_file(&path).with_context(|| format!("remove {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Whether the user opted out of installing subscription-routed Claude Code subagents.
+pub(crate) fn route_agents_opted_out() -> bool {
+    crate::daemon::home_dir()
+        .map(|home| route_agents_opted_out_at(&home))
+        .unwrap_or(false)
+}
+
+fn set_route_agents_opt_out(value: bool) -> Result<()> {
+    set_route_agents_opt_out_at(&crate::daemon::home_dir()?, value)
 }
 
 /// Persistent integration state under `~/.llmtrim/integrations.json`.
@@ -195,7 +226,7 @@ fn probe_with(state: &State) -> Vec<Gap> {
     }
 
     #[cfg(feature = "intercept")]
-    if claude && !state.opt_out.route_agents {
+    if claude && !route_agents_opted_out() {
         match crate::route_agents::status() {
             Ok(status) if status.installed == 0 => gaps.push(Gap {
                 id: "route_agents",
@@ -390,7 +421,7 @@ pub fn apply(opts: Options) -> Result<Report> {
     }
 
     #[cfg(feature = "intercept")]
-    if claude && !state.opt_out.route_agents {
+    if claude && !route_agents_opted_out() {
         match crate::route_agents::status() {
             Ok(status) => {
                 let missing = status.installed == 0;
@@ -424,7 +455,7 @@ pub fn apply(opts: Options) -> Result<Report> {
                 format!("could not inspect: {e:#}"),
             )),
         }
-    } else if claude && state.opt_out.route_agents {
+    } else if claude && route_agents_opted_out() {
         report
             .rows
             .push((ui::NOTE, "Subagents".into(), "opted out".into()));
@@ -695,12 +726,15 @@ pub fn run_cli(quiet: bool) -> Result<()> {
 
 /// Record an opt-out (e.g. after `guard uninstall`).
 pub fn set_opt_out(id: &str, value: bool) -> Result<()> {
+    // Routed-subagent opt-out is a sidecar file so [`OptOut`]'s public field set stays stable.
+    if matches!(id, "route_agents" | "route-agents" | "agents") {
+        return set_route_agents_opt_out(value);
+    }
     let mut state = State::load()?;
     match id {
         "statusline" => state.opt_out.statusline = value,
         "guard" => state.opt_out.guard = value,
         "window_sub" | "window-sub" | "sub" => state.opt_out.window_sub = value,
-        "route_agents" | "route-agents" | "agents" => state.opt_out.route_agents = value,
         "compact" => state.opt_out.compact = value,
         "tray_autostart" | "tray" => state.opt_out.tray_autostart = value,
         "tray_download" => state.opt_out.tray_download = value,
@@ -945,6 +979,28 @@ mod tests {
         assert!(!s.opt_out.statusline);
         assert!(!s.opt_out.guard);
         assert!(!s.opt_out.window_sub);
-        assert!(!s.opt_out.route_agents);
+    }
+
+    #[test]
+    fn route_agents_opt_out_is_sidecar_not_optout_field() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmtrim-route-agents-opt-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(!route_agents_opted_out_at(&dir));
+        set_route_agents_opt_out_at(&dir, true).unwrap();
+        assert!(route_agents_opted_out_at(&dir));
+        assert!(dir.join(ROUTE_AGENTS_OPT_OUT).is_file());
+        // Public OptOut shape is unchanged — no route_agents field to set.
+        assert_eq!(State::default().opt_out, OptOut::default());
+        set_route_agents_opt_out_at(&dir, false).unwrap();
+        assert!(!route_agents_opted_out_at(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -14,9 +14,6 @@ use crate::ui;
 
 const CURRENT: &str = env!("CARGO_PKG_VERSION");
 const STATE_FILE: &str = "integrations.json";
-/// Sidecar opt-out for routed subagents. Kept out of [`OptOut`] so adding the feature does not
-/// change that constructible public struct (cargo-semver-checks / 0.11.x patch).
-const ROUTE_AGENTS_OPT_OUT: &str = "route-agents.opt-out";
 
 /// User opt-outs, remembered forever so ensure never re-prompts after an explicit no.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -33,34 +30,45 @@ pub struct OptOut {
     pub sub_nudge: bool,
 }
 
-fn route_agents_opted_out_at(home: &Path) -> bool {
-    home.join(ROUTE_AGENTS_OPT_OUT).is_file()
-}
+/// Sidecar opt-out for routed subagents. Kept out of [`OptOut`] so adding the feature does not
+/// change that constructible public struct (cargo-semver-checks / 0.11.x patch).
+#[cfg(feature = "intercept")]
+mod route_agents_opt_out {
+    use super::*;
 
-fn set_route_agents_opt_out_at(home: &Path, value: bool) -> Result<()> {
-    let path = home.join(ROUTE_AGENTS_OPT_OUT);
-    if value {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("create {}", parent.display()))?;
-        }
-        std::fs::write(&path, b"").with_context(|| format!("write {}", path.display()))?;
-    } else if path.exists() {
-        std::fs::remove_file(&path).with_context(|| format!("remove {}", path.display()))?;
+    const MARKER: &str = "route-agents.opt-out";
+
+    pub(super) fn opted_out_at(home: &Path) -> bool {
+        home.join(MARKER).is_file()
     }
-    Ok(())
+
+    pub(super) fn set_at(home: &Path, value: bool) -> Result<()> {
+        let path = home.join(MARKER);
+        if value {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("create {}", parent.display()))?;
+            }
+            std::fs::write(&path, b"").with_context(|| format!("write {}", path.display()))?;
+        } else if path.exists() {
+            std::fs::remove_file(&path).with_context(|| format!("remove {}", path.display()))?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn opted_out() -> bool {
+        crate::daemon::home_dir()
+            .map(|home| opted_out_at(&home))
+            .unwrap_or(false)
+    }
+
+    pub(super) fn set(value: bool) -> Result<()> {
+        set_at(&crate::daemon::home_dir()?, value)
+    }
 }
 
-/// Whether the user opted out of installing subscription-routed Claude Code subagents.
-pub(crate) fn route_agents_opted_out() -> bool {
-    crate::daemon::home_dir()
-        .map(|home| route_agents_opted_out_at(&home))
-        .unwrap_or(false)
-}
-
-fn set_route_agents_opt_out(value: bool) -> Result<()> {
-    set_route_agents_opt_out_at(&crate::daemon::home_dir()?, value)
-}
+#[cfg(feature = "intercept")]
+use route_agents_opt_out::opted_out as route_agents_opted_out;
 
 /// Persistent integration state under `~/.llmtrim/integrations.json`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -727,8 +735,9 @@ pub fn run_cli(quiet: bool) -> Result<()> {
 /// Record an opt-out (e.g. after `guard uninstall`).
 pub fn set_opt_out(id: &str, value: bool) -> Result<()> {
     // Routed-subagent opt-out is a sidecar file so [`OptOut`]'s public field set stays stable.
+    #[cfg(feature = "intercept")]
     if matches!(id, "route_agents" | "route-agents" | "agents") {
-        return set_route_agents_opt_out(value);
+        return route_agents_opt_out::set(value);
     }
     let mut state = State::load()?;
     match id {
@@ -981,6 +990,7 @@ mod tests {
         assert!(!s.opt_out.window_sub);
     }
 
+    #[cfg(feature = "intercept")]
     #[test]
     fn route_agents_opt_out_is_sidecar_not_optout_field() {
         let dir = std::env::temp_dir().join(format!(
@@ -993,14 +1003,14 @@ mod tests {
         ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
-        assert!(!route_agents_opted_out_at(&dir));
-        set_route_agents_opt_out_at(&dir, true).unwrap();
-        assert!(route_agents_opted_out_at(&dir));
-        assert!(dir.join(ROUTE_AGENTS_OPT_OUT).is_file());
+        assert!(!route_agents_opt_out::opted_out_at(&dir));
+        route_agents_opt_out::set_at(&dir, true).unwrap();
+        assert!(route_agents_opt_out::opted_out_at(&dir));
+        assert!(dir.join("route-agents.opt-out").is_file());
         // Public OptOut shape is unchanged — no route_agents field to set.
         assert_eq!(State::default().opt_out, OptOut::default());
-        set_route_agents_opt_out_at(&dir, false).unwrap();
-        assert!(!route_agents_opted_out_at(&dir));
+        route_agents_opt_out::set_at(&dir, false).unwrap();
+        assert!(!route_agents_opt_out::opted_out_at(&dir));
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -22,6 +22,7 @@ pub struct OptOut {
     pub statusline: bool,
     pub guard: bool,
     pub window_sub: bool,
+    pub route_agents: bool,
     pub compact: bool,
     pub tray_autostart: bool,
     /// User declined the optional Linux tray download.
@@ -190,6 +191,23 @@ fn probe_with(state: &State) -> Vec<Gap> {
                 detail: "stale (binary path)".into(),
             }),
             crate::window_sub::OwnedStatus::Current => {}
+        }
+    }
+
+    #[cfg(feature = "intercept")]
+    if claude && !state.opt_out.route_agents {
+        match crate::route_agents::status() {
+            Ok(status) if status.installed == 0 => gaps.push(Gap {
+                id: "route_agents",
+                label: "Subagents".into(),
+                detail: "subscription-routed Claude Code subagents not installed".into(),
+            }),
+            Ok(status) if status.current < status.expected => gaps.push(Gap {
+                id: "route_agents",
+                label: "Subagents".into(),
+                detail: "routed subagent definitions are stale".into(),
+            }),
+            Ok(_) | Err(_) => {}
         }
     }
 
@@ -369,6 +387,47 @@ pub fn apply(opts: Options) -> Result<Report> {
         report
             .rows
             .push((ui::NOTE, "/sub".into(), "opted out".into()));
+    }
+
+    #[cfg(feature = "intercept")]
+    if claude && !state.opt_out.route_agents {
+        match crate::route_agents::status() {
+            Ok(status) => {
+                let missing = status.installed == 0;
+                let skip_missing = !opts.install_missing && missing;
+                if !skip_missing {
+                    match crate::route_agents::install() {
+                        Ok(after) => {
+                            if status.current < status.expected {
+                                report.applied.push("route_agents");
+                            }
+                            report.rows.push((
+                                ui::OK,
+                                "Subagents".into(),
+                                format!(
+                                    "{}/{} routed provider/model agents current",
+                                    after.current, after.expected
+                                ),
+                            ));
+                        }
+                        Err(e) => report.rows.push((
+                            ui::WARN,
+                            "Subagents".into(),
+                            format!("not installed: {e:#}"),
+                        )),
+                    }
+                }
+            }
+            Err(e) => report.rows.push((
+                ui::WARN,
+                "Subagents".into(),
+                format!("could not inspect: {e:#}"),
+            )),
+        }
+    } else if claude && state.opt_out.route_agents {
+        report
+            .rows
+            .push((ui::NOTE, "Subagents".into(), "opted out".into()));
     }
 
     if claude
@@ -641,6 +700,7 @@ pub fn set_opt_out(id: &str, value: bool) -> Result<()> {
         "statusline" => state.opt_out.statusline = value,
         "guard" => state.opt_out.guard = value,
         "window_sub" | "window-sub" | "sub" => state.opt_out.window_sub = value,
+        "route_agents" | "route-agents" | "agents" => state.opt_out.route_agents = value,
         "compact" => state.opt_out.compact = value,
         "tray_autostart" | "tray" => state.opt_out.tray_autostart = value,
         "tray_download" => state.opt_out.tray_download = value,
@@ -885,5 +945,6 @@ mod tests {
         assert!(!s.opt_out.statusline);
         assert!(!s.opt_out.guard);
         assert!(!s.opt_out.window_sub);
+        assert!(!s.opt_out.route_agents);
     }
 }

--- a/crates/llmtrim-cli/src/lib.rs
+++ b/crates/llmtrim-cli/src/lib.rs
@@ -22,6 +22,8 @@ pub mod monitor;
 pub mod quality;
 #[cfg(feature = "intercept")]
 pub mod reroute;
+#[cfg(feature = "intercept")]
+pub mod route_agents;
 pub mod serve;
 pub mod setup;
 pub mod statusline;

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -52,6 +52,7 @@ Get started:
   ensure     Bring this machine to the recommended current state
   wrap       Launch an agent (claude, codex, …) routed through the interceptor
   sub        Reroute Claude Code to another subscription's backend (codex|kimi|grok)
+  agents     Install routed Claude Code subagents (Grok, Codex/Terra, Kimi)
   tray       Open the desktop tray app (savings menu-bar / system-tray)
 
 Daemon:
@@ -120,6 +121,16 @@ enum Commands {
     Sub {
         #[command(subcommand)]
         action: SubCmd,
+    },
+    /// Install request-local subscription-routed Claude Code subagents
+    ///
+    /// Generated agents let prompts such as "use a Grok subagent" or "implement with Terra"
+    /// delegate only that child thread to the selected subscription provider/model. The parent
+    /// window keeps its existing Anthropic or `/sub` route.
+    #[cfg(feature = "intercept")]
+    Agents {
+        #[command(subcommand)]
+        action: AgentsCmd,
     },
     /// Configure cheaper models for Claude Code `/compact`
     ///
@@ -439,6 +450,18 @@ enum BenchCmd {
     Latency(LatencyArgs),
     /// Head-to-head vs a third-party compressor (Python comparators).
     Compare(CompareArgs),
+}
+
+/// Manage request-local subscription-routed Claude Code subagents.
+#[cfg(feature = "intercept")]
+#[derive(Subcommand)]
+enum AgentsCmd {
+    /// Install or refresh all llmtrim-owned routed subagents
+    Install,
+    /// Show how many routed subagents are installed
+    Status,
+    /// Remove only llmtrim-owned routed subagents
+    Uninstall,
 }
 
 /// Subscription reroute: send Claude Code traffic to another subscription's backend.
@@ -1136,6 +1159,35 @@ fn run_compact(action: CompactCmd) -> Result<()> {
     }
 }
 
+#[cfg(feature = "intercept")]
+fn run_agents(action: AgentsCmd) -> Result<()> {
+    match action {
+        AgentsCmd::Install => {
+            let status = llmtrim::route_agents::install()?;
+            llmtrim::ensure::set_opt_out("route_agents", false)?;
+            println!(
+                "Installed {} routed Claude Code subagents in {}.",
+                status.current,
+                llmtrim::route_agents::agents_dir()?.display()
+            );
+            println!("Restart Claude Code, then ask for a Grok, Terra, Codex, or Kimi subagent.");
+        }
+        AgentsCmd::Status => {
+            let status = llmtrim::route_agents::status()?;
+            println!(
+                "Routed Claude Code subagents: {}/{} current ({} installed).",
+                status.current, status.expected, status.installed
+            );
+        }
+        AgentsCmd::Uninstall => {
+            let removed = llmtrim::route_agents::uninstall()?;
+            llmtrim::ensure::set_opt_out("route_agents", true)?;
+            println!("Removed {removed} llmtrim-owned routed Claude Code subagents.");
+        }
+    }
+    Ok(())
+}
+
 /// Handle `llmtrim sub <setup|on|off|status>`.
 #[cfg(feature = "intercept")]
 fn run_sub(action: SubCmd) -> Result<()> {
@@ -1778,6 +1830,8 @@ fn run() -> Result<()> {
             ),
         },
         Commands::Sub { action } => run_sub(action)?,
+        #[cfg(feature = "intercept")]
+        Commands::Agents { action } => run_agents(action)?,
         Commands::Compact { action } => run_compact(action)?,
         Commands::WindowSub { args } => {
             let hook = args.first().is_some_and(|arg| arg.starts_with("hook-"));

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -21,6 +21,7 @@ pub mod grok;
 pub mod kimi;
 pub mod quota;
 pub mod read_rewrite;
+pub mod route;
 pub mod sse;
 #[cfg(feature = "breakdown")]
 pub mod tui;
@@ -65,6 +66,47 @@ pub(crate) fn build_upstream_for_model(
     token: &auth::TokenSet,
     session_id: Option<&str>,
 ) -> Result<UpstreamRewrite> {
+    build_upstream_with_model(
+        provider,
+        anthropic_body,
+        logical_model,
+        overrides,
+        token,
+        session_id,
+        false,
+    )
+}
+
+/// Build a request for a concrete model selected by a routed custom agent. Unlike compact/tier
+/// routing, this never substitutes another model behind the explicit selection.
+pub(crate) fn build_upstream_for_explicit_model(
+    provider: SubProvider,
+    anthropic_body: &Value,
+    model: &str,
+    overrides: &BTreeMap<String, String>,
+    token: &auth::TokenSet,
+    session_id: Option<&str>,
+) -> Result<UpstreamRewrite> {
+    build_upstream_with_model(
+        provider,
+        anthropic_body,
+        Some(model),
+        overrides,
+        token,
+        session_id,
+        true,
+    )
+}
+
+fn build_upstream_with_model(
+    provider: SubProvider,
+    anthropic_body: &Value,
+    logical_model: Option<&str>,
+    overrides: &BTreeMap<String, String>,
+    token: &auth::TokenSet,
+    session_id: Option<&str>,
+    explicit: bool,
+) -> Result<UpstreamRewrite> {
     let incoming = logical_model.unwrap_or_else(|| {
         anthropic_body
             .get("model")
@@ -74,7 +116,7 @@ pub(crate) fn build_upstream_for_model(
     let mut model = resolve_model(provider, incoming, overrides);
     // Hosted web_search needs the full Responses API; luna only exists on the lite lane and
     // 404s there as a `-free` id, so upgrade to the nearest full-lane sibling.
-    if provider == SubProvider::Codex && codex::has_hosted_web_search(anthropic_body) {
+    if !explicit && provider == SubProvider::Codex && codex::has_hosted_web_search(anthropic_body) {
         model = codex::full_lane_web_search_model(&model).to_string();
     }
     let (host, path, body, headers) = match provider {
@@ -649,6 +691,29 @@ mod tests {
             parsed["tool_choice"]["tools"],
             serde_json::json!([{ "type": "web_search" }])
         );
+    }
+
+    #[test]
+    fn explicit_codex_model_is_not_upgraded_for_web_search() {
+        let token = auth::TokenSet {
+            access: "tok".into(),
+            account_id: None,
+        };
+        let body = serde_json::json!({
+            "model": "claude-sonnet-5",
+            "messages": [],
+            "tools": [{ "type": "web_search_20250305", "name": "web_search" }]
+        });
+        let up = build_upstream_for_explicit_model(
+            SubProvider::Codex,
+            &body,
+            "gpt-5.6-luna",
+            &BTreeMap::new(),
+            &token,
+            None,
+        )
+        .expect("build");
+        assert_eq!(up.model, "gpt-5.6-luna");
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/route.rs
+++ b/crates/llmtrim-cli/src/reroute/route.rs
@@ -1,0 +1,243 @@
+//! Trusted request-local routes carried by generated Claude Code agents.
+//!
+//! The marker is deliberately accepted only as a standalone line in the top-level Anthropic
+//! system prompt; user messages and ordinary system prose are never interpreted as routes.
+
+use anyhow::{Result, bail};
+use serde_json::Value;
+
+use super::{SubProvider, resolve_model};
+
+/// Exact text of a generated-agent route marker.
+pub const MARKER_PREFIX: &str = "<!-- llmtrim-route-v1:";
+pub const MARKER_SUFFIX: &str = " -->";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestRoute {
+    pub provider: SubProvider,
+    /// `Some` means the custom agent selected a concrete upstream model.
+    pub model: Option<String>,
+}
+
+impl RequestRoute {
+    pub fn resolve(
+        &self,
+        incoming: &str,
+        tiers: &std::collections::BTreeMap<String, String>,
+    ) -> String {
+        self.model
+            .clone()
+            .unwrap_or_else(|| resolve_model(self.provider, incoming, tiers))
+    }
+}
+
+/// Remove and return a single trusted route marker line from the top-level Anthropic system
+/// prompt. User, assistant, and tool content is never inspected. A marker-shaped line which is not
+/// valid is a client error rather than prompt text, making accidental near-markers visible.
+pub fn take_marker(body: &mut Value) -> Result<Option<RequestRoute>> {
+    let Some(system) = body.get_mut("system") else {
+        return Ok(None);
+    };
+    let mut found = None;
+    match system {
+        Value::String(text) => take_marker_line(text, &mut found)?,
+        Value::Array(blocks) => {
+            for block in blocks.iter_mut() {
+                let Some(text) = block.get("text").and_then(Value::as_str) else {
+                    continue;
+                };
+                if !text
+                    .lines()
+                    .any(|line| line.trim().starts_with(MARKER_PREFIX))
+                {
+                    continue;
+                }
+                if block.get("type").and_then(Value::as_str) != Some("text") {
+                    bail!("llmtrim: request-local route marker must be in a system text block");
+                }
+                let Some(Value::String(text)) = block.get_mut("text") else {
+                    unreachable!("text was checked above");
+                };
+                take_marker_line(text, &mut found)?;
+            }
+            blocks.retain(|block| {
+                block.get("type").and_then(Value::as_str) != Some("text")
+                    || block.get("text").and_then(Value::as_str) != Some("")
+            });
+        }
+        _ => return Ok(None),
+    }
+    Ok(found)
+}
+
+fn take_marker_line(text: &mut String, found: &mut Option<RequestRoute>) -> Result<()> {
+    let mut kept = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with(MARKER_PREFIX) {
+            let route = parse_marker(trimmed)?;
+            if found.replace(route).is_some() {
+                bail!("llmtrim: duplicate request-local route marker");
+            }
+        } else {
+            kept.push(line);
+        }
+    }
+    if kept.len() != text.lines().count() {
+        *text = kept.join("\n");
+    }
+    Ok(())
+}
+
+fn parse_marker(text: &str) -> Result<RequestRoute> {
+    let route = text
+        .strip_prefix(MARKER_PREFIX)
+        .and_then(|s| s.strip_suffix(MARKER_SUFFIX))
+        .ok_or_else(|| anyhow::anyhow!("llmtrim: malformed request-local route marker"))?;
+    if route.is_empty() || route.contains(char::is_whitespace) || route.matches('/').count() > 1 {
+        bail!("llmtrim: malformed request-local route marker");
+    }
+    let mut pieces = route.split('/');
+    let provider = SubProvider::parse(pieces.next().unwrap())
+        .filter(|p| p.as_str() == route.split('/').next().unwrap())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "llmtrim: route marker provider must be canonical (codex, kimi, or grok)"
+            )
+        })?;
+    let model = pieces
+        .next()
+        .map(|m| resolve_explicit_model(provider, m))
+        .transpose()?;
+    Ok(RequestRoute { provider, model })
+}
+
+/// Resolve curated provider-scoped aliases used by the agent installer. Unknown explicit ids never
+/// use the ordinary tier fallback.
+pub fn resolve_explicit_model(provider: SubProvider, value: &str) -> Result<String> {
+    let normalized: String = value
+        .chars()
+        .filter(|c| !matches!(c, '-' | '_' | ' '))
+        .flat_map(char::to_lowercase)
+        .collect();
+    let model = match provider {
+        SubProvider::Codex => match normalized.as_str() {
+            "terra" | "gptterra" | "gpt5terra" | "gpt56terra" => "gpt-5.6-terra",
+            "luna" | "gptluna" | "gpt5luna" | "gpt56luna" => "gpt-5.6-luna",
+            "sol" | "gptsol" | "gpt5sol" | "gpt56sol" => "gpt-5.6-sol",
+            "mini" | "gptmini" | "gpt54mini" => "gpt-5.4-mini",
+            _ => value,
+        },
+        SubProvider::Grok => match normalized.as_str() {
+            "grok" | "grok45" => "grok-4.5",
+            "composer" | "grokcomposer" | "grokcomposer25fast" => "grok-composer-2.5-fast",
+            _ => value,
+        },
+        SubProvider::Kimi => match normalized.as_str() {
+            "kimi" | "k2" | "kimik2" | "kimiforcoding" => super::KIMI_MODEL,
+            _ => value,
+        },
+    };
+    let accepted = match provider {
+        SubProvider::Codex => super::CODEX_MODELS.contains(&model),
+        SubProvider::Grok => super::GROK_MODELS.contains(&model),
+        SubProvider::Kimi => model == super::KIMI_MODEL,
+    };
+    if accepted {
+        return Ok(model.to_ascii_lowercase());
+    }
+    let supported = match provider {
+        SubProvider::Codex => super::CODEX_MODELS.join(", "),
+        SubProvider::Grok => super::GROK_MODELS.join(", "),
+        SubProvider::Kimi => super::KIMI_MODEL.to_string(),
+    };
+    bail!(
+        "llmtrim: unknown {provider} route model `{value}`; supported models: {supported}",
+        provider = provider.as_str()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn takes_only_standalone_top_level_system_block() {
+        let mut body = json!({"system":[{"type":"text","text":"<!-- llmtrim-route-v1:codex/gpt-5.6-terra -->"},{"type":"text","text":"keep"}],"messages":[{"content":"<!-- llmtrim-route-v1:grok -->"} ]});
+        assert_eq!(
+            take_marker(&mut body).unwrap().unwrap().model.as_deref(),
+            Some("gpt-5.6-terra")
+        );
+        assert_eq!(body["system"][0]["text"], "keep");
+        assert_eq!(
+            body["messages"][0]["content"],
+            "<!-- llmtrim-route-v1:grok -->"
+        );
+    }
+    #[test]
+    fn rejects_malformed_and_duplicate_markers() {
+        let mut malformed = json!({"system":"<!-- llmtrim-route-v1:chatgpt -->"});
+        assert!(take_marker(&mut malformed).is_err());
+        let mut duplicate = json!({"system":[{"text":"<!-- llmtrim-route-v1:codex -->"},{"text":"<!-- llmtrim-route-v1:grok -->"}]});
+        assert!(take_marker(&mut duplicate).is_err());
+    }
+    #[test]
+    fn extracts_marker_line_from_generated_agent_prompt() {
+        let mut body = json!({
+            "system": [{
+                "type": "text",
+                "text": "Agent instructions\n<!-- llmtrim-route-v1:grok -->\nComplete the task."
+            }]
+        });
+        let route = take_marker(&mut body).unwrap().unwrap();
+        assert_eq!(route.provider, SubProvider::Grok);
+        assert_eq!(
+            body["system"][0]["text"],
+            "Agent instructions\nComplete the task."
+        );
+    }
+
+    #[test]
+    fn rejects_marker_in_non_text_system_block() {
+        let mut body = json!({
+            "system": [{
+                "type": "tool_use",
+                "text": "<!-- llmtrim-route-v1:grok -->"
+            }]
+        });
+        assert!(take_marker(&mut body).is_err());
+    }
+
+    #[test]
+    fn provider_only_route_preserves_claude_tier_and_override() {
+        let route = RequestRoute {
+            provider: SubProvider::Codex,
+            model: None,
+        };
+        assert_eq!(
+            route.resolve("claude-fable-5", &Default::default()),
+            "gpt-5.6-sol"
+        );
+        let tiers =
+            std::collections::BTreeMap::from([("fable".to_string(), "gpt-5.6-terra".to_string())]);
+        assert_eq!(route.resolve("claude-fable-5", &tiers), "gpt-5.6-terra");
+    }
+
+    #[test]
+    fn resolves_terra_aliases_without_fallback() {
+        for name in [
+            "terra",
+            "gpt-terra",
+            "gpt5-terra",
+            "gpt-5.6-terra",
+            "gpt terra",
+        ] {
+            assert_eq!(
+                resolve_explicit_model(SubProvider::Codex, name).unwrap(),
+                "gpt-5.6-terra"
+            );
+        }
+        assert!(resolve_explicit_model(SubProvider::Codex, "unknown").is_err());
+    }
+}

--- a/crates/llmtrim-cli/src/route_agents.rs
+++ b/crates/llmtrim-cli/src/route_agents.rs
@@ -1,0 +1,315 @@
+//! Claude Code custom agents for request-local subscription routing.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::reroute::{CODEX_MODELS, GROK_MODELS};
+
+const OWNED_MARKER: &str = "<!-- llmtrim-owned-route-agent-v1 -->";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Status {
+    pub installed: usize,
+    pub current: usize,
+    pub expected: usize,
+}
+
+struct Agent {
+    name: String,
+    description: String,
+    route: String,
+}
+
+fn claude_dir() -> Result<PathBuf> {
+    if let Some(dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .context("neither HOME nor USERPROFILE is set")?;
+    Ok(PathBuf::from(home).join(".claude"))
+}
+
+pub fn agents_dir() -> Result<PathBuf> {
+    Ok(claude_dir()?.join("agents"))
+}
+
+fn machine_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn display_name(model: &str) -> &str {
+    match model {
+        "gpt-5.6-terra" => "Terra (GPT Terra)",
+        "gpt-5.6-luna" => "Luna (GPT Luna)",
+        "gpt-5.6-sol" => "Sol (GPT Sol)",
+        "gpt-5.4-mini" => "Mini (GPT Mini)",
+        "grok-4.5" => "Grok 4.5",
+        "grok-composer-2.5-fast" => "Grok Composer",
+        "kimi-for-coding" => "Kimi",
+        other => other,
+    }
+}
+
+fn definitions() -> Vec<Agent> {
+    let mut agents = vec![
+        Agent {
+            name: "llmtrim-codex".into(),
+            description: "Use when the user asks for a Codex, ChatGPT, or OpenAI subagent. The provider model follows the current Claude model tier.".into(),
+            route: "codex".into(),
+        },
+        Agent {
+            name: "llmtrim-grok".into(),
+            description: "Use when the user asks to delegate work to Grok or a Grok subagent. The provider model follows the current Claude model tier.".into(),
+            route: "grok".into(),
+        },
+        Agent {
+            name: "llmtrim-kimi".into(),
+            description: "Use when the user asks to delegate work to Kimi, Moonshot, or a Kimi subagent.".into(),
+            route: "kimi".into(),
+        },
+    ];
+    for model in CODEX_MODELS {
+        agents.push(Agent {
+            name: format!("llmtrim-codex-{}", machine_component(model)),
+            description: format!(
+                "Use when the user explicitly asks for {}, {model}, or that Codex model as a subagent.",
+                display_name(model)
+            ),
+            route: format!("codex/{model}"),
+        });
+    }
+    for model in GROK_MODELS {
+        agents.push(Agent {
+            name: format!("llmtrim-grok-{}", machine_component(model)),
+            description: format!(
+                "Use when the user explicitly asks for {}, {model}, or that Grok model as a subagent.",
+                display_name(model)
+            ),
+            route: format!("grok/{model}"),
+        });
+    }
+    // The provider-only Kimi agent already resolves to its sole concrete model.
+    agents
+}
+
+fn render(agent: &Agent) -> String {
+    format!(
+        "---\nname: {}\ndescription: {}\nmodel: inherit\n---\n\n{}\n<!-- llmtrim-route-v1:{} -->\n\nComplete the delegated task in this thread and return the result to the parent agent.\n",
+        agent.name, agent.description, OWNED_MARKER, agent.route
+    )
+}
+
+fn is_owned(path: &Path) -> bool {
+    fs::read_to_string(path)
+        .map(|text| text.contains(OWNED_MARKER))
+        .unwrap_or(false)
+}
+
+fn write_atomic(path: &Path, content: &str) -> Result<()> {
+    let tmp = path.with_extension("md.tmp");
+    if tmp.exists() && fs::symlink_metadata(&tmp)?.file_type().is_symlink() {
+        bail!(
+            "refusing symlinked route-agent temporary file: {}",
+            tmp.display()
+        );
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&tmp)?;
+    file.write_all(content.as_bytes())?;
+    file.sync_all()?;
+    #[cfg(windows)]
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+    fs::rename(tmp, path)?;
+    Ok(())
+}
+
+pub fn install() -> Result<Status> {
+    install_at(&agents_dir()?)
+}
+
+fn install_at(dir: &Path) -> Result<Status> {
+    fs::create_dir_all(dir)?;
+    let definitions = definitions();
+
+    // Check every collision before changing anything.
+    for agent in &definitions {
+        let path = dir.join(format!("{}.md", agent.name));
+        if path.exists() && !is_owned(&path) {
+            bail!(
+                "refusing to overwrite non-llmtrim Claude agent: {}",
+                path.display()
+            );
+        }
+    }
+
+    for agent in &definitions {
+        let path = dir.join(format!("{}.md", agent.name));
+        write_atomic(&path, &render(agent))?;
+    }
+
+    // Remove stale files only when both their name and ownership marker identify this integration.
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        if name.starts_with("llmtrim-")
+            && name.ends_with(".md")
+            && is_owned(&path)
+            && !definitions
+                .iter()
+                .any(|agent| name == format!("{}.md", agent.name))
+        {
+            fs::remove_file(path)?;
+        }
+    }
+
+    status_at(dir)
+}
+
+pub fn uninstall() -> Result<usize> {
+    uninstall_at(&agents_dir()?)
+}
+
+fn uninstall_at(dir: &Path) -> Result<usize> {
+    if !dir.exists() {
+        return Ok(0);
+    }
+    let mut removed = 0;
+    for entry in fs::read_dir(dir)? {
+        let path = entry?.path();
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        if name.starts_with("llmtrim-") && name.ends_with(".md") && is_owned(&path) {
+            fs::remove_file(path)?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+pub fn status() -> Result<Status> {
+    status_at(&agents_dir()?)
+}
+
+fn status_at(dir: &Path) -> Result<Status> {
+    let definitions = definitions();
+    let installed = definitions
+        .iter()
+        .filter(|agent| {
+            let path = dir.join(format!("{}.md", agent.name));
+            path.is_file() && is_owned(&path)
+        })
+        .count();
+    let current = definitions
+        .iter()
+        .filter(|agent| {
+            let path = dir.join(format!("{}.md", agent.name));
+            fs::read_to_string(path).is_ok_and(|text| text == render(agent))
+        })
+        .count();
+    Ok(Status {
+        installed,
+        current,
+        expected: definitions.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct TempAgents(PathBuf);
+
+    impl TempAgents {
+        fn new() -> Self {
+            Self(std::env::temp_dir().join(format!(
+                "llmtrim-route-agents-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            )))
+        }
+    }
+
+    impl Drop for TempAgents {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn install_is_idempotent_and_uninstall_is_owned_only() {
+        let temp = TempAgents::new();
+        let first = install_at(&temp.0).unwrap();
+        assert_eq!(first.installed, first.expected);
+        let second = install_at(&temp.0).unwrap();
+        assert_eq!(second, first);
+        let user = temp.0.join("user.md");
+        fs::write(&user, "---\nname: user\n---\n").unwrap();
+        assert_eq!(uninstall_at(&temp.0).unwrap(), first.expected);
+        assert!(user.exists());
+    }
+
+    #[test]
+    fn install_refuses_non_owned_collision_before_writing() {
+        let temp = TempAgents::new();
+        fs::create_dir_all(&temp.0).unwrap();
+        fs::write(temp.0.join("llmtrim-codex.md"), "user content").unwrap();
+        assert!(install_at(&temp.0).is_err());
+        assert!(!temp.0.join("llmtrim-grok.md").exists());
+    }
+
+    #[test]
+    fn generated_terra_agent_uses_canonical_marker_and_alias_description() {
+        let terra = definitions()
+            .into_iter()
+            .find(|agent| agent.route == "codex/gpt-5.6-terra")
+            .unwrap();
+        let text = render(&terra);
+        assert!(text.contains("<!-- llmtrim-route-v1:codex/gpt-5.6-terra -->"));
+        assert!(text.contains("Terra (GPT Terra)"));
+        assert!(text.contains("model: inherit"));
+    }
+
+    #[test]
+    fn sole_kimi_model_is_not_duplicated() {
+        let agents = definitions();
+        assert_eq!(
+            agents.iter().filter(|agent| agent.route == "kimi").count(),
+            1
+        );
+        assert!(
+            !agents
+                .iter()
+                .any(|agent| agent.route == format!("kimi/{}", crate::reroute::KIMI_MODEL))
+        );
+    }
+}

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1972,6 +1972,21 @@ mod imp {
             // (401 → "Please run /login"). Messages that aren't rerouted (e.g. window `/sub off`)
             // must not reach Anthropic either — return a clear llmtrim error instead.
             let mut fallback_arm: Option<(Vec<crate::reroute::SubProvider>, Option<String>)> = None;
+            // A generated custom agent can carry one trusted, standalone system marker. Read and
+            // remove it before every later stage so it never becomes prompt/cache/capture content.
+            let (req, request_route) = if matches!(provider, Some(ProviderKind::Anthropic))
+                && req.method() == Method::POST
+                && matches!(
+                    classify_anthropic_api_path(req.uri().path()),
+                    AnthropicApiPath::Messages | AnthropicApiPath::CountTokens
+                ) {
+                match Self::strip_request_route_marker(req).await {
+                    Ok(value) => value,
+                    Err(message) => return anthropic_error(400, &message).into(),
+                }
+            } else {
+                (req, None)
+            };
             if matches!(provider, Some(ProviderKind::Anthropic)) {
                 let path_kind = classify_anthropic_api_path(req.uri().path());
                 // The filesystem registry is consulted per request, keyed by Claude Code's
@@ -1990,7 +2005,18 @@ mod imp {
                 };
                 let window_disabled =
                     matches!(window_intent, Some(crate::window_sub::Intent::Disabled));
-                if !window_disabled && (!self.sub_fallback || window_sub.is_some()) {
+                // An explicit marker is a direct route, including when this window selected off
+                // or the daemon is configured for fallback-only. It never arms fallback state.
+                if let Some(route) = request_route {
+                    if req.method() == Method::POST && path_kind == AnthropicApiPath::CountTokens {
+                        return self.reroute_count_tokens(req).await;
+                    }
+                    if req.method() == Method::POST && path_kind == AnthropicApiPath::Messages {
+                        return self
+                            .reroute_messages(req, route.provider, route.model)
+                            .await;
+                    }
+                } else if !window_disabled && (!self.sub_fallback || window_sub.is_some()) {
                     if let Some(sub) = window_sub.or(self.sub) {
                         if req.method() == Method::POST
                             && path_kind == AnthropicApiPath::CountTokens
@@ -1998,7 +2024,7 @@ mod imp {
                             return self.reroute_count_tokens(req).await;
                         }
                         if req.method() == Method::POST && path_kind == AnthropicApiPath::Messages {
-                            return self.reroute_messages(req, sub).await;
+                            return self.reroute_messages(req, sub, None).await;
                         }
                     }
                 } else if !window_disabled
@@ -2305,6 +2331,35 @@ mod imp {
             Request::from_parts(parts, new_body).into()
         }
 
+        /// Parse a body once at the trusted Anthropic boundary and remove an agent marker before
+        /// any path can compress, count, capture, cache, replay, or translate it.
+        async fn strip_request_route_marker(
+            req: Request<Body>,
+        ) -> Result<(Request<Body>, Option<crate::reroute::route::RequestRoute>), String> {
+            let (mut parts, body) = req.into_parts();
+            let collected = body
+                .collect()
+                .await
+                .map_err(|_| "llmtrim: could not read request body".to_string())?
+                .to_bytes();
+            let decoded = decode_request_body(&parts.headers, &collected);
+            let bytes = decoded.as_deref().unwrap_or(&collected);
+            let Ok(mut value) = serde_json::from_slice::<Value>(bytes) else {
+                return Ok((Request::from_parts(parts, Body::from(collected)), None));
+            };
+            let route =
+                crate::reroute::route::take_marker(&mut value).map_err(|e| e.to_string())?;
+            if route.is_some() || decoded.is_some() {
+                let encoded = serde_json::to_vec(&value)
+                    .map_err(|_| "llmtrim: could not encode cleaned request".to_string())?;
+                parts.headers.remove(header::CONTENT_LENGTH);
+                parts.headers.remove(header::CONTENT_ENCODING);
+                Ok((Request::from_parts(parts, Body::from(encoded)), route))
+            } else {
+                Ok((Request::from_parts(parts, Body::from(collected)), None))
+            }
+        }
+
         /// Answer Claude Code's `/v1/messages/count_tokens` locally (see
         /// [`crate::reroute::count_tokens_json`]). The request can't be proxied to Anthropic once a
         /// `sub` is active (it would be billed against the sub), so short-circuit with a JSON reply.
@@ -2333,6 +2388,7 @@ mod imp {
             &mut self,
             req: Request<Body>,
             sub: crate::reroute::SubProvider,
+            explicit_model: Option<String>,
         ) -> RequestOrResponse {
             let (mut parts, body) = req.into_parts();
             let session_id = parts
@@ -2386,8 +2442,14 @@ mod imp {
             let compact_cache_warm = session_id
                 .as_deref()
                 .is_some_and(crate::statusline::session_cache_warm);
+            // A request-local explicit model is authoritative: do not substitute hidden compact
+            // candidates and accidentally route the delegated turn elsewhere.
             let mut compact_candidates = crate::compact::detect(&anthropic)
-                .filter(|_| !self.compact_models.is_empty() && !compact_cache_warm)
+                .filter(|_| {
+                    explicit_model.is_none()
+                        && !self.compact_models.is_empty()
+                        && !compact_cache_warm
+                })
                 .map(|original| {
                     let tiers = llmtrim_core::config::sub_tiers_for(sub.as_str());
                     crate::compact::plan(&self.compact_models, &original, Some(sub), &tiers)
@@ -2514,14 +2576,26 @@ mod imp {
             // with global `sub = codex` must use `[sub.grok.tiers]` (or Grok defaults), not the
             // Codex mapping snapshotted into `self.sub_tiers` at daemon start.
             let tiers = llmtrim_core::config::sub_tiers_for(sub.as_str());
-            let rewrite = match crate::reroute::build_upstream_for_model(
-                sub,
-                &translate_value,
-                compact_current.as_ref().map(|c| c.logical_model.as_str()),
-                &tiers,
-                &token,
-                session_id.as_deref(),
-            ) {
+            let rewrite_result = if let Some(model) = explicit_model.as_deref() {
+                crate::reroute::build_upstream_for_explicit_model(
+                    sub,
+                    &translate_value,
+                    model,
+                    &tiers,
+                    &token,
+                    session_id.as_deref(),
+                )
+            } else {
+                crate::reroute::build_upstream_for_model(
+                    sub,
+                    &translate_value,
+                    compact_current.as_ref().map(|c| c.logical_model.as_str()),
+                    &tiers,
+                    &token,
+                    session_id.as_deref(),
+                )
+            };
+            let rewrite = match rewrite_result {
                 Ok(r) => r,
                 Err(e) => {
                     return anthropic_error(


### PR DESCRIPTION
## Summary

Adds request-local subscription routing for Claude Code custom subagents. Generated agents under `~/.claude/agents/` carry a trusted `<!-- llmtrim-route-v1:… -->` system marker; the proxy strips it and reroutes only that request, so a Terra/Grok/Codex child can run on a different provider/model than the parent window or global `sub` policy.

- `llmtrim agents install|status|uninstall` (+ ensure/setup opt-out `route_agents`)
- Marker accepted only as a standalone system-block line (never user/tool content)
- Explicit model agents pin the upstream model; provider-only agents keep the Claude tier map
- Request-local route wins over window `/sub` and global always-sub (including `/sub off`)

## Live verification (isolated proxy on :43271, always-sub Grok parent)

| Subagent | Upstream | Result |
|----------|----------|--------|
| `llmtrim-codex-gpt-5-6-terra` | `codex` / `gpt-5.6-terra` | `PARENT_OK 6` |
| `llmtrim-grok-grok-composer-2-5-fast` | `grok` / `grok-composer-2.5-fast` | `PARENT_OK 6` |
| `llmtrim-codex` (provider-only) | `codex` / tier→`gpt-5.6-terra` | `PARENT_OK 6` |

Route marker absent from every upstream-sent payload. Shared daemon on `43117` was not touched.

## Test plan

- [x] Unit tests for marker parse/strip, agent install ownership, alias resolution
- [x] `cargo clippy -p llmtrim --all-targets -- -D warnings`
- [x] Live Claude Code inline delegations (above)
- [ ] CI green