### PR TITLE
feat(toolout): tighten recoverable first-arrival shaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Recoverable first-arrival tool-output shaping.** Shell-capable agents can now keep a smaller,
+  aggressively selected view of logs, diffs, grep results, and dumps in the prompt cache while the
+  exact raw result remains in bounded daemon memory for five hours by default. An emitted
+  `llmtrim recall r_…` command restores the original bytes on demand. Recovery is enabled by
+  default, uses a tighter inline budget than ordinary live-zone shaping, works through subscription
+  reroutes, and falls back to normalization-only cache writes when admission or recovery is not
+  available. Set `first_arrival_recall = false` to opt out.
+
 ### Fixed
 
 - **Always-sub skip-login no longer 401s when the shell has no `HTTPS_PROXY`.** Skip-login

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -651,7 +651,7 @@ mod tests {
     }
 
     #[test]
-    fn recovery_hinted_boundary_uses_live_shaping_and_query() {
+    fn recovery_hinted_boundary_uses_tighter_budget_and_query() {
         let log = (0..90)
             .map(|i| format!("INFO routine line {i} with unrelated payload"))
             .chain(std::iter::once(
@@ -677,6 +677,7 @@ mod tests {
         let pointer = "/messages/1/content/0/content".to_string();
         let mut cfg = config::DenseConfig::preset("agent").unwrap();
         cfg.toolout_template = false;
+        cfg.toolout_max_lines = 40;
         let recovered = compress_with_config_model_and_recovery(
             &boundary.to_string(),
             Some(ProviderKind::Anthropic),
@@ -709,14 +710,16 @@ mod tests {
             .and_then(Value::as_str)
             .unwrap();
         let ordinary_shaped = live_body.pointer(&pointer).and_then(Value::as_str).unwrap();
-        assert_eq!(
-            shaped
-                .strip_suffix(
-                    "\n[llmtrim: full output: llmtrim recall r_a; if unavailable, re-run the tool]"
-                )
-                .unwrap(),
-            ordinary_shaped,
-            "boundary uses the identical shaping pipeline before its marker"
+        let recovered_inline = shaped
+            .strip_suffix(
+                "\n[llmtrim: full output: llmtrim recall r_a; if unavailable, re-run the tool]",
+            )
+            .unwrap();
+        assert!(
+            recovered_inline.lines().count() < ordinary_shaped.lines().count(),
+            "recoverable boundary uses a tighter inline budget: {} vs {} lines",
+            recovered_inline.lines().count(),
+            ordinary_shaped.lines().count()
         );
         assert!(shaped.contains("relevant_identifier_omega"));
         assert!(shaped.ends_with("llmtrim recall r_a; if unavailable, re-run the tool]"));

--- a/crates/llmtrim-core/src/stages/toolout/mod.rs
+++ b/crates/llmtrim-core/src/stages/toolout/mod.rs
@@ -183,6 +183,14 @@ impl Transform for ToolOutputStage {
             template: self.template,
             mode: self.mode,
         };
+        // A durable raw copy changes the boundary trade-off: keep half the ordinary inline budget
+        // and prefer signal-only selection where the kind supports it. The model can recover exact
+        // omitted bytes instead of carrying a cautious window through every cached turn.
+        let recovery_ctx = Ctx {
+            max_lines: self.max_lines.div_ceil(2).max(MIN_KEEP),
+            template: self.template,
+            mode: ModeSetting::Aggressive,
+        };
 
         // Build one request-derived ask for both the ordinary and recoverable boundary paths.
         // The boundary is frozen by its marker, so its preceding user ask may be frozen too.
@@ -199,7 +207,7 @@ impl Transform for ToolOutputStage {
                 continue;
             };
             if let Some(handle) = req.recovery_hint(&pointer)
-                && let Some(shaped) = shape_lossy(raw, &ctx, &query, self.min_lines)
+                && let Some(shaped) = shape_lossy(raw, &recovery_ctx, &query, self.min_lines)
             {
                 req.set(&pointer, Value::String(format!(
                     "{shaped}\n[llmtrim: full output: llmtrim recall {handle}; if unavailable, re-run the tool]"


### PR DESCRIPTION
## Summary

- give recoverable first-arrival results half the ordinary inline line budget
- prefer signal-only selection when a tool-output kind supports it
- preserve query matches and exact on-demand recovery
- document recoverable shaping in the changelog

## Validation

- `cargo nextest run --profile ci` — 1,301 passed, 1 skipped
- `cargo clippy -p llmtrim --all-targets -- -D warnings`
- focused tighter-budget and recall-loop tests