### PR TITLE
fix(monitor): price bare wire ids via snapshot aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Bare wire model ids resolve against `provider/id` pricing rows.** The models.dev
+  snapshot keys many models as `x-ai/grok-4.5` (etc.), while the ledger and status path
+  record bare ids like `grok-4.5`. Lookup only stripped a prefix when one was present, so
+  bare ids missed the snapshot, froze `input_rate`/`bill_micros` at zero, and dropped out
+  of Overview dollar lists / understated totals. `load_pricing` now dual-indexes unique
+  bare aliases (never overwriting an explicit bare row; never aliasing when prefixed
+  siblings disagree). Combined with the daily zero-rate reprice (#244), historical
+  unpriced turns heal on the next ledger open once rates are known.
+
 ## [0.12.3] - 2026-08-01
 
 ### Fixed

--- a/crates/llmtrim-cli/src/bench/mod.rs
+++ b/crates/llmtrim-cli/src/bench/mod.rs
@@ -713,12 +713,54 @@ pub fn load_pricing(json: &str) -> PriceTable {
             },
         );
     }
+    // models.dev keys are often `provider/id` while wire/ledger traffic records the bare
+    // id (`grok-4.5`). Index a bare alias when it is unambiguous so exact lookup works
+    // for both shapes. Never overwrite an explicit bare row, and never invent an alias
+    // when several prefixed rows disagree on price.
+    index_unique_bare_aliases(&mut table);
     table
 }
 
+/// For each `provider/id` row whose bare `id` is not already keyed, insert `id → price`
+/// when every prefixed candidate shares the same rates. Leaves collisions alone.
+fn index_unique_bare_aliases(table: &mut PriceTable) {
+    let mut candidates: std::collections::HashMap<String, Pricing> =
+        std::collections::HashMap::new();
+    let mut ambiguous = std::collections::HashSet::new();
+    for (id, price) in table.iter() {
+        let Some((_, bare)) = id.split_once('/') else {
+            continue;
+        };
+        if table.contains_key(bare) || ambiguous.contains(bare) {
+            continue;
+        }
+        match candidates.get(bare) {
+            None => {
+                candidates.insert(bare.to_string(), *price);
+            }
+            Some(existing) if pricing_eq(existing, price) => {}
+            Some(_) => {
+                candidates.remove(bare);
+                ambiguous.insert(bare.to_string());
+            }
+        }
+    }
+    for (bare, price) in candidates {
+        // Re-check: an explicit bare key may have been present from the start.
+        table.entry(bare).or_insert(price);
+    }
+}
+
+fn pricing_eq(a: &Pricing, b: &Pricing) -> bool {
+    a.input_per_1k == b.input_per_1k
+        && a.output_per_1k == b.output_per_1k
+        && a.cache_per_1k == b.cache_per_1k
+}
+
 /// Resolve pricing for a model: the pinned table first (exact id, then with the
-/// `provider/` prefix stripped), else the hardcoded fallback. Lets the live snapshot
-/// drive cost while staying correct offline.
+/// `provider/` prefix stripped). Bare ids also hit when [`load_pricing`] indexed a unique
+/// `provider/id` alias (e.g. wire `grok-4.5` → snapshot `x-ai/grok-4.5`). Else the
+/// hardcoded fallback. Lets the live snapshot drive cost while staying correct offline.
 pub fn resolve_pricing(table: &PriceTable, model: &str) -> Pricing {
     if let Some(p) = table.get(model) {
         return *p;
@@ -1578,6 +1620,46 @@ mod tests {
         assert!(resolve_pricing(&table, "gpt-4o-mini").output_per_1k > 0.0);
         // garbage json → empty table → fallback still works.
         assert!(load_pricing("not json").is_empty());
+    }
+
+    #[test]
+    fn bare_id_aliases_unique_prefixed_snapshot_rows() {
+        // Wire traffic often records bare ids; models.dev keys are provider-prefixed.
+        let snap = r#"{"source":"x","unit":"usd_per_1m","models":{
+            "x-ai/grok-4.5":{"input":2,"output":6,"cache_read":0.5},
+            "anthropic/claude-sonnet-4":{"input":3,"output":15,"cache_read":0.3},
+            "deepseek-chat":{"input":0.14,"output":0.28,"cache_read":0},
+            "deepseek/deepseek-chat":{"input":0.2002,"output":0.8001,"cache_read":0},
+            "acme/twin":{"input":1,"output":2,"cache_read":0},
+            "other/twin":{"input":9,"output":9,"cache_read":0}
+        }}"#;
+        let table = load_pricing(snap);
+
+        // Unique prefixed → bare alias.
+        let grok = resolve_pricing(&table, "grok-4.5");
+        assert!((grok.input_per_1k - 0.002).abs() < 1e-9, "2/1M = 0.002/1k");
+        assert!((grok.output_per_1k - 0.006).abs() < 1e-9);
+        assert!((grok.cache_per_1k - 0.0005).abs() < 1e-9);
+        // Prefixed form still works.
+        assert_eq!(
+            resolve_pricing(&table, "x-ai/grok-4.5").input_per_1k,
+            grok.input_per_1k
+        );
+
+        let sonnet = resolve_pricing(&table, "claude-sonnet-4");
+        assert!((sonnet.input_per_1k - 0.003).abs() < 1e-9);
+
+        // Explicit bare row wins over a disagreeing prefixed sibling.
+        let ds = resolve_pricing(&table, "deepseek-chat");
+        assert!(
+            (ds.input_per_1k - 0.00014).abs() < 1e-9,
+            "bare snapshot row wins"
+        );
+
+        // Ambiguous bare name with disagreeing prices → no alias (hardcoded fallback = 0).
+        let twin = resolve_pricing(&table, "twin");
+        assert_eq!(twin.input_per_1k, 0.0);
+        assert_eq!(twin.output_per_1k, 0.0);
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -1282,10 +1282,12 @@ fn build_registry_price_table() -> std::collections::HashMap<&'static str, (f64,
 }
 
 /// Fallback table: the pinned models.dev snapshot the bench prices from, embedded at
