### PR TITLE
fix(recall): generalize recovery and satisfy CodeQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ npm install -g @llmtrim/cli@latest && llmtrim setup
 llmtrim status
 ```
 
-That's it. `setup` starts a local proxy, wires your shell, and (when Claude Code is present) turns on the status line, cold-cache guard, `/sub`, and cheaper `/compact`. You do not run a separate install for each of those.
+That's it. `setup` starts a local proxy, wires your shell, and enables recoverable tool-output shaping. When Claude Code is present, it also turns on the status line, cold-cache guard, `/sub`, and cheaper `/compact`. You do not run a separate install for each of those.
 
 | You want | Run |
 |---|---|
@@ -137,7 +137,7 @@ Same technique as [mitmproxy](https://mitmproxy.org), scoped to LLM API hosts on
 2. Shell env: `HTTPS_PROXY` + CA trust
 3. Login service: daemon at login
 
-No API keys stored (your tool's auth is forwarded). Prompts never touch disk; only anonymous token counts. Full threat model: [SECURITY.md](SECURITY.md).
+No API keys stored (your tool's auth is forwarded). Prompts never touch disk; only anonymous token counts. Recoverable tool results stay in bounded daemon RAM for five hours by default and disappear on restart. Full threat model: [SECURITY.md](SECURITY.md).
 
 ```bash
 llmtrim ca
@@ -214,7 +214,7 @@ Log folding is one stage. Others kick in on different waste:
 > [!IMPORTANT]
 > Compression cannot raise your bill or break a request. Each stage is re-measured with the provider's real tokenizer and undone if it does not save tokens. If the provider rejects the compressed body, the original is resent. Worst case is zero savings.
 
-Prompt-cache prefixes (`cache_control`) are left alone.
+Existing prompt-cache prefixes (`cache_control`) are left alone. On shell-capable agent turns, a newly arriving tool result may be shaped once before its first cache write; the exact raw result remains recoverable with the emitted `llmtrim recall r_…` command.
 
 <details>
 <summary><b>All 10 compressors</b></summary>
@@ -223,7 +223,7 @@ Stages run in savings order. Nothing under a `cache_control` marker is rewritten
 
 | Stage | What it does | When it runs |
 |---|---|---|
-| **tool-output** | Lossless template fold first, then window logs · diffs · grep · dumps down to errors / changes / matches | tool results |
+| **tool-output** | Lossless template fold first, then window logs · diffs · grep · dumps down to errors / changes / matches; shell-capable agents can restore omitted first-arrival results with `llmtrim recall` | tool results |
 | **cache discipline** | Mark + stabilize the invariant prefix (sort tools/schema · OpenAI `prompt_cache_key`) so it stays cached | tools |
 | **lexical retrieval** | BM25+ ranking with RM3 feedback · TextTiling topic cuts · budgeted non-redundant selection; question protected | long context |
 | **skeletonization** | tree-sitter keeps relevant function bodies, drops the rest to signatures (14 languages) | code |
@@ -518,6 +518,8 @@ These knobs are orthogonal to compression. Each resolves env-first, then from th
 | `LLMTRIM_DB_PATH` | `db_path` | ledger location |
 | `LLMTRIM_CAPTURE_DIR` | `capture_dir` | before/after QA capture directory |
 | `LLMTRIM_CAPTURE_MAX_MB` | `capture_max_mb` | capture corpus size ceiling (`0` disables) |
