### PR TITLE
feat(sub): make grok-4.6 the sole Grok flagship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **Grok Fable tier maps to `grok-4.6`.** Default Grok tier preset now sends Claude Fable to
+  `grok-4.6`; Opus/Sonnet stay on `grok-4.5` and Haiku on `grok-composer-2.5-fast`.
+
 ## [0.12.6] - 2026-08-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable changes to this project are documented here. The format follows
 
 ### Changed
 
-- **Grok Fable tier maps to `grok-4.6`.** Default Grok tier preset now sends Claude Fable to
-  `grok-4.6`; Opus/Sonnet stay on `grok-4.5` and Haiku on `grok-composer-2.5-fast`.
+- **Grok flagship is `grok-4.6`.** Default Grok tier preset maps Opus/Sonnet/Fable to
+  `grok-4.6` (replacing `grok-4.5`); Haiku stays on `grok-composer-2.5-fast`. The subscription
+  catalog no longer lists `grok-4.5`.
 
 ## [0.12.6] - 2026-08-11
 

--- a/crates/llmtrim-cli/bench/pricing.json
+++ b/crates/llmtrim-cli/bench/pricing.json
@@ -2231,7 +2231,7 @@
 "input": 1.25,
 "output": 2.5
 },
-"x-ai/grok-4.5": {
+"x-ai/grok-4.6": {
 "cache_read": 0.3,
 "input": 2,
 "output": 6

--- a/crates/llmtrim-cli/src/bench/mod.rs
+++ b/crates/llmtrim-cli/src/bench/mod.rs
@@ -714,7 +714,7 @@ pub fn load_pricing(json: &str) -> PriceTable {
         );
     }
     // models.dev keys are often `provider/id` while wire/ledger traffic records the bare
-    // id (`grok-4.5`). Index a bare alias when it is unambiguous so exact lookup works
+    // id (`grok-4.6`). Index a bare alias when it is unambiguous so exact lookup works
     // for both shapes. Never overwrite an explicit bare row, and never invent an alias
     // when several prefixed rows disagree on price.
     index_unique_bare_aliases(&mut table);
@@ -759,7 +759,7 @@ fn pricing_eq(a: &Pricing, b: &Pricing) -> bool {
 
 /// Resolve pricing for a model: the pinned table first (exact id, then with the
 /// `provider/` prefix stripped). Bare ids also hit when [`load_pricing`] indexed a unique
-/// `provider/id` alias (e.g. wire `grok-4.5` → snapshot `x-ai/grok-4.5`). Else the
+/// `provider/id` alias (e.g. wire `grok-4.6` → snapshot `x-ai/grok-4.6`). Else the
 /// hardcoded fallback. Lets the live snapshot drive cost while staying correct offline.
 pub fn resolve_pricing(table: &PriceTable, model: &str) -> Pricing {
     if let Some(p) = table.get(model) {
@@ -1626,7 +1626,7 @@ mod tests {
     fn bare_id_aliases_unique_prefixed_snapshot_rows() {
         // Wire traffic often records bare ids; models.dev keys are provider-prefixed.
         let snap = r#"{"source":"x","unit":"usd_per_1m","models":{
-            "x-ai/grok-4.5":{"input":2,"output":6,"cache_read":0.5},
+            "x-ai/grok-4.6":{"input":2,"output":6,"cache_read":0.5},
             "anthropic/claude-sonnet-4":{"input":3,"output":15,"cache_read":0.3},
             "deepseek-chat":{"input":0.14,"output":0.28,"cache_read":0},
             "deepseek/deepseek-chat":{"input":0.2002,"output":0.8001,"cache_read":0},
@@ -1636,13 +1636,13 @@ mod tests {
         let table = load_pricing(snap);
 
         // Unique prefixed → bare alias.
-        let grok = resolve_pricing(&table, "grok-4.5");
+        let grok = resolve_pricing(&table, "grok-4.6");
         assert!((grok.input_per_1k - 0.002).abs() < 1e-9, "2/1M = 0.002/1k");
         assert!((grok.output_per_1k - 0.006).abs() < 1e-9);
         assert!((grok.cache_per_1k - 0.0005).abs() < 1e-9);
         // Prefixed form still works.
         assert_eq!(
-            resolve_pricing(&table, "x-ai/grok-4.5").input_per_1k,
+            resolve_pricing(&table, "x-ai/grok-4.6").input_per_1k,
             grok.input_per_1k
         );
 

--- a/crates/llmtrim-cli/src/monitor.rs
+++ b/crates/llmtrim-cli/src/monitor.rs
@@ -1284,7 +1284,7 @@ fn build_registry_price_table() -> std::collections::HashMap<&'static str, (f64,
 /// Fallback table: the pinned models.dev snapshot the bench prices from, embedded at
 /// compile time (the package re-includes bench/pricing.json for this). Exact id first
 /// (including bare aliases dual-indexed by [`crate::bench::load_pricing`] for unique
-/// `provider/id` rows such as `grok-4.5` ← `x-ai/grok-4.5`), then with the `provider/`
+/// `provider/id` rows such as `grok-4.6` ← `x-ai/grok-4.6`), then with the `provider/`
 /// prefix stripped, mirroring [`crate::bench::resolve_pricing`] — but zero-priced rows
 /// (free tiers, parse gaps) return `None` so an unknown model shows a blank cost cell
 /// rather than a misleading $0.00.
@@ -2361,12 +2361,12 @@ mod tests {
 
     #[test]
     fn llm_prices_resolves_bare_grok_4_5() {
-        // Ledger/wire id is bare; models.dev snapshot keys x-ai/grok-4.5.
-        let (input, output) = llm_prices("grok-4.5").expect("bare grok-4.5 must be priced");
+        // Ledger/wire id is bare; models.dev snapshot keys x-ai/grok-4.6.
+        let (input, output) = llm_prices("grok-4.6").expect("bare grok-4.6 must be priced");
         assert!((input - 2.0).abs() < 1e-9, "input $/1M got {input}");
         assert!((output - 6.0).abs() < 1e-9, "output $/1M got {output}");
         assert_eq!(
-            llm_prices("x-ai/grok-4.5").expect("prefixed form"),
+            llm_prices("x-ai/grok-4.6").expect("prefixed form"),
             (input, output)
         );
     }

--- a/crates/llmtrim-cli/src/reroute/grok.rs
+++ b/crates/llmtrim-cli/src/reroute/grok.rs
@@ -5,8 +5,9 @@
 //! back into the shared [`ReduceEvent`] stream that
 //! [`crate::reroute::sse::AnthropicSseEncoder`] re-encodes as Anthropic SSE.
 //!
-//! Wire models: `grok-4.5` (flagship) and `grok-composer-2.5-fast` (cheap/fast). Auth is OAuth
-//! against `auth.x.ai` (see [`crate::reroute::auth`]).
+//! Wire models: `grok-4.6` (Fable), `grok-4.5` (Opus/Sonnet flagship), and
+//! `grok-composer-2.5-fast` (cheap/fast). Auth is OAuth against `auth.x.ai` (see
+//! [`crate::reroute::auth`]).
 
 use anyhow::Result;
 use serde_json::{Map, Value, json};

--- a/crates/llmtrim-cli/src/reroute/grok.rs
+++ b/crates/llmtrim-cli/src/reroute/grok.rs
@@ -5,9 +5,8 @@
 //! back into the shared [`ReduceEvent`] stream that
 //! [`crate::reroute::sse::AnthropicSseEncoder`] re-encodes as Anthropic SSE.
 //!
-//! Wire models: `grok-4.6` (Fable), `grok-4.5` (Opus/Sonnet flagship), and
-//! `grok-composer-2.5-fast` (cheap/fast). Auth is OAuth against `auth.x.ai` (see
-//! [`crate::reroute::auth`]).
+//! Wire models: `grok-4.6` (flagship) and `grok-composer-2.5-fast` (cheap/fast). Auth is OAuth
+//! against `auth.x.ai` (see [`crate::reroute::auth`]).
 
 use anyhow::Result;
 use serde_json::{Map, Value, json};
@@ -121,7 +120,7 @@ pub fn build_request_body(
     // Ask cli-chat-proxy for `encrypted_content` on reasoning items so the next turn can
     // replay it. Live probe: without `include`, items only carry `summary`; with it, done
     // items gain `encrypted_content`. xAI docs list omitted prior reasoning as a top cause
-    // of cache misses on reasoning models (grok-4.5 bills large `reasoning_tokens`).
+    // of cache misses on reasoning models (grok-4.6 bills large `reasoning_tokens`).
     body.insert("include".into(), json!(["reasoning.encrypted_content"]));
 
     if let Some(max) = anthropic.get("max_tokens").and_then(Value::as_u64) {
@@ -1472,7 +1471,7 @@ mod tests {
     fn system_becomes_instructions() {
         let body = build_request_body(
             &json!({ "system": "Be concise.", "messages": [] }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -1482,7 +1481,7 @@ mod tests {
                 .unwrap()
                 .starts_with("Be concise.")
         );
-        assert_eq!(body["model"], "grok-4.5");
+        assert_eq!(body["model"], "grok-4.6");
         assert_eq!(body["stream"], true);
         assert_eq!(body["store"], false);
         assert_eq!(
@@ -1509,7 +1508,7 @@ mod tests {
                     {"role":"user","content":"again"}
                 ]
             }),
-            "grok-4.5",
+            "grok-4.6",
             Some("sess-think"),
         )
         .expect("build");
@@ -1546,7 +1545,7 @@ mod tests {
                     ]}
                 ]
             }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -1579,7 +1578,7 @@ mod tests {
                     ]}
                 ]
             }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -1607,7 +1606,7 @@ mod tests {
                     ]}
                 ]
             }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -1632,7 +1631,7 @@ mod tests {
                     {"role":"assistant","content":"plain reply"}
                 ]
             }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -1655,7 +1654,7 @@ mod tests {
                     { "name": "WebSearch", "description": "search", "input_schema": {} }
                 ]
             }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -1732,7 +1731,7 @@ mod tests {
     fn prompt_cache_key_from_session_id() {
         let body = build_request_body(
             &json!({ "messages": [{"role": "user", "content": "hi"}] }),
-            "grok-4.5",
+            "grok-4.6",
             Some("sess-1"),
         )
         .expect("build");
@@ -1743,7 +1742,7 @@ mod tests {
     fn prompt_cache_key_omitted_without_session() {
         let body = build_request_body(
             &json!({ "messages": [{"role": "user", "content": "hi"}] }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -1800,7 +1799,7 @@ mod tests {
             "output_tokens": 41,
             "output_tokens_details": {"reasoning_tokens": 40},
         });
-        write_upstream_usage_capture(&dir, &raw, "grok-4.5", "grok");
+        write_upstream_usage_capture(&dir, &raw, "grok-4.6", "grok");
         let files: Vec<_> = std::fs::read_dir(&dir)
             .unwrap()
             .filter_map(|e| e.ok())
@@ -1816,7 +1815,7 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(&files[0]).unwrap()).unwrap();
         assert_eq!(rec["kind"], "upstream_usage");
         assert_eq!(rec["provider"], "grok");
-        assert_eq!(rec["model"], "grok-4.5");
+        assert_eq!(rec["model"], "grok-4.6");
         assert_eq!(rec["usage"]["input_tokens_details"]["cached_tokens"], 128);
         assert_eq!(rec["mapped"]["cache_read"], 128);
         assert_eq!(rec["mapped"]["input"], 90); // 218 - 128
@@ -1826,7 +1825,7 @@ mod tests {
 
     #[test]
     fn reducer_finish_maps_cached_tokens_into_usage() {
-        let mut r = Reducer::new("grok-4.5");
+        let mut r = Reducer::new("grok-4.6");
         let chunk = concat!(
             "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
             "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":100,\"input_tokens_details\":{\"cached_tokens\":40},\"output_tokens\":5}}}\n\n",
@@ -1853,7 +1852,7 @@ mod tests {
 
     #[test]
     fn reducer_streams_text_and_tools() {
-        let mut r = Reducer::new("grok-4.5");
+        let mut r = Reducer::new("grok-4.6");
         let chunk = concat!(
             "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
             "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"Bash\"},\"output_index\":1}\n\n",
@@ -1881,7 +1880,7 @@ mod tests {
 
     #[test]
     fn reducer_maps_reasoning_to_thinking() {
-        let mut r = Reducer::new("grok-4.5");
+        let mut r = Reducer::new("grok-4.6");
         let chunk = concat!(
             "data: {\"type\":\"response.reasoning_text.delta\",\"delta\":\"hmm\"}\n\n",
             "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
@@ -1902,7 +1901,7 @@ mod tests {
 
     #[test]
     fn reducer_tunnels_encrypted_reasoning_as_thinking_signature() {
-        let mut r = Reducer::new("grok-4.5");
+        let mut r = Reducer::new("grok-4.6");
         let chunk = concat!(
             "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"summary\":[],\"status\":\"in_progress\"}}\n\n",
             "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"ponder\"}\n\n",
@@ -1944,7 +1943,7 @@ mod tests {
 
     #[test]
     fn reducer_buffers_interleaved_tool_args_by_call_id() {
-        let mut r = Reducer::new("grok-4.5");
+        let mut r = Reducer::new("grok-4.6");
         // Two function calls; argument deltas arrive interleaved without output_index.
         let chunk = concat!(
             "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"Bash\",\"id\":\"item_1\"}}\n\n",
@@ -2002,7 +2001,7 @@ mod tests {
 
     #[test]
     fn web_search_call_emits_server_tool_blocks_before_text() {
-        let mut r = Reducer::new("grok-4.5");
+        let mut r = Reducer::new("grok-4.6");
         let sse = concat!(
             "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\"}}\n\n",
             "data: {\"type\":\"response.web_search_call.in_progress\",\"item_id\":\"ws_1\"}\n\n",
@@ -2068,7 +2067,7 @@ mod tests {
 
     #[test]
     fn x_search_custom_tool_call_emits_server_tool_blocks() {
-        let mut r = Reducer::new("grok-4.5");
+        let mut r = Reducer::new("grok-4.6");
         let sse = concat!(
             "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"custom_tool_call\",\"name\":\"x_search\",\"id\":\"xs_1\"}}\n\n",
             "data: {\"type\":\"response.custom_tool_call_input.delta\",\"item_id\":\"xs_1\",\"delta\":\"{\\\"query\\\":\\\"claude-code-proxy\\\"}\"}\n\n",
@@ -2118,7 +2117,7 @@ mod tests {
 
     #[test]
     fn x_keyword_search_normalizes_to_x_search() {
-        let mut r = Reducer::new("grok-4.5");
+        let mut r = Reducer::new("grok-4.6");
         let sse = concat!(
             "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"custom_tool_call\",\"name\":\"x_keyword_search\",\"id\":\"search_1\"}}\n\n",
             "data: {\"type\":\"response.custom_tool_call_input.delta\",\"item_id\":\"search_1\",\"delta\":\"{\\\"query\\\":\\\"test\\\"}\"}\n\n",
@@ -2152,7 +2151,7 @@ mod tests {
                     ]
                 }]
             }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -2181,7 +2180,7 @@ mod tests {
                     }]
                 }]
             }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -2210,7 +2209,7 @@ mod tests {
                     }]
                 }]
             }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");
@@ -2238,7 +2237,7 @@ mod tests {
                     }]
                 }]
             }),
-            "grok-4.5",
+            "grok-4.6",
             None,
         )
         .expect("build");

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -344,12 +344,11 @@ pub fn default_codex_tier_model(tier: Tier) -> &'static str {
     }
 }
 
-/// Built-in Grok tier preset: flagship for Opus/Sonnet, Grok 4.6 for Fable, composer-fast for
-/// Haiku (background title/token calls).
+/// Built-in Grok tier preset: flagship for heavy tiers, composer-fast for Haiku (background
+/// title/token calls).
 pub fn default_grok_tier_model(tier: Tier) -> &'static str {
     match tier {
-        Tier::Opus | Tier::Sonnet => "grok-4.5",
-        Tier::Fable => "grok-4.6",
+        Tier::Opus | Tier::Sonnet | Tier::Fable => "grok-4.6",
         Tier::Haiku => "grok-composer-2.5-fast",
     }
 }
@@ -358,7 +357,7 @@ pub fn default_grok_tier_model(tier: Tier) -> &'static str {
 pub const KIMI_MODEL: &str = "kimi-for-coding";
 
 /// Grok models the CLI subscription endpoint accepts.
-pub const GROK_MODELS: [&str; 3] = ["grok-4.6", "grok-4.5", "grok-composer-2.5-fast"];
+pub const GROK_MODELS: [&str; 2] = ["grok-4.6", "grok-composer-2.5-fast"];
 
 /// Resolve the incoming Anthropic model id to the upstream provider model for `provider`, applying
 /// (in order): an exact-id override, then the tier's override, then the preset default. `overrides`
@@ -595,9 +594,9 @@ mod tests {
         let ov = BTreeMap::new();
         assert_eq!(
             resolve_model(SubProvider::Grok, "claude-opus-4-8", &ov),
-            "grok-4.5"
+            "grok-4.6"
         );
-        assert_eq!(resolve_model(SubProvider::Grok, "sonnet", &ov), "grok-4.5");
+        assert_eq!(resolve_model(SubProvider::Grok, "sonnet", &ov), "grok-4.6");
         assert_eq!(
             resolve_model(SubProvider::Grok, "claude-fable-5", &ov),
             "grok-4.6"
@@ -629,24 +628,24 @@ mod tests {
         ov.insert("haiku".to_string(), "gpt-5.4-mini".to_string());
         assert_eq!(
             resolve_model(SubProvider::Grok, "claude-opus-4-8", &ov),
-            "grok-4.5"
+            "grok-4.6"
         );
         assert_eq!(
             resolve_model(SubProvider::Grok, "haiku", &ov),
             "grok-composer-2.5-fast"
         );
         // A legitimate Grok override still wins.
-        ov.insert("opus".to_string(), "grok-4.5".to_string());
+        ov.insert("opus".to_string(), "grok-4.6".to_string());
         assert_eq!(
             resolve_model(SubProvider::Grok, "claude-opus-4-8", &ov),
-            "grok-4.5"
+            "grok-4.6"
         );
     }
 
     #[test]
     fn codex_ignores_grok_tier_overrides() {
         let mut ov = BTreeMap::new();
-        ov.insert("opus".to_string(), "grok-4.5".to_string());
+        ov.insert("opus".to_string(), "grok-4.6".to_string());
         assert_eq!(
             resolve_model(SubProvider::Codex, "claude-opus-4-8", &ov),
             "gpt-5.6-terra"

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -344,11 +344,12 @@ pub fn default_codex_tier_model(tier: Tier) -> &'static str {
     }
 }
 
-/// Built-in Grok tier preset: flagship for heavy tiers, composer-fast for Haiku (background
-/// title/token calls).
+/// Built-in Grok tier preset: flagship for Opus/Sonnet, Grok 4.6 for Fable, composer-fast for
+/// Haiku (background title/token calls).
 pub fn default_grok_tier_model(tier: Tier) -> &'static str {
     match tier {
-        Tier::Opus | Tier::Sonnet | Tier::Fable => "grok-4.5",
+        Tier::Opus | Tier::Sonnet => "grok-4.5",
+        Tier::Fable => "grok-4.6",
         Tier::Haiku => "grok-composer-2.5-fast",
     }
 }
@@ -357,7 +358,7 @@ pub fn default_grok_tier_model(tier: Tier) -> &'static str {
 pub const KIMI_MODEL: &str = "kimi-for-coding";
 
 /// Grok models the CLI subscription endpoint accepts.
-pub const GROK_MODELS: [&str; 2] = ["grok-4.5", "grok-composer-2.5-fast"];
+pub const GROK_MODELS: [&str; 3] = ["grok-4.6", "grok-4.5", "grok-composer-2.5-fast"];
 
 /// Resolve the incoming Anthropic model id to the upstream provider model for `provider`, applying
 /// (in order): an exact-id override, then the tier's override, then the preset default. `overrides`
@@ -597,6 +598,10 @@ mod tests {
             "grok-4.5"
         );
         assert_eq!(resolve_model(SubProvider::Grok, "sonnet", &ov), "grok-4.5");
+        assert_eq!(
+            resolve_model(SubProvider::Grok, "claude-fable-5", &ov),
+            "grok-4.6"
+        );
         assert_eq!(
             resolve_model(SubProvider::Grok, "haiku", &ov),
             "grok-composer-2.5-fast"

--- a/crates/llmtrim-cli/src/reroute/route.rs
+++ b/crates/llmtrim-cli/src/reroute/route.rs
@@ -129,8 +129,7 @@ pub fn resolve_explicit_model(provider: SubProvider, value: &str) -> Result<Stri
             _ => value,
         },
         SubProvider::Grok => match normalized.as_str() {
-            "grok" | "grok45" => "grok-4.5",
-            "grok46" => "grok-4.6",
+            "grok" | "grok46" | "grok45" => "grok-4.6",
             "composer" | "grokcomposer" | "grokcomposer25fast" => "grok-composer-2.5-fast",
             _ => value,
         },

--- a/crates/llmtrim-cli/src/reroute/route.rs
+++ b/crates/llmtrim-cli/src/reroute/route.rs
@@ -130,6 +130,7 @@ pub fn resolve_explicit_model(provider: SubProvider, value: &str) -> Result<Stri
         },
         SubProvider::Grok => match normalized.as_str() {
             "grok" | "grok45" => "grok-4.5",
+            "grok46" => "grok-4.6",
             "composer" | "grokcomposer" | "grokcomposer25fast" => "grok-composer-2.5-fast",
             _ => value,
         },

--- a/crates/llmtrim-cli/src/route_agents.rs
+++ b/crates/llmtrim-cli/src/route_agents.rs
@@ -60,6 +60,7 @@ fn display_name(model: &str) -> &str {
         "gpt-5.6-luna" => "Luna (GPT Luna)",
         "gpt-5.6-sol" => "Sol (GPT Sol)",
         "gpt-5.4-mini" => "Mini (GPT Mini)",
+        "grok-4.6" => "Grok 4.6",
         "grok-4.5" => "Grok 4.5",
         "grok-composer-2.5-fast" => "Grok Composer",
         "kimi-for-coding" => "Kimi",

--- a/crates/llmtrim-cli/src/route_agents.rs
+++ b/crates/llmtrim-cli/src/route_agents.rs
@@ -61,7 +61,6 @@ fn display_name(model: &str) -> &str {
         "gpt-5.6-sol" => "Sol (GPT Sol)",
         "gpt-5.4-mini" => "Mini (GPT Mini)",
         "grok-4.6" => "Grok 4.6",
-        "grok-4.5" => "Grok 4.5",
         "grok-composer-2.5-fast" => "Grok Composer",
         "kimi-for-coding" => "Kimi",
         other => other,

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -610,7 +610,7 @@ fn reroute_real_window(
 }
 
 /// Parallel to [`reroute_real_window`]: returns the concrete upstream model id (e.g.
-/// "gpt-5.6-terra" / "grok-4.5") chosen by tier mapping for the status line. `None` for Kimi,
+/// "gpt-5.6-terra" / "grok-4.6") chosen by tier mapping for the status line. `None` for Kimi,
 /// whose tiers all collapse to one internal wire id: the shortname is what a reader wants there.
 #[cfg(feature = "intercept")]
 fn reroute_resolved_model(
@@ -2009,9 +2009,9 @@ mod tests {
         let mut l = led(Health::Healthy);
         l.reroute = Some("grok".to_string());
         l.resolved_model = reroute_resolved_model("grok", "claude-opus-4-8", &tiers);
-        assert_eq!(l.resolved_model.as_deref(), Some("grok-4.5"));
+        assert_eq!(l.resolved_model.as_deref(), Some("grok-4.6"));
         let out = render_line(&cc(72_000), &l, 0, true);
-        assert!(out.contains("→grok-4.5"), "grok arrow shows model: {out}");
+        assert!(out.contains("→grok-4.6"), "grok arrow shows model: {out}");
     }
 
     fn ledger_row(sub: Option<&str>, model: Option<&str>) -> SessionLedgerRow {

--- a/crates/llmtrim-core/data/lmarena_text.json
+++ b/crates/llmtrim-core/data/lmarena_text.json
@@ -190,7 +190,7 @@
   "grok-4.20-beta1": 1444,
   "grok-4.20-multi-agent-beta-0309": 1450,
   "grok-4.3": 1401,
-  "grok-4.5": 1455,
+  "grok-4.6": 1455,
   "guanaco-33b": 1054,
   "hunyuan-hy3-preview": 1405,
   "hunyuan-large-2025-02-10": 1288,

--- a/crates/llmtrim-core/data/model_context.json
+++ b/crates/llmtrim-core/data/model_context.json
@@ -442,7 +442,7 @@
 "x-ai/grok-4.20": 2000000,
 "x-ai/grok-4.20-multi-agent": 2000000,
 "x-ai/grok-4.3": 1000000,
-"x-ai/grok-4.5": 500000,
+"x-ai/grok-4.6": 500000,
 "x-ai/grok-build-0.1": 256000,
 "xiaomi/mimo-v2.5": 1050000,
 "xiaomi/mimo-v2.5-pro": 1050000,

--- a/crates/llmtrim-core/data/model_reasoning.json
+++ b/crates/llmtrim-core/data/model_reasoning.json
@@ -447,7 +447,7 @@
 "x-ai/grok-4.20": true,
 "x-ai/grok-4.20-multi-agent": true,
 "x-ai/grok-4.3": true,
-"x-ai/grok-4.5": true,
+"x-ai/grok-4.6": true,
 "x-ai/grok-build-0.1": true,
 "xiaomi/mimo-v2.5": true,
 "xiaomi/mimo-v2.5-pro": true,


### PR DESCRIPTION
## Summary
- Default Grok tier preset maps Opus/Sonnet/Fable to `grok-4.6` (replaces `grok-4.5`)
- Haiku stays on `grok-composer-2.5-fast`
- Drop `grok-4.5` from `GROK_MODELS`; aliases (`grok` / `grok46` / `grok45`) resolve to `grok-4.6`
- Update agent display name, fixtures, statusline/monitor/bench examples, and models.dev snapshots

## Test plan
- [x] `cargo test -p llmtrim --lib reroute::`
- [x] `cargo test -p llmtrim --lib statusline::`
- [x] `cargo test -p llmtrim --lib monitor::`
- [x] `cargo test -p llmtrim --lib bench::`
- [x] `cargo test -p llmtrim-core --lib capability::`
- [ ] CI green on this PR