-/// compile time (the package re-includes bench/pricing.json for this). Exact id first,
-/// then with the `provider/` prefix stripped, mirroring [`crate::bench::resolve_pricing`]
-/// — but zero-priced rows (free tiers, parse gaps) return `None` so an unknown model
-/// shows a blank cost cell rather than a misleading $0.00.
+/// compile time (the package re-includes bench/pricing.json for this). Exact id first
+/// (including bare aliases dual-indexed by [`crate::bench::load_pricing`] for unique
+/// `provider/id` rows such as `grok-4.5` ← `x-ai/grok-4.5`), then with the `provider/`
+/// prefix stripped, mirroring [`crate::bench::resolve_pricing`] — but zero-priced rows
+/// (free tiers, parse gaps) return `None` so an unknown model shows a blank cost cell
+/// rather than a misleading $0.00.
 fn snapshot_prices(model_id: &str) -> Option<(f64, f64)> {
     use crate::bench;
     static TABLE: once_cell::sync::Lazy<bench::PriceTable> =
@@ -2354,6 +2356,18 @@ mod tests {
         assert_eq!(
             llm_prices("anthropic/claude-opus-5").expect("prefixed"),
             (5.0, 25.0)
+        );
+    }
+
+    #[test]
+    fn llm_prices_resolves_bare_grok_4_5() {
+        // Ledger/wire id is bare; models.dev snapshot keys x-ai/grok-4.5.
+        let (input, output) = llm_prices("grok-4.5").expect("bare grok-4.5 must be priced");
+        assert!((input - 2.0).abs() < 1e-9, "input $/1M got {input}");
+        assert!((output - 6.0).abs() < 1e-9, "output $/1M got {output}");
+        assert_eq!(
+            llm_prices("x-ai/grok-4.5").expect("prefixed form"),
+            (input, output)
         );
     }
 }


### PR DESCRIPTION
## What & why

Wire/ledger traffic often records bare model ids (`grok-4.5`), while the embedded models.dev snapshot keys many of those rows as `provider/id` (`x-ai/grok-4.5`). Pricing lookup did exact match, then stripped a prefix if present — it never reverse-matched bare → prefixed. Misses froze `input_rate` / `bill_micros` at 0, so status Overview dollars understated traffic and unpriced models dropped out of the dollar-by-model list (or showed `—`).

`load_pricing` now dual-indexes a bare alias when the bare name is unique across prefixed rows (never overwrites an explicit bare key; never aliases when prefixed siblings disagree on price). That feeds `snapshot_prices` / `rates_for` and, with the existing daily zero-rate reprice (#244), heals historical unpriced turns on the next ledger open once rates resolve.

## Linked issue

No issue filed — follow-on to #244 / #239 class of snapshot-lag pricing bugs (observed on Grok 4.5 bare wire ids).

## How it was verified

- [x] `cargo fmt` is clean
- [x] Targeted tests pass:
  - `bench::tests::bare_id_aliases_unique_prefixed_snapshot_rows`
  - `monitor::tests::llm_prices_resolves_bare_grok_4_5`
- [ ] `cargo clippy --all-targets` (CI)
- [ ] `cargo nextest run --profile ci` (CI)
- [x] New behavior covered by tests (unique alias, explicit bare wins, ambiguous bare stays unpriced, live `grok-4.5` rates)
- [x] `CHANGELOG.md` entry under `## [Unreleased]`
- [x] Commit signed off (`git commit -s`)

Local ledger heal (after clearing same-day `zero_rate_check_day` so reprice could run again with the fixed lookup): `grok-4.5` unpriced rows 14683 → 0; rates `$2/$6` per 1M; status BY MODEL shows `grok-4.5` with non-zero `$ saved`.

## Notes

- Does not add snapshot rows for models still missing entirely (e.g. `grok-composer-2.5-fast` stays unpriced until the snapshot/registry knows them).
- Daily reprice is still once per UTC day; if lookup failed earlier the same day, the gate must roll or be cleared for an immediate heal (normal next-day open is enough for users).