+| `LLMTRIM_FIRST_ARRIVAL_RECALL` | `first_arrival_recall` | recoverable first-arrival tool-output shaping (default `true`; set `false` for normalization-only cache writes) |
+| `LLMTRIM_FIRST_ARRIVAL_RECALL_TTL_SECS` | `first_arrival_recall_ttl_secs` | in-memory raw-result lifetime (default 18,000 seconds / five hours) |
 | `LLMTRIM_BIND` | `bind` | listen IP (default loopback; `0.0.0.0` for containers) |
 | `LLMTRIM_BREAKDOWN_WINDOW` | `breakdown_window` | context-window override for the cost breakdown |
 | `LLMTRIM_RETENTION_DAYS` | `retention_days` | ledger age-retention in days |

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -4228,7 +4228,14 @@ mod imp {
 
     /// Recovery is available only when the caller actually supplied a Bash tool definition. A
     /// model mentioning Bash in prose is not evidence that it can execute `llmtrim recall`.
-    fn has_bash_tool_definition(value: &Value) -> bool {
+    fn is_recall_command_tool_name(name: &str) -> bool {
+        matches!(
+            name.to_ascii_lowercase().as_str(),
+            "bash" | "shell" | "terminal" | "execute_command" | "run_command"
+        )
+    }
+
+    fn has_recall_command_tool(value: &Value) -> bool {
         value
             .get("tools")
             .and_then(Value::as_array)
@@ -4239,7 +4246,7 @@ mod imp {
                     .or_else(|| tool.pointer("/function/name"))
                     .and_then(Value::as_str)
             })
-            .any(|name| name.eq_ignore_ascii_case("bash"))
+            .any(is_recall_command_tool_name)
     }
 
     /// A successful recall is already the recovery path. Its Bash result must pass through rather
@@ -4269,7 +4276,10 @@ mod imp {
             .any(|block| {
                 block.get("type").and_then(Value::as_str) == Some("tool_use")
                     && block.get("id").and_then(Value::as_str) == Some(tool_use_id)
-                    && block.get("name").and_then(Value::as_str) == Some("Bash")
+                    && block
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .is_some_and(is_recall_command_tool_name)
                     && block
                         .pointer("/input/command")
                         .and_then(Value::as_str)
@@ -4346,18 +4356,24 @@ mod imp {
             .and_then(|v| llmtrim_core::provider::detect(&v))
             .unwrap_or(provider);
         let started = std::time::Instant::now();
-        // Fail closed unless the request proves both Claude Code identity (its session header)
-        // and practical recovery availability (an actual Bash definition).
+        let value: Value = serde_json::from_str(text).ok()?;
+        // Recovery is client-agnostic, but it requires an actual local command tool. Prefer the
+        // client's session identity for rerun scoping; unidentified agents share a conservative
+        // daemon-local bucket, where a false repeat only passes a result through in full.
+        let identity = llmtrim_core::attribution::extract_identity(&value, kind);
+        let recovery_scope = cc_session_id
+            .clone()
+            .or(identity.session_id)
+            .unwrap_or_else(|| "local-anthropic-agent".to_string());
         let mut recovery_hints = std::collections::BTreeMap::new();
         let mut admissions = AdmissionGuard {
             recall,
             entries: Vec::new(),
         };
-        let value: Value = serde_json::from_str(text).ok()?;
         if RuntimeConfig::get().first_arrival_recall
             && kind == ProviderKind::Anthropic
-            && let (Some(session), Some(recall)) = (cc_session_id.as_deref(), recall)
-            && has_bash_tool_definition(&value)
+            && let Some(recall) = recall
+            && has_recall_command_tool(&value)
         {
             let req = llmtrim_core::ir::Request::from_value(kind, value.clone());
             let adapter = llmtrim_core::provider::for_kind(kind);
@@ -4367,7 +4383,7 @@ mod imp {
                 if !is_recall_tool_result(&value, &pointer)
                     && let Some(raw) = req.get_str(&pointer)
                     && let Ok(crate::recall::Admission::Stored(handle)) =
-                        recall.admit(session, raw.as_bytes().to_vec())
+                        recall.admit(&recovery_scope, raw.as_bytes().to_vec())
                 {
                     recovery_hints.insert(pointer.clone(), handle.clone());
                     admissions.entries.push((pointer, handle));

--- a/crates/llmtrim-core/src/memo.rs
+++ b/crates/llmtrim-core/src/memo.rs
@@ -443,11 +443,16 @@ mod tests {
     #[test]
     fn replay_is_transactional_until_selected_body_is_recorded() {
         let memo = Memo::with_capacity(DEFAULT_CAPACITY);
+        let salt = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .to_le_bytes();
         let a = json!({"messages": [user("context one. detail"), user("question one")]});
         let mut ca = fake_compress(&a);
-        assert_eq!(replay(&memo, b"t", &a, &mut ca), 0);
+        assert_eq!(replay(&memo, &salt, &a, &mut ca), 0);
         assert!(memo.is_empty(), "a candidate replay must not record itself");
-        record(&memo, b"t", &a, &ca);
+        record(&memo, &salt, &a, &ca);
         assert!(
             !memo.is_empty(),
             "the selected wire body is committed explicitly"
@@ -459,7 +464,7 @@ mod tests {
             user("new appended turn")
         ]});
         let mut cb = fake_compress(&b);
-        assert_eq!(replay(&memo, b"t", &b, &mut cb), 2);
+        assert_eq!(replay(&memo, &salt, &b, &mut cb), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- allow shell-capable agents to use recovery without requiring a Claude Code session header
- recognize common Bash, shell, terminal, and command-tool names
- document the default recovery behavior and five-hour RAM-only lifetime
- replace the test-only hard-coded memo salt reported by CodeQL alert #22

## Validation

- `cargo nextest run --profile ci` — 1,301 passed, 1 skipped
- `cargo clippy -p llmtrim --all-targets -- -D warnings`
- targeted recovery, memo, and default-config tests