### PR TITLE
fix(toolout): recovery shaping uses Aggressive only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ All notable changes to this project are documented here. The format follows
   aggressively selected view of logs, diffs, grep results, and dumps in the prompt cache while the
   exact raw result remains in bounded daemon memory for five hours by default. An emitted
   `llmtrim recall r_…` command restores the original bytes on demand. Recovery is enabled by
-  default, uses a tighter inline budget than ordinary live-zone shaping, works through subscription
-  reroutes, and falls back to normalization-only cache writes when admission or recovery is not
-  available. Set `first_arrival_recall = false` to opt out.
+  default, forces signal-only (`Aggressive`) selection where the tool-output kind supports it
+  under the ordinary live-zone line budget, works through subscription reroutes, and falls back
+  to normalization-only cache writes when admission or recovery is not available. Set
+  `first_arrival_recall = false` to opt out.
 
 ### Fixed
 

--- a/crates/llmtrim-core/src/lib.rs
+++ b/crates/llmtrim-core/src/lib.rs
@@ -651,12 +651,15 @@ mod tests {
     }
 
     #[test]
-    fn recovery_hinted_boundary_uses_tighter_budget_and_query() {
-        let log = (0..90)
+    fn recovery_hinted_boundary_uses_aggressive_mode_and_query() {
+        // Sparse errors under AUTO_MIN_LINES so ordinary Auto/Adaptive keeps a windowed
+        // view, while recovery forces Aggressive → errors-only. Same max_lines both paths.
+        let log = (0..40)
             .map(|i| format!("INFO routine line {i} with unrelated payload"))
             .chain(std::iter::once(
-                "INFO relevant_identifier_omega must survive".to_string(),
+                "ERROR relevant_identifier_omega disk full on /dev/sda1".to_string(),
             ))
+            .chain(std::iter::once("    at main.rs:12:5".to_string()))
             .collect::<Vec<_>>()
             .join("\n");
         let boundary = serde_json::json!({
@@ -678,6 +681,8 @@ mod tests {
         let mut cfg = config::DenseConfig::preset("agent").unwrap();
         cfg.toolout_template = false;
         cfg.toolout_max_lines = 40;
+        // Pin adaptive so the live-zone comparison is not mode-coupled to recovery.
+        cfg.toolout_mode = "adaptive".to_string();
         let recovered = compress_with_config_model_and_recovery(
             &boundary.to_string(),
             Some(ProviderKind::Anthropic),
@@ -717,9 +722,13 @@ mod tests {
             .unwrap();
         assert!(
             recovered_inline.lines().count() < ordinary_shaped.lines().count(),
-            "recoverable boundary uses a tighter inline budget: {} vs {} lines",
+            "recoverable boundary uses Aggressive signal-only selection: {} vs {} lines",
             recovered_inline.lines().count(),
             ordinary_shaped.lines().count()
+        );
+        assert!(
+            recovered_inline.starts_with("[log:"),
+            "Aggressive log path emits the summary header: {recovered_inline}"
         );
         assert!(shaped.contains("relevant_identifier_omega"));
         assert!(shaped.ends_with("llmtrim recall r_a; if unavailable, re-run the tool]"));

--- a/crates/llmtrim-core/src/stages/toolout/mod.rs
+++ b/crates/llmtrim-core/src/stages/toolout/mod.rs
@@ -183,11 +183,12 @@ impl Transform for ToolOutputStage {
             template: self.template,
             mode: self.mode,
         };
-        // A durable raw copy changes the boundary trade-off: keep half the ordinary inline budget
-        // and prefer signal-only selection where the kind supports it. The model can recover exact
-        // omitted bytes instead of carrying a cautious window through every cached turn.
+        // A durable raw copy changes the boundary trade-off: prefer signal-only selection
+        // (Aggressive) where the kind supports it, under the same line budget as live-zone
+        // shaping. The model can recover exact omitted bytes instead of carrying a cautious
+        // adaptive window through every cached turn.
         let recovery_ctx = Ctx {
-            max_lines: self.max_lines.div_ceil(2).max(MIN_KEEP),
+            max_lines: self.max_lines,
             template: self.template,
             mode: ModeSetting::Aggressive,
         };


### PR DESCRIPTION
## Summary

- drop the hardcoded `max_lines / 2` on recoverable first-arrival toolout
- keep only `ModeSetting::Aggressive` (signal-only where the kind supports it) under the ordinary live-zone line budget
- retarget the boundary test: Adaptive live-zone vs Aggressive recovery (errors-only), not a smaller cap
- changelog: describe Aggressive selection, not a tighter budget

#235 already shipped half-budget + Aggressive. The half-budget is a blunt second knob; Adaptive fall-through already uses `optimal_keep` under `max_lines`, and true Aggressive paths (errorful logs, context-heavy diffs) ignore the line cap anyway.

## Validation

- `cargo test -p llmtrim-core recovery_hinted_boundary` — pass
- `cargo test -p llmtrim-core --lib toolout::` — 92 pass