### PR TITLE
feat(recall): add recoverable first-arrival tool output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,7 @@ dependencies = [
  "llm_providers",
  "llmtrim-core",
  "llmtrim-ledger",
+ "nix",
  "once_cell",
  "owo-colors",
  "rand 0.8.6",
@@ -3160,6 +3161,7 @@ dependencies = [
  "ureq",
  "uuid",
  "wait-timeout",
+ "windows-sys 0.61.2",
  "winreg 0.56.0",
  "zstd",
 ]

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -95,9 +95,9 @@ llm_providers = { version = "0.14", optional = true }
 # translation. base64/sha2/rand build the PKCE verifier+challenge; uuid mints session/message
 # ids + the persistent Kimi device id. All small, pure, no new TLS stack (the reroute forwards
 # over hudsucker's existing aws-lc client via a URI-authority rewrite).
-base64 = { workspace = true, optional = true }
-sha2 = { version = "0.10", optional = true }
-rand = { version = "0.8", optional = true }
+base64.workspace = true
+sha2 = "0.10"
+rand = "0.8"
 uuid = { version = "1", features = ["v4"], optional = true }
 # Request-side body decompression (#193): Codex CLI 0.144+ sends its request bodies with
 # `Content-Encoding: zstd`; without decoding them the interceptor can't parse (let alone
@@ -135,8 +135,12 @@ rmcp = { version = "2.0", default-features = false, features = ["client", "trans
 [target.'cfg(not(windows))'.dependencies]
 auto-launch = "0.6.0"
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", features = ["user"] }
+
 [target.'cfg(windows)'.dependencies]
 winreg = "0.56"
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Pipes"] }
 
 [features]
 # `mcp` is in `default` (like `intercept`) because the release binaries are built with
@@ -156,9 +160,6 @@ intercept = [
   "dep:time",
   "dep:hyper-http-proxy",
   "dep:hyper-util",
-  "dep:base64",
-  "dep:sha2",
-  "dep:rand",
   "dep:uuid",
   "dep:zstd",
   "dep:flate2",

--- a/crates/llmtrim-cli/src/lib.rs
+++ b/crates/llmtrim-cli/src/lib.rs
@@ -20,6 +20,7 @@ pub mod guard;
 pub mod mcp;
 pub mod monitor;
 pub mod quality;
+pub mod recall;
 #[cfg(feature = "intercept")]
 pub mod reroute;
 #[cfg(feature = "intercept")]

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -67,6 +67,7 @@ When something's wrong:
 Pipes & one-shots:
   compress   Compress a request from stdin to stdout
   send       Compress a request, send it to the provider, print the response
+  recall     Recover raw bytes from an ephemeral recall handle
   serve      Run the HTTPS interceptor in the foreground
   ca         Print the local CA certificate path and how to trust it
 
@@ -235,6 +236,11 @@ enum Commands {
         /// The agent binary to launch, followed by its arguments (use `--` before flags).
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
+    },
+    /// Print an ephemeral raw tool result recovered from the running daemon.
+    Recall {
+        /// Opaque handle from recoverable first-arrival shaping (memory-only; five-hour default TTL).
+        handle: String,
     },
     /// Stop the background interceptor daemon
     Stop,
@@ -1770,6 +1776,13 @@ fn run() -> Result<()> {
             if llmtrim::daemon::running().is_none() {
                 std::process::exit(1);
             }
+        }
+        Commands::Recall { handle } => {
+            let bytes = llmtrim::recall::request(&handle)?;
+            std::io::stdout()
+                .lock()
+                .write_all(&bytes)
+                .context("failed to write stdout")?;
         }
         Commands::Stop => match llmtrim::daemon::stop()? {
             Some(pid) => {

--- a/crates/llmtrim-cli/src/recall.rs
+++ b/crates/llmtrim-cli/src/recall.rs
@@ -1,0 +1,759 @@
+//! Ephemeral recovery storage for future lossy first-arrival tool-output shaping.
+//!
+//! Entries live only in the proxy process. The local control endpoint uses a bounded,
+//! length-delimited protocol and is deliberately separate from HTTPS proxy traffic.
+
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[cfg(feature = "intercept")]
+use anyhow::Context;
+use anyhow::{Result, bail};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use rand::RngCore;
+
+pub const DEFAULT_TTL: Duration = Duration::from_secs(18_000);
+pub const DEFAULT_MAX_ENTRIES: usize = 256;
+pub const DEFAULT_MAX_BYTES: usize = 64 * 1024 * 1024;
+pub const DEFAULT_MAX_ENTRY_BYTES: usize = 8 * 1024 * 1024;
+/// Hard upper bound for a single control-protocol response, even if configuration is corrupt.
+pub const MAX_PROTOCOL_RESPONSE_BYTES: usize = DEFAULT_MAX_ENTRY_BYTES;
+#[cfg(feature = "intercept")]
+const MAX_HANDLE_BYTES: usize = 45;
+#[cfg(feature = "intercept")]
+const MAX_HEADER_BYTES: usize = 64;
+#[cfg(feature = "intercept")]
+const MAX_ERROR_BYTES: usize = 1024;
+#[cfg(feature = "intercept")]
+const IO_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug)]
+pub struct Limits {
+    pub ttl: Duration,
+    pub max_entries: usize,
+    pub max_bytes: usize,
+    pub max_entry_bytes: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            ttl: DEFAULT_TTL,
+            max_entries: DEFAULT_MAX_ENTRIES,
+            max_bytes: DEFAULT_MAX_BYTES,
+            max_entry_bytes: DEFAULT_MAX_ENTRY_BYTES,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Entry {
+    bytes: Vec<u8>,
+    expires_at: Instant,
+    sequence: u64,
+    /// Present only for transactional first-arrival admissions. Ordinary IPC/store inserts have
+    /// no rerun fingerprint.
+    fingerprint: Option<[u8; 32]>,
+}
+#[derive(Debug)]
+struct Inner {
+    entries: HashMap<String, Entry>,
+    bytes: usize,
+    next_sequence: u64,
+    /// Hashed `(session, tool identity, content)` keys. These intentionally outlive raw entries
+    /// for one TTL so an expired/restarted recovery cannot create a compression loop.
+    fingerprints: HashMap<[u8; 32], Instant>,
+    fingerprint_secret: [u8; 32],
+}
+
+/// Admission distinguishes a retrievable new entry from a known rerun that must pass through.
+pub enum Admission {
+    Stored(String),
+    Seen,
+}
+
+/// Bounded, process-local raw-byte store. Handles are opaque capabilities rather than paths.
+#[derive(Debug)]
+pub struct RecallStore {
+    limits: Limits,
+    inner: Mutex<Inner>,
+}
+
+impl RecallStore {
+    pub fn new(limits: Limits) -> Self {
+        let mut fingerprint_secret = [0_u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut fingerprint_secret);
+        Self {
+            limits,
+            inner: Mutex::new(Inner {
+                entries: HashMap::new(),
+                bytes: 0,
+                next_sequence: 0,
+                fingerprints: HashMap::new(),
+                fingerprint_secret,
+            }),
+        }
+    }
+
+    /// Transactionally admits bytes for one session-scoped tool result. Only a hash is retained
+    /// after the raw entry expires; the bounded map is capped at `max_entries`. The fingerprint
+    /// deliberately excludes the JSON pointer/tool-use id: a recall arrives in a new turn at a new
+    /// pointer, but must still be recognized as the same raw result and pass through in full.
+    pub fn admit(&self, session: &str, bytes: Vec<u8>) -> Result<Admission> {
+        if bytes.len() > self.limits.max_entry_bytes || bytes.len() > self.limits.max_bytes {
+            bail!("recall entry exceeds the configured size limit")
+        }
+        let now = Instant::now();
+        let mut inner = self.inner.lock().expect("recall store lock poisoned");
+        purge_expired(&mut inner, now);
+        let key = fingerprint(&inner.fingerprint_secret, session, &bytes);
+        if inner.fingerprints.contains_key(&key) {
+            return Ok(Admission::Seen);
+        }
+        while inner.entries.len() >= self.limits.max_entries
+            || inner.bytes.saturating_add(bytes.len()) > self.limits.max_bytes
+        {
+            let Some(oldest) = oldest_handle(&inner) else {
+                break;
+            };
+            let _ = remove(&mut inner, &oldest);
+        }
+        if inner.entries.len() >= self.limits.max_entries
+            || inner.bytes.saturating_add(bytes.len()) > self.limits.max_bytes
+        {
+            bail!("recall store has no capacity for entry")
+        }
+        if inner.fingerprints.len() >= self.limits.max_entries
+            && let Some(oldest) = inner
+                .fingerprints
+                .iter()
+                .min_by_key(|(_, when)| *when)
+                .map(|(k, _)| *k)
+        {
+            inner.fingerprints.remove(&oldest);
+        }
+        let handle = new_handle(&inner);
+        let sequence = inner.next_sequence;
+        inner.next_sequence = inner.next_sequence.wrapping_add(1);
+        inner.bytes += bytes.len();
+        inner.entries.insert(
+            handle.clone(),
+            Entry {
+                bytes,
+                expires_at: now + self.limits.ttl,
+                sequence,
+                fingerprint: Some(key),
+            },
+        );
+        inner
+            .fingerprints
+            .insert(key, now + self.limits.ttl.saturating_mul(2));
+        Ok(Admission::Stored(handle))
+    }
+
+    /// Stores exact bytes and returns an unguessable, URL-safe opaque handle.
+    pub fn insert(&self, bytes: Vec<u8>) -> Result<String> {
+        if bytes.len() > self.limits.max_entry_bytes || bytes.len() > self.limits.max_bytes {
+            bail!("recall entry exceeds the configured size limit")
+        }
+        let now = Instant::now();
+        let mut inner = self.inner.lock().expect("recall store lock poisoned");
+        purge_expired(&mut inner, now);
+        while inner.entries.len() >= self.limits.max_entries
+            || inner.bytes.saturating_add(bytes.len()) > self.limits.max_bytes
+        {
+            let Some(oldest) = oldest_handle(&inner) else {
+                break;
+            };
+            let _ = remove(&mut inner, &oldest);
+        }
+        if inner.entries.len() >= self.limits.max_entries
+            || inner.bytes.saturating_add(bytes.len()) > self.limits.max_bytes
+        {
+            bail!("recall store has no capacity for entry")
+        }
+        let handle = new_handle(&inner);
+        let sequence = inner.next_sequence;
+        inner.next_sequence = inner.next_sequence.wrapping_add(1);
+        inner.bytes += bytes.len();
+        inner.entries.insert(
+            handle.clone(),
+            Entry {
+                bytes,
+                expires_at: now + self.limits.ttl,
+                sequence,
+                fingerprint: None,
+            },
+        );
+        Ok(handle)
+    }
+
+    /// Rolls back an uncommitted admission after a later gate rejects its marker. The rerun
+    /// fingerprint must go too: the agent never saw this handle, so a later identical result is
+    /// still a legitimate first arrival.
+    pub fn rollback(&self, handle: &str) {
+        let mut inner = self.inner.lock().expect("recall store lock poisoned");
+        if let Some(entry) = remove(&mut inner, handle)
+            && let Some(fingerprint) = entry.fingerprint
+        {
+            inner.fingerprints.remove(&fingerprint);
+        }
+    }
+
+    /// Retrieves a copy. Entries are multi-use until their fixed expiry.
+    pub fn get(&self, handle: &str) -> Result<Vec<u8>> {
+        if !valid_handle(handle) {
+            bail!("malformed recall handle")
+        }
+        let mut inner = self.inner.lock().expect("recall store lock poisoned");
+        purge_expired(&mut inner, Instant::now());
+        inner
+            .entries
+            .get(handle)
+            .map(|entry| entry.bytes.clone())
+            .ok_or_else(|| anyhow::anyhow!("unknown or expired recall handle"))
+    }
+}
+
+fn new_handle(inner: &Inner) -> String {
+    loop {
+        let mut raw = [0_u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut raw);
+        let handle = format!("r_{}", URL_SAFE_NO_PAD.encode(raw));
+        if !inner.entries.contains_key(&handle) {
+            return handle;
+        }
+    }
+}
+fn valid_handle(handle: &str) -> bool {
+    let Some(encoded) = handle.strip_prefix("r_") else {
+        return false;
+    };
+    encoded.len() == 43
+        && encoded
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+fn fingerprint(secret: &[u8; 32], session: &str, bytes: &[u8]) -> [u8; 32] {
+    // Domain separation and length prefixes prevent tuple ambiguity; the random process secret
+    // keeps session-derived keys unlinkable outside this daemon lifetime.
+    let mut h = Sha256::new();
+    h.update(secret);
+    for part in [session.as_bytes(), bytes] {
+        h.update((part.len() as u64).to_le_bytes());
+        h.update(part);
+    }
+    h.finalize().into()
+}
+fn purge_expired(inner: &mut Inner, now: Instant) {
+    inner.fingerprints.retain(|_, expires| *expires > now);
+    let expired: Vec<String> = inner
+        .entries
+        .iter()
+        .filter(|(_, e)| e.expires_at <= now)
+        .map(|(h, _)| h.clone())
+        .collect();
+    for handle in expired {
+        let _ = remove(inner, &handle);
+    }
+}
+fn oldest_handle(inner: &Inner) -> Option<String> {
+    inner
+        .entries
+        .iter()
+        .min_by_key(|(_, e)| e.sequence)
+        .map(|(h, _)| h.clone())
+}
+fn remove(inner: &mut Inner, handle: &str) -> Option<Entry> {
+    let entry = inner.entries.remove(handle)?;
+    inner.bytes -= entry.bytes.len();
+    Some(entry)
+}
+
+pub type SharedStore = Arc<RecallStore>;
+pub fn from_runtime(config: &llmtrim_core::config::RuntimeConfig) -> SharedStore {
+    Arc::new(RecallStore::new(Limits {
+        ttl: Duration::from_secs(
+            config
+                .first_arrival_recall_ttl_secs
+                .unwrap_or(DEFAULT_TTL.as_secs()),
+        ),
+        max_entries: config
+            .first_arrival_recall_max_entries
+            .unwrap_or(DEFAULT_MAX_ENTRIES),
+        max_bytes: config
+            .first_arrival_recall_max_bytes
+            .unwrap_or(DEFAULT_MAX_BYTES),
+        max_entry_bytes: config
+            .first_arrival_recall_max_entry_bytes
+            .unwrap_or(DEFAULT_MAX_ENTRY_BYTES)
+            .min(MAX_PROTOCOL_RESPONSE_BYTES),
+    }))
+}
+
+/// `GET <length>\n<handle>` requests and `OK|ERR <length>\n<payload>` replies are binary-safe.
+/// The declared length is always checked before allocation or reading payload bytes.
+#[cfg(feature = "intercept")]
+mod wire {
+    use super::*;
+    use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+    pub async fn read_header<R: AsyncRead + Unpin>(stream: &mut R) -> Result<(String, usize)> {
+        let mut header = Vec::new();
+        loop {
+            let mut byte = [0_u8; 1];
+            if stream.read_exact(&mut byte).await.is_err() {
+                bail!("truncated recall frame")
+            }
+            if byte[0] == b'\n' {
+                break;
+            }
+            if header.len() == MAX_HEADER_BYTES {
+                bail!("overlong recall frame header")
+            }
+            header.push(byte[0]);
+        }
+        let header = std::str::from_utf8(&header).context("non-UTF-8 recall frame header")?;
+        let Some((status, len)) = header.split_once(' ') else {
+            bail!("malformed recall frame header")
+        };
+        if status.is_empty() || len.is_empty() || len.contains(' ') {
+            bail!("malformed recall frame header")
+        }
+        let len = len
+            .parse::<usize>()
+            .context("invalid recall frame length")?;
+        Ok((status.to_owned(), len))
+    }
+
+    pub async fn read_exact_bounded<R: AsyncRead + Unpin>(
+        stream: &mut R,
+        len: usize,
+        max: usize,
+    ) -> Result<Vec<u8>> {
+        if len > max {
+            bail!("recall frame exceeds size limit")
+        }
+        let mut body = vec![0; len];
+        stream
+            .read_exact(&mut body)
+            .await
+            .context("truncated recall frame payload")?;
+        Ok(body)
+    }
+
+    pub async fn write_frame<W: AsyncWrite + Unpin>(
+        stream: &mut W,
+        status: &str,
+        body: &[u8],
+        max: usize,
+    ) -> Result<()> {
+        if body.len() > max {
+            bail!("recall frame exceeds size limit")
+        }
+        stream
+            .write_all(format!("{status} {}\n", body.len()).as_bytes())
+            .await?;
+        stream.write_all(body).await?;
+        stream.flush().await?;
+        Ok(())
+    }
+
+    pub async fn serve_connection<S: AsyncRead + AsyncWrite + Unpin>(
+        mut stream: S,
+        store: SharedStore,
+        max_response: usize,
+    ) {
+        let result = tokio::time::timeout(IO_TIMEOUT, async {
+            let (verb, len) = read_header(&mut stream).await?;
+            if verb != "GET" {
+                bail!("malformed recall request")
+            }
+            let request = read_exact_bounded(&mut stream, len, MAX_HANDLE_BYTES).await?;
+            let handle = std::str::from_utf8(&request).context("malformed recall handle")?;
+            store.get(handle)
+        })
+        .await;
+        match result {
+            Ok(Ok(bytes)) => {
+                let _ = tokio::time::timeout(
+                    IO_TIMEOUT,
+                    write_frame(&mut stream, "OK", &bytes, max_response),
+                )
+                .await;
+            }
+            Ok(Err(error)) => {
+                let message = error.to_string();
+                let message = &message.as_bytes()[..message.len().min(MAX_ERROR_BYTES)];
+                let _ = tokio::time::timeout(
+                    IO_TIMEOUT,
+                    write_frame(&mut stream, "ERR", message, MAX_ERROR_BYTES),
+                )
+                .await;
+            }
+            Err(_) => {
+                let _ = tokio::time::timeout(
+                    IO_TIMEOUT,
+                    write_frame(
+                        &mut stream,
+                        "ERR",
+                        b"recall request timed out",
+                        MAX_ERROR_BYTES,
+                    ),
+                )
+                .await;
+            }
+        }
+    }
+
+    pub async fn request_over<S: AsyncRead + AsyncWrite + Unpin>(
+        mut stream: S,
+        handle: &str,
+        max_response: usize,
+    ) -> Result<Vec<u8>> {
+        tokio::time::timeout(IO_TIMEOUT, async {
+            write_frame(&mut stream, "GET", handle.as_bytes(), MAX_HANDLE_BYTES).await?;
+            let (status, len) = read_header(&mut stream).await?;
+            let max = if status == "ERR" {
+                MAX_ERROR_BYTES
+            } else {
+                max_response
+            };
+            let body = read_exact_bounded(&mut stream, len, max).await?;
+            match status.as_str() {
+                "OK" => Ok(body),
+                "ERR" if len <= MAX_ERROR_BYTES => bail!("{}", String::from_utf8_lossy(&body)),
+                _ => bail!("malformed recall response"),
+            }
+        })
+        .await
+        .context("recall request timed out")?
+    }
+}
+
+#[cfg(all(unix, feature = "intercept"))]
+fn socket_path() -> Result<std::path::PathBuf> {
+    Ok(crate::daemon::home_dir()?.join("recall.sock"))
+}
+
+#[cfg(feature = "intercept")]
+fn client_max_response() -> usize {
+    llmtrim_core::config::RuntimeConfig::get()
+        .first_arrival_recall_max_entry_bytes
+        .unwrap_or(DEFAULT_MAX_ENTRY_BYTES)
+        .min(MAX_PROTOCOL_RESPONSE_BYTES)
+}
+
+#[cfg(all(unix, feature = "intercept"))]
+pub fn request(handle: &str) -> Result<Vec<u8>> {
+    if !valid_handle(handle) {
+        bail!("malformed recall handle")
+    }
+    let path = socket_path()?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()?;
+    runtime.block_on(async {
+        let stream = tokio::time::timeout(IO_TIMEOUT, tokio::net::UnixStream::connect(&path))
+            .await
+            .context("recall connect timed out")?
+            .with_context(|| format!("recall daemon unavailable at {}", path.display()))?;
+        wire::request_over(stream, handle, client_max_response()).await
+    })
+}
+
+#[cfg(all(unix, not(feature = "intercept")))]
+pub fn request(_handle: &str) -> Result<Vec<u8>> {
+    bail!("recall requires the interceptor build feature")
+}
+
+#[cfg(windows)]
+fn pipe_name() -> Result<String> {
+    let user = std::env::var("USERNAME").or_else(|_| std::env::var("USER"))?;
+    Ok(format!(r"\\.\pipe\llmtrim-recall-{user}"))
+}
+
+#[cfg(all(windows, feature = "intercept"))]
+pub fn request(handle: &str) -> Result<Vec<u8>> {
+    use tokio::net::windows::named_pipe::ClientOptions;
+    if !valid_handle(handle) {
+        bail!("malformed recall handle")
+    }
+    let name = pipe_name()?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()?;
+    runtime.block_on(async {
+        let stream = tokio::time::timeout(IO_TIMEOUT, async {
+            loop {
+                match ClientOptions::new().open(&name) {
+                    Ok(pipe) => return Ok(pipe),
+                    Err(error)
+                        if error.kind() == std::io::ErrorKind::NotFound
+                            || error.raw_os_error()
+                                == Some(windows_sys::Win32::Foundation::ERROR_PIPE_BUSY as i32) =>
+                    {
+                        tokio::time::sleep(Duration::from_millis(20)).await
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+        })
+        .await
+        .context("recall connect timed out")??;
+        wire::request_over(stream, handle, client_max_response()).await
+    })
+}
+
+#[cfg(all(windows, not(feature = "intercept")))]
+pub fn request(_handle: &str) -> Result<Vec<u8>> {
+    bail!("recall requires the interceptor build feature")
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn request(_handle: &str) -> Result<Vec<u8>> {
+    bail!("recall is unsupported on this platform")
+}
+
+#[cfg(all(unix, feature = "intercept"))]
+struct SocketOwner(std::path::PathBuf);
+#[cfg(all(unix, feature = "intercept"))]
+impl Drop for SocketOwner {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+#[cfg(all(unix, feature = "intercept"))]
+fn ensure_private_socket_parent(path: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    let parent = path
+        .parent()
+        .context("recall socket has no parent directory")?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create {}", parent.display()))?;
+    let metadata = std::fs::symlink_metadata(parent)?;
+    if !metadata.is_dir()
+        || metadata.file_type().is_symlink()
+        || metadata.uid() != nix::unistd::geteuid().as_raw()
+    {
+        bail!("recall socket parent is not a private directory owned by this user")
+    }
+    if metadata.mode() & 0o077 != 0 {
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+    }
+    if std::fs::symlink_metadata(parent)?.mode() & 0o077 != 0 {
+        bail!("recall socket parent is accessible by other users")
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, feature = "intercept"))]
+pub async fn serve(store: SharedStore) -> Result<()> {
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+    let path = socket_path()?;
+    ensure_private_socket_parent(&path)?;
+    if let Ok(metadata) = std::fs::symlink_metadata(&path) {
+        if !metadata.file_type().is_socket() {
+            bail!("refusing to replace non-socket recall endpoint")
+        }
+        match tokio::time::timeout(IO_TIMEOUT, tokio::net::UnixStream::connect(&path)).await {
+            Ok(Ok(_)) | Err(_) => bail!("recall endpoint is already owned by a running daemon"),
+            Ok(Err(error)) if error.kind() == std::io::ErrorKind::ConnectionRefused => {
+                std::fs::remove_file(&path)
+                    .with_context(|| format!("failed to remove stale {}", path.display()))?
+            }
+            Ok(Err(error)) => return Err(error).context("failed to probe recall endpoint"),
+        }
+    }
+    let listener = tokio::net::UnixListener::bind(&path)
+        .with_context(|| format!("failed to bind {}", path.display()))?;
+    let owner = SocketOwner(path.clone());
+    if let Err(error) = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)) {
+        drop(owner);
+        return Err(error.into());
+    }
+    let max_response = store.limits.max_entry_bytes;
+    tokio::spawn(async move {
+        let _owner = owner;
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(wire::serve_connection(stream, store.clone(), max_response));
+        }
+    });
+    Ok(())
+}
+
+#[cfg(all(windows, feature = "intercept"))]
+pub async fn serve(store: SharedStore) -> Result<()> {
+    use tokio::net::windows::named_pipe::ServerOptions;
+    let name = pipe_name()?;
+    let max_response = store.limits.max_entry_bytes;
+    tokio::spawn(async move {
+        // Tokio's default security descriptor uses the creating user's default DACL; reject
+        // remote clients and FIRST_PIPE_INSTANCE prevent network peers and pipe-name takeover.
+        let mut first = true;
+        loop {
+            let pipe = match ServerOptions::new()
+                .first_pipe_instance(first)
+                .reject_remote_clients(true)
+                .create(&name)
+            {
+                Ok(pipe) => pipe,
+                Err(_) => break,
+            };
+            first = false;
+            if pipe.connect().await.is_err() {
+                continue;
+            }
+            tokio::spawn(wire::serve_connection(pipe, store.clone(), max_response));
+        }
+    });
+    Ok(())
+}
+
+#[cfg(not(all(any(unix, windows), feature = "intercept")))]
+pub async fn serve(_store: SharedStore) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "intercept")]
+    use tokio::io::AsyncWriteExt;
+    #[test]
+    fn exact_bytes_and_multi_use() {
+        let s = RecallStore::new(Limits::default());
+        let bytes = b"nul\0unicode: \xF0\x9F\xA6\x80".to_vec();
+        let h = s.insert(bytes.clone()).unwrap();
+        assert!(valid_handle(&h));
+        assert_eq!(s.get(&h).unwrap(), bytes);
+        assert_eq!(s.get(&h).unwrap(), bytes);
+    }
+    #[test]
+    fn limits_evict_oldest_and_reject_oversized() {
+        let s = RecallStore::new(Limits {
+            ttl: Duration::from_secs(60),
+            max_entries: 2,
+            max_bytes: 4,
+            max_entry_bytes: 3,
+        });
+        let a = s.insert(vec![1]).unwrap();
+        let b = s.insert(vec![2]).unwrap();
+        let _ = s.insert(vec![3, 4, 5]).unwrap();
+        assert!(s.get(&a).is_err());
+        assert!(s.get(&b).is_ok());
+        assert!(s.insert(vec![0; 4]).is_err());
+    }
+    #[test]
+    fn seen_session_scoped_rerun_is_not_readmitted() {
+        let s = RecallStore::new(Limits::default());
+        assert!(matches!(
+            s.admit("s1", b"raw".to_vec()).unwrap(),
+            Admission::Stored(_)
+        ));
+        assert!(matches!(
+            s.admit("s1", b"raw".to_vec()).unwrap(),
+            Admission::Seen
+        ));
+        assert!(matches!(
+            s.admit("s2", b"raw".to_vec()).unwrap(),
+            Admission::Stored(_)
+        ));
+    }
+    #[test]
+    fn rolled_back_admission_can_be_admitted_again() {
+        let s = RecallStore::new(Limits::default());
+        let Admission::Stored(handle) = s.admit("s1", b"raw".to_vec()).unwrap() else {
+            panic!("first result must be stored");
+        };
+        s.rollback(&handle);
+        assert!(s.get(&handle).is_err());
+        assert!(matches!(
+            s.admit("s1", b"raw".to_vec()).unwrap(),
+            Admission::Stored(_)
+        ));
+    }
+
+    #[test]
+    fn malformed_and_unknown_fail() {
+        let s = RecallStore::new(Limits::default());
+        assert!(s.get("bad").is_err());
+        assert!(s.get(&format!("r_{}", "A".repeat(43))).is_err());
+    }
+    #[test]
+    fn immediate_expiry() {
+        let s = RecallStore::new(Limits {
+            ttl: Duration::ZERO,
+            ..Limits::default()
+        });
+        let h = s.insert(vec![1]).unwrap();
+        assert!(s.get(&h).is_err());
+    }
+
+    #[cfg(feature = "intercept")]
+    #[tokio::test]
+    async fn framed_response_preserves_err_prefix_nul_and_unicode() {
+        let payload = b"ERR \0unicode: \xF0\x9F\xA6\x80".to_vec();
+        let (mut client, mut server) = tokio::io::duplex(256);
+        let handle = format!("r_{}", "A".repeat(43));
+        let expected = payload.clone();
+        let peer = tokio::spawn(async move {
+            let (verb, len) = wire::read_header(&mut server).await.unwrap();
+            assert_eq!(verb, "GET");
+            let _ = wire::read_exact_bounded(&mut server, len, MAX_HANDLE_BYTES)
+                .await
+                .unwrap();
+            wire::write_frame(&mut server, "OK", &expected, 128)
+                .await
+                .unwrap();
+        });
+        assert_eq!(
+            wire::request_over(&mut client, &handle, 128).await.unwrap(),
+            payload
+        );
+        peer.await.unwrap();
+    }
+
+    #[cfg(feature = "intercept")]
+    #[tokio::test]
+    async fn protocol_rejects_overlong_headers_and_payloads() {
+        let (mut writer, mut reader) = tokio::io::duplex(256);
+        let peer = tokio::spawn(async move {
+            writer
+                .write_all(&[b'x'; MAX_HEADER_BYTES + 1])
+                .await
+                .unwrap();
+            writer.write_all(b"\n").await.unwrap();
+        });
+        assert!(wire::read_header(&mut reader).await.is_err());
+        peer.await.unwrap();
+        let (mut writer, _reader) = tokio::io::duplex(256);
+        assert!(
+            wire::write_frame(&mut writer, "OK", &[0; 129], 128)
+                .await
+                .is_err()
+        );
+    }
+
+    #[cfg(all(unix, feature = "intercept"))]
+    #[test]
+    fn private_parent_is_created_and_restricted() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("llmtrim-recall-test-{}", std::process::id()));
+        let path = dir.join("recall.sock");
+        ensure_private_socket_parent(&path).unwrap();
+        assert_eq!(
+            std::fs::metadata(&dir).unwrap().permissions().mode() & 0o077,
+            0
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1735,6 +1735,8 @@ mod imp {
         /// clones so a conversation's earlier-turn compressed prefix is reusable on its next
         /// turn — keeping the provider prefix cache warm on agent loops. In-memory only.
         memo: Arc<Memo>,
+        /// Same daemon-owned store served by the local recall IPC endpoint.
+        recall: Option<crate::recall::SharedStore>,
         /// The compressed request awaiting its response (set in `handle_request`).
         pending: Option<Pending>,
         /// Whether this request asked for a streamed reply (set in `handle_request`, read by
@@ -2208,6 +2210,7 @@ mod imp {
                             ProviderKind::Anthropic,
                             None,
                             &memo,
+                            None,
                             sid,
                         )
                     })
@@ -2260,6 +2263,7 @@ mod imp {
             // everyone). Cheap to move in: `Bytes` is ref-counted, `config` is an `Arc`.
             let config = self.config.clone();
             let memo = self.memo.clone();
+            let recall = self.recall.clone();
             let body_for_compress = bytes.clone();
             // Gemini/Vertex carry the model in the URL, not the body; capture it so the
             // capability gate can see it (the body-only lookup returns nothing for them).
@@ -2271,6 +2275,7 @@ mod imp {
                     provider,
                     model_override.as_deref(),
                     &memo,
+                    recall.as_deref(),
                     cc_session_id,
                 )
             })
@@ -2468,10 +2473,19 @@ mod imp {
             if compact_candidates.is_empty() {
                 let config = self.config.clone();
                 let memo = self.memo.clone();
+                let recall = self.recall.clone();
                 let raw = bytes.clone();
                 let sid = session_id.clone();
                 compressed = tokio::task::spawn_blocking(move || {
-                    compress_blocking(&config, &raw, ProviderKind::Anthropic, None, &memo, sid)
+                    compress_blocking(
+                        &config,
+                        &raw,
+                        ProviderKind::Anthropic,
+                        None,
+                        &memo,
+                        recall.as_deref(),
+                        sid,
+                    )
                 })
                 .await
                 .ok()
@@ -2490,6 +2504,7 @@ mod imp {
                             ProviderKind::Anthropic,
                             Some(&model),
                             &memo,
+                            None,
                             sid,
                         )
                     })
@@ -3806,6 +3821,7 @@ mod imp {
                         ProviderKind::Anthropic,
                         Some(&model),
                         &memo,
+                        None,
                         sid,
                     )
                 })
@@ -3930,7 +3946,15 @@ mod imp {
                 let memo = self.memo.clone();
                 let sid = state.session_id.clone();
                 let (json, next) = tokio::task::spawn_blocking(move || {
-                    compress_blocking(&config, &raw, ProviderKind::Anthropic, None, &memo, sid)
+                    compress_blocking(
+                        &config,
+                        &raw,
+                        ProviderKind::Anthropic,
+                        None,
+                        &memo,
+                        None,
+                        sid,
+                    )
                 })
                 .await
                 .ok()
@@ -4202,12 +4226,112 @@ mod imp {
         (!model.is_empty()).then_some(model)
     }
 
+    /// Recovery is available only when the caller actually supplied a Bash tool definition. A
+    /// model mentioning Bash in prose is not evidence that it can execute `llmtrim recall`.
+    fn has_bash_tool_definition(value: &Value) -> bool {
+        value
+            .get("tools")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|tool| {
+                tool.get("name")
+                    .or_else(|| tool.pointer("/function/name"))
+                    .and_then(Value::as_str)
+            })
+            .any(|name| name.eq_ignore_ascii_case("bash"))
+    }
+
+    /// A successful recall is already the recovery path. Its Bash result must pass through rather
+    /// than being admitted and windowed again, which would turn recovery into a marker loop.
+    fn is_recall_tool_result(value: &Value, content_pointer: &str) -> bool {
+        let Some(block_pointer) = content_pointer.strip_suffix("/content") else {
+            return false;
+        };
+        let Some(tool_use_id) = value
+            .pointer(&format!("{block_pointer}/tool_use_id"))
+            .and_then(Value::as_str)
+        else {
+            return false;
+        };
+        value
+            .get("messages")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .flat_map(|message| {
+                message
+                    .get("content")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+            })
+            .any(|block| {
+                block.get("type").and_then(Value::as_str) == Some("tool_use")
+                    && block.get("id").and_then(Value::as_str) == Some(tool_use_id)
+                    && block.get("name").and_then(Value::as_str) == Some("Bash")
+                    && block
+                        .pointer("/input/command")
+                        .and_then(Value::as_str)
+                        .is_some_and(|command| {
+                            let words: Vec<&str> = command.split_ascii_whitespace().collect();
+                            words.len() == 3
+                                && words[0].ends_with("llmtrim")
+                                && words[1] == "recall"
+                                && words[2].starts_with("r_")
+                        })
+            })
+    }
+
+    /// Rolls back every stored recall entry unless its exact marker reaches the intended JSON
+    /// pointer in the final body. This covers parse/compression failures and every token/body gate.
+    struct AdmissionGuard<'a> {
+        recall: Option<&'a crate::recall::RecallStore>,
+        entries: Vec<(String, String)>,
+    }
+
+    impl AdmissionGuard<'_> {
+        fn commit(&mut self, body: &str) {
+            let Ok(value) = serde_json::from_str::<Value>(body) else {
+                return;
+            };
+            let mut committed = Vec::new();
+            for (pointer, handle) in self.entries.drain(..) {
+                let present = value.pointer(&pointer).and_then(Value::as_str).is_some_and(|text| {
+                    text.lines().any(|line| line == format!(
+                        "[llmtrim: full output: llmtrim recall {handle}; if unavailable, re-run the tool]"
+                    ))
+                });
+                if !present {
+                    if let Some(recall) = self.recall {
+                        recall.rollback(&handle);
+                    }
+                } else {
+                    committed.push((pointer, handle));
+                }
+            }
+            // Kept entries are committed: suppress Drop cleanup.
+            drop(committed);
+        }
+    }
+
+    impl Drop for AdmissionGuard<'_> {
+        fn drop(&mut self) {
+            if let Some(recall) = self.recall {
+                for (_, handle) in &self.entries {
+                    recall.rollback(handle);
+                }
+            }
+        }
+    }
+
     fn compress_blocking(
         config: &DenseConfig,
         body: &[u8],
         provider: ProviderKind,
         model_override: Option<&str>,
         memo: &Memo,
+        recall: Option<&crate::recall::RecallStore>,
         cc_session_id: Option<String>,
     ) -> Option<(String, Pending)> {
         let text = std::str::from_utf8(body).ok()?;
@@ -4222,9 +4346,45 @@ mod imp {
             .and_then(|v| llmtrim_core::provider::detect(&v))
             .unwrap_or(provider);
         let started = std::time::Instant::now();
-        let mut result =
-            llmtrim_core::compress_with_config_model(text, Some(kind), config, model_override)
-                .ok()?;
+        // Fail closed unless the request proves both Claude Code identity (its session header)
+        // and practical recovery availability (an actual Bash definition).
+        let mut recovery_hints = std::collections::BTreeMap::new();
+        let mut admissions = AdmissionGuard {
+            recall,
+            entries: Vec::new(),
+        };
+        let value: Value = serde_json::from_str(text).ok()?;
+        if RuntimeConfig::get().first_arrival_recall
+            && kind == ProviderKind::Anthropic
+            && let (Some(session), Some(recall)) = (cc_session_id.as_deref(), recall)
+            && has_bash_tool_definition(&value)
+        {
+            let req = llmtrim_core::ir::Request::from_value(kind, value.clone());
+            let adapter = llmtrim_core::provider::for_kind(kind);
+            for pointer in
+                llmtrim_core::cache_zone::first_arrival_tool_result_pointers(&req, adapter.as_ref())
+            {
+                if !is_recall_tool_result(&value, &pointer)
+                    && let Some(raw) = req.get_str(&pointer)
+                    && let Ok(crate::recall::Admission::Stored(handle)) =
+                        recall.admit(session, raw.as_bytes().to_vec())
+                {
+                    recovery_hints.insert(pointer.clone(), handle.clone());
+                    admissions.entries.push((pointer, handle));
+                }
+            }
+        }
+        let mut result = llmtrim_core::compress_with_config_model_and_recovery(
+            text,
+            Some(kind),
+            config,
+            model_override,
+            recovery_hints,
+        )
+        .ok()?;
+        // Replay previously-forwarded prefix bytes before deciding whether this turn has a net
+        // win. A turn with no fresh savings may still need replay to preserve the provider cache.
+        apply_turn_memo(config, memo, kind, text, &mut result);
         // Never forward a request larger than we received. On tiny or non-chat bodies (e.g.
         // token-count / auxiliary calls) the input-side stages can't offset the output-control
         // instruction's fixed cost, so the compressed form is a net token *increase*. Forward
@@ -4232,10 +4392,9 @@ mod imp {
         // zero-savings row: the dashboard's request count and savings %s must describe ALL
         // proxied chat traffic, not just the wins (else the % is a self-selected best case).
         //
-        // The turn-stability memo runs only on the compression-*success* path below, so its
-        // invariant is clean — it stores and replays exactly the bytes we forward as the
-        // compressed body. Passthrough requests (the original is forwarded) are left stateless,
-        // so a later turn never replays a compressed prefix the provider never actually cached.
+        // Memo replay ran above because an older shaped prefix must stay byte-stable even when
+        // this turn has no fresh savings. Recording remains below this gate: passthrough requests
+        // never commit candidate bytes the provider did not actually cache.
         if result.input_tokens_after >= result.input_tokens_before {
             let pending = Pending {
                 provider: kind,
@@ -4263,13 +4422,12 @@ mod imp {
             };
             return Some((text.to_string(), pending));
         }
-        // Compression won: replay an already-seen conversation prefix's compressed bytes verbatim
-        // across turns so the provider prefix cache stays warm (the highest-traffic agent-loop
-        // shape). The memo only reuses bytes it itself produced for a byte-identical earlier
-        // message and keeps the result ≤ the original, so it can't flip this win into a loss;
-        // it recomputes `input_after` over the rewritten body so the ledger stays honest.
-        apply_turn_memo(config, memo, kind, text, &mut result);
+        // The selected body is a real win (fresh compression and/or stable-prefix replay). Only
+        // now commit it for the next turn; a body reverted above must never enter the memo.
+        record_turn_memo(config, memo, kind, text, &result);
         let compress_micros = started.elapsed().as_micros() as i64;
+        let admitted = admissions.entries.clone();
+        admissions.commit(&result.request_json);
         let pending = Pending {
             // The detected kind, not the host fallback — `handle_response` reads the response
             // usage with this provider's field shapes, so it must match what we compressed as.
@@ -4296,7 +4454,13 @@ mod imp {
             fallback: None,
             compact: None,
         };
-        capture_pair(text, &result.request_json, &pending, &result.stages);
+        capture_pair(
+            text,
+            &result.request_json,
+            &pending,
+            &result.stages,
+            &admitted,
+        );
         Some((result.request_json, pending))
     }
 
@@ -4332,11 +4496,20 @@ mod imp {
         }
     }
 
+    /// Capture artifacts are audit data, not a capability channel. Never persist recall handles.
+    fn redact_recall_handles(text: &str) -> String {
+        regex::Regex::new(r"r_[A-Za-z0-9_-]{43}")
+            .expect("constant recall-handle regex")
+            .replace_all(text, "r_[redacted]")
+            .into_owned()
+    }
+
     fn capture_pair(
         before: &str,
         after: &str,
         pending: &Pending,
         stages: &[llmtrim_core::pipeline::StageReport],
+        admitted: &[(String, String)],
     ) {
         let Some(dir_path) = RuntimeConfig::get().capture_dir.clone() else {
             return;
@@ -4350,6 +4523,21 @@ mod imp {
             .filter(|s| s.applied)
             .map(|s| s.name.as_str())
             .collect();
+        // Capture artifacts historically store request bodies as JSON *strings*. Parse only to
+        // sanitize admitted pointers, then serialize straight back to that schema.
+        let captured_before = match serde_json::from_str::<Value>(before) {
+            Ok(mut value) => {
+                for (pointer, _) in admitted {
+                    if let Some(value) = value.pointer_mut(pointer) {
+                        *value =
+                            Value::String("[llmtrim: admitted tool output redacted]".to_string());
+                    }
+                }
+                serde_json::to_string(&value).unwrap_or_else(|_| before.to_string())
+            }
+            Err(_) => before.to_string(),
+        };
+        let captured_after = redact_recall_handles(after);
         let record = serde_json::json!({
             "ts": chrono::Utc::now().to_rfc3339(),
             "provider": pending.provider.as_str(),
@@ -4359,8 +4547,8 @@ mod imp {
             "output_shaped": pending.output_shaped,
             "stages": stages_applied,
             "plan": pending.plan,
-            "before": before,
-            "after": after,
+            "before": captured_before,
+            "after": captured_after,
         });
         let name = format!(
             "{}-{:x}.json",
@@ -4433,7 +4621,7 @@ mod imp {
 
     /// Apply the turn-stability memo to a freshly compressed `result`, in place. Replays an
     /// already-seen conversation prefix's compressed `content` verbatim (keeping the provider
-    /// prefix cache warm) and records this turn for the next one. On reuse it recomputes
+    /// prefix cache warm) without recording this candidate. On reuse it recomputes
     /// `input_tokens_after` over the rewritten body so the recorded savings reflect what is
     /// actually sent. No-op (full stateless behavior) when the flag is off, the n-gram carve-out
     /// applies, or the JSON can't be re-parsed.
@@ -4478,7 +4666,7 @@ mod imp {
             "{kind:?}|{lineup}|{}",
             serde_json::to_string(config).unwrap_or_default()
         );
-        let reused = llmtrim_core::memo::apply(memo, salt.as_bytes(), &original, &mut compressed);
+        let reused = llmtrim_core::memo::replay(memo, salt.as_bytes(), &original, &mut compressed);
         if reused == 0 {
             // Either nothing matched (cold prefix) or an unmodelled shape: `compressed` is
             // unchanged from `result.request_json`, so leave the result (and its counts) as-is.
@@ -4490,14 +4678,51 @@ mod imp {
         let Ok(rewritten) = serde_json::to_string(&compressed) else {
             return;
         };
-        if let Ok(counter) = llmtrim_core::tokenizer::counter_for(kind, result.model.as_deref()) {
-            let adapter = llmtrim_core::provider::for_kind(kind);
-            let req = llmtrim_core::ir::Request::from_value(kind, compressed);
-            let after =
-                llmtrim_core::pipeline::content_tokens(&req, adapter.as_ref(), counter.as_ref());
-            result.input_tokens_after = llmtrim_core::tokenizer::Tokens(after);
+        let Ok(counter) = llmtrim_core::tokenizer::counter_for(kind, result.model.as_deref())
+        else {
+            return;
+        };
+        let adapter = llmtrim_core::provider::for_kind(kind);
+        let req = llmtrim_core::ir::Request::from_value(kind, compressed);
+        let after =
+            llmtrim_core::pipeline::content_tokens(&req, adapter.as_ref(), counter.as_ref());
+        // A context-dependent earlier representation can be larger than this turn's fresh
+        // compression. Cache stability never justifies forwarding a request that lost its win.
+        if after >= result.input_tokens_before.0 {
+            return;
         }
+        result.input_tokens_after = llmtrim_core::tokenizer::Tokens(after);
         result.request_json = rewritten;
+    }
+
+    /// Commit exactly the selected wire body after all token and admission gates accepted it.
+    fn record_turn_memo(
+        config: &DenseConfig,
+        memo: &Memo,
+        kind: ProviderKind,
+        original_body: &str,
+        result: &llmtrim_core::CompressResult,
+    ) {
+        if !config.memo || result.stages.iter().any(|s| s.applied && s.name == "ngram") {
+            return;
+        }
+        let (Ok(original), Ok(forwarded)) = (
+            serde_json::from_str::<Value>(original_body),
+            serde_json::from_str::<Value>(&result.request_json),
+        ) else {
+            return;
+        };
+        let lineup = result
+            .stages
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+        let salt = format!(
+            "{kind:?}|{lineup}|{}",
+            serde_json::to_string(config).unwrap_or_default()
+        );
+        llmtrim_core::memo::record(memo, salt.as_bytes(), &original, &forwarded);
     }
 
     /// Owns the accumulated response bytes; on drop (stream complete/aborted) it measures
@@ -5084,6 +5309,9 @@ mod imp {
             domains: Arc::new(covered_domains()),
             // One process-wide turn-stability memo, shared across the per-request handler clones.
             memo: Arc::new(Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY)),
+            recall: RuntimeConfig::get()
+                .first_arrival_recall
+                .then(|| crate::recall::from_runtime(RuntimeConfig::get())),
             pending: None,
             streaming: false,
             upstream_proxy: upstream_proxy.clone(),
@@ -5144,6 +5372,12 @@ mod imp {
                 }
             })?,
         );
+        // Only opt-in recall starts a control endpoint. Do this after the proxy pre-flight
+        // bind, so a second daemon failing to claim the proxy port never touches its endpoint.
+        if let Some(recall) = handler.recall.clone() {
+            crate::recall::serve(recall).await?;
+        }
+
         eprintln!("llmtrim: MITM interceptor on http://{addr}");
         eprintln!("  export HTTPS_PROXY=http://{addr}");
         eprintln!(
@@ -6790,17 +7024,49 @@ mod imp {
         }
 
         #[test]
+        fn recalled_bash_result_is_never_readmitted() {
+            let value = serde_json::json!({
+                "messages": [
+                    {"role": "assistant", "content": [{
+                        "type": "tool_use", "id": "call_recall", "name": "Bash",
+                        "input": {"command": format!("llmtrim recall r_{}", "A".repeat(43))}
+                    }]},
+                    {"role": "user", "content": [{
+                        "type": "tool_result", "tool_use_id": "call_recall", "content": "raw"
+                    }]}
+                ]
+            });
+            assert!(is_recall_tool_result(
+                &value,
+                "/messages/1/content/0/content"
+            ));
+            assert!(!is_recall_tool_result(
+                &value,
+                "/messages/0/content/0/content"
+            ));
+        }
+
+        #[test]
         fn compress_blocking_rejects_non_json() {
             use llmtrim_core::config::DenseConfig;
             use llmtrim_core::ir::ProviderKind;
             let cfg = DenseConfig::default();
             let memo = Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY);
             assert!(
-                compress_blocking(&cfg, b"not json", ProviderKind::OpenAi, None, &memo, None)
-                    .is_none()
+                compress_blocking(
+                    &cfg,
+                    b"not json",
+                    ProviderKind::OpenAi,
+                    None,
+                    &memo,
+                    None,
+                    None
+                )
+                .is_none()
             );
             assert!(
-                compress_blocking(&cfg, b"", ProviderKind::OpenAi, None, &memo, None).is_none()
+                compress_blocking(&cfg, b"", ProviderKind::OpenAi, None, &memo, None, None)
+                    .is_none()
             );
         }
 
@@ -6820,6 +7086,7 @@ mod imp {
                 ProviderKind::OpenAi,
                 None,
                 &memo,
+                None,
                 None,
             ) {
                 assert!(
@@ -6853,6 +7120,7 @@ mod imp {
                 ProviderKind::OpenAi,
                 None,
                 &memo,
+                None,
                 None,
             )
             .expect("50 identical log lines must produce a net token win");
@@ -7027,6 +7295,7 @@ mod imp {
                 None,
                 &memo,
                 None,
+                None,
             ) {
                 // compress_blocking now always returns Some for valid JSON, even on zero-savings
                 // inputs (the caller records the row; `input_after == input_before` means
@@ -7070,6 +7339,7 @@ mod imp {
                 breakdown_ledger: breakdown_tx,
                 domains: Arc::new(intercept_domains().into_iter().collect()),
                 memo: Arc::new(Memo::with_capacity(llmtrim_core::memo::DEFAULT_CAPACITY)),
+                recall: None,
                 pending: None,
                 streaming: false,
                 upstream_proxy: None,

--- a/crates/llmtrim-core/src/cache_zone.rs
+++ b/crates/llmtrim-core/src/cache_zone.rs
@@ -7,8 +7,10 @@
 //! false economy" trap). So content-mutating stages ordinarily compress only the **live zone**:
 //! the segments after the last `cache_control` marker. Tool output has one narrow exception: a
 //! tool result in the final marked message receives terminal-equivalent normalization as that
-//! cache entry is first written, then the turn memo replays the emitted bytes verbatim. Template
-//! folding and lossy windowing remain confined to the live zone.
+//! cache entry is first written, then the turn memo replays the emitted bytes verbatim. An
+//! experimental opt-in may lossily shape an admitted result and attach a daemon-memory recall
+//! handle (five-hour default TTL); without that admission, template folding and lossy windowing
+//! remain confined to the live zone.
 //!
 //! No markers ⇒ no known cache ⇒ everything is compressible (behavior unchanged):
 //! determinism keeps an identical prefix cache-stable across calls, and Stage A's OpenAI
@@ -36,7 +38,8 @@ pub fn compressible_pointers(req: &Request, provider: &dyn Provider) -> Vec<Stri
 
 /// Tool-result pointers entering the cache at the final breakpoint. Claude Code may append a
 /// system reminder carrying the marker after the result, so skip those trailing system messages
-/// and select the adjacent tool-result message. Lossy transforms remain confined to the live zone.
+/// and select the adjacent tool-result message. Callers must still require a durable recovery
+/// admission before applying any lossy transform at these otherwise-frozen pointers.
 pub fn first_arrival_tool_result_pointers(req: &Request, provider: &dyn Provider) -> Vec<String> {
     let Some(messages) = req.raw().get("messages").and_then(Value::as_array) else {
         return Vec::new();

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -542,6 +542,11 @@ pub(crate) const RUNTIME_ONLY_KEYS: &[&str] = &[
     "theme",
     "sub",
     "compact",
+    "first_arrival_recall",
+    "first_arrival_recall_ttl_secs",
+    "first_arrival_recall_max_entries",
+    "first_arrival_recall_max_bytes",
+    "first_arrival_recall_max_entry_bytes",
 ];
 
 /// The resolved config-file path (`LLMTRIM_CONFIG`, else `$XDG_CONFIG_HOME`/`$HOME/.config` +
@@ -924,6 +929,18 @@ pub struct RuntimeConfig {
     /// model substitution is disabled. File-only: model routing is persistent policy, not an
     /// environment toggle.
     pub compact_models: Vec<String>,
+    /// Enable recoverable lossy first-arrival tool-output shaping (default true). It activates on
+    /// auto-routed agent requests; set false to retain normalization-only cache writes. Raw output
+    /// remains only in daemon memory and can be recalled for the configured TTL.
+    pub first_arrival_recall: bool,
+    /// Recall-store TTL in seconds; unset uses five hours (18,000 seconds).
+    pub first_arrival_recall_ttl_secs: Option<u64>,
+    /// Recall-store entry cap; unset uses 256.
+    pub first_arrival_recall_max_entries: Option<usize>,
+    /// Recall-store aggregate byte cap; unset uses 64 MiB.
+    pub first_arrival_recall_max_bytes: Option<usize>,
+    /// Recall-store per-entry byte cap; unset uses 8 MiB.
+    pub first_arrival_recall_max_entry_bytes: Option<usize>,
 }
 
 impl RuntimeConfig {
@@ -1012,6 +1029,36 @@ impl RuntimeConfig {
             sub_effort: resolve_sub_effort(&env, file),
             sub_codex_previous_response_id: resolve_sub_codex_continuation(&env, file),
             compact_models: resolve_compact_models(file),
+            first_arrival_recall: env_set("LLMTRIM_FIRST_ARRIVAL_RECALL")
+                .and_then(|s| s.parse().ok())
+                .or_else(|| fbool("first_arrival_recall"))
+                .unwrap_or(true),
+            first_arrival_recall_ttl_secs: env_set("LLMTRIM_FIRST_ARRIVAL_RECALL_TTL_SECS")
+                .and_then(|s| s.parse().ok())
+                .or_else(|| {
+                    fint("first_arrival_recall_ttl_secs").and_then(|n| u64::try_from(n).ok())
+                })
+                .filter(|n| *n > 0),
+            first_arrival_recall_max_entries: env_set("LLMTRIM_FIRST_ARRIVAL_RECALL_MAX_ENTRIES")
+                .and_then(|s| s.parse().ok())
+                .or_else(|| {
+                    fint("first_arrival_recall_max_entries").and_then(|n| usize::try_from(n).ok())
+                })
+                .filter(|n| *n > 0),
+            first_arrival_recall_max_bytes: env_set("LLMTRIM_FIRST_ARRIVAL_RECALL_MAX_BYTES")
+                .and_then(|s| s.parse().ok())
+                .or_else(|| {
+                    fint("first_arrival_recall_max_bytes").and_then(|n| usize::try_from(n).ok())
+                })
+                .filter(|n| *n > 0),
+            first_arrival_recall_max_entry_bytes: env_set(
+                "LLMTRIM_FIRST_ARRIVAL_RECALL_MAX_ENTRY_BYTES",
+            )
+            .and_then(|s| s.parse().ok())
+            .or_else(|| {
+                fint("first_arrival_recall_max_entry_bytes").and_then(|n| usize::try_from(n).ok())
+            })
+            .filter(|n| *n > 0),
         }
     }
 }
@@ -2790,6 +2837,29 @@ active = \"off\"
             c.hygiene && c.serialize,
             "retention_days is ignored by DenseConfig"
         );
+    }
+
+    #[test]
+    fn first_arrival_recall_defaults_on_allows_opt_out_and_parses_limits() {
+        let defaults = resolve_file("");
+        assert!(defaults.first_arrival_recall);
+        assert_eq!(defaults.first_arrival_recall_ttl_secs, None);
+        assert!(!resolve_file("first_arrival_recall = false").first_arrival_recall);
+        let c = resolve_env(
+            &[
+                ("LLMTRIM_FIRST_ARRIVAL_RECALL", "true"),
+                ("LLMTRIM_FIRST_ARRIVAL_RECALL_TTL_SECS", "60"),
+                ("LLMTRIM_FIRST_ARRIVAL_RECALL_MAX_ENTRIES", "2"),
+                ("LLMTRIM_FIRST_ARRIVAL_RECALL_MAX_BYTES", "1024"),
+                ("LLMTRIM_FIRST_ARRIVAL_RECALL_MAX_ENTRY_BYTES", "256"),
+            ],
+            "first_arrival_recall = false\nfirst_arrival_recall_ttl_secs = 1",
+        );
+        assert!(c.first_arrival_recall);
+        assert_eq!(c.first_arrival_recall_ttl_secs, Some(60));
+        assert_eq!(c.first_arrival_recall_max_entries, Some(2));
+        assert_eq!(c.first_arrival_recall_max_bytes, Some(1024));
+        assert_eq!(c.first_arrival_recall_max_entry_bytes, Some(256));
     }
 
     #[test]

--- a/crates/llmtrim-core/src/ir.rs
+++ b/crates/llmtrim-core/src/ir.rs
@@ -9,6 +9,8 @@
 
 use std::str::FromStr;
 
+use std::collections::BTreeMap;
+
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
@@ -52,6 +54,8 @@ pub struct Request {
     /// Out-of-band model id for providers that don't carry it in the body (Gemini puts the
     /// model in the URL path). Never serialized — `to_json_string` emits only `raw`.
     model_hint: Option<String>,
+    /// Opaque, request-local recovery handles keyed by content pointer. Never serialized.
+    recovery_hints: BTreeMap<String, String>,
 }
 
 impl Request {
@@ -62,6 +66,7 @@ impl Request {
             kind,
             raw,
             model_hint: None,
+            recovery_hints: BTreeMap::new(),
         })
     }
 
@@ -71,6 +76,7 @@ impl Request {
             kind,
             raw,
             model_hint: None,
+            recovery_hints: BTreeMap::new(),
         }
     }
 
@@ -82,6 +88,14 @@ impl Request {
     /// body). Never affects serialization; only [`Request::model_id`] reads it.
     pub fn set_model_hint(&mut self, model: Option<&str>) {
         self.model_hint = model.map(str::to_string);
+    }
+
+    pub(crate) fn set_recovery_hints(&mut self, hints: BTreeMap<String, String>) {
+        self.recovery_hints = hints;
+    }
+
+    pub(crate) fn recovery_hint(&self, pointer: &str) -> Option<&str> {
+        self.recovery_hints.get(pointer).map(String::as_str)
     }
 
     /// The request's model id: the body's `model` field if present, else the out-of-band hint.

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -34,6 +34,8 @@
 //! ```
 //!
 
+use std::collections::BTreeMap;
+
 use anyhow::{Context, Result};
 use serde_json::Value;
 
@@ -292,6 +294,25 @@ pub fn compress_with_config_model(
     config: &config::DenseConfig,
     model_override: Option<&str>,
 ) -> Result<CompressResult> {
+    compress_with_config_model_and_recovery(
+        input,
+        provider,
+        config,
+        model_override,
+        BTreeMap::new(),
+    )
+}
+
+/// Internal integration entrypoint carrying opaque request-local recovery capabilities without
+/// changing the public configuration structs.
+#[doc(hidden)]
+pub fn compress_with_config_model_and_recovery(
+    input: &str,
+    provider: Option<ProviderKind>,
+    config: &config::DenseConfig,
+    model_override: Option<&str>,
+    recovery_hints: BTreeMap<String, String>,
+) -> Result<CompressResult> {
     let value: Value = serde_json::from_str(input).context("request body is not valid JSON")?;
     let kind = match provider {
         Some(k) => k,
@@ -308,6 +329,7 @@ pub fn compress_with_config_model(
     let adapter = provider::for_kind(kind);
     let mut req = Request::from_value(kind, value);
     req.set_model_hint(model_override);
+    req.set_recovery_hints(recovery_hints);
 
     // `auto` resolves the preset from the request shape (structural, zero-model).
     let routed;
@@ -625,6 +647,83 @@ mod tests {
         assert_eq!(
             result.frozen_input_tokens.0, expected_frozen,
             "the frozen-zone meter must describe the normalized bytes actually forwarded"
+        );
+    }
+
+    #[test]
+    fn recovery_hinted_boundary_uses_live_shaping_and_query() {
+        let log = (0..90)
+            .map(|i| format!("INFO routine line {i} with unrelated payload"))
+            .chain(std::iter::once(
+                "INFO relevant_identifier_omega must survive".to_string(),
+            ))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let boundary = serde_json::json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {"role": "user", "content": "find relevant_identifier_omega"},
+                {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t", "content": log}]},
+                {"role": "system", "content": [{"type": "text", "text": "cached", "cache_control": {"type": "ephemeral"}}]}
+            ]
+        });
+        let ordinary = serde_json::json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {"role": "user", "content": "find relevant_identifier_omega"},
+                {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t", "content": log}]}
+            ]
+        });
+        let pointer = "/messages/1/content/0/content".to_string();
+        let mut cfg = config::DenseConfig::preset("agent").unwrap();
+        cfg.toolout_template = false;
+        let recovered = compress_with_config_model_and_recovery(
+            &boundary.to_string(),
+            Some(ProviderKind::Anthropic),
+            &cfg,
+            None,
+            BTreeMap::from([(pointer.clone(), "r_a".to_string())]),
+        )
+        .unwrap();
+        let auto_cfg = config::DenseConfig::auto();
+        let auto_recovered = compress_with_config_model_and_recovery(
+            &boundary.to_string(),
+            Some(ProviderKind::Anthropic),
+            &auto_cfg,
+            None,
+            BTreeMap::from([(pointer.clone(), "r_auto".to_string())]),
+        )
+        .unwrap();
+        assert!(
+            auto_recovered
+                .request_json
+                .contains("llmtrim recall r_auto"),
+            "auto routing must preserve daemon-issued recovery hints"
+        );
+        let live = compress_with_config(&ordinary.to_string(), Some(ProviderKind::Anthropic), &cfg)
+            .unwrap();
+        let recovered_body: Value = serde_json::from_str(&recovered.request_json).unwrap();
+        let live_body: Value = serde_json::from_str(&live.request_json).unwrap();
+        let shaped = recovered_body
+            .pointer(&pointer)
+            .and_then(Value::as_str)
+            .unwrap();
+        let ordinary_shaped = live_body.pointer(&pointer).and_then(Value::as_str).unwrap();
+        assert_eq!(
+            shaped
+                .strip_suffix(
+                    "\n[llmtrim: full output: llmtrim recall r_a; if unavailable, re-run the tool]"
+                )
+                .unwrap(),
+            ordinary_shaped,
+            "boundary uses the identical shaping pipeline before its marker"
+        );
+        assert!(shaped.contains("relevant_identifier_omega"));
+        assert!(shaped.ends_with("llmtrim recall r_a; if unavailable, re-run the tool]"));
+        assert_eq!(
+            recovered_body.pointer("/messages/2/content/0/cache_control"),
+            boundary.pointer("/messages/2/content/0/cache_control"),
+            "cache control remains exact"
         );
     }
 

--- a/crates/llmtrim-core/src/memo.rs
+++ b/crates/llmtrim-core/src/memo.rs
@@ -304,17 +304,20 @@ fn plan(salt: &[u8], original: &Value, compressed: &Value) -> Option<PrefixPlan>
 /// reused, i.e. behavior identical to no memo). Pure and synchronous; never panics; on any
 /// structural surprise it makes no change and returns 0 (full stateless fallback).
 pub fn apply(memo: &Memo, salt: &[u8], original: &Value, compressed: &mut Value) -> usize {
+    let reused = replay(memo, salt, original, compressed);
+    record(memo, salt, original, compressed);
+    reused
+}
+
+/// Replay an already-recorded contiguous prefix without mutating the memo. This split lets callers
+/// decide whether the resulting request is actually forwarded before committing new entries.
+pub fn replay(memo: &Memo, salt: &[u8], original: &Value, compressed: &mut Value) -> usize {
     if memo.cap == 0 {
         return 0;
     }
     let Some(plan) = plan(salt, original, compressed) else {
         return 0;
     };
-    let offset = plan.offset;
-
-    // Longest already-seen prefix: stored values to splice in, in original order. We stop at the
-    // first cold boundary — reuse must be a contiguous prefix (the suffix is this turn's new
-    // work), matching the provider cache's prefix semantics.
     let mut reused: Vec<(usize, Value)> = Vec::new();
     for (idx, h, _) in &plan.entries {
         match memo.get(*h) {
@@ -322,35 +325,39 @@ pub fn apply(memo: &Memo, salt: &[u8], original: &Value, compressed: &mut Value)
             None => break,
         }
     }
-
     let reused_count = reused.len();
     if reused_count > 0
         && let Some(comp_msgs) = compressed.get_mut(plan.key).and_then(Value::as_array_mut)
     {
         for (idx, stored) in reused {
-            if let Some(slot) = comp_msgs.get_mut(idx + offset)
+            if let Some(slot) = comp_msgs.get_mut(idx + plan.offset)
                 && let Some(obj) = slot.as_object_mut()
             {
                 obj.insert("content".to_string(), stored);
             }
         }
     }
+    reused_count
+}
 
-    // Record THIS turn for next time — including the messages we just reused (so the entry stays
-    // hot and a longer prefix can freeze next turn). We re-read the (now possibly rewritten)
-    // compressed content so what we store is exactly what we emit on the wire.
+/// Record exactly the content that the caller selected for forwarding.
+pub fn record(memo: &Memo, salt: &[u8], original: &Value, forwarded: &Value) {
+    if memo.cap == 0 {
+        return;
+    }
+    let Some(plan) = plan(salt, original, forwarded) else {
+        return;
+    };
     for (idx, h, fresh_content) in plan.entries {
-        let to_store = compressed
+        let to_store = forwarded
             .get(plan.key)
             .and_then(Value::as_array)
-            .and_then(|a| a.get(idx + offset))
+            .and_then(|a| a.get(idx + plan.offset))
             .and_then(|m| m.get("content"))
             .cloned()
             .unwrap_or(fresh_content);
         memo.put(h, to_store);
     }
-
-    reused_count
 }
 
 #[cfg(test)]
@@ -431,6 +438,28 @@ mod tests {
         // Same context still works (the salt isn't accidentally over-invalidating).
         let mut cb2 = fake_compress(&b);
         assert_eq!(apply(&memo, b"ctx-rag", &b, &mut cb2), 2);
+    }
+
+    #[test]
+    fn replay_is_transactional_until_selected_body_is_recorded() {
+        let memo = Memo::with_capacity(DEFAULT_CAPACITY);
+        let a = json!({"messages": [user("context one. detail"), user("question one")]});
+        let mut ca = fake_compress(&a);
+        assert_eq!(replay(&memo, b"t", &a, &mut ca), 0);
+        assert!(memo.is_empty(), "a candidate replay must not record itself");
+        record(&memo, b"t", &a, &ca);
+        assert!(
+            !memo.is_empty(),
+            "the selected wire body is committed explicitly"
+        );
+
+        let b = json!({"messages": [
+            user("context one. detail"),
+            user("question one"),
+            user("new appended turn")
+        ]});
+        let mut cb = fake_compress(&b);
+        assert_eq!(replay(&memo, b"t", &b, &mut cb), 2);
     }
 
     #[test]

--- a/crates/llmtrim-core/src/stages/toolout/mod.rs
+++ b/crates/llmtrim-core/src/stages/toolout/mod.rs
@@ -34,10 +34,13 @@
 //! 3. **Never inflate** (`elide_into`): an elision marker is emitted only when it is
 //!    shorter than the lines it hides; a lone `--` separator survives as itself.
 //!
-//! Live-zone windowing is lossy. First-arrival cache-boundary results receive only terminal-
-//! equivalent normalization; even template folding stays live-zone-only because it rewrites
-//! literal values into compact notation. The combined stage is `InputTokens`-gated (reverts if it
-//! doesn't cut tokens), `Content`-scoped, and uses zero model calls.
+//! Live-zone windowing is lossy. First-arrival cache-boundary results receive recoverable
+//! windowing by default on auto-routed agent requests: an admitted result gets an opaque recall
+//! handle, while its raw bytes live only in the daemon memory store for five hours by default.
+//! When recovery is disabled or admission fails, the boundary receives terminal-equivalent
+//! normalization only. Without an admission hint, template folding and lossy
+//! windowing stay live-zone-only. The combined stage is `InputTokens`-gated (reverts if it doesn't
+//! cut tokens), `Content`-scoped, and uses zero model calls.
 //!
 //! Note on universality: the level/failure keywords scored below are tokens
 //! *machine-emitted* by runtimes and build tools (`ERROR`, `FATAL`, `Traceback`,
@@ -171,19 +174,46 @@ impl Transform for ToolOutputStage {
         provider: &dyn Provider,
         _plan: &mut Vec<PlanEntry>,
     ) -> Result<()> {
+        // Lossy classification and windowing ordinarily remain restricted to the live zone.
+        let pointers = crate::cache_zone::compressible_pointers(req, provider);
         let first_arrival = crate::cache_zone::first_arrival_tool_result_pointers(req, provider);
+
+        let ctx = Ctx {
+            max_lines: self.max_lines,
+            template: self.template,
+            mode: self.mode,
+        };
+
+        // Build one request-derived ask for both the ordinary and recoverable boundary paths.
+        // The boundary is frozen by its marker, so its preceding user ask may be frozen too.
+        let query: HashSet<String> = provider
+            .content_text_pointers(req)
+            .into_iter()
+            .filter_map(|p| req.get_str(&p).map(normalize::normalize))
+            .filter(|(text, _)| text.lines().count() < self.min_lines)
+            .flat_map(|(text, _)| lex_words(&text))
+            .collect();
+
         for pointer in first_arrival {
             let Some(raw) = req.get_str(&pointer) else {
                 continue;
             };
-            let (shaped, changed) = normalize::normalize(raw);
-            if changed {
-                req.set(&pointer, Value::String(shaped));
+            if let Some(handle) = req.recovery_hint(&pointer)
+                && let Some(shaped) = shape_lossy(raw, &ctx, &query, self.min_lines)
+            {
+                req.set(&pointer, Value::String(format!(
+                    "{shaped}\n[llmtrim: full output: llmtrim recall {handle}; if unavailable, re-run the tool]"
+                )));
+            } else {
+                // A cache-boundary result without a durable recovery hint is normalization-only.
+                let (normalized, changed) = normalize::normalize(raw);
+                if changed {
+                    req.set(&pointer, Value::String(normalized));
+                }
             }
         }
 
-        // Lossy classification and windowing remain restricted to the ordinary live zone.
-        let pointers = crate::cache_zone::compressible_pointers(req, provider);
+        // The shared shaping pipeline below applies only to ordinary live-zone candidates.
 
         // Pre-pass (feature #6): strip ANSI escapes and collapse carriage-return progress
         // on each candidate *before* detection. This is lossless for the model and lets
@@ -198,22 +228,6 @@ impl Transform for ToolOutputStage {
             .iter()
             .map(|t| t.as_ref().and_then(|(t, _)| detect::detect(t)))
             .collect();
-
-        // The "ask" = the short segments (instruction / question). Tool-output lines
-        // overlapping it are biased to survive. Built from length, not kind, so it stays
-        // the question even when the long segments are unrecognized (PlainText) output.
-        let query: HashSet<String> = texts
-            .iter()
-            .filter_map(|t| t.as_ref().map(|(t, _)| t.as_str()))
-            .filter(|t| t.lines().count() < self.min_lines)
-            .flat_map(lex_words)
-            .collect();
-
-        let ctx = Ctx {
-            max_lines: self.max_lines,
-            template: self.template,
-            mode: self.mode,
-        };
 
         // Rail: repeat → passthrough. A candidate whose content already appears at an
         // earlier content pointer is a re-invocation returning the same output — the
@@ -254,17 +268,8 @@ impl Transform for ToolOutputStage {
                 }
                 continue;
             }
-            let compressed = match kind {
-                Some(OutKind::Log) => log::compress(text, &ctx, &query),
-                Some(OutKind::Grep) => grep::compress(text, &ctx, &query),
-                Some(OutKind::Diff) => diff::compress(text, &ctx, &query),
-                // Unrecognized shape. First try the generated/lockfile near-total elision
-                // (feature #7, high-confidence machine-noise shapes only); otherwise the
-                // redundancy-gated generic fallback ("any tool").
-                None => {
-                    generated::compress(text).or_else(|| plaintext::compress(text, &ctx, &query))
-                }
-            };
+            let compressed = compress_shaped(text, &ctx, &query, *kind);
+
             if let Some(compressed) = compressed {
                 req.set(ptr, Value::String(compressed));
             } else if *normalized {
@@ -274,6 +279,32 @@ impl Transform for ToolOutputStage {
             }
         }
         Ok(())
+    }
+}
+
+/// Apply normalization plus the shared lossy shaping pipeline. `None` means no information was
+/// omitted, so a cache-boundary caller must keep only the normalization and discard its handle.
+fn shape_lossy(text: &str, ctx: &Ctx, query: &HashSet<String>, min_lines: usize) -> Option<String> {
+    let (normalized, _) = normalize::normalize(text);
+    if normalized.lines().count() < min_lines {
+        return None;
+    }
+    compress_shaped(&normalized, ctx, query, detect::detect(&normalized))
+}
+
+/// The single lossy shaping dispatch used by ordinary live results and recovery-admitted
+/// first-arrival boundary results.
+fn compress_shaped(
+    text: &str,
+    ctx: &Ctx,
+    query: &HashSet<String>,
+    kind: Option<OutKind>,
+) -> Option<String> {
+    match kind {
+        Some(OutKind::Log) => log::compress(text, ctx, query),
+        Some(OutKind::Grep) => grep::compress(text, ctx, query),
+        Some(OutKind::Diff) => diff::compress(text, ctx, query),
+        None => generated::compress(text).or_else(|| plaintext::compress(text, ctx, query)),
     }
 }
 


### PR DESCRIPTION
## Summary

- retain exact first-arrival tool results in a bounded, memory-only daemon store
- lossily shape admitted cache-boundary results with an opaque `llmtrim recall` handle
- recover exact bytes through a private Unix socket or Windows named pipe
- prevent expired, rejected, repeated, and recalled results from entering recovery loops
- enable recoverable shaping by default for auto-routed agent requests; `first_arrival_recall = false` opts out
- replay only provider-cached memo bytes and commit memo entries transactionally after the final token gate

## Validation

- `cargo nextest run --profile ci` — 1,301 passed, 1 skipped
- `cargo test --doc`
- `cargo clippy -p llmtrim --all-targets -- -D warnings`
- `cargo semver-checks check-release --package llmtrim-core --baseline-rev v0.11.12`
- isolated live Claude Code validation through the subscription backend:
  - normalization-only control completed correctly
  - recoverable shaping completed correctly
  - forced omission recovered with one `llmtrim recall` call and returned the exact answer

## Runtime behavior

The default five-hour recall store is RAM-only and clears on daemon restart. Admission, size, token, client, or recovery-capability failures fall back to normalization-only cache writes. Generic clients without verified Claude Code session and Bash recovery capability are unchanged.