### PR TITLE
fix(tray): stop KDE Wayland popover panic (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Linux tray no longer panics when opening the popover on KDE Plasma Wayland.**
+  `tauri-plugin-positioner` 2.3.2 unwrapped a missing current-monitor on still-hidden
+  windows. Bump to 2.3.3 (returns `Err` instead) and, on that failure path, show the
+  window first then retry `TrayCenter` positioning so the popover still opens. (#240)
+
 ## [0.12.1] - 2026-07-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5994,9 +5994,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-positioner"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686204dc3171a2d59436e470c8ea99f08c5f5bf63ef1a40f900d6d48f433b816"
+checksum = "1a285cd1dca2bef15e45a591694050773d0beadbe133a55779d5251d08fa2396"
 dependencies = [
  "log",
  "serde",

--- a/crates/llmtrim-tray/Cargo.toml
+++ b/crates/llmtrim-tray/Cargo.toml
@@ -20,7 +20,9 @@ tauri-build = { version = "2", features = [] }
 llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.12.2-dev" }
 # image-png: required for Image::from_bytes to decode the embedded PNG tray icon.
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
-tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }
+# 2.3.3+ returns Err instead of panicking when a still-hidden window has no
+# current monitor (KDE Plasma Wayland). See issue #240.
+tauri-plugin-positioner = { version = "2.3.3", features = ["tray-icon"] }
 tauri-plugin-single-instance = "2"
 anyhow = "1"
 chrono = "0.4"

--- a/crates/llmtrim-tray/src/main.rs
+++ b/crates/llmtrim-tray/src/main.rs
@@ -598,8 +598,17 @@ fn show_popover(app: &AppHandle) {
     let Some(popover) = app.get_webview_window("popover") else {
         return;
     };
-    let _ = popover.move_window(Position::TrayCenter);
-    let _ = popover.show();
+    // Prefer position-then-show so the window never flashes at a default origin.
+    // On some Wayland compositors (notably KDE Plasma) a still-hidden window has
+    // no current monitor, so the positioner fails. tauri-plugin-positioner
+    // 2.3.3+ returns Err instead of panicking (#240); show first in that case
+    // and retry once the window is mapped.
+    if popover.move_window(Position::TrayCenter).is_err() {
+        let _ = popover.show();
+        let _ = popover.move_window(Position::TrayCenter);
+    } else {
+        let _ = popover.show();
+    }
     let _ = popover.set_focus();
 }
 


### PR DESCRIPTION
## Summary

- Bump `tauri-plugin-positioner` from 2.3.2 → **2.3.3** (min-version pin in `llmtrim-tray`). 2.3.2 panics on `current_monitor()?.unwrap()` when a still-hidden window has no monitor; 2.3.3 returns `Err` instead ([upstream fix](https://github.com/tauri-apps/plugins-workspace/commit/4be76900854cae3dc91363dea71b54505896e928)).
- Harden `show_popover`: on positioner failure, `show()` first then retry `TrayCenter` so the popover still opens once mapped on KDE Plasma Wayland.
- Changelog entry under Unreleased.

Fixes #240

## Test plan

- [ ] On KDE Plasma Wayland: `RUST_BACKTRACE=1 llmtrim tray`, open tray menu → **Open llmtrim** — process stays alive, 360×480 popover appears (may land slightly off tray on the first open if the compositor only attaches a monitor after map).
- [ ] Same path via StatusNotifier D-Bus menu item 2 (as in the issue repro) — exit status not 101.
- [ ] Left-click tray icon toggle still shows/hides the popover on X11 / macOS / Windows (position-then-show happy path unchanged).
- [ ] `GDK_BACKEND=x11` workaround still works if needed; no longer required for crash avoidance.

Note: full `cargo check -p llmtrim-tray` wasn't run here (host missing `libdbus-1-dev` / webkit gtk); lockfile update and the 2.3.3 `ext.rs` diff were verified from the crates.io source.