### PR TITLE
feat(sub): route Claude Code through a managed CLIProxyAPI sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ All notable changes to this project are documented here. The format follows
   / `ensure` install the sidecar, import stored tokens, and keep the old tier→model map.
   First-party protocol translation is no longer the live path.
   `llmtrim sub on`, `/sub on`, and status tab 4 accept every CLIProxyAPI CLI
-  (codex, claude, gemini/antigravity, grok, kimi, vertex, qwen, copilot) plus live
-  model ids from the sidecar. (`LLMTRIM_CLIPROXY_URL` / `LLMTRIM_CLIPROXY_KEY` point
-  at an existing instance instead of the managed sidecar.)
+  (codex, claude, gemini/antigravity, grok, kimi, vertex, qwen, copilot). Status
+  tab 4 is mode (off / always / fallback) plus a searchable opus/sonnet/haiku/fable
+  → official CLIProxyAPI model map (`https://models.router-for.me/models.json`).
+  `sub on grok` writes that tier map; it does not pin every turn to one id.
 
 - **Grok flagship is `grok-4.6`.** Default Grok tier preset maps Opus/Sonnet/Fable to
   `grok-4.6` (replacing `grok-4.5`); Haiku stays on `grok-composer-2.5-fast`. The subscription

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ All notable changes to this project are documented here. The format follows
   [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI), then rewrites intercepted
   Anthropic traffic to it. `/sub on [model]` does the same for one Claude Code window.
   `llmtrim status` tab 4 lists CLIProxyAPI models. `llmtrim update` also updates the
-  sidecar when you use it. First-party Codex/Kimi/Grok protocol translation is no longer
-  the live path. (`LLMTRIM_CLIPROXY_URL` / `LLMTRIM_CLIPROXY_KEY` point at an existing
-  instance instead of the managed sidecar.)
+  sidecar when you use it. Existing `sub = codex|kimi|grok` configs keep working: `update`
+  / `ensure` install the sidecar, import stored tokens, and keep the old tier→model map.
+  First-party protocol translation is no longer the live path.
+  (`LLMTRIM_CLIPROXY_URL` / `LLMTRIM_CLIPROXY_KEY` point at an existing instance instead
+  of the managed sidecar.)
 
 - **Grok flagship is `grok-4.6`.** Default Grok tier preset maps Opus/Sonnet/Fable to
   `grok-4.6` (replacing `grok-4.5`); Haiku stays on `grok-composer-2.5-fast`. The subscription

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project are documented here. The format follows
 
 ### Changed
 
+- **`sub` now uses CLIProxyAPI.** `llmtrim sub on` installs and starts
+  [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI), then rewrites intercepted
+  Anthropic traffic to it. `/sub on [model]` does the same for one Claude Code window.
+  `llmtrim status` tab 4 lists CLIProxyAPI models. `llmtrim update` also updates the
+  sidecar when you use it. First-party Codex/Kimi/Grok protocol translation is no longer
+  the live path. (`LLMTRIM_CLIPROXY_URL` / `LLMTRIM_CLIPROXY_KEY` point at an existing
+  instance instead of the managed sidecar.)
+
 - **Grok flagship is `grok-4.6`.** Default Grok tier preset maps Opus/Sonnet/Fable to
   `grok-4.6` (replacing `grok-4.5`); Haiku stays on `grok-composer-2.5-fast`. The subscription
   catalog no longer lists `grok-4.5`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,25 @@ All notable changes to this project are documented here. The format follows
 
 - **`sub` now uses CLIProxyAPI.** `llmtrim sub on` installs and starts
   [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI), then rewrites intercepted
-  Anthropic traffic to it. `/sub on [model]` does the same for one Claude Code window.
-  `llmtrim status` tab 4 lists CLIProxyAPI models. `llmtrim update` also updates the
-  sidecar when you use it. Existing `sub = codex|kimi|grok` configs keep working: `update`
-  / `ensure` install the sidecar, import stored tokens, and keep the old tier→model map.
-  First-party protocol translation is no longer the live path.
-  `llmtrim sub on`, `/sub on`, and status tab 4 accept every CLIProxyAPI CLI
-  (codex, claude, gemini/antigravity, grok, kimi, vertex, qwen, copilot). Status
-  tab 4 is mode (off / always / fallback) plus a searchable opus/sonnet/haiku/fable
-  → official CLIProxyAPI model map (`https://models.router-for.me/models.json`).
-  `sub on grok` writes that tier map; it does not pin every turn to one id.
+  Anthropic `/v1/messages` to it. Existing `sub = codex|kimi|grok` configs keep working:
+  `update` / `ensure` install the sidecar, import stored tokens, and keep the old
+  tier→model map. First-party Codex/Kimi/Grok protocol translation is no longer the
+  live path.
+
+  - **CLI / `/sub` / tab 4:** `llmtrim sub on [cli-or-model]`, `/sub on [cli-or-model]`,
+    and status tab 4 accept every CLIProxyAPI CLI (codex, claude, gemini/antigravity,
+    grok, kimi, vertex, qwen, copilot) plus official catalog ids
+    (`https://models.router-for.me/models.json`). `sub on grok` writes the
+    opus/sonnet/haiku/fable map; it does not pin every turn to one id.
+  - **Fallback hops:** `sub mode fallback` plus `sub chain anthropic,codex,…` — first
+    hop is primary (can be what's in use, Codex, Gemini, …); later hops run on failure.
+    Tab 4 `[` `]` rotate the first hop.
+  - **Tab 4 map editor:** `e` to edit, type to search, ↑↓ pick, `s` save, `a` add,
+    `d` delete. `llmtrim update` also updates CLIProxyAPI when you use it.
+  - **Images:** blocks smaller than 8×8 (Claude 2×2 placeholders) are omitted before
+    the sidecar so Grok does not 400 `invalid_image`.
+  - **Escape hatch:** `LLMTRIM_CLIPROXY_URL` / `LLMTRIM_CLIPROXY_KEY` point at an
+    existing instance instead of the managed sidecar.
 
 - **Grok flagship is `grok-4.6`.** Default Grok tier preset maps Opus/Sonnet/Fable to
   `grok-4.6` (replacing `grok-4.5`); Haiku stays on `grok-composer-2.5-fast`. The subscription

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ All notable changes to this project are documented here. The format follows
   sidecar when you use it. Existing `sub = codex|kimi|grok` configs keep working: `update`
   / `ensure` install the sidecar, import stored tokens, and keep the old tier→model map.
   First-party protocol translation is no longer the live path.
-  (`LLMTRIM_CLIPROXY_URL` / `LLMTRIM_CLIPROXY_KEY` point at an existing instance instead
-  of the managed sidecar.)
+  `llmtrim sub on`, `/sub on`, and status tab 4 accept every CLIProxyAPI CLI
+  (codex, claude, gemini/antigravity, grok, kimi, vertex, qwen, copilot) plus live
+  model ids from the sidecar. (`LLMTRIM_CLIPROXY_URL` / `LLMTRIM_CLIPROXY_KEY` point
+  at an existing instance instead of the managed sidecar.)
 
 - **Grok flagship is `grok-4.6`.** Default Grok tier preset maps Opus/Sonnet/Fable to
   `grok-4.6` (replacing `grok-4.5`); Haiku stays on `grok-composer-2.5-fast`. The subscription

--- a/README.md
+++ b/README.md
@@ -308,19 +308,20 @@ The redirect only fires once the prompt cache has gone cold. `/compact` re-sends
 <details>
 <summary><b>Subscription reroute (`sub`)</b> (opt-in; may conflict with provider ToS)</summary>
 
-Serve Claude Code from a ChatGPT/Codex, Kimi, or SuperGrok plan instead of Anthropic, or as fallback when Anthropic fails. Login prints a warning; decide for yourself.
+Send Claude Code through [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) instead of Anthropic, or as fallback when Anthropic fails. Login is CLIProxyAPI's own TUI; decide for yourself whether that fits the provider ToS.
 
 ```bash
-llmtrim sub auth codex login    # or kimi / grok
-llmtrim sub on codex            # or kimi / grok
+llmtrim sub on                  # install + start CLIProxyAPI, enable redirect
+llmtrim sub auth                # CLIProxyAPI TUI — sign in to Codex / Claude / Gemini / Grok / …
+llmtrim sub models              # models the sidecar can serve
 llmtrim sub status
 llmtrim sub mode fallback       # only when Anthropic fails
-llmtrim sub chain codex,kimi,grok
 llmtrim sub off
 ```
 
-Interactive: `llmtrim status` → tab **4 Sub** (or `llmtrim sub setup`) — cycle routing
-presets with ←/→, Enter to apply, `e` to edit the tier→model map.
+Interactive: `llmtrim status` → tab **4 Sub** — lists CLIProxyAPI models; Enter toggles reroute.
+`llmtrim update` also updates CLIProxyAPI when you use it. Point `LLMTRIM_CLIPROXY_URL` at an
+existing instance to skip the managed sidecar.
 
 Route only a delegated Claude Code subagent while leaving the parent window unchanged:
 
@@ -337,12 +338,14 @@ agent files and records an opt-out so `ensure` leaves them removed.
 This window only (installed with ensure; includes subagents; survives `/clear`):
 
 ```text
-/sub on [optional:codex|kimi|grok]   # bare /sub on = last window provider or global sub
+/sub on [optional:model-id]   # bare /sub on = CLIProxyAPI with Claude model ids passed through
 /sub off
 /sub status
 ```
 
-Tokens: `~/.llmtrim/<provider>/auth.json` (mode 0600). Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_SUB_CHAIN`.
+Sidecar: `~/.llmtrim/cliproxy/` (binary + config). Auth: `~/.cli-proxy-api` when present, else
+`~/.llmtrim/cliproxy/auth`. Env: `LLMTRIM_SUB`, `LLMTRIM_SUB_MODE`, `LLMTRIM_CLIPROXY_URL`,
+`LLMTRIM_CLIPROXY_KEY`.
 
 **Anthropic `/login` vs claude.ai connectors:** with global `sub` in `always` mode, by
 default llmtrim writes a dummy `ANTHROPIC_AUTH_TOKEN` into `~/.claude/settings.json` (same

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <sub>
     Using <b>Claude Code</b>? One install also gets you a live <a href="#claude-code">status line</a>,
     a <a href="#claude-code">cold-cache guard</a>, cheaper <a href="#claude-code"><code>/compact</code></a>,
-    and <a href="#claude-code"><code>/sub</code></a> to serve it from a Codex / Kimi / SuperGrok plan.
+    and <a href="#claude-code"><code>/sub</code></a> to serve it through CLIProxyAPI.
   </sub>
 </p>
 
@@ -308,19 +308,23 @@ The redirect only fires once the prompt cache has gone cold. `/compact` re-sends
 <details>
 <summary><b>Subscription reroute (`sub`)</b> (opt-in; may conflict with provider ToS)</summary>
 
-Send Claude Code through [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) instead of Anthropic, or as fallback when Anthropic fails. Login is CLIProxyAPI's own TUI; decide for yourself whether that fits the provider ToS.
+Send Claude Code through [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) instead of Anthropic, or as a fallback hop when the current path fails. Login is CLIProxyAPI's TUI; decide for yourself whether that fits the provider ToS.
 
 ```bash
 llmtrim sub on                  # install + start CLIProxyAPI, enable redirect
-llmtrim sub on gemini           # pin that CLIProxyAPI CLI (codex|claude|gemini|grok|kimi|vertex|qwen|copilot)
-llmtrim sub auth                # CLIProxyAPI TUI — sign in to Codex / Claude / Gemini / Grok / …
-llmtrim sub models              # models the sidecar can serve
+llmtrim sub on grok             # write opus/sonnet/haiku/fable → that CLI's models
+llmtrim sub auth                # CLIProxyAPI TUI — sign in
+llmtrim sub models              # official + live sidecar models
+llmtrim sub map on opus grok-4.6
+llmtrim sub chain anthropic,codex
+llmtrim sub mode fallback       # try hops in order when the current one fails
 llmtrim sub status
-llmtrim sub mode fallback       # only when Anthropic fails
 llmtrim sub off
 ```
 
-Interactive: `llmtrim status` → tab **4 Sub** — lists CLIProxyAPI models; Enter toggles reroute.
+Interactive: `llmtrim status` → tab **4 Sub** — Off / Always / Fallback, then `e` to edit the
+input→output map (type to search [CLIProxyAPI's catalog](https://models.router-for.me/models.json);
+`s` save, `a` add, `d` delete). `[` `]` rotate the fallback first hop.
 `llmtrim update` also updates CLIProxyAPI when you use it. Point `LLMTRIM_CLIPROXY_URL` at an
 existing instance to skip the managed sidecar.
 
@@ -352,7 +356,7 @@ Sidecar: `~/.llmtrim/cliproxy/` (binary + config). Auth: `~/.cli-proxy-api` when
 default llmtrim writes a dummy `ANTHROPIC_AUTH_TOKEN` into `~/.claude/settings.json` (same
 idea as [claude-code-proxy](https://github.com/raine/claude-code-proxy)'s
 `ANTHROPIC_AUTH_TOKEN=unused`) so Claude Code does not need a live Anthropic OAuth session.
-The MITM strips that dummy token and injects the real Grok/Codex/Kimi credential; non-messages
+The MITM strips that dummy token and sends `/v1/messages` to CLIProxyAPI; non-messages
 Anthropic probes are answered locally so they never return `401 Invalid bearer token`.
 
 Claude Code treats any API-key auth as overriding claude.ai login, so **claude.ai connectors
@@ -365,8 +369,8 @@ llmtrim sub anthropic-login skip   # default: no Anthropic /login; connectors of
 ```
 
 Restart Claude Code after `sub on` / `sub off` / `sub mode` / `sub anthropic-login` for the
-settings change to take effect. `sub mode fallback` always needs a real Anthropic login (the
-primary path is Anthropic).
+settings change to take effect. Fallback whose first hop is "what's in use" still needs a real
+Anthropic login.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Send Claude Code through [CLIProxyAPI](https://github.com/router-for-me/CLIProxy
 
 ```bash
 llmtrim sub on                  # install + start CLIProxyAPI, enable redirect
+llmtrim sub on gemini           # pin that CLIProxyAPI CLI (codex|claude|gemini|grok|kimi|vertex|qwen|copilot)
 llmtrim sub auth                # CLIProxyAPI TUI — sign in to Codex / Claude / Gemini / Grok / …
 llmtrim sub models              # models the sidecar can serve
 llmtrim sub status
@@ -338,7 +339,7 @@ agent files and records an opt-out so `ensure` leaves them removed.
 This window only (installed with ensure; includes subagents; survives `/clear`):
 
 ```text
-/sub on [optional:model-id]   # bare /sub on = CLIProxyAPI with Claude model ids passed through
+/sub on [optional:cli-or-model]  # gemini, codex, claude, grok, kimi, vertex, qwen, copilot, or a model id
 /sub off
 /sub status
 ```

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -330,7 +330,8 @@ pub fn run(
                 {
                     let ctrl_c = key.modifiers.contains(KeyModifiers::CONTROL)
                         && key.code == KeyCode::Char('c');
-                    if ctrl_c || app.handle_key(key.code) {
+                    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+                    if ctrl_c || app.handle_key(key.code, ctrl) {
                         break;
                     }
                     dirty = true;
@@ -507,7 +508,7 @@ impl App {
     }
 
     /// Handle a key; returns true to quit.
-    fn handle_key(&mut self, code: KeyCode) -> bool {
+    fn handle_key(&mut self, code: KeyCode, ctrl: bool) -> bool {
         // A help overlay swallows the next keypress to dismiss itself.
         if self.show_help {
             self.show_help = false;
@@ -516,7 +517,11 @@ impl App {
         // Map editor owns letters (including q) and ←/→ so search/column focus work.
         #[cfg(feature = "intercept")]
         if self.tab == Tab::Sub && self.sub.capturing_keys() {
-            let _ = self.sub.handle_key(code);
+            if ctrl && matches!(code, KeyCode::Char('s')) {
+                self.sub.save_now();
+            } else {
+                let _ = self.sub.handle_key(code);
+            }
             if self.sub.needs_apply {
                 self.pending_sub_apply = true;
             }
@@ -2575,9 +2580,9 @@ mod tests {
 
         // On Overview, `c` toggles the gauge basis.
         assert!(!app.whole_prompt);
-        app.handle_key(KeyCode::Char('c'));
+        app.handle_key(KeyCode::Char('c'), false);
         assert!(app.whole_prompt);
-        app.handle_key(KeyCode::Char('c'));
+        app.handle_key(KeyCode::Char('c'), false);
         assert!(!app.whole_prompt);
 
         // On the other tabs there is no size figure to reframe, so `c` is a no-op.
@@ -2593,7 +2598,7 @@ mod tests {
         };
         for tab in other {
             app.tab = tab;
-            app.handle_key(KeyCode::Char('c'));
+            app.handle_key(KeyCode::Char('c'), false);
             assert!(
                 !app.whole_prompt,
                 "c must not toggle the basis off Overview"
@@ -2606,7 +2611,7 @@ mod tests {
     fn four_key_and_tab_cycle_reach_sub() {
         let mut app = App::new(None, Duration::from_secs(2));
         assert!(matches!(app.tab, Tab::Overview));
-        app.handle_key(KeyCode::Char('4'));
+        app.handle_key(KeyCode::Char('4'), false);
         assert!(matches!(app.tab, Tab::Sub));
         // Forward cycle: Sub → Overview
         app.cycle_tab();
@@ -2635,14 +2640,14 @@ mod tests {
         // Not installed: `y` is inert — no quit, no action.
         let mut app = App::new(None, Duration::from_secs(2));
         app.tray_available = false;
-        assert!(!app.handle_key(KeyCode::Char('y')));
+        assert!(!app.handle_key(KeyCode::Char('y'), false));
         assert_eq!(app.action, PostAction::None);
 
         // Installed: `y` launches the tray in the background and stays on the dashboard
         // (returns false = no quit) without queuing a post-teardown action. The launch is
         // best-effort — no sibling binary exists in tests, so it no-ops.
         app.tray_available = true;
-        assert!(!app.handle_key(KeyCode::Char('y')));
+        assert!(!app.handle_key(KeyCode::Char('y'), false));
         assert_eq!(app.action, PostAction::None);
     }
 
@@ -2652,14 +2657,14 @@ mod tests {
         let mut ov = sample_overview();
         ov.status.kind = StatusKind::Stale;
         app.overview = Some(ov);
-        app.handle_key(KeyCode::Char('u'));
+        app.handle_key(KeyCode::Char('u'), false);
         assert_eq!(app.action, PostAction::Restart);
 
         let mut app = App::new(None, Duration::from_secs(2));
         let mut ov = sample_overview();
         ov.status.kind = StatusKind::Working;
         app.overview = Some(ov);
-        app.handle_key(KeyCode::Char('u'));
+        app.handle_key(KeyCode::Char('u'), false);
         assert_eq!(app.action, PostAction::Update);
     }
 
@@ -2672,7 +2677,7 @@ mod tests {
         ov.status.kind = StatusKind::Stale;
         ov.update_available = Some("0.3.0".into());
         app.overview = Some(ov);
-        app.handle_key(KeyCode::Char('u'));
+        app.handle_key(KeyCode::Char('u'), false);
         assert_eq!(app.action, PostAction::Update);
     }
 

--- a/crates/llmtrim-cli/src/breakdown/app.rs
+++ b/crates/llmtrim-cli/src/breakdown/app.rs
@@ -513,6 +513,15 @@ impl App {
             self.show_help = false;
             return false;
         }
+        // Map editor owns letters (including q) and ←/→ so search/column focus work.
+        #[cfg(feature = "intercept")]
+        if self.tab == Tab::Sub && self.sub.capturing_keys() {
+            let _ = self.sub.handle_key(code);
+            if self.sub.needs_apply {
+                self.pending_sub_apply = true;
+            }
+            return false;
+        }
         match code {
             KeyCode::Char('q') => return true,
             KeyCode::Char('?') => self.show_help = true,

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -17,21 +17,35 @@ use crate::reroute::{SubProvider, Tier};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RoutingPreset {
     Off,
-    Always,
+    AlwaysCodex,
+    AlwaysKimi,
+    AlwaysGrok,
+    /// What's in use first; on failure, try the saved hop chain.
     Fallback,
 }
 
 impl RoutingPreset {
-    pub const ALL: [RoutingPreset; 3] = [
+    /// Public list kept at 5 variants for semver. The TUI cycles Off / Always / Fallback.
+    pub const ALL: [RoutingPreset; 5] = [
         RoutingPreset::Off,
-        RoutingPreset::Always,
+        RoutingPreset::AlwaysCodex,
+        RoutingPreset::AlwaysKimi,
+        RoutingPreset::AlwaysGrok,
+        RoutingPreset::Fallback,
+    ];
+
+    const CYCLE: [RoutingPreset; 3] = [
+        RoutingPreset::Off,
+        RoutingPreset::AlwaysCodex,
         RoutingPreset::Fallback,
     ];
 
     fn label(self) -> &'static str {
         match self {
             RoutingPreset::Off => "Off",
-            RoutingPreset::Always => "Always",
+            RoutingPreset::AlwaysCodex | RoutingPreset::AlwaysKimi | RoutingPreset::AlwaysGrok => {
+                "Always"
+            }
             RoutingPreset::Fallback => "Fallback",
         }
     }
@@ -149,13 +163,13 @@ impl SubPanel {
     }
 
     pub fn preselect_provider(&mut self, _provider: SubProvider) {
-        self.selected = RoutingPreset::Always;
+        self.selected = RoutingPreset::AlwaysCodex;
         self.status = "highlighted Always — Enter to apply · e to edit map".into();
     }
 
     pub fn seed_export_demo(&mut self) {
-        self.selected = RoutingPreset::Always;
-        self.applied = RoutingPreset::Always;
+        self.selected = RoutingPreset::AlwaysCodex;
+        self.applied = RoutingPreset::AlwaysCodex;
         self.running = true;
         self.rows = vec![
             ("fable".into(), "grok-4.6".into()),
@@ -175,7 +189,7 @@ impl SubPanel {
         if resolve_fallback(&env, file.as_ref()) {
             RoutingPreset::Fallback
         } else {
-            RoutingPreset::Always
+            RoutingPreset::AlwaysCodex
         }
     }
 
@@ -395,7 +409,7 @@ impl SubPanel {
     }
 
     fn cycle_preset(&mut self, dir: i32) {
-        let list = RoutingPreset::ALL;
+        let list = RoutingPreset::CYCLE;
         let pos = list.iter().position(|p| *p == self.selected).unwrap_or(0) as i32;
         let next = (pos + dir).rem_euclid(list.len() as i32) as usize;
         self.selected = list[next];
@@ -457,7 +471,7 @@ impl SubPanel {
                 llmtrim_core::config::disable_sub()?;
                 Ok("reroute off — Anthropic only".into())
             }
-            RoutingPreset::Always => {
+            RoutingPreset::AlwaysCodex | RoutingPreset::AlwaysKimi | RoutingPreset::AlwaysGrok => {
                 cliproxy::ensure_for_existing_user()?;
                 llmtrim_core::config::enable_sub("on")?;
                 llmtrim_core::config::write_sub_mode(false)?;
@@ -535,7 +549,7 @@ impl SubPanel {
         ])
         .split(inner);
 
-        let presets: Vec<Span> = RoutingPreset::ALL
+        let presets: Vec<Span> = RoutingPreset::CYCLE
             .iter()
             .flat_map(|p| {
                 let on = *p == self.selected;

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -1,658 +1,26 @@
-//! Status TUI **Sub** tab — simple subscription routing.
-//!
-//! Level 1 (default): cycle a small set of **routing presets** with ←/→ and apply with Enter.
-//! Level 2 (opt-in via `e`): edit the active provider's Claude-tier → model map
-//! (Fable first, then Opus/Sonnet/Haiku).
-//!
-//! Chain order, effort, anthropic-login, window `/sub`, and OAuth stay on the CLI.
-
-use std::collections::BTreeMap;
+//! Status TUI **Sub** tab — CLIProxyAPI sidecar + available models.
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Cell, Padding, Paragraph, Row, Table};
+use ratatui::widgets::{Block, BorderType, Borders, Padding, Paragraph, Row, Table};
 
 use super::palette;
-use crate::reroute::catalog::{self, CatalogEntry};
-use crate::reroute::{
-    KIMI_MODEL, SubProvider, Tier, default_codex_tier_model, default_grok_tier_model,
-};
-
-/// One selectable routing policy. Provider and mode are packaged so the user never has to
-/// juggle "active" vs "edit" vs "mode" as separate dials on the default surface.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RoutingPreset {
-    Off,
-    AlwaysCodex,
-    AlwaysKimi,
-    AlwaysGrok,
-    /// Anthropic first; on failure, try the saved chain (or the last/active provider).
-    Fallback,
-}
-
-impl RoutingPreset {
-    pub const ALL: [RoutingPreset; 5] = [
-        RoutingPreset::Off,
-        RoutingPreset::AlwaysCodex,
-        RoutingPreset::AlwaysKimi,
-        RoutingPreset::AlwaysGrok,
-        RoutingPreset::Fallback,
-    ];
-
-    fn label(self) -> &'static str {
-        match self {
-            RoutingPreset::Off => "Off",
-            RoutingPreset::AlwaysCodex => "Always → Codex",
-            RoutingPreset::AlwaysKimi => "Always → Kimi",
-            RoutingPreset::AlwaysGrok => "Always → Grok",
-            RoutingPreset::Fallback => "Fallback (Anthropic first)",
-        }
-    }
-
-    fn short(self) -> &'static str {
-        match self {
-            RoutingPreset::Off => "off",
-            RoutingPreset::AlwaysCodex => "always/codex",
-            RoutingPreset::AlwaysKimi => "always/kimi",
-            RoutingPreset::AlwaysGrok => "always/grok",
-            RoutingPreset::Fallback => "fallback",
-        }
-    }
-
-    fn always_provider(self) -> Option<SubProvider> {
-        match self {
-            RoutingPreset::AlwaysCodex => Some(SubProvider::Codex),
-            RoutingPreset::AlwaysKimi => Some(SubProvider::Kimi),
-            RoutingPreset::AlwaysGrok => Some(SubProvider::Grok),
-            RoutingPreset::Off | RoutingPreset::Fallback => None,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Focus {
-    /// Cycle presets with ←/→, apply with Enter.
-    Presets,
-    /// Edit the active provider's tier map.
-    Map,
-}
+use crate::reroute::SubProvider;
+use crate::reroute::cliproxy::{self, Model};
 
 /// Live state for the Sub tab.
 pub struct SubPanel {
-    focus: Focus,
-    /// Highlighted preset (not necessarily applied yet).
-    selected: RoutingPreset,
-    /// What is currently on disk / last applied.
-    applied: RoutingPreset,
-    /// Auth flags per provider (Codex, Kimi, Grok) — refreshed on enter/apply.
-    auth: [bool; 3],
-    /// Map editor: provider whose tiers we show (always the active always-provider, or
-    /// the last re-enable target when in fallback/off).
-    map_provider: SubProvider,
-    tiers: [Tier; 4],
-    chosen: [String; 4],
-    catalog: Vec<CatalogEntry>,
-    tier_row: usize,
-    map_dirty: bool,
+    enabled: bool,
+    running: bool,
+    version: Option<String>,
+    url: String,
+    models: Vec<Model>,
+    selected: usize,
     status: String,
     /// True when a config write needs daemon restart + Claude auth sync after the TUI exits.
     pub needs_apply: bool,
-}
-
-impl SubPanel {
-    pub fn new() -> Self {
-        let applied = Self::read_applied_preset();
-        let map_provider = Self::map_provider_for(applied);
-        let mut panel = Self {
-            focus: Focus::Presets,
-            selected: applied,
-            applied,
-            auth: Self::read_auth(),
-            map_provider,
-            tiers: Tier::ALL,
-            chosen: [String::new(), String::new(), String::new(), String::new()],
-            catalog: Vec::new(),
-            tier_row: 0,
-            map_dirty: false,
-            status: String::new(),
-            needs_apply: false,
-        };
-        panel.reload_map();
-        panel
-    }
-
-    /// Re-read config + auth when the user lands on this tab.
-    pub fn refresh(&mut self) {
-        self.applied = Self::read_applied_preset();
-        // Keep the user's in-progress selection if they haven't applied yet and nothing
-        // external changed the applied preset; otherwise snap to disk.
-        if !self.needs_apply {
-            self.selected = self.applied;
-        }
-        self.auth = Self::read_auth();
-        if self.focus == Focus::Presets {
-            self.map_provider = Self::map_provider_for(self.selected);
-            self.reload_map();
-            self.map_dirty = false;
-        }
-    }
-
-    fn read_applied_preset() -> RoutingPreset {
-        // Fresh disk read — RuntimeConfig is process-cached and wrong after our own writes.
-        let file = load_config_file();
-        let env = |k: &str| std::env::var(k).ok();
-        // `disable_sub` leaves `mode = "fallback"` on disk. Off is "no active provider", not
-        // "mode string says fallback" — otherwise Off → refresh shows Fallback and Enter
-        // re-enables the last provider.
-        let Some(active) = resolve_active(&env, file.as_ref()) else {
-            return RoutingPreset::Off;
-        };
-        if resolve_fallback(&env, file.as_ref()) {
-            return RoutingPreset::Fallback;
-        }
-        match active.as_str() {
-            "codex" => RoutingPreset::AlwaysCodex,
-            "kimi" => RoutingPreset::AlwaysKimi,
-            "grok" => RoutingPreset::AlwaysGrok,
-            _ => RoutingPreset::Off,
-        }
-    }
-
-    /// Highlight a preset (and its map) without writing config — used by `sub setup <provider>`.
-    pub fn preselect_provider(&mut self, provider: SubProvider) {
-        self.selected = match provider {
-            SubProvider::Codex => RoutingPreset::AlwaysCodex,
-            SubProvider::Kimi => RoutingPreset::AlwaysKimi,
-            SubProvider::Grok => RoutingPreset::AlwaysGrok,
-        };
-        self.map_provider = provider;
-        self.reload_map();
-        self.map_dirty = false;
-        self.status = format!(
-            "highlighted {} — Enter to apply · e to edit map",
-            provider.as_str()
-        );
-    }
-
-    /// Stable demo state for the README SVG export (not written to disk).
-    #[cfg(test)]
-    pub(crate) fn seed_export_demo(&mut self) {
-        self.focus = Focus::Presets;
-        self.applied = RoutingPreset::AlwaysCodex;
-        self.selected = RoutingPreset::AlwaysCodex;
-        self.auth = [true, false, true]; // codex ✓ · kimi · · grok ✓
-        self.map_provider = SubProvider::Codex;
-        self.reload_map();
-        self.map_dirty = false;
-        self.status.clear();
-        self.needs_apply = false;
-    }
-
-    fn map_provider_for(preset: RoutingPreset) -> SubProvider {
-        if let Some(p) = preset.always_provider() {
-            return p;
-        }
-        // Fallback / Off: prefer last/active provider so the map still has a target.
-        llmtrim_core::config::sub_reenable_provider()
-            .as_deref()
-            .and_then(SubProvider::parse)
-            .unwrap_or(SubProvider::Codex)
-    }
-
-    fn read_auth() -> [bool; 3] {
-        [
-            auth_ok(SubProvider::Codex),
-            auth_ok(SubProvider::Kimi),
-            auth_ok(SubProvider::Grok),
-        ]
-    }
-
-    fn reload_map(&mut self) {
-        self.catalog = catalog::models_for(self.map_provider);
-        let overrides = llmtrim_core::config::sub_tiers_for(self.map_provider.as_str());
-        let in_catalog = |id: &str| self.catalog.iter().any(|e| e.id == id);
-        self.chosen = self.tiers.map(|t| match self.map_provider {
-            SubProvider::Kimi => KIMI_MODEL.to_string(),
-            SubProvider::Codex => overrides
-                .get(t.as_str())
-                .filter(|m| in_catalog(m) || m.starts_with("gpt-"))
-                .cloned()
-                .unwrap_or_else(|| default_codex_tier_model(t).to_string()),
-            SubProvider::Grok => overrides
-                .get(t.as_str())
-                .filter(|m| in_catalog(m) || m.starts_with("grok-"))
-                .cloned()
-                .unwrap_or_else(|| default_grok_tier_model(t).to_string()),
-        });
-        self.tier_row = self.tier_row.min(self.tiers.len().saturating_sub(1));
-    }
-
-    /// Handle a key while the Sub tab is focused. Returns true if the TUI should quit.
-    pub fn handle_key(&mut self, code: crossterm::event::KeyCode) -> bool {
-        use crossterm::event::KeyCode;
-        match self.focus {
-            Focus::Presets => match code {
-                KeyCode::Left | KeyCode::Char('h') => self.cycle_preset(-1),
-                KeyCode::Right | KeyCode::Char('l') => self.cycle_preset(1),
-                KeyCode::Enter => self.apply_selected(),
-                KeyCode::Char('e') => self.enter_map(),
-                KeyCode::Char('r') => {
-                    self.refresh();
-                    self.status = "refreshed".into();
-                }
-                _ => {}
-            },
-            Focus::Map => match code {
-                KeyCode::Esc => {
-                    if self.map_dirty {
-                        self.status = "unsaved map changes discarded".into();
-                    }
-                    self.map_dirty = false;
-                    self.focus = Focus::Presets;
-                    self.reload_map();
-                }
-                KeyCode::Up | KeyCode::Char('k') => {
-                    self.tier_row = self.tier_row.saturating_sub(1);
-                }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    self.tier_row = (self.tier_row + 1).min(self.tiers.len() - 1);
-                }
-                KeyCode::Left | KeyCode::Char('h') => self.cycle_model(-1),
-                KeyCode::Right | KeyCode::Char('l') | KeyCode::Enter => self.cycle_model(1),
-                KeyCode::Char('s') => self.save_map(),
-                _ => {}
-            },
-        }
-        false
-    }
-
-    fn cycle_preset(&mut self, dir: i32) {
-        let list = RoutingPreset::ALL;
-        let pos = list.iter().position(|p| *p == self.selected).unwrap_or(0) as i32;
-        let next = (pos + dir).rem_euclid(list.len() as i32) as usize;
-        self.selected = list[next];
-        self.map_provider = Self::map_provider_for(self.selected);
-        self.reload_map();
-        self.map_dirty = false;
-        self.status.clear();
-    }
-
-    fn apply_selected(&mut self) {
-        match self.apply_preset(self.selected) {
-            Ok(msg) => {
-                self.applied = self.selected;
-                self.needs_apply = true;
-                self.auth = Self::read_auth();
-                self.map_provider = Self::map_provider_for(self.applied);
-                self.reload_map();
-                self.status = msg;
-            }
-            Err(e) => self.status = format!("apply failed: {e}"),
-        }
-    }
-
-    fn apply_preset(&self, preset: RoutingPreset) -> anyhow::Result<String> {
-        match preset {
-            RoutingPreset::Off => {
-                llmtrim_core::config::disable_sub()?;
-                Ok(
-                    "routing off — traffic stays on Anthropic (compression only). Restart applies."
-                        .into(),
-                )
-            }
-            RoutingPreset::AlwaysCodex | RoutingPreset::AlwaysKimi | RoutingPreset::AlwaysGrok => {
-                let p = preset.always_provider().expect("always_* has provider");
-                // Mode first so a prior fallback config doesn't leave always-intent half-applied.
-                llmtrim_core::config::write_sub_mode(false)?;
-                // enable_sub keeps an existing map; if the provider was never configured,
-                // seed defaults via write_sub_mapping (also sets active).
-                let had_map = !llmtrim_core::config::sub_tiers_for(p.as_str()).is_empty();
-                if had_map {
-                    llmtrim_core::config::enable_sub(p.as_str())?;
-                } else {
-                    let map = default_tier_map(p);
-                    llmtrim_core::config::write_sub_mapping(p.as_str(), &map)?;
-                }
-                let auth = auth_ok(p);
-                let mut msg = format!(
-                    "always → {} applied. Restart applies to the live daemon.",
-                    p.as_str()
-                );
-                if !auth {
-                    msg.push_str(&format!(
-                        " Not logged in — run `llmtrim sub auth {} login`.",
-                        p.as_str()
-                    ));
-                }
-                Ok(msg)
-            }
-            RoutingPreset::Fallback => {
-                llmtrim_core::config::write_sub_mode(true)?;
-                // Ensure there is someone to fall back to: keep active if set, else re-enable last.
-                let file = load_config_file();
-                let env = |k: &str| std::env::var(k).ok();
-                if resolve_active(&env, file.as_ref()).is_none() {
-                    if let Some(p) = llmtrim_core::config::sub_reenable_provider() {
-                        llmtrim_core::config::enable_sub(&p)?;
-                    } else {
-                        // First-time fallback: seed Codex as the chain target.
-                        let map = default_tier_map(SubProvider::Codex);
-                        llmtrim_core::config::write_sub_mapping(SubProvider::Codex.as_str(), &map)?;
-                        llmtrim_core::config::write_sub_mode(true)?;
-                    }
-                }
-                Ok(
-                    "fallback applied — Anthropic first; subscription chain on failure. \
-                     Needs a live Anthropic login. Restart applies."
-                        .into(),
-                )
-            }
-        }
-    }
-
-    fn enter_map(&mut self) {
-        self.map_provider = Self::map_provider_for(self.applied);
-        // Prefer the selected always-provider if user is about to apply, but map edits
-        // always target the *applied* backend so we never write tiers for a backend that
-        // is not live (and confuse "I edited Grok" with "I'm still on Codex").
-        if let Some(p) = self.applied.always_provider() {
-            self.map_provider = p;
-        } else if let Some(p) = self.selected.always_provider() {
-            // Off/Fallback applied but user highlighted Always·X — still edit that provider's
-            // staged map so they can prepare before applying.
-            self.map_provider = p;
-        }
-        self.reload_map();
-        self.map_dirty = false;
-        self.focus = Focus::Map;
-        self.status = format!(
-            "editing {} map — s save · Esc back",
-            self.map_provider.as_str()
-        );
-    }
-
-    fn cycle_model(&mut self, dir: i32) {
-        if self.map_provider == SubProvider::Kimi || self.catalog.is_empty() {
-            self.status = "Kimi has a single model; nothing to change.".into();
-            return;
-        }
-        let cur = &self.chosen[self.tier_row];
-        let pos = self.catalog.iter().position(|e| &e.id == cur).unwrap_or(0);
-        let len = self.catalog.len() as i32;
-        let next = ((pos as i32) + dir).rem_euclid(len) as usize;
-        self.chosen[self.tier_row] = self.catalog[next].id.clone();
-        self.map_dirty = true;
-        self.status.clear();
-    }
-
-    fn save_map(&mut self) {
-        let mut map = BTreeMap::new();
-        for (t, m) in self.tiers.iter().zip(self.chosen.iter()) {
-            map.insert(t.as_str().to_string(), m.clone());
-        }
-        match llmtrim_core::config::write_sub_tiers(self.map_provider.as_str(), &map) {
-            Ok(()) => {
-                self.map_dirty = false;
-                // Only restart if this provider is the live one (always mode) or in the chain.
-                let live = self.applied.always_provider() == Some(self.map_provider)
-                    || self.applied == RoutingPreset::Fallback;
-                if live {
-                    self.needs_apply = true;
-                }
-                self.status = format!(
-                    "saved {} map{}",
-                    self.map_provider.as_str(),
-                    if live {
-                        " — restart applies"
-                    } else {
-                        " (not live until you apply that provider)"
-                    }
-                );
-            }
-            Err(e) => self.status = format!("save failed: {e}"),
-        }
-    }
-
-    pub fn help_keys(&self) -> &'static str {
-        match self.focus {
-            Focus::Presets => {
-                " Tab tabs · ←→ preset · ⏎ apply · e edit map · r refresh · t theme · q"
-            }
-            Focus::Map => " ↑↓ tier · ←→ model · s save · Esc back · t theme · q",
-        }
-    }
-
-    pub fn render(&self, f: &mut Frame, area: Rect) {
-        let frame = Style::default().fg(palette::frame());
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(frame)
-            .title(" sub · subscription routing ")
-            .title_style(frame.add_modifier(Modifier::BOLD))
-            .padding(Padding::new(1, 1, 0, 0));
-        let inner = block.inner(area);
-        f.render_widget(block, area);
-
-        let chunks = Layout::vertical([
-            Constraint::Length(7), // presets + auth
-            Constraint::Min(6),    // map summary / editor
-            Constraint::Length(2), // status
-        ])
-        .split(inner);
-
-        self.render_presets(f, chunks[0]);
-        self.render_map(f, chunks[1]);
-        self.render_status(f, chunks[2]);
-    }
-
-    fn render_presets(&self, f: &mut Frame, area: Rect) {
-        let mut lines = Vec::new();
-        lines.push(Line::from(vec![
-            Span::styled("Routing  ", Style::default().fg(palette::muted_gray())),
-            Span::styled(
-                self.applied.label(),
-                Style::default()
-                    .fg(palette::text())
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                if self.selected != self.applied {
-                    format!("   →  {}", self.selected.label())
-                } else {
-                    String::new()
-                },
-                Style::default().fg(palette::accent()),
-            ),
-        ]));
-
-        // Preset chips
-        let mut chips = Vec::new();
-        for (i, p) in RoutingPreset::ALL.iter().enumerate() {
-            if i > 0 {
-                chips.push(Span::raw("  "));
-            }
-            let selected = *p == self.selected;
-            let applied = *p == self.applied;
-            let style = if selected && self.focus == Focus::Presets {
-                Style::default()
-                    .bg(palette::accent())
-                    .fg(palette::bg())
-                    .add_modifier(Modifier::BOLD)
-            } else if applied {
-                Style::default()
-                    .fg(palette::green())
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(palette::muted_gray())
-            };
-            let mark = if applied { "● " } else { "○ " };
-            chips.push(Span::styled(format!("{mark}{}", p.short()), style));
-        }
-        lines.push(Line::from(chips));
-
-        // Auth row
-        let providers = [
-            (SubProvider::Codex, self.auth[0]),
-            (SubProvider::Kimi, self.auth[1]),
-            (SubProvider::Grok, self.auth[2]),
-        ];
-        let mut auth_spans = vec![Span::styled(
-            "Auth     ",
-            Style::default().fg(palette::muted_gray()),
-        )];
-        for (i, (p, ok)) in providers.iter().enumerate() {
-            if i > 0 {
-                auth_spans.push(Span::raw("  "));
-            }
-            let (glyph, color) = if *ok {
-                ("✓", palette::green())
-            } else {
-                ("·", palette::muted_gray())
-            };
-            auth_spans.push(Span::styled(
-                format!("{glyph} {}", p.as_str()),
-                Style::default().fg(color),
-            ));
-        }
-        lines.push(Line::from(auth_spans));
-
-        // Mode side-effect hint
-        let hint = match self.selected {
-            RoutingPreset::Off => "Claude uses Anthropic only (compression still on).",
-            RoutingPreset::AlwaysCodex | RoutingPreset::AlwaysKimi | RoutingPreset::AlwaysGrok => {
-                "Always-on: dummy Anthropic token by default (connectors off). Restart Claude Code after apply."
-            }
-            RoutingPreset::Fallback => {
-                "Fallback needs a live Anthropic login; connectors stay available."
-            }
-        };
-        lines.push(Line::from(Span::styled(
-            hint,
-            Style::default().fg(palette::muted_gray()),
-        )));
-        lines.push(Line::from(Span::styled(
-            "Enter applies the highlighted preset.  e edits models for the target provider.",
-            Style::default().fg(palette::muted_gray()),
-        )));
-
-        f.render_widget(Paragraph::new(lines), area);
-    }
-
-    fn render_map(&self, f: &mut Frame, area: Rect) {
-        let title = match self.focus {
-            Focus::Presets => format!(
-                " map · {} (read-only — press e to edit) ",
-                self.map_provider.as_str()
-            ),
-            Focus::Map => {
-                let dirty = if self.map_dirty { " · unsaved" } else { "" };
-                format!(" map · {}{dirty} ", self.map_provider.as_str())
-            }
-        };
-        let editing = self.focus == Focus::Map;
-        let border = if editing {
-            Style::default().fg(palette::accent())
-        } else {
-            Style::default().fg(palette::frame())
-        };
-
-        let rows = self.tiers.iter().enumerate().map(|(i, t)| {
-            let model = &self.chosen[i];
-            let (inp, outp) = self
-                .catalog
-                .iter()
-                .find(|e| e.id == *model)
-                .map(|e| {
-                    (
-                        e.input
-                            .map(|v| format!("${v:.2}"))
-                            .unwrap_or_else(|| "—".into()),
-                        e.output
-                            .map(|v| format!("${v:.2}"))
-                            .unwrap_or_else(|| "—".into()),
-                    )
-                })
-                .unwrap_or_else(|| ("—".into(), "—".into()));
-            let style = if editing && i == self.tier_row {
-                Style::default()
-                    .bg(palette::accent())
-                    .fg(palette::bg())
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(palette::text())
-            };
-            Row::new(vec![
-                Cell::from(t.as_str().to_string()),
-                Cell::from("→"),
-                Cell::from(model.clone()),
-                Cell::from(inp),
-                Cell::from(outp),
-            ])
-            .style(style)
-        });
-
-        let table = Table::new(
-            rows,
-            [
-                Constraint::Length(10),
-                Constraint::Length(3),
-                Constraint::Min(18),
-                Constraint::Length(10),
-                Constraint::Length(10),
-            ],
-        )
-        .header(
-            Row::new(vec!["Claude tier", "", "Model", "$/1M in", "$/1M out"]).style(
-                Style::default()
-                    .fg(palette::muted_gray())
-                    .add_modifier(Modifier::BOLD),
-            ),
-        )
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(border)
-                .title(title)
-                .title_style(border.add_modifier(Modifier::BOLD)),
-        );
-        f.render_widget(table, area);
-    }
-
-    fn render_status(&self, f: &mut Frame, area: Rect) {
-        let text = if self.status.is_empty() {
-            match self.focus {
-                Focus::Presets => {
-                    if self.selected != self.applied {
-                        format!(
-                            "highlight: {} · applied: {} · Enter to apply",
-                            self.selected.short(),
-                            self.applied.short()
-                        )
-                    } else {
-                        format!("applied: {}", self.applied.short())
-                    }
-                }
-                Focus::Map => format!(
-                    "editing {}{}",
-                    self.map_provider.as_str(),
-                    if self.map_dirty { " [unsaved]" } else { "" }
-                ),
-            }
-        } else {
-            self.status.clone()
-        };
-        f.render_widget(
-            Paragraph::new(Line::from(Span::styled(
-                text,
-                Style::default().fg(palette::muted_gray()),
-            ))),
-            area,
-        );
-    }
 }
 
 impl Default for SubPanel {
@@ -661,81 +29,194 @@ impl Default for SubPanel {
     }
 }
 
-fn auth_ok(p: SubProvider) -> bool {
-    crate::reroute::auth::auth_status_json(p)["logged_in"]
-        .as_bool()
-        .unwrap_or(false)
-}
+impl SubPanel {
+    pub fn new() -> Self {
+        let mut panel = Self {
+            enabled: false,
+            running: false,
+            version: None,
+            url: cliproxy::default_base_url(),
+            models: Vec::new(),
+            selected: 0,
+            status: String::new(),
+            needs_apply: false,
+        };
+        panel.refresh();
+        panel
+    }
 
-fn default_tier_map(p: SubProvider) -> BTreeMap<String, String> {
-    let mut map = BTreeMap::new();
-    match p {
-        SubProvider::Codex => {
-            for t in Tier::ALL {
-                map.insert(
-                    t.as_str().to_string(),
-                    default_codex_tier_model(t).to_string(),
-                );
-            }
-        }
-        SubProvider::Grok => {
-            for t in Tier::ALL {
-                map.insert(
-                    t.as_str().to_string(),
-                    default_grok_tier_model(t).to_string(),
-                );
-            }
-        }
-        SubProvider::Kimi => {
-            for t in Tier::ALL {
-                map.insert(t.as_str().to_string(), KIMI_MODEL.to_string());
-            }
+    pub fn refresh(&mut self) {
+        let st = cliproxy::status();
+        self.enabled = st.enabled;
+        self.running = st.running;
+        self.version = st.version;
+        self.url = st.base_url;
+        self.models = cliproxy::list_models().unwrap_or_default();
+        if self.selected >= self.models.len() {
+            self.selected = self.models.len().saturating_sub(1);
         }
     }
-    map
-}
 
-fn load_config_file() -> Option<toml::Value> {
-    let path = llmtrim_core::config::config_file_path()?;
-    let text = std::fs::read_to_string(path).ok()?;
-    toml::from_str(&text).ok()
-}
-
-fn resolve_active(
-    env: &impl Fn(&str) -> Option<String>,
-    file: Option<&toml::Value>,
-) -> Option<String> {
-    if let Some(v) = env("LLMTRIM_SUB").filter(|s| !s.is_empty()) {
-        let s = v.trim().to_ascii_lowercase();
-        return (s != "off").then_some(s);
+    pub fn preselect_provider(&mut self, _provider: SubProvider) {
+        self.status = "CLIProxyAPI — Enter toggles reroute · r refresh models".into();
     }
-    let sub = file?.get("sub")?;
-    let s = sub
-        .as_str()
-        .or_else(|| {
-            sub.get("active")
-                .or_else(|| sub.get("provider"))
-                .and_then(toml::Value::as_str)
-        })?
-        .trim()
-        .to_ascii_lowercase();
-    (s != "off" && !s.is_empty()).then_some(s)
-}
 
-fn resolve_fallback(env: &impl Fn(&str) -> Option<String>, file: Option<&toml::Value>) -> bool {
-    let parse = |raw: &str| {
-        matches!(
-            raw.trim().to_ascii_lowercase().as_str(),
-            "fallback" | "on_error" | "on-error" | "onerror"
-        )
-    };
-    if let Some(v) = env("LLMTRIM_SUB_MODE").filter(|s| !s.is_empty()) {
-        return parse(&v);
+    /// Stable demo state for the README SVG export (not written to disk).
+    pub fn seed_export_demo(&mut self) {
+        self.enabled = true;
+        self.running = true;
+        self.version = Some("7.2.130".into());
+        self.url = cliproxy::default_base_url();
+        self.models = vec![
+            Model {
+                id: "gpt-5.4".into(),
+                owned_by: "openai".into(),
+            },
+            Model {
+                id: "gemini-3-flash".into(),
+                owned_by: "google".into(),
+            },
+        ];
+        self.status = "demo".into();
     }
-    file.and_then(|v| v.get("sub"))
-        .and_then(|v| v.get("mode"))
-        .and_then(toml::Value::as_str)
-        .is_some_and(parse)
+
+    pub fn handle_key(&mut self, code: crossterm::event::KeyCode) -> bool {
+        use crossterm::event::KeyCode;
+        match code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.selected > 0 {
+                    self.selected -= 1;
+                }
+                true
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.models.is_empty() && self.selected + 1 < self.models.len() {
+                    self.selected += 1;
+                }
+                true
+            }
+            KeyCode::Enter => {
+                self.toggle();
+                true
+            }
+            KeyCode::Char('r') => {
+                self.refresh();
+                self.status = "refreshed".into();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn toggle(&mut self) {
+        if self.enabled {
+            if let Err(e) = llmtrim_core::config::disable_sub() {
+                self.status = format!("could not disable: {e:#}");
+                return;
+            }
+            let _ = cliproxy::stop();
+            self.enabled = false;
+            self.needs_apply = true;
+            self.status = "reroute off".into();
+        } else {
+            if let Err(e) = cliproxy::ensure_running() {
+                self.status = format!("CLIProxyAPI: {e:#}");
+                return;
+            }
+            if let Err(e) = llmtrim_core::config::enable_sub("on") {
+                self.status = format!("could not enable: {e:#}");
+                return;
+            }
+            self.enabled = true;
+            self.running = cliproxy::is_running();
+            self.needs_apply = true;
+            self.status = "reroute on via CLIProxyAPI".into();
+        }
+        self.refresh();
+    }
+
+    pub fn help_keys(&self) -> &'static str {
+        " Tab tabs · ↑↓ models · ⏎ on/off · r refresh · t theme · q"
+    }
+
+    pub fn render(&self, f: &mut Frame, area: Rect) {
+        let frame = Style::default().fg(palette::frame());
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(frame)
+            .title(" sub · CLIProxyAPI ")
+            .title_style(frame.add_modifier(Modifier::BOLD))
+            .padding(Padding::new(1, 1, 0, 0));
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+
+        let chunks = Layout::vertical([
+            Constraint::Length(5),
+            Constraint::Min(4),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+        let state = if self.enabled && self.running {
+            "on · running"
+        } else if self.enabled {
+            "on · sidecar down"
+        } else {
+            "off"
+        };
+        let ver = self
+            .version
+            .as_deref()
+            .map(|v| format!(" v{v}"))
+            .unwrap_or_default();
+        let header = Paragraph::new(vec![
+            Line::from(vec![
+                Span::styled("CLIProxyAPI ", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(format!("{state}{ver}")),
+            ]),
+            Line::from(self.url.as_str()),
+            Line::from("Enter toggles reroute. Sign in: llmtrim sub auth"),
+        ]);
+        f.render_widget(header, chunks[0]);
+
+        if self.models.is_empty() {
+            let empty = if self.running {
+                "No models yet — run `llmtrim sub auth` to sign in."
+            } else {
+                "Sidecar not running — Enter to start, or `llmtrim sub on`."
+            };
+            f.render_widget(Paragraph::new(empty), chunks[1]);
+        } else {
+            let rows: Vec<Row> = self
+                .models
+                .iter()
+                .enumerate()
+                .map(|(i, m)| {
+                    let style = if i == self.selected {
+                        Style::default()
+                            .fg(palette::accent())
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    };
+                    Row::new(vec![m.id.clone(), m.owned_by.clone()]).style(style)
+                })
+                .collect();
+            let table = Table::new(
+                rows,
+                [Constraint::Percentage(65), Constraint::Percentage(35)],
+            )
+            .header(
+                Row::new(vec!["model", "owned_by"]).style(Style::default().add_modifier(Modifier::BOLD)),
+            );
+            f.render_widget(table, chunks[1]);
+        }
+
+        if !self.status.is_empty() {
+            f.render_widget(Paragraph::new(self.status.as_str()), chunks[2]);
+        }
+    }
 }
 
 /// Reconcile Claude dummy-auth + restart the interceptor so a Sub-tab write takes effect.
@@ -745,7 +226,6 @@ fn resolve_fallback(env: &impl Fn(&str) -> Option<String>, file: Option<&toml::V
 /// already running (so a pure-config edit never spawns a new interceptor by surprise).
 pub fn apply_pending_changes() -> String {
     use crate::statusline::SubAuthEnvChange;
-    // Same rule as main::sync_claude_sub_auth.
     let want = llmtrim_core::config::sub_skip_anthropic_login();
     let mut parts = Vec::new();
     match crate::statusline::sync_sub_auth_env(want) {
@@ -760,6 +240,11 @@ pub fn apply_pending_changes() -> String {
         Ok(SubAuthEnvChange::Unchanged) => {}
         Err(e) => parts.push(format!("Claude Code auth env update failed: {e:#}")),
     }
+    if llmtrim_core::config::sub_always_on()
+        && let Err(e) = cliproxy::ensure_running()
+    {
+        parts.push(format!("CLIProxyAPI: {e:#}"));
+    }
     let daemon_msg = match crate::daemon::running() {
         None => {
             "Subscription routing saved (no daemon running — next start picks it up).".to_string()
@@ -772,15 +257,15 @@ pub fn apply_pending_changes() -> String {
                         format!("Subscription routing applied (restarted daemon pid {pid}).")
                     }
                     Err(e) => format!(
-                        "Subscription config saved, but restart failed: {e:#}.                          Run `llmtrim start --force`."
+                        "Subscription config saved, but restart failed: {e:#}. Run `llmtrim start --force`."
                     ),
                 },
                 Ok(false) => {
-                    "Subscription config saved, but the old daemon did not release the port.                      Run `llmtrim start --force`."
+                    "Subscription config saved, but the old daemon did not release the port. Run `llmtrim start --force`."
                         .to_string()
                 }
                 Err(e) => format!(
-                    "Subscription config saved, but restart failed: {e:#}.                      Run `llmtrim start --force`."
+                    "Subscription config saved, but restart failed: {e:#}. Run `llmtrim start --force`."
                 ),
             }
         }
@@ -794,60 +279,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn preset_cycle_wraps() {
-        let mut p = SubPanel::new();
-        p.selected = RoutingPreset::Off;
-        p.cycle_preset(1);
-        assert_eq!(p.selected, RoutingPreset::AlwaysCodex);
-        p.selected = RoutingPreset::Fallback;
-        p.cycle_preset(1);
-        assert_eq!(p.selected, RoutingPreset::Off);
-        p.cycle_preset(-1);
-        assert_eq!(p.selected, RoutingPreset::Fallback);
-    }
-
-    #[test]
-    fn map_provider_for_always_matches() {
-        assert_eq!(
-            SubPanel::map_provider_for(RoutingPreset::AlwaysGrok),
-            SubProvider::Grok
-        );
-        assert_eq!(
-            SubPanel::map_provider_for(RoutingPreset::AlwaysKimi),
-            SubProvider::Kimi
-        );
-    }
-
-    #[test]
-    fn read_applied_preset_off_wins_over_stale_fallback_mode() {
-        // Unit-level: resolve_active None => Off, even if resolve_fallback would be true.
-        // (Integration against a temp config file would also work; this guards the branch order.)
-        assert_eq!(
-            {
-                // Simulate the fixed decision order with local values.
-                let active: Option<String> = None;
-                let fallback = true;
-                match active {
-                    None => RoutingPreset::Off,
-                    Some(_) if fallback => RoutingPreset::Fallback,
-                    Some(a) => match a.as_str() {
-                        "codex" => RoutingPreset::AlwaysCodex,
-                        _ => RoutingPreset::Off,
-                    },
-                }
-            },
-            RoutingPreset::Off
-        );
-    }
-
-    #[test]
-    fn kimi_cycle_model_is_noop() {
-        let mut p = SubPanel::new();
-        p.map_provider = SubProvider::Kimi;
-        p.reload_map();
-        let before = p.chosen.clone();
-        p.cycle_model(1);
-        assert_eq!(p.chosen, before);
-        assert!(!p.map_dirty);
+    fn new_panel_starts_on_presets() {
+        let p = SubPanel::new();
+        assert!(!p.needs_apply);
+        assert_eq!(p.selected, 0);
     }
 }

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -6,7 +6,9 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Padding, Paragraph, Row, Table};
+use ratatui::widgets::{
+    Block, BorderType, Borders, List, ListItem, ListState, Padding, Paragraph, Row, Table,
+};
 
 use super::palette;
 use crate::reroute::cliproxy::{self, OfficialModel};
@@ -45,6 +47,13 @@ enum Focus {
 enum Col {
     From,
     To,
+}
+
+fn side_label(col: Col) -> &'static str {
+    match col {
+        Col::From => "input",
+        Col::To => "output",
+    }
 }
 
 pub struct SubPanel {
@@ -568,39 +577,38 @@ impl SubPanel {
         f.render_widget(table, chunks[1]);
 
         if self.focus == Focus::Map {
-            let q = if self.search.is_empty() {
-                "_".to_string()
+            let title = if self.search.is_empty() {
+                format!("{} · {} models", side_label(self.col), self.filtered.len())
             } else {
-                self.search.clone()
+                format!("\"{}\" · {} matches", self.search, self.filtered.len())
             };
-            let mut lines = vec![Line::from(Span::styled(
-                q,
-                Style::default().add_modifier(Modifier::BOLD),
-            ))];
-            let window = 6usize;
-            let start = self.filter_idx.saturating_sub(1);
-            let end = (start + window).min(self.filtered.len());
-            for (i, id) in self.filtered[start..end].iter().enumerate() {
-                let idx = start + i;
-                let mark = if idx == self.filter_idx { "* " } else { "  " };
-                let style = if idx == self.filter_idx {
+            let items: Vec<ListItem> = if self.filtered.is_empty() {
+                vec![ListItem::new("(no matches)")]
+            } else {
+                self.filtered
+                    .iter()
+                    .map(|id| ListItem::new(id.as_str()))
+                    .collect()
+            };
+            let list = List::new(items)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(palette::frame()))
+                        .title(title),
+                )
+                .highlight_style(
                     Style::default()
                         .fg(palette::accent())
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default()
-                };
-                lines.push(Line::from(Span::styled(format!("{mark}{id}"), style)));
+                        .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+                )
+                .highlight_symbol("› ");
+            let mut state = ListState::default();
+            if !self.filtered.is_empty() {
+                state.select(Some(self.filter_idx.min(self.filtered.len() - 1)));
             }
-            if self.filtered.is_empty() {
-                lines.push(Line::from("  (no matches)"));
-            } else if end < self.filtered.len() {
-                lines.push(Line::from(format!(
-                    "  … {} more",
-                    self.filtered.len() - end
-                )));
-            }
-            f.render_widget(Paragraph::new(lines), chunks[2]);
+            f.render_stateful_widget(list, chunks[2], &mut state);
         }
 
         let hint = if self.focus == Focus::Map {

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -30,7 +30,7 @@ impl RoutingPreset {
         match self {
             RoutingPreset::Off => "Off",
             RoutingPreset::Always => "Always → CLIProxyAPI",
-            RoutingPreset::Fallback => "Fallback (Anthropic first)",
+            RoutingPreset::Fallback => "Fallback",
         }
     }
 }
@@ -45,6 +45,7 @@ pub struct SubPanel {
     focus: Focus,
     selected: RoutingPreset,
     applied: RoutingPreset,
+    chain: Vec<String>,
     tiers: [Tier; 4],
     chosen: [String; 4],
     catalog: Vec<OfficialModel>,
@@ -71,6 +72,7 @@ impl SubPanel {
             focus: Focus::Presets,
             selected: applied,
             applied,
+            chain: Self::read_chain(),
             tiers: Tier::ALL,
             chosen: [String::new(), String::new(), String::new(), String::new()],
             catalog: Vec::new(),
@@ -94,6 +96,7 @@ impl SubPanel {
             self.selected = applied;
         }
         self.applied = applied;
+        self.chain = Self::read_chain();
         self.running = cliproxy::is_running();
         if self.focus == Focus::Presets && !self.map_dirty {
             self.reload_catalog();
@@ -164,6 +167,8 @@ impl SubPanel {
             Focus::Presets => match code {
                 KeyCode::Left | KeyCode::Char('h') => self.cycle_preset(-1),
                 KeyCode::Right | KeyCode::Char('l') => self.cycle_preset(1),
+                KeyCode::Char('[') => self.rotate_chain(-1),
+                KeyCode::Char(']') => self.rotate_chain(1),
                 KeyCode::Enter => self.apply_selected(),
                 KeyCode::Char('e') => {
                     self.focus = Focus::Map;
@@ -239,6 +244,42 @@ impl SubPanel {
         self.map_dirty = true;
     }
 
+    fn read_chain() -> Vec<String> {
+        if let Ok(v) = std::env::var("LLMTRIM_SUB_CHAIN") {
+            return v.split(',').filter_map(cliproxy::parse_hop).collect();
+        }
+        load_config_file()
+            .as_ref()
+            .and_then(|v| v.get("sub"))
+            .and_then(|v| v.get("chain"))
+            .map(|v| match v {
+                toml::Value::Array(items) => items
+                    .iter()
+                    .filter_map(toml::Value::as_str)
+                    .filter_map(cliproxy::parse_hop)
+                    .collect(),
+                toml::Value::String(s) => s.split(',').filter_map(cliproxy::parse_hop).collect(),
+                _ => Vec::new(),
+            })
+            .unwrap_or_default()
+    }
+
+    fn rotate_chain(&mut self, dir: i32) {
+        if self.selected != RoutingPreset::Fallback {
+            self.selected = RoutingPreset::Fallback;
+        }
+        if self.chain.is_empty() {
+            self.chain = vec!["anthropic".into(), "on".into()];
+        }
+        let n = self.chain.len() as i32;
+        if n == 0 {
+            return;
+        }
+        let k = dir.rem_euclid(n) as usize;
+        self.chain.rotate_left(k);
+        self.status = format!("chain {}", self.chain.join(" → "));
+    }
+
     fn apply_selected(&mut self) {
         match self.apply_preset(self.selected) {
             Ok(msg) => {
@@ -268,7 +309,13 @@ impl SubPanel {
                 cliproxy::ensure_for_existing_user()?;
                 llmtrim_core::config::enable_sub("on")?;
                 llmtrim_core::config::write_sub_mode(true)?;
-                Ok("fallback — Anthropic first, then CLIProxyAPI".into())
+                let chain = if self.chain.is_empty() {
+                    vec!["anthropic".into(), "on".into()]
+                } else {
+                    self.chain.clone()
+                };
+                llmtrim_core::config::write_sub_chain(&chain)?;
+                Ok(format!("fallback · {}", chain.join(" → ")))
             }
         }
     }
@@ -292,7 +339,7 @@ impl SubPanel {
 
     pub fn help_keys(&self) -> &'static str {
         match self.focus {
-            Focus::Presets => " Tab tabs · ←→ mode · ⏎ apply · e map · r refresh · q",
+            Focus::Presets => " Tab tabs · ←→ mode · [ ] chain · ⏎ apply · e map · r refresh · q",
             Focus::Map => " ↑↓ tier · type search · ←→ model · w save · Esc back · q",
         }
     }
@@ -339,6 +386,11 @@ impl SubPanel {
                 "{sidecar} · {} official models · * = applied",
                 self.catalog.len()
             )),
+            Line::from(if self.selected == RoutingPreset::Fallback {
+                format!("chain {}", if self.chain.is_empty() { "anthropic → on".into() } else { self.chain.join(" → ") })
+            } else {
+                String::new()
+            }),
         ]);
         f.render_widget(header, chunks[0]);
 

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -504,13 +504,13 @@ impl SubPanel {
 
     pub fn help_keys(&self) -> &'static str {
         match self.focus {
-            Focus::Presets => " Tab tabs · ←→ mode · [ ] chain · Enter apply · e map · r refresh · q",
+            Focus::Presets => {
+                " Tab tabs · ←→ mode · [ ] chain · Enter apply · e map · r refresh · q"
+            }
             Focus::Map if self.map_dirty => {
                 " ← from · → to · ↑↓ pick · Enter pick · s SAVE · a add · d del · Esc discard"
             }
-            Focus::Map => {
-                " ← from · → to · ↑↓ pick · Enter pick · s save · a add · d del · Esc"
-            }
+            Focus::Map => " ← from · → to · ↑↓ pick · Enter pick · s save · a add · d del · Esc",
         }
     }
 
@@ -581,7 +581,11 @@ impl SubPanel {
             .enumerate()
             .map(|(i, (from, to))| {
                 let active = self.focus == Focus::Map && i == self.row;
-                let from_s = if from.is_empty() { "…" } else { from.as_str() };
+                let from_s = if from.is_empty() {
+                    "…"
+                } else {
+                    from.as_str()
+                };
                 let to_s = if to.is_empty() {
                     "(pass through)"
                 } else {
@@ -611,11 +615,13 @@ impl SubPanel {
                 ])
             })
             .collect();
-        let table = Table::new(rows, [Constraint::Percentage(40), Constraint::Percentage(60)])
-            .header(
-                Row::new(vec!["input", "output"])
-                    .style(Style::default().add_modifier(Modifier::BOLD)),
-            );
+        let table = Table::new(
+            rows,
+            [Constraint::Percentage(40), Constraint::Percentage(60)],
+        )
+        .header(
+            Row::new(vec!["input", "output"]).style(Style::default().add_modifier(Modifier::BOLD)),
+        );
         f.render_widget(table, chunks[1]);
 
         if self.focus == Focus::Map {

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -265,8 +265,10 @@ impl SubPanel {
                     self.refilter();
                     self.status = "editing output (CLIProxyAPI model)".into();
                 }
-                KeyCode::Up => self.move_row(-1),
-                KeyCode::Down => self.move_row(1),
+                KeyCode::Up => self.move_pick(-1),
+                KeyCode::Down => self.move_pick(1),
+                KeyCode::Tab => self.move_row(1),
+                KeyCode::BackTab => self.move_row(-1),
                 KeyCode::Char('+') | KeyCode::Insert => self.add_row(),
                 KeyCode::Char('-') | KeyCode::Delete => self.remove_row(),
                 KeyCode::Char('w') if self.search.is_empty() => self.save_map(),
@@ -337,13 +339,16 @@ impl SubPanel {
 
     fn apply_search_to_cell(&mut self) {
         self.refilter();
-        let value = self
-            .filtered
-            .first()
-            .cloned()
-            .unwrap_or_else(|| self.search.clone());
         self.filter_idx = 0;
-        self.set_cell(value);
+        self.set_cell(self.search.clone());
+    }
+
+    fn move_pick(&mut self, dir: i32) {
+        if self.filtered.is_empty() {
+            return;
+        }
+        let n = self.filtered.len() as i32;
+        self.filter_idx = (self.filter_idx as i32 + dir).rem_euclid(n) as usize;
     }
 
     fn cycle_preset(&mut self, dir: i32) {
@@ -452,7 +457,7 @@ impl SubPanel {
     pub fn help_keys(&self) -> &'static str {
         match self.focus {
             Focus::Presets => " Tab tabs · ←→ mode · [ ] chain · Enter apply · e map · r refresh · q",
-            Focus::Map => " ← from · → to · ↑↓ row · type search · +/- row · w save · Esc",
+            Focus::Map => " ← from · → to · type · ↑↓ pick · Tab row · +/- · Enter · w · Esc",
         }
     }
 
@@ -468,9 +473,11 @@ impl SubPanel {
         let inner = block.inner(area);
         f.render_widget(block, area);
 
+        let suggest_h = if self.focus == Focus::Map { 8 } else { 0 };
         let chunks = Layout::vertical([
             Constraint::Length(4),
-            Constraint::Min(8),
+            Constraint::Min(4),
+            Constraint::Length(suggest_h),
             Constraint::Length(2),
         ])
         .split(inner);
@@ -559,6 +566,42 @@ impl SubPanel {
                     .style(Style::default().add_modifier(Modifier::BOLD)),
             );
         f.render_widget(table, chunks[1]);
+
+        if self.focus == Focus::Map {
+            let q = if self.search.is_empty() {
+                "_".to_string()
+            } else {
+                self.search.clone()
+            };
+            let mut lines = vec![Line::from(Span::styled(
+                q,
+                Style::default().add_modifier(Modifier::BOLD),
+            ))];
+            let window = 6usize;
+            let start = self.filter_idx.saturating_sub(1);
+            let end = (start + window).min(self.filtered.len());
+            for (i, id) in self.filtered[start..end].iter().enumerate() {
+                let idx = start + i;
+                let mark = if idx == self.filter_idx { "* " } else { "  " };
+                let style = if idx == self.filter_idx {
+                    Style::default()
+                        .fg(palette::accent())
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                lines.push(Line::from(Span::styled(format!("{mark}{id}"), style)));
+            }
+            if self.filtered.is_empty() {
+                lines.push(Line::from("  (no matches)"));
+            } else if end < self.filtered.len() {
+                lines.push(Line::from(format!(
+                    "  … {} more",
+                    self.filtered.len() - end
+                )));
+            }
+            f.render_widget(Paragraph::new(lines), chunks[2]);
+        }
 
         let hint = if self.focus == Focus::Map {
             let n = self.filtered.len();

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -291,13 +291,13 @@ impl SubPanel {
                     self.col = Col::From;
                     self.search.clear();
                     self.refilter();
-                    self.status = "editing input (Claude tier or model id)".into();
+                    self.status = "editing input (incoming model or tier)".into();
                 }
                 KeyCode::Right => {
                     self.col = Col::To;
                     self.search.clear();
                     self.refilter();
-                    self.status = "editing output (CLIProxyAPI model)".into();
+                    self.status = "editing output (mapped model)".into();
                 }
                 KeyCode::Up => self.move_pick(-1),
                 KeyCode::Down => self.move_pick(1),
@@ -613,7 +613,7 @@ impl SubPanel {
             .collect();
         let table = Table::new(rows, [Constraint::Percentage(40), Constraint::Percentage(60)])
             .header(
-                Row::new(vec!["input (Claude)", "output (CLIProxyAPI)"])
+                Row::new(vec!["input", "output"])
                     .style(Style::default().add_modifier(Modifier::BOLD)),
             );
         f.render_widget(table, chunks[1]);

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -31,7 +31,7 @@ impl RoutingPreset {
     fn label(self) -> &'static str {
         match self {
             RoutingPreset::Off => "Off",
-            RoutingPreset::Always => "Always → CLIProxyAPI",
+            RoutingPreset::Always => "Always",
             RoutingPreset::Fallback => "Fallback",
         }
     }
@@ -47,6 +47,31 @@ enum Focus {
 enum Col {
     From,
     To,
+}
+
+fn hop_display(hop: &str) -> &str {
+    match hop {
+        "anthropic" | "direct" => "Anthropic",
+        "on" | "cliproxy" | "cli-proxy" | "cli-proxy-api" | "cliproxyapi" => "mapped models",
+        "codex" | "chatgpt" | "openai" => "Codex",
+        "claude" => "Claude",
+        "gemini" | "antigravity" | "aistudio" => "Gemini",
+        "grok" | "xai" | "x-ai" => "Grok",
+        "kimi" | "moonshot" => "Kimi",
+        "vertex" => "Vertex",
+        "qwen" => "Qwen",
+        "copilot" | "github" => "Copilot",
+        other => other,
+    }
+}
+
+fn format_try_chain(hops: &[String]) -> String {
+    let names: Vec<&str> = hops.iter().map(|h| hop_display(h)).collect();
+    match names.as_slice() {
+        [] => "Try the next hop on failure".into(),
+        [one] => format!("Try {one}"),
+        [first, rest @ ..] => format!("Try {first}, then {}", rest.join(", then ")),
+    }
 }
 
 fn side_label(col: Col) -> &'static str {
@@ -410,7 +435,7 @@ impl SubPanel {
         }
         let k = dir.rem_euclid(n) as usize;
         self.chain.rotate_left(k);
-        self.status = format!("chain {}", self.chain.join(" → "));
+        self.status = format_try_chain(&self.chain);
     }
 
     fn apply_selected(&mut self) {
@@ -436,7 +461,7 @@ impl SubPanel {
                 cliproxy::ensure_for_existing_user()?;
                 llmtrim_core::config::enable_sub("on")?;
                 llmtrim_core::config::write_sub_mode(false)?;
-                Ok("always → CLIProxyAPI (tier map still applies)".into())
+                Ok("always on — every turn uses the mapped models".into())
             }
             RoutingPreset::Fallback => {
                 cliproxy::ensure_for_existing_user()?;
@@ -448,7 +473,7 @@ impl SubPanel {
                     self.chain.clone()
                 };
                 llmtrim_core::config::write_sub_chain(&chain)?;
-                Ok(format!("fallback · {}", chain.join(" → ")))
+                Ok(format_try_chain(&chain))
             }
         }
     }
@@ -538,14 +563,12 @@ impl SubPanel {
                 self.catalog.len()
             )),
             Line::from(if self.selected == RoutingPreset::Fallback {
-                format!(
-                    "chain {}",
-                    if self.chain.is_empty() {
-                        "anthropic → on".into()
-                    } else {
-                        self.chain.join(" → ")
-                    }
-                )
+                let hops = if self.chain.is_empty() {
+                    vec!["anthropic".into(), "on".into()]
+                } else {
+                    self.chain.clone()
+                };
+                format_try_chain(&hops)
             } else {
                 String::new()
             }),
@@ -769,5 +792,17 @@ mod tests {
         let p = SubPanel::new();
         assert!(!p.needs_apply);
         assert!(!p.capturing_keys());
+    }
+
+    #[test]
+    fn try_chain_sentence_hides_internal_on() {
+        assert_eq!(
+            format_try_chain(&["anthropic".into(), "on".into()]),
+            "Try Anthropic, then mapped models"
+        );
+        assert_eq!(
+            format_try_chain(&["codex".into(), "anthropic".into()]),
+            "Try Codex, then Anthropic"
+        );
     }
 }

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -51,7 +51,7 @@ enum Col {
 
 fn hop_display(hop: &str) -> &str {
     match hop {
-        "anthropic" | "direct" => "Anthropic",
+        "anthropic" | "direct" => "what's in use",
         "on" | "cliproxy" | "cli-proxy" | "cli-proxy-api" | "cliproxyapi" => "mapped models",
         "codex" | "chatgpt" | "openai" => "Codex",
         "claude" => "Claude",
@@ -798,11 +798,11 @@ mod tests {
     fn try_chain_sentence_hides_internal_on() {
         assert_eq!(
             format_try_chain(&["anthropic".into(), "on".into()]),
-            "Try Anthropic, then mapped models"
+            "Try what's in use, then mapped models"
         );
         assert_eq!(
             format_try_chain(&["codex".into(), "anthropic".into()]),
-            "Try Codex, then Anthropic"
+            "Try Codex, then what's in use"
         );
     }
 }

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -239,7 +239,7 @@ impl SubPanel {
                     self.search.clear();
                     self.refilter();
                     self.status =
-                        "← from  → to  ·  type to search  ·  +/- rows  ·  w save  ·  Esc"
+                        "← from  → to  ·  type to search  ·  s save  ·  a add  ·  d del  ·  Esc"
                             .into();
                 }
                 KeyCode::Char('r') => {
@@ -278,8 +278,17 @@ impl SubPanel {
                 KeyCode::Down => self.move_pick(1),
                 KeyCode::Tab => self.move_row(1),
                 KeyCode::BackTab => self.move_row(-1),
-                KeyCode::Char('+') | KeyCode::Insert => self.add_row(),
-                KeyCode::Char('-') | KeyCode::Delete => self.remove_row(),
+                KeyCode::Char('a') | KeyCode::Char('+') | KeyCode::Insert
+                    if self.search.is_empty() =>
+                {
+                    self.add_row();
+                }
+                KeyCode::Char('d') | KeyCode::Char('-') | KeyCode::Delete
+                    if self.search.is_empty() =>
+                {
+                    self.remove_row();
+                }
+                KeyCode::Char('s') if self.search.is_empty() => self.save_map(),
                 KeyCode::Char('w') if self.search.is_empty() => self.save_map(),
                 KeyCode::Backspace => {
                     self.search.pop();
@@ -472,9 +481,11 @@ impl SubPanel {
         match self.focus {
             Focus::Presets => " Tab tabs · ←→ mode · [ ] chain · Enter apply · e map · r refresh · q",
             Focus::Map if self.map_dirty => {
-                " ← from · → to · ↑↓ pick · Enter pick · w / Ctrl+s SAVE · Esc discard"
+                " ← from · → to · ↑↓ pick · Enter pick · s SAVE · a add · d del · Esc discard"
             }
-            Focus::Map => " ← from · → to · ↑↓ pick · Enter pick · w / Ctrl+s save · Esc",
+            Focus::Map => {
+                " ← from · → to · ↑↓ pick · Enter pick · s save · a add · d del · Esc"
+            }
         }
     }
 

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -1,4 +1,6 @@
-//! Status TUI **Sub** tab — CLIProxyAPI sidecar + available models.
+//! Status TUI **Sub** tab — mode (off / always / fallback) + Claude-tier → CLIProxyAPI map.
+
+use std::collections::BTreeMap;
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -7,19 +9,52 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Padding, Paragraph, Row, Table};
 
 use super::palette;
-use crate::reroute::SubProvider;
-use crate::reroute::cliproxy::{self, Model};
+use crate::reroute::cliproxy::{self, OfficialModel};
+use crate::reroute::{SubProvider, Tier};
 
-/// Live state for the Sub tab.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RoutingPreset {
+    Off,
+    Always,
+    Fallback,
+}
+
+impl RoutingPreset {
+    pub const ALL: [RoutingPreset; 3] = [
+        RoutingPreset::Off,
+        RoutingPreset::Always,
+        RoutingPreset::Fallback,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            RoutingPreset::Off => "Off",
+            RoutingPreset::Always => "Always → CLIProxyAPI",
+            RoutingPreset::Fallback => "Fallback (Anthropic first)",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Focus {
+    Presets,
+    Map,
+}
+
 pub struct SubPanel {
-    enabled: bool,
+    focus: Focus,
+    selected: RoutingPreset,
+    applied: RoutingPreset,
+    tiers: [Tier; 4],
+    chosen: [String; 4],
+    catalog: Vec<OfficialModel>,
+    search: String,
+    filtered: Vec<OfficialModel>,
+    filter_idx: usize,
+    tier_row: usize,
+    map_dirty: bool,
     running: bool,
-    version: Option<String>,
-    url: String,
-    models: Vec<Model>,
-    selected: usize,
     status: String,
-    /// True when a config write needs daemon restart + Claude auth sync after the TUI exits.
     pub needs_apply: bool,
 }
 
@@ -31,165 +66,235 @@ impl Default for SubPanel {
 
 impl SubPanel {
     pub fn new() -> Self {
+        let applied = Self::read_applied_preset();
         let mut panel = Self {
-            enabled: false,
+            focus: Focus::Presets,
+            selected: applied,
+            applied,
+            tiers: Tier::ALL,
+            chosen: [String::new(), String::new(), String::new(), String::new()],
+            catalog: Vec::new(),
+            search: String::new(),
+            filtered: Vec::new(),
+            filter_idx: 0,
+            tier_row: 0,
+            map_dirty: false,
             running: false,
-            version: None,
-            url: cliproxy::default_base_url(),
-            models: Vec::new(),
-            selected: 0,
             status: String::new(),
             needs_apply: false,
         };
-        panel.refresh();
+        panel.reload_catalog();
+        panel.reload_map();
         panel
     }
 
     pub fn refresh(&mut self) {
-        let st = cliproxy::status();
-        self.enabled = st.enabled;
-        self.running = st.running;
-        self.version = st.version;
-        self.url = st.base_url;
-        self.models = cliproxy::list_models().unwrap_or_default();
-        let n = self.row_count();
-        if self.selected >= n {
-            self.selected = n.saturating_sub(1);
+        let applied = Self::read_applied_preset();
+        if !self.needs_apply {
+            self.selected = applied;
+        }
+        self.applied = applied;
+        self.running = cliproxy::is_running();
+        if self.focus == Focus::Presets && !self.map_dirty {
+            self.reload_catalog();
+            self.reload_map();
         }
     }
 
     pub fn preselect_provider(&mut self, _provider: SubProvider) {
-        self.status = "Enter pins a CLIProxyAPI model · x turns reroute off".into();
+        self.selected = RoutingPreset::Always;
+        self.status = "highlighted Always — Enter to apply · e to edit opus/sonnet/haiku/fable map"
+            .into();
     }
 
-    /// Stable demo state for the README SVG export (not written to disk).
     pub fn seed_export_demo(&mut self) {
-        self.enabled = true;
+        self.selected = RoutingPreset::Always;
+        self.applied = RoutingPreset::Always;
         self.running = true;
-        self.version = Some("7.2.130".into());
-        self.url = cliproxy::default_base_url();
-        self.models = vec![
-            Model {
-                id: "gpt-5.4".into(),
-                owned_by: "openai".into(),
-            },
-            Model {
-                id: "gemini-3-flash".into(),
-                owned_by: "google".into(),
-            },
+        self.chosen = [
+            "grok-4.6".into(),
+            "grok-4.6".into(),
+            "grok-4.6".into(),
+            "grok-composer-2.5-fast".into(),
         ];
         self.status = "demo".into();
     }
 
-    fn rows(&self) -> Vec<(String, String)> {
-        if !self.models.is_empty() {
-            return self
-                .models
-                .iter()
-                .map(|m| (m.id.clone(), m.owned_by.clone()))
-                .collect();
+    fn read_applied_preset() -> RoutingPreset {
+        let file = load_config_file();
+        let env = |k: &str| std::env::var(k).ok();
+        let Some(_active) = resolve_active(&env, file.as_ref()) else {
+            return RoutingPreset::Off;
+        };
+        if resolve_fallback(&env, file.as_ref()) {
+            RoutingPreset::Fallback
+        } else {
+            RoutingPreset::Always
         }
-        cliproxy::BACKENDS
-            .iter()
-            .map(|b| (b.id.to_string(), b.aliases.join(", ")))
-            .collect()
     }
 
-    fn row_count(&self) -> usize {
-        self.rows().len()
+    fn reload_catalog(&mut self) {
+        self.catalog = cliproxy::official_models();
+        self.refilter();
+    }
+
+    fn reload_map(&mut self) {
+        let overrides = llmtrim_core::config::sub_tiers_for("on");
+        for (i, t) in self.tiers.iter().enumerate() {
+            self.chosen[i] = overrides.get(t.as_str()).cloned().unwrap_or_default();
+        }
+        self.map_dirty = false;
+        self.refilter();
+    }
+
+    fn refilter(&mut self) {
+        self.filtered = cliproxy::search_official(&self.catalog, &self.search);
+        if self.filter_idx >= self.filtered.len() {
+            self.filter_idx = self.filtered.len().saturating_sub(1);
+        }
+        let current = self.chosen[self.tier_row].as_str();
+        if let Some(i) = self.filtered.iter().position(|m| m.id == current) {
+            self.filter_idx = i;
+        }
     }
 
     pub fn handle_key(&mut self, code: crossterm::event::KeyCode) -> bool {
         use crossterm::event::KeyCode;
-        match code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.selected > 0 {
-                    self.selected -= 1;
+        match self.focus {
+            Focus::Presets => match code {
+                KeyCode::Left | KeyCode::Char('h') => self.cycle_preset(-1),
+                KeyCode::Right | KeyCode::Char('l') => self.cycle_preset(1),
+                KeyCode::Enter => self.apply_selected(),
+                KeyCode::Char('e') => {
+                    self.focus = Focus::Map;
+                    self.refilter();
+                    self.status = "type to search official CLIProxyAPI models · ←→ pick · w save"
+                        .into();
                 }
-                true
-            }
-            KeyCode::Down | KeyCode::Char('j') => {
-                let n = self.row_count();
-                if n > 0 && self.selected + 1 < n {
-                    self.selected += 1;
+                KeyCode::Char('r') => {
+                    self.reload_catalog();
+                    self.refresh();
+                    self.status = "refreshed official model list".into();
                 }
-                true
+                _ => return false,
+            },
+            Focus::Map => match code {
+                KeyCode::Esc => {
+                    if self.map_dirty {
+                        self.reload_map();
+                        self.status = "unsaved map changes discarded".into();
+                    }
+                    self.search.clear();
+                    self.focus = Focus::Presets;
+                }
+                KeyCode::Up | KeyCode::Char('k') if self.search.is_empty() => {
+                    if self.tier_row > 0 {
+                        self.tier_row -= 1;
+                        self.refilter();
+                    }
+                }
+                KeyCode::Down | KeyCode::Char('j') if self.search.is_empty() => {
+                    if self.tier_row + 1 < self.tiers.len() {
+                        self.tier_row += 1;
+                        self.refilter();
+                    }
+                }
+                KeyCode::Left => self.cycle_model(-1),
+                KeyCode::Right => self.cycle_model(1),
+                KeyCode::Char('w') => self.save_map(),
+                KeyCode::Backspace => {
+                    self.search.pop();
+                    self.refilter();
+                }
+                KeyCode::Char(c) if !c.is_control() => {
+                    self.search.push(c);
+                    self.refilter();
+                    if let Some(m) = self.filtered.first() {
+                        self.filter_idx = 0;
+                        self.chosen[self.tier_row] = m.id.clone();
+                        self.map_dirty = true;
+                    }
+                }
+                _ => return false,
+            },
+        }
+        true
+    }
+
+    fn cycle_preset(&mut self, dir: i32) {
+        let list = RoutingPreset::ALL;
+        let pos = list.iter().position(|p| *p == self.selected).unwrap_or(0) as i32;
+        let next = (pos + dir).rem_euclid(list.len() as i32) as usize;
+        self.selected = list[next];
+        self.status.clear();
+    }
+
+    fn cycle_model(&mut self, dir: i32) {
+        if self.filtered.is_empty() {
+            return;
+        }
+        let n = self.filtered.len() as i32;
+        self.filter_idx = (self.filter_idx as i32 + dir).rem_euclid(n) as usize;
+        self.chosen[self.tier_row] = self.filtered[self.filter_idx].id.clone();
+        self.map_dirty = true;
+    }
+
+    fn apply_selected(&mut self) {
+        match self.apply_preset(self.selected) {
+            Ok(msg) => {
+                self.applied = self.selected;
+                self.needs_apply = true;
+                self.reload_map();
+                self.status = msg;
             }
-            KeyCode::Enter => {
-                self.pin_selected();
-                true
-            }
-            KeyCode::Char('x') | KeyCode::Backspace => {
-                self.turn_off();
-                true
-            }
-            KeyCode::Char('r') => {
-                self.refresh();
-                self.status = "refreshed".into();
-                true
-            }
-            _ => false,
+            Err(e) => self.status = format!("apply failed: {e}"),
         }
     }
 
-    fn pin_selected(&mut self) {
-        let rows = self.rows();
-        let Some((id, _)) = rows.get(self.selected) else {
-            self.turn_on();
-            return;
-        };
-        let id = id.clone();
-        if let Err(e) = cliproxy::ensure_running() {
-            self.status = format!("CLIProxyAPI: {e:#}");
-            return;
-        }
-        if let Err(e) = llmtrim_core::config::enable_sub("on") {
-            self.status = format!("could not enable: {e:#}");
-            return;
-        }
-        if let Err(e) = llmtrim_core::config::write_sub_model(Some(&id)) {
-            self.status = format!("could not pin {id}: {e:#}");
-            return;
-        }
-        self.enabled = true;
-        self.running = cliproxy::is_running();
-        self.needs_apply = true;
-        self.status = format!("pinned {id}");
-        self.refresh();
-    }
-
-    fn turn_on(&mut self) {
-        if let Err(e) = cliproxy::ensure_running() {
-            self.status = format!("CLIProxyAPI: {e:#}");
-            return;
-        }
-        if let Err(e) = llmtrim_core::config::enable_sub("on") {
-            self.status = format!("could not enable: {e:#}");
-            return;
-        }
+    fn apply_preset(&self, preset: RoutingPreset) -> anyhow::Result<String> {
         let _ = llmtrim_core::config::write_sub_model(None);
-        self.enabled = true;
-        self.running = cliproxy::is_running();
-        self.needs_apply = true;
-        self.status = "reroute on via CLIProxyAPI".into();
-        self.refresh();
+        match preset {
+            RoutingPreset::Off => {
+                llmtrim_core::config::disable_sub()?;
+                Ok("reroute off — Anthropic only".into())
+            }
+            RoutingPreset::Always => {
+                cliproxy::ensure_for_existing_user()?;
+                llmtrim_core::config::enable_sub("on")?;
+                llmtrim_core::config::write_sub_mode(false)?;
+                Ok("always → CLIProxyAPI (tier map still applies)".into())
+            }
+            RoutingPreset::Fallback => {
+                cliproxy::ensure_for_existing_user()?;
+                llmtrim_core::config::enable_sub("on")?;
+                llmtrim_core::config::write_sub_mode(true)?;
+                Ok("fallback — Anthropic first, then CLIProxyAPI".into())
+            }
+        }
     }
 
-    fn turn_off(&mut self) {
-        if let Err(e) = llmtrim_core::config::disable_sub() {
-            self.status = format!("could not disable: {e:#}");
-            return;
+    fn save_map(&mut self) {
+        let mut map = BTreeMap::new();
+        for (t, m) in self.tiers.iter().zip(self.chosen.iter()) {
+            if !m.is_empty() {
+                map.insert(t.as_str().to_string(), m.clone());
+            }
         }
-        let _ = llmtrim_core::config::write_sub_model(None);
-        let _ = cliproxy::stop();
-        self.enabled = false;
-        self.needs_apply = true;
-        self.status = "reroute off".into();
-        self.refresh();
+        match llmtrim_core::config::write_sub_tiers("on", &map) {
+            Ok(()) => {
+                self.map_dirty = false;
+                self.needs_apply = true;
+                self.status = "tier map saved".into();
+            }
+            Err(e) => self.status = format!("save failed: {e}"),
+        }
     }
 
     pub fn help_keys(&self) -> &'static str {
-        " Tab tabs · ↑↓ models · ⏎ pin · x off · r refresh · t theme · q"
+        match self.focus {
+            Focus::Presets => " Tab tabs · ←→ mode · ⏎ apply · e map · r refresh · q",
+            Focus::Map => " ↑↓ tier · type search · ←→ model · w save · Esc back · q",
+        }
     }
 
     pub fn render(&self, f: &mut Frame, area: Rect) {
@@ -205,82 +310,141 @@ impl SubPanel {
         f.render_widget(block, area);
 
         let chunks = Layout::vertical([
-            Constraint::Length(5),
-            Constraint::Min(4),
-            Constraint::Length(1),
+            Constraint::Length(4),
+            Constraint::Min(8),
+            Constraint::Length(2),
         ])
         .split(inner);
 
-        let state = if self.enabled && self.running {
-            "on · running"
-        } else if self.enabled {
-            "on · sidecar down"
-        } else {
-            "off"
-        };
-        let ver = self
-            .version
-            .as_deref()
-            .map(|v| format!(" v{v}"))
-            .unwrap_or_default();
+        let presets: Vec<Span> = RoutingPreset::ALL
+            .iter()
+            .flat_map(|p| {
+                let on = *p == self.selected;
+                let applied = *p == self.applied;
+                let mut style = Style::default();
+                if on {
+                    style = style.fg(palette::accent()).add_modifier(Modifier::BOLD);
+                }
+                let mark = if applied { "*" } else { " " };
+                [
+                    Span::styled(format!("{mark}{} ", p.label()), style),
+                    Span::raw(" "),
+                ]
+            })
+            .collect();
+        let sidecar = if self.running { "sidecar up" } else { "sidecar down" };
         let header = Paragraph::new(vec![
-            Line::from(vec![
-                Span::styled("CLIProxyAPI ", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(format!("{state}{ver}")),
-            ]),
-            Line::from(self.url.as_str()),
-            Line::from("Enter pins a model/CLI. x off. Sign in: llmtrim sub auth"),
+            Line::from(presets),
+            Line::from(format!(
+                "{sidecar} · {} official models · * = applied",
+                self.catalog.len()
+            )),
         ]);
         f.render_widget(header, chunks[0]);
 
-        let rows = self.rows();
-        if rows.is_empty() {
-            f.render_widget(
-                Paragraph::new("Sidecar not running — Enter to start, or `llmtrim sub on`."),
-                chunks[1],
-            );
-        } else {
-            let table_rows: Vec<Row> = rows
-                .iter()
-                .enumerate()
-                .map(|(i, (id, owner))| {
-                    let style = if i == self.selected {
-                        Style::default()
-                            .fg(palette::accent())
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default()
-                    };
-                    Row::new(vec![id.clone(), owner.clone()]).style(style)
-                })
-                .collect();
-            let col2 = if self.models.is_empty() {
-                "cli aliases"
-            } else {
-                "owned_by"
-            };
-            let table = Table::new(
-                table_rows,
-                [Constraint::Percentage(65), Constraint::Percentage(35)],
-            )
-            .header(
-                Row::new(vec!["model / cli", col2])
-                    .style(Style::default().add_modifier(Modifier::BOLD)),
-            );
-            f.render_widget(table, chunks[1]);
-        }
+        let rows: Vec<Row> = self
+            .tiers
+            .iter()
+            .zip(self.chosen.iter())
+            .enumerate()
+            .map(|(i, (t, m))| {
+                let style = if self.focus == Focus::Map && i == self.tier_row {
+                    Style::default()
+                        .fg(palette::accent())
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                let label = if m.is_empty() {
+                    "(pass through)".to_string()
+                } else {
+                    m.clone()
+                };
+                Row::new(vec![t.as_str().to_string(), label]).style(style)
+            })
+            .collect();
+        let table = Table::new(rows, [Constraint::Length(10), Constraint::Min(20)]).header(
+            Row::new(vec!["claude", "CLIProxyAPI model"])
+                .style(Style::default().add_modifier(Modifier::BOLD)),
+        );
+        f.render_widget(table, chunks[1]);
 
-        if !self.status.is_empty() {
-            f.render_widget(Paragraph::new(self.status.as_str()), chunks[2]);
-        }
+        let hint = if self.focus == Focus::Map {
+            let n = self.filtered.len();
+            format!(
+                "search: {}  ·  {n} hits  ·  {}",
+                if self.search.is_empty() {
+                    "_"
+                } else {
+                    self.search.as_str()
+                },
+                self.status
+            )
+        } else {
+            self.status.clone()
+        };
+        f.render_widget(Paragraph::new(hint), chunks[2]);
     }
 }
 
+fn load_config_file() -> Option<toml::Value> {
+    let path = std::env::var("LLMTRIM_CONFIG")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var("XDG_CONFIG_HOME")
+                .ok()
+                .map(std::path::PathBuf::from)
+                .or_else(|| {
+                    std::env::var("HOME")
+                        .ok()
+                        .map(|h| std::path::PathBuf::from(h).join(".config"))
+                })
+                .map(|b| b.join("llmtrim").join("config.toml"))
+        })?;
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|t| toml::from_str(&t).ok())
+}
+
+fn resolve_active(
+    env: &impl Fn(&str) -> Option<String>,
+    file: Option<&toml::Value>,
+) -> Option<String> {
+    if let Some(v) = env("LLMTRIM_SUB").filter(|s| !s.is_empty()) {
+        let s = v.trim().to_ascii_lowercase();
+        return (s != "off").then_some(s);
+    }
+    let sub = file?.get("sub")?;
+    let s = sub
+        .as_str()
+        .or_else(|| {
+            sub.get("active")
+                .or_else(|| sub.get("provider"))
+                .and_then(toml::Value::as_str)
+        })?
+        .trim()
+        .to_ascii_lowercase();
+    (s != "off" && !s.is_empty()).then_some(s)
+}
+
+fn resolve_fallback(env: &impl Fn(&str) -> Option<String>, file: Option<&toml::Value>) -> bool {
+    let parse = |raw: &str| {
+        matches!(
+            raw.trim().to_ascii_lowercase().as_str(),
+            "fallback" | "on_error" | "on-error" | "onerror"
+        )
+    };
+    if let Some(v) = env("LLMTRIM_SUB_MODE").filter(|s| !s.is_empty()) {
+        return parse(&v);
+    }
+    file.and_then(|v| v.get("sub"))
+        .and_then(|v| v.get("mode"))
+        .and_then(toml::Value::as_str)
+        .is_some_and(parse)
+}
+
 /// Reconcile Claude dummy-auth + restart the interceptor so a Sub-tab write takes effect.
-/// Best-effort: never panics; returns a short status string for the caller to print after exit.
-///
-/// Mirrors `main::apply_sub_change`: always sync auth env; only restart when a daemon is
-/// already running (so a pure-config edit never spawns a new interceptor by surprise).
 pub fn apply_pending_changes() -> String {
     use crate::statusline::SubAuthEnvChange;
     let want = llmtrim_core::config::sub_skip_anthropic_login();
@@ -339,6 +503,6 @@ mod tests {
     fn new_panel_starts_on_presets() {
         let p = SubPanel::new();
         assert!(!p.needs_apply);
-        assert_eq!(p.selected, 0);
+        assert_eq!(p.focus, Focus::Presets);
     }
 }

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -1,4 +1,4 @@
-//! Status TUI **Sub** tab — mode (off / always / fallback) + Claude-tier → CLIProxyAPI map.
+//! Status TUI **Sub** tab — mode (off / always / fallback) + Claude → CLIProxyAPI map.
 
 use std::collections::BTreeMap;
 
@@ -41,18 +41,24 @@ enum Focus {
     Map,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Col {
+    From,
+    To,
+}
+
 pub struct SubPanel {
     focus: Focus,
     selected: RoutingPreset,
     applied: RoutingPreset,
     chain: Vec<String>,
-    tiers: [Tier; 4],
-    chosen: [String; 4],
+    rows: Vec<(String, String)>,
+    row: usize,
+    col: Col,
     catalog: Vec<OfficialModel>,
     search: String,
-    filtered: Vec<OfficialModel>,
+    filtered: Vec<String>,
     filter_idx: usize,
-    tier_row: usize,
     map_dirty: bool,
     running: bool,
     status: String,
@@ -73,13 +79,13 @@ impl SubPanel {
             selected: applied,
             applied,
             chain: Self::read_chain(),
-            tiers: Tier::ALL,
-            chosen: [String::new(), String::new(), String::new(), String::new()],
+            rows: Vec::new(),
+            row: 0,
+            col: Col::To,
             catalog: Vec::new(),
             search: String::new(),
             filtered: Vec::new(),
             filter_idx: 0,
-            tier_row: 0,
             map_dirty: false,
             running: false,
             status: String::new(),
@@ -88,6 +94,10 @@ impl SubPanel {
         panel.reload_catalog();
         panel.reload_map();
         panel
+    }
+
+    pub fn capturing_keys(&self) -> bool {
+        self.focus == Focus::Map
     }
 
     pub fn refresh(&mut self) {
@@ -106,19 +116,18 @@ impl SubPanel {
 
     pub fn preselect_provider(&mut self, _provider: SubProvider) {
         self.selected = RoutingPreset::Always;
-        self.status = "highlighted Always — Enter to apply · e to edit opus/sonnet/haiku/fable map"
-            .into();
+        self.status = "highlighted Always — Enter to apply · e to edit map".into();
     }
 
     pub fn seed_export_demo(&mut self) {
         self.selected = RoutingPreset::Always;
         self.applied = RoutingPreset::Always;
         self.running = true;
-        self.chosen = [
-            "grok-4.6".into(),
-            "grok-4.6".into(),
-            "grok-4.6".into(),
-            "grok-composer-2.5-fast".into(),
+        self.rows = vec![
+            ("fable".into(), "grok-4.6".into()),
+            ("opus".into(), "grok-4.6".into()),
+            ("sonnet".into(), "grok-4.6".into()),
+            ("haiku".into(), "grok-composer-2.5-fast".into()),
         ];
         self.status = "demo".into();
     }
@@ -143,21 +152,66 @@ impl SubPanel {
 
     fn reload_map(&mut self) {
         let overrides = llmtrim_core::config::sub_tiers_for("on");
-        for (i, t) in self.tiers.iter().enumerate() {
-            self.chosen[i] = overrides.get(t.as_str()).cloned().unwrap_or_default();
+        let mut rows: Vec<(String, String)> = overrides.into_iter().collect();
+        if rows.is_empty() {
+            rows = Tier::ALL
+                .iter()
+                .map(|t| (t.as_str().to_string(), String::new()))
+                .collect();
+        }
+        self.rows = rows;
+        if self.row >= self.rows.len() {
+            self.row = self.rows.len().saturating_sub(1);
         }
         self.map_dirty = false;
+        self.search.clear();
         self.refilter();
     }
 
+    fn input_suggestions(&self) -> Vec<String> {
+        let mut out: Vec<String> = Tier::ALL.iter().map(|t| t.as_str().to_string()).collect();
+        for m in &self.catalog {
+            if !out.iter().any(|x| x == &m.id) {
+                out.push(m.id.clone());
+            }
+        }
+        out
+    }
+
     fn refilter(&mut self) {
-        self.filtered = cliproxy::search_official(&self.catalog, &self.search);
+        let q = self.search.trim().to_ascii_lowercase();
+        let pool = match self.col {
+            Col::From => self.input_suggestions(),
+            Col::To => self
+                .catalog
+                .iter()
+                .map(|m| m.id.clone())
+                .collect::<Vec<_>>(),
+        };
+        self.filtered = if q.is_empty() {
+            pool
+        } else {
+            pool.into_iter()
+                .filter(|id| {
+                    id.to_ascii_lowercase().contains(&q)
+                        || self.catalog.iter().any(|m| {
+                            m.id == *id
+                                && (m.display_name.to_ascii_lowercase().contains(&q)
+                                    || m.family.to_ascii_lowercase().contains(&q)
+                                    || m.owned_by.to_ascii_lowercase().contains(&q))
+                        })
+                })
+                .collect()
+        };
+        let current = self.rows.get(self.row).map(|(f, t)| match self.col {
+            Col::From => f.as_str(),
+            Col::To => t.as_str(),
+        });
+        self.filter_idx = current
+            .and_then(|c| self.filtered.iter().position(|id| id == c))
+            .unwrap_or(0);
         if self.filter_idx >= self.filtered.len() {
             self.filter_idx = self.filtered.len().saturating_sub(1);
-        }
-        let current = self.chosen[self.tier_row].as_str();
-        if let Some(i) = self.filtered.iter().position(|m| m.id == current) {
-            self.filter_idx = i;
         }
     }
 
@@ -172,9 +226,12 @@ impl SubPanel {
                 KeyCode::Enter => self.apply_selected(),
                 KeyCode::Char('e') => {
                     self.focus = Focus::Map;
+                    self.col = Col::To;
+                    self.search.clear();
                     self.refilter();
-                    self.status = "type to search official CLIProxyAPI models · ←→ pick · w save"
-                        .into();
+                    self.status =
+                        "← from  → to  ·  type to search  ·  +/- rows  ·  w save  ·  Esc"
+                            .into();
                 }
                 KeyCode::Char('r') => {
                     self.reload_catalog();
@@ -185,45 +242,108 @@ impl SubPanel {
             },
             Focus::Map => match code {
                 KeyCode::Esc => {
-                    if self.map_dirty {
+                    if !self.search.is_empty() {
+                        self.search.clear();
+                        self.refilter();
+                    } else if self.map_dirty {
                         self.reload_map();
                         self.status = "unsaved map changes discarded".into();
+                        self.focus = Focus::Presets;
+                    } else {
+                        self.focus = Focus::Presets;
                     }
+                }
+                KeyCode::Left => {
+                    self.col = Col::From;
                     self.search.clear();
-                    self.focus = Focus::Presets;
+                    self.refilter();
+                    self.status = "editing input (Claude tier or model id)".into();
                 }
-                KeyCode::Up | KeyCode::Char('k') if self.search.is_empty() => {
-                    if self.tier_row > 0 {
-                        self.tier_row -= 1;
-                        self.refilter();
-                    }
+                KeyCode::Right => {
+                    self.col = Col::To;
+                    self.search.clear();
+                    self.refilter();
+                    self.status = "editing output (CLIProxyAPI model)".into();
                 }
-                KeyCode::Down | KeyCode::Char('j') if self.search.is_empty() => {
-                    if self.tier_row + 1 < self.tiers.len() {
-                        self.tier_row += 1;
-                        self.refilter();
-                    }
-                }
-                KeyCode::Left => self.cycle_model(-1),
-                KeyCode::Right => self.cycle_model(1),
-                KeyCode::Char('w') => self.save_map(),
+                KeyCode::Up => self.move_row(-1),
+                KeyCode::Down => self.move_row(1),
+                KeyCode::Char('+') | KeyCode::Insert => self.add_row(),
+                KeyCode::Char('-') | KeyCode::Delete => self.remove_row(),
+                KeyCode::Char('w') if self.search.is_empty() => self.save_map(),
                 KeyCode::Backspace => {
                     self.search.pop();
-                    self.refilter();
+                    self.apply_search_to_cell();
+                }
+                KeyCode::Enter => {
+                    if let Some(id) = self.filtered.get(self.filter_idx).cloned() {
+                        self.set_cell(id);
+                        self.search.clear();
+                        self.refilter();
+                    }
                 }
                 KeyCode::Char(c) if !c.is_control() => {
                     self.search.push(c);
-                    self.refilter();
-                    if let Some(m) = self.filtered.first() {
-                        self.filter_idx = 0;
-                        self.chosen[self.tier_row] = m.id.clone();
-                        self.map_dirty = true;
-                    }
+                    self.apply_search_to_cell();
                 }
                 _ => return false,
             },
         }
         true
+    }
+
+    fn move_row(&mut self, dir: i32) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let n = self.rows.len() as i32;
+        self.row = (self.row as i32 + dir).rem_euclid(n) as usize;
+        self.search.clear();
+        self.refilter();
+    }
+
+    fn add_row(&mut self) {
+        self.rows.push((String::new(), String::new()));
+        self.row = self.rows.len() - 1;
+        self.col = Col::From;
+        self.search.clear();
+        self.map_dirty = true;
+        self.refilter();
+        self.status = "new row — type the input model".into();
+    }
+
+    fn remove_row(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        self.rows.remove(self.row);
+        if self.row >= self.rows.len() {
+            self.row = self.rows.len().saturating_sub(1);
+        }
+        self.map_dirty = true;
+        self.search.clear();
+        self.refilter();
+        self.status = "row removed".into();
+    }
+
+    fn set_cell(&mut self, value: String) {
+        if let Some(row) = self.rows.get_mut(self.row) {
+            match self.col {
+                Col::From => row.0 = value,
+                Col::To => row.1 = value,
+            }
+            self.map_dirty = true;
+        }
+    }
+
+    fn apply_search_to_cell(&mut self) {
+        self.refilter();
+        let value = self
+            .filtered
+            .first()
+            .cloned()
+            .unwrap_or_else(|| self.search.clone());
+        self.filter_idx = 0;
+        self.set_cell(value);
     }
 
     fn cycle_preset(&mut self, dir: i32) {
@@ -232,16 +352,6 @@ impl SubPanel {
         let next = (pos + dir).rem_euclid(list.len() as i32) as usize;
         self.selected = list[next];
         self.status.clear();
-    }
-
-    fn cycle_model(&mut self, dir: i32) {
-        if self.filtered.is_empty() {
-            return;
-        }
-        let n = self.filtered.len() as i32;
-        self.filter_idx = (self.filter_idx as i32 + dir).rem_euclid(n) as usize;
-        self.chosen[self.tier_row] = self.filtered[self.filter_idx].id.clone();
-        self.map_dirty = true;
     }
 
     fn read_chain() -> Vec<String> {
@@ -322,16 +432,18 @@ impl SubPanel {
 
     fn save_map(&mut self) {
         let mut map = BTreeMap::new();
-        for (t, m) in self.tiers.iter().zip(self.chosen.iter()) {
-            if !m.is_empty() {
-                map.insert(t.as_str().to_string(), m.clone());
+        for (from, to) in &self.rows {
+            let from = from.trim();
+            let to = to.trim();
+            if !from.is_empty() && !to.is_empty() {
+                map.insert(from.to_string(), to.to_string());
             }
         }
         match llmtrim_core::config::write_sub_tiers("on", &map) {
             Ok(()) => {
                 self.map_dirty = false;
                 self.needs_apply = true;
-                self.status = "tier map saved".into();
+                self.status = format!("saved {} mappings", map.len());
             }
             Err(e) => self.status = format!("save failed: {e}"),
         }
@@ -339,8 +451,8 @@ impl SubPanel {
 
     pub fn help_keys(&self) -> &'static str {
         match self.focus {
-            Focus::Presets => " Tab tabs · ←→ mode · [ ] chain · ⏎ apply · e map · r refresh · q",
-            Focus::Map => " ↑↓ tier · type search · ←→ model · w save · Esc back · q",
+            Focus::Presets => " Tab tabs · ←→ mode · [ ] chain · Enter apply · e map · r refresh · q",
+            Focus::Map => " ← from · → to · ↑↓ row · type search · +/- row · w save · Esc",
         }
     }
 
@@ -379,7 +491,11 @@ impl SubPanel {
                 ]
             })
             .collect();
-        let sidecar = if self.running { "sidecar up" } else { "sidecar down" };
+        let sidecar = if self.running {
+            "sidecar up"
+        } else {
+            "sidecar down"
+        };
         let header = Paragraph::new(vec![
             Line::from(presets),
             Line::from(format!(
@@ -387,7 +503,14 @@ impl SubPanel {
                 self.catalog.len()
             )),
             Line::from(if self.selected == RoutingPreset::Fallback {
-                format!("chain {}", if self.chain.is_empty() { "anthropic → on".into() } else { self.chain.join(" → ") })
+                format!(
+                    "chain {}",
+                    if self.chain.is_empty() {
+                        "anthropic → on".into()
+                    } else {
+                        self.chain.join(" → ")
+                    }
+                )
             } else {
                 String::new()
             }),
@@ -395,36 +518,56 @@ impl SubPanel {
         f.render_widget(header, chunks[0]);
 
         let rows: Vec<Row> = self
-            .tiers
+            .rows
             .iter()
-            .zip(self.chosen.iter())
             .enumerate()
-            .map(|(i, (t, m))| {
-                let style = if self.focus == Focus::Map && i == self.tier_row {
+            .map(|(i, (from, to))| {
+                let active = self.focus == Focus::Map && i == self.row;
+                let from_s = if from.is_empty() { "…" } else { from.as_str() };
+                let to_s = if to.is_empty() {
+                    "(pass through)"
+                } else {
+                    to.as_str()
+                };
+                let from_style = if active && self.col == Col::From {
                     Style::default()
                         .fg(palette::accent())
-                        .add_modifier(Modifier::BOLD)
+                        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+                } else if active {
+                    Style::default().add_modifier(Modifier::BOLD)
                 } else {
                     Style::default()
                 };
-                let label = if m.is_empty() {
-                    "(pass through)".to_string()
+                let to_style = if active && self.col == Col::To {
+                    Style::default()
+                        .fg(palette::accent())
+                        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+                } else if active {
+                    Style::default().add_modifier(Modifier::BOLD)
                 } else {
-                    m.clone()
+                    Style::default()
                 };
-                Row::new(vec![t.as_str().to_string(), label]).style(style)
+                Row::new(vec![
+                    ratatui::widgets::Cell::from(from_s.to_string()).style(from_style),
+                    ratatui::widgets::Cell::from(to_s.to_string()).style(to_style),
+                ])
             })
             .collect();
-        let table = Table::new(rows, [Constraint::Length(10), Constraint::Min(20)]).header(
-            Row::new(vec!["claude", "CLIProxyAPI model"])
-                .style(Style::default().add_modifier(Modifier::BOLD)),
-        );
+        let table = Table::new(rows, [Constraint::Percentage(40), Constraint::Percentage(60)])
+            .header(
+                Row::new(vec!["input (Claude)", "output (CLIProxyAPI)"])
+                    .style(Style::default().add_modifier(Modifier::BOLD)),
+            );
         f.render_widget(table, chunks[1]);
 
         let hint = if self.focus == Focus::Map {
             let n = self.filtered.len();
+            let side = match self.col {
+                Col::From => "from",
+                Col::To => "to",
+            };
             format!(
-                "search: {}  ·  {n} hits  ·  {}",
+                "{side} search: {}  ·  {n} hits  ·  {}",
                 if self.search.is_empty() {
                     "_"
                 } else {
@@ -555,6 +698,6 @@ mod tests {
     fn new_panel_starts_on_presets() {
         let p = SubPanel::new();
         assert!(!p.needs_apply);
-        assert_eq!(p.focus, Focus::Presets);
+        assert!(!p.capturing_keys());
     }
 }

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -457,16 +457,24 @@ impl SubPanel {
             Ok(()) => {
                 self.map_dirty = false;
                 self.needs_apply = true;
-                self.status = format!("saved {} mappings", map.len());
+                self.search.clear();
+                self.status = format!("saved {} mappings — quit the TUI to apply", map.len());
             }
             Err(e) => self.status = format!("save failed: {e}"),
         }
     }
 
+    pub fn save_now(&mut self) {
+        self.save_map();
+    }
+
     pub fn help_keys(&self) -> &'static str {
         match self.focus {
             Focus::Presets => " Tab tabs · ←→ mode · [ ] chain · Enter apply · e map · r refresh · q",
-            Focus::Map => " ← from · → to · type · ↑↓ pick · Tab row · +/- · Enter · w · Esc",
+            Focus::Map if self.map_dirty => {
+                " ← from · → to · ↑↓ pick · Enter pick · w / Ctrl+s SAVE · Esc discard"
+            }
+            Focus::Map => " ← from · → to · ↑↓ pick · Enter pick · w / Ctrl+s save · Esc",
         }
     }
 

--- a/crates/llmtrim-cli/src/breakdown/sub_panel.rs
+++ b/crates/llmtrim-cli/src/breakdown/sub_panel.rs
@@ -52,13 +52,14 @@ impl SubPanel {
         self.version = st.version;
         self.url = st.base_url;
         self.models = cliproxy::list_models().unwrap_or_default();
-        if self.selected >= self.models.len() {
-            self.selected = self.models.len().saturating_sub(1);
+        let n = self.row_count();
+        if self.selected >= n {
+            self.selected = n.saturating_sub(1);
         }
     }
 
     pub fn preselect_provider(&mut self, _provider: SubProvider) {
-        self.status = "CLIProxyAPI — Enter toggles reroute · r refresh models".into();
+        self.status = "Enter pins a CLIProxyAPI model · x turns reroute off".into();
     }
 
     /// Stable demo state for the README SVG export (not written to disk).
@@ -80,6 +81,24 @@ impl SubPanel {
         self.status = "demo".into();
     }
 
+    fn rows(&self) -> Vec<(String, String)> {
+        if !self.models.is_empty() {
+            return self
+                .models
+                .iter()
+                .map(|m| (m.id.clone(), m.owned_by.clone()))
+                .collect();
+        }
+        cliproxy::BACKENDS
+            .iter()
+            .map(|b| (b.id.to_string(), b.aliases.join(", ")))
+            .collect()
+    }
+
+    fn row_count(&self) -> usize {
+        self.rows().len()
+    }
+
     pub fn handle_key(&mut self, code: crossterm::event::KeyCode) -> bool {
         use crossterm::event::KeyCode;
         match code {
@@ -90,13 +109,18 @@ impl SubPanel {
                 true
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                if !self.models.is_empty() && self.selected + 1 < self.models.len() {
+                let n = self.row_count();
+                if n > 0 && self.selected + 1 < n {
                     self.selected += 1;
                 }
                 true
             }
             KeyCode::Enter => {
-                self.toggle();
+                self.pin_selected();
+                true
+            }
+            KeyCode::Char('x') | KeyCode::Backspace => {
+                self.turn_off();
                 true
             }
             KeyCode::Char('r') => {
@@ -108,35 +132,64 @@ impl SubPanel {
         }
     }
 
-    fn toggle(&mut self) {
-        if self.enabled {
-            if let Err(e) = llmtrim_core::config::disable_sub() {
-                self.status = format!("could not disable: {e:#}");
-                return;
-            }
-            let _ = cliproxy::stop();
-            self.enabled = false;
-            self.needs_apply = true;
-            self.status = "reroute off".into();
-        } else {
-            if let Err(e) = cliproxy::ensure_running() {
-                self.status = format!("CLIProxyAPI: {e:#}");
-                return;
-            }
-            if let Err(e) = llmtrim_core::config::enable_sub("on") {
-                self.status = format!("could not enable: {e:#}");
-                return;
-            }
-            self.enabled = true;
-            self.running = cliproxy::is_running();
-            self.needs_apply = true;
-            self.status = "reroute on via CLIProxyAPI".into();
+    fn pin_selected(&mut self) {
+        let rows = self.rows();
+        let Some((id, _)) = rows.get(self.selected) else {
+            self.turn_on();
+            return;
+        };
+        let id = id.clone();
+        if let Err(e) = cliproxy::ensure_running() {
+            self.status = format!("CLIProxyAPI: {e:#}");
+            return;
         }
+        if let Err(e) = llmtrim_core::config::enable_sub("on") {
+            self.status = format!("could not enable: {e:#}");
+            return;
+        }
+        if let Err(e) = llmtrim_core::config::write_sub_model(Some(&id)) {
+            self.status = format!("could not pin {id}: {e:#}");
+            return;
+        }
+        self.enabled = true;
+        self.running = cliproxy::is_running();
+        self.needs_apply = true;
+        self.status = format!("pinned {id}");
+        self.refresh();
+    }
+
+    fn turn_on(&mut self) {
+        if let Err(e) = cliproxy::ensure_running() {
+            self.status = format!("CLIProxyAPI: {e:#}");
+            return;
+        }
+        if let Err(e) = llmtrim_core::config::enable_sub("on") {
+            self.status = format!("could not enable: {e:#}");
+            return;
+        }
+        let _ = llmtrim_core::config::write_sub_model(None);
+        self.enabled = true;
+        self.running = cliproxy::is_running();
+        self.needs_apply = true;
+        self.status = "reroute on via CLIProxyAPI".into();
+        self.refresh();
+    }
+
+    fn turn_off(&mut self) {
+        if let Err(e) = llmtrim_core::config::disable_sub() {
+            self.status = format!("could not disable: {e:#}");
+            return;
+        }
+        let _ = llmtrim_core::config::write_sub_model(None);
+        let _ = cliproxy::stop();
+        self.enabled = false;
+        self.needs_apply = true;
+        self.status = "reroute off".into();
         self.refresh();
     }
 
     pub fn help_keys(&self) -> &'static str {
-        " Tab tabs · ↑↓ models · ⏎ on/off · r refresh · t theme · q"
+        " Tab tabs · ↑↓ models · ⏎ pin · x off · r refresh · t theme · q"
     }
 
     pub fn render(&self, f: &mut Frame, area: Rect) {
@@ -176,23 +229,21 @@ impl SubPanel {
                 Span::raw(format!("{state}{ver}")),
             ]),
             Line::from(self.url.as_str()),
-            Line::from("Enter toggles reroute. Sign in: llmtrim sub auth"),
+            Line::from("Enter pins a model/CLI. x off. Sign in: llmtrim sub auth"),
         ]);
         f.render_widget(header, chunks[0]);
 
-        if self.models.is_empty() {
-            let empty = if self.running {
-                "No models yet — run `llmtrim sub auth` to sign in."
-            } else {
-                "Sidecar not running — Enter to start, or `llmtrim sub on`."
-            };
-            f.render_widget(Paragraph::new(empty), chunks[1]);
+        let rows = self.rows();
+        if rows.is_empty() {
+            f.render_widget(
+                Paragraph::new("Sidecar not running — Enter to start, or `llmtrim sub on`."),
+                chunks[1],
+            );
         } else {
-            let rows: Vec<Row> = self
-                .models
+            let table_rows: Vec<Row> = rows
                 .iter()
                 .enumerate()
-                .map(|(i, m)| {
+                .map(|(i, (id, owner))| {
                     let style = if i == self.selected {
                         Style::default()
                             .fg(palette::accent())
@@ -200,15 +251,21 @@ impl SubPanel {
                     } else {
                         Style::default()
                     };
-                    Row::new(vec![m.id.clone(), m.owned_by.clone()]).style(style)
+                    Row::new(vec![id.clone(), owner.clone()]).style(style)
                 })
                 .collect();
+            let col2 = if self.models.is_empty() {
+                "cli aliases"
+            } else {
+                "owned_by"
+            };
             let table = Table::new(
-                rows,
+                table_rows,
                 [Constraint::Percentage(65), Constraint::Percentage(35)],
             )
             .header(
-                Row::new(vec!["model", "owned_by"]).style(Style::default().add_modifier(Modifier::BOLD)),
+                Row::new(vec!["model / cli", col2])
+                    .style(Style::default().add_modifier(Modifier::BOLD)),
             );
             f.render_widget(table, chunks[1]);
         }
@@ -241,7 +298,7 @@ pub fn apply_pending_changes() -> String {
         Err(e) => parts.push(format!("Claude Code auth env update failed: {e:#}")),
     }
     if llmtrim_core::config::sub_always_on()
-        && let Err(e) = cliproxy::ensure_running()
+        && let Err(e) = cliproxy::ensure_for_existing_user()
     {
         parts.push(format!("CLIProxyAPI: {e:#}"));
     }

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -636,6 +636,24 @@ pub fn apply(opts: Options) -> Result<Report> {
         }
     }
 
+    // Existing `sub = codex|kimi|grok|on` users: install CLIProxyAPI, import tokens, start it.
+    #[cfg(feature = "intercept")]
+    if crate::reroute::cliproxy::is_enabled() {
+        match crate::reroute::cliproxy::ensure_for_existing_user() {
+            Ok(msg) => {
+                report.applied.push("cliproxy");
+                report
+                    .rows
+                    .push((ui::OK, "CLIProxyAPI".into(), msg));
+            }
+            Err(e) => report.rows.push((
+                ui::WARN,
+                "CLIProxyAPI".into(),
+                format!("{e:#} — `llmtrim sub on` to retry"),
+            )),
+        }
+    }
+
     // Daemon version skew.
     if opts.restart_daemon
         && let Some(d) = crate::daemon::running()

--- a/crates/llmtrim-cli/src/ensure.rs
+++ b/crates/llmtrim-cli/src/ensure.rs
@@ -642,9 +642,7 @@ pub fn apply(opts: Options) -> Result<Report> {
         match crate::reroute::cliproxy::ensure_for_existing_user() {
             Ok(msg) => {
                 report.applied.push("cliproxy");
-                report
-                    .rows
-                    .push((ui::OK, "CLIProxyAPI".into(), msg));
+                report.rows.push((ui::OK, "CLIProxyAPI".into(), msg));
             }
             Err(e) => report.rows.push((
                 ui::WARN,

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -479,8 +479,8 @@ enum SubCmd {
     },
     /// Enable reroute through CLIProxyAPI (installs + starts the sidecar).
     ///
-    /// An optional model id pins every turn to that CLIProxyAPI model. `sub use` and
-    /// `sub start` are accepted aliases.
+    /// An optional CLIProxyAPI CLI (`gemini`, `codex`, …) or model id pins every turn.
+    /// `sub use` and `sub start` are accepted aliases.
     #[command(visible_alias = "use", alias = "start")]
     On {
         /// Optional CLIProxyAPI model id to pin. Omit to pass Claude model ids through.
@@ -803,26 +803,21 @@ fn read_stdin() -> Result<String> {
     Ok(buf)
 }
 
-/// Resolve which label a window `/sub on [model]` should store.
-/// Bare `/sub on` enables CLIProxyAPI for the window. An argument is a model pin
-/// (or a legacy provider alias, which just enables the sidecar).
+/// Resolve which label a window `/sub on [backend|model]` should store.
+/// Bare `/sub on` enables CLIProxyAPI. A CLIProxyAPI CLI name (`gemini`, `codex`, …)
+/// or a model id is pinned for this window.
 #[cfg(feature = "intercept")]
 fn window_sub_provider(requested: Option<&str>) -> Result<String> {
+    use llmtrim::reroute::cliproxy::{PinRequest, parse_pin_request, resolve_pin_live};
     match requested {
         None => Ok("on".into()),
-        Some(raw) => {
-            let raw = raw.trim();
-            if raw.is_empty() {
-                return Ok("on".into());
-            }
-            if llmtrim::reroute::SubProvider::parse(raw).is_some() {
-                return Ok("on".into());
-            }
-            if llmtrim::window_sub::valid_model_id(raw) {
-                return Ok(raw.to_string());
-            }
-            bail!("usage: /sub on [model-id] | off | status");
-        }
+        Some(raw) => match parse_pin_request(raw) {
+            Some(PinRequest::Enable) => Ok("on".into()),
+            Some(PinRequest::Pin(pin)) => Ok(resolve_pin_live(&pin).unwrap_or(pin)),
+            None => bail!(
+                "usage: /sub on [codex|claude|gemini|grok|kimi|vertex|qwen|copilot|model-id] | off | status"
+            ),
+        },
     }
 }
 
@@ -930,7 +925,9 @@ fn run_window_sub(args: Vec<String>) -> Result<()> {
                     }
                     None => println!("This window follows the global subscription policy."),
                 },
-                _ => bail!("usage: /sub on [model-id] | off | status"),
+                _ => bail!(
+                    "usage: /sub on [codex|claude|gemini|grok|kimi|vertex|qwen|copilot|model-id] | off | status"
+                ),
             }
         }
         _ => bail!("unknown window-sub action"),
@@ -1229,13 +1226,28 @@ fn run_sub(action: SubCmd) -> Result<()> {
             println!("Installing/starting CLIProxyAPI…");
             llmtrim::reroute::cliproxy::ensure_running()?;
             llmtrim_core::config::enable_sub("on")?;
-            if let Some(model) = provider
+            match provider
                 .as_deref()
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
-                && llmtrim::reroute::SubProvider::parse(model).is_none()
             {
-                println!("Pinned model: {model} (window `/sub on {model}` to pin one session).");
+                None => {
+                    llmtrim_core::config::write_sub_model(None)?;
+                }
+                Some(raw) => match llmtrim::reroute::cliproxy::parse_pin_request(raw) {
+                    Some(llmtrim::reroute::cliproxy::PinRequest::Enable) => {
+                        llmtrim_core::config::write_sub_model(None)?;
+                    }
+                    Some(llmtrim::reroute::cliproxy::PinRequest::Pin(pin)) => {
+                        let wire = llmtrim::reroute::cliproxy::resolve_pin_live(&pin)
+                            .unwrap_or_else(|| pin.clone());
+                        llmtrim_core::config::write_sub_model(Some(&wire))?;
+                        println!("Pinned: {wire}.");
+                    }
+                    None => anyhow::bail!(
+                        "unknown target '{raw}' (codex|claude|gemini|grok|kimi|vertex|qwen|copilot or a model id)"
+                    ),
+                },
             }
             println!(
                 "Reroute enabled via CLIProxyAPI at {}.",

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -472,9 +472,10 @@ enum AgentsCmd {
 /// Subscription reroute: send Claude Code traffic to another subscription's backend.
 #[derive(Subcommand)]
 enum SubCmd {
-    /// Open the interactive tier→model mapping editor for a provider (codex|kimi|grok).
+    /// Open tab 4 of `llmtrim status` to edit the input→output model map.
     Setup {
-        /// Provider to edit: codex|kimi|grok.
+        /// Ignored (kept so old `sub setup grok` still opens the map). Any CLIProxyAPI CLI is fine.
+        #[arg(default_value = "on")]
         provider: String,
     },
     /// Enable reroute through CLIProxyAPI (installs + starts the sidecar).
@@ -483,13 +484,13 @@ enum SubCmd {
     /// `sub use` and `sub start` are accepted aliases.
     #[command(visible_alias = "use", alias = "start")]
     On {
-        /// Optional CLIProxyAPI model id to pin. Omit to pass Claude model ids through.
+        /// Optional CLI (`gemini`, `codex`, …) or model id. Writes the input→output map.
         provider: Option<String>,
         /// Don't restart a running interceptor to apply the change (just print the hint).
         #[arg(long)]
         no_restart: bool,
     },
-    /// Disable reroute (sets `sub = off`); traffic goes back to Anthropic with compression only.
+    /// Disable reroute (`sub = off`); traffic stays on what's in use, compression only.
     ///
     /// `sub stop` is an accepted alias.
     #[command(alias = "stop")]
@@ -498,8 +499,8 @@ enum SubCmd {
         #[arg(long)]
         no_restart: bool,
     },
-    /// Set the reroute mode: `always` (reroute every turn) or `fallback` (use the ordered
-    /// subscription chain only when Anthropic cannot serve the turn).
+    /// Set the reroute mode: `always` (every turn uses the map) or `fallback` (try hops
+    /// in `sub chain` order when the current hop cannot serve the turn).
     Mode {
         /// `always` or `fallback`.
         mode: String,
@@ -507,16 +508,15 @@ enum SubCmd {
         #[arg(long)]
         no_restart: bool,
     },
-    /// Set the ordered providers used by `sub mode fallback` (for example `codex,kimi,grok`).
+    /// Set the fallback hop list (for example `anthropic,codex` or `gemini,anthropic`).
     Chain {
-        /// Comma-separated providers in try order: codex,kimi,grok.
+        /// Comma-separated hops: anthropic,codex,claude,gemini,grok,kimi,vertex,qwen,copilot.
         providers: String,
         /// Don't restart a running interceptor to apply the change.
         #[arg(long)]
         no_restart: bool,
     },
-    /// Override the Codex reasoning effort on every rerouted request. By default the reroute honors
-    /// the effort Claude Code asks for per turn; this forces one level instead (Kimi ignores it).
+    /// Override reasoning effort on rerouted requests. Default: honor what Claude Code asks.
     Effort {
         /// `none` | `low` | `medium` | `high` | `xhigh` (`max` = `xhigh`).
         level: String,
@@ -524,10 +524,10 @@ enum SubCmd {
         #[arg(long)]
         no_restart: bool,
     },
-    /// Map one incoming model (a Claude tier `opus|sonnet|haiku|fable`, or an exact model id) to a
-    /// provider model. Non-interactive form of `setup`, for scripts and the tray.
+    /// Map one incoming model (tier `opus|sonnet|haiku|fable`, or an exact id) to a
+    /// CLIProxyAPI model. Non-interactive form of `setup`.
     Map {
-        /// Provider whose mapping to edit: codex|kimi|grok.
+        /// Map key: `on` (live map) or a legacy name. Prefer `on`.
         provider: String,
         /// Incoming model or tier name to map from.
         from: String,
@@ -537,9 +537,9 @@ enum SubCmd {
         #[arg(long)]
         no_restart: bool,
     },
-    /// Remove one mapping entry (falls back to the preset default for that model).
+    /// Remove one mapping entry from the live map.
     Unmap {
-        /// Provider whose mapping to edit: codex|kimi|grok.
+        /// Map key: `on` (live map) or a legacy name. Prefer `on`.
         provider: String,
         /// Incoming model or tier name to unmap.
         from: String,
@@ -547,9 +547,9 @@ enum SubCmd {
         #[arg(long)]
         no_restart: bool,
     },
-    /// List the provider's candidate models (for autocompletion). `--json` for machine output.
+    /// List CLIProxyAPI models (live sidecar, else the official catalog). `--json` for machines.
     Models {
-        /// Provider: codex|kimi|grok.
+        /// Unused; kept so `sub models grok` still lists the sidecar.
         provider: String,
         /// Emit a JSON array of model ids.
         #[arg(long)]
@@ -561,9 +561,9 @@ enum SubCmd {
         #[arg(long)]
         json: bool,
     },
-    /// Sign in / out of a subscription (`llmtrim sub auth codex login`).
+    /// Open the CLIProxyAPI TUI to sign in (`llmtrim sub auth`).
     Auth {
-        /// Provider: codex|kimi|grok.
+        /// Unused; sign-in is the sidecar TUI.
         provider: String,
         #[command(subcommand)]
         action: AuthAction,
@@ -1066,12 +1066,8 @@ fn apply_sub_change(no_restart: bool) {
 /// the provider reroute is currently pointed at — a change to some other provider's mapping is
 /// inert until you switch to it, so there's no reason to disturb a live session.
 #[cfg(feature = "intercept")]
-fn apply_sub_map_change(edited: llmtrim::reroute::SubProvider, no_restart: bool) {
-    let active = llmtrim_core::config::RuntimeConfig::get()
-        .sub
-        .as_deref()
-        .and_then(llmtrim::reroute::SubProvider::parse);
-    if active == Some(edited) {
+fn apply_sub_map_change(no_restart: bool) {
+    if llmtrim_core::config::sub_always_on() {
         apply_sub_change(no_restart);
     }
 }
@@ -1187,35 +1183,43 @@ fn run_agents(action: AgentsCmd) -> Result<()> {
 #[cfg(feature = "intercept")]
 fn run_sub(action: SubCmd) -> Result<()> {
     use llmtrim::reroute::{SubProvider, Tier, default_codex_tier_model};
-    let parse = |p: &str| {
+    let parse = |p: &str| -> anyhow::Result<String> {
+        let p = p.trim();
+        if p.is_empty()
+            || llmtrim::reroute::cliproxy::is_passthrough_label(p)
+            || llmtrim::reroute::cliproxy::parse_hop(p).is_some()
+        {
+            return Ok("on".into());
+        }
         SubProvider::parse(p)
-            .ok_or_else(|| anyhow::anyhow!("unknown provider '{p}' (codex|kimi|grok)"))
+            .map(|x| x.as_str().to_string())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "unknown target '{p}' (on|anthropic|codex|claude|gemini|grok|kimi|vertex|qwen|copilot)"
+                )
+            })
     };
     match action {
-        SubCmd::Setup { provider } => {
-            let p = parse(&provider)?;
-            // The interactive editor lives in `llmtrim status` tab 4 (Sub). Prefer that
-            // surface so mode + provider routing share one TUI; keep the standalone
-            // mapping editor as a fallback when status isn't available.
+        SubCmd::Setup { provider: _ } => {
+            // The interactive editor lives in `llmtrim status` tab 4 (Sub).
             #[cfg(all(feature = "breakdown", feature = "intercept"))]
             {
                 use std::io::IsTerminal;
                 if std::io::stdout().is_terminal() {
-                    llmtrim::breakdown::app::open_on_sub_next(Some(p));
+                    llmtrim::breakdown::app::open_on_sub_next(None);
                     // Same live dashboard as `llmtrim status`, focused on the Sub tab
                     // with the named provider highlighted (Enter applies).
                     return run_monitor(2, false, false, false, false, false, false, false);
                 }
                 // Non-TTY: fall through to the headless mapping editor.
-                llmtrim::reroute::tui::run(p)
+                llmtrim::reroute::tui::run(SubProvider::CliProxy)
             }
             #[cfg(all(feature = "breakdown", not(feature = "intercept")))]
             {
-                llmtrim::reroute::tui::run(p)
+                llmtrim::reroute::tui::run(SubProvider::CliProxy)
             }
             #[cfg(not(feature = "breakdown"))]
             {
-                let _ = p;
                 anyhow::bail!("the mapping editor needs the `breakdown` feature")
             }
         }
@@ -1362,10 +1366,10 @@ fn run_sub(action: SubCmd) -> Result<()> {
             to,
             no_restart,
         } => {
-            let p = parse(&provider)?;
-            llmtrim_core::config::write_sub_map_entry(p.as_str(), &from, &to)?;
-            println!("Mapped {from} -> {to} for {}.", p.as_str());
-            apply_sub_map_change(p, no_restart);
+            let key = parse(&provider)?;
+            llmtrim_core::config::write_sub_map_entry(&key, &from, &to)?;
+            println!("Mapped {from} -> {to}.");
+            apply_sub_map_change(no_restart);
             Ok(())
         }
         SubCmd::Unmap {
@@ -1373,19 +1377,23 @@ fn run_sub(action: SubCmd) -> Result<()> {
             from,
             no_restart,
         } => {
-            let p = parse(&provider)?;
-            llmtrim_core::config::remove_sub_map_entry(p.as_str(), &from)?;
-            println!(
-                "Unmapped {from} for {} (back to the preset default).",
-                p.as_str()
-            );
-            apply_sub_map_change(p, no_restart);
+            let key = parse(&provider)?;
+            llmtrim_core::config::remove_sub_map_entry(&key, &from)?;
+            println!("Unmapped {from}.");
+            apply_sub_map_change(no_restart);
             Ok(())
         }
         SubCmd::Models { json, .. } => {
-            let models = llmtrim::reroute::cliproxy::list_models().map_err(|e| {
-                anyhow::anyhow!("{e} — is CLIProxyAPI running? Try `llmtrim sub on`.")
-            })?;
+            let models = match llmtrim::reroute::cliproxy::list_models() {
+                Ok(m) if !m.is_empty() => m,
+                Ok(_) | Err(_) => llmtrim::reroute::cliproxy::official_models()
+                    .into_iter()
+                    .map(|m| llmtrim::reroute::cliproxy::Model {
+                        id: m.id,
+                        owned_by: m.owned_by,
+                    })
+                    .collect(),
+            };
             if json {
                 println!(
                     "{}",
@@ -1416,30 +1424,7 @@ fn run_sub(action: SubCmd) -> Result<()> {
                 // One effective map: the four resolved Codex tiers, then every configured entry
                 // laid over them (a configured tier wins, a free-form `model-id -> model` adds a
                 // row). One key, not a resolved/raw pair the caller has to reconcile.
-                let mut mapping: std::collections::BTreeMap<String, String> = match active {
-                    Some(SubProvider::Codex) => Tier::ALL
-                        .iter()
-                        .map(|t| {
-                            (
-                                t.as_str().to_string(),
-                                default_codex_tier_model(*t).to_string(),
-                            )
-                        })
-                        .collect(),
-                    Some(SubProvider::Grok) => Tier::ALL
-                        .iter()
-                        .map(|t| {
-                            (
-                                t.as_str().to_string(),
-                                llmtrim::reroute::default_grok_tier_model(*t).to_string(),
-                            )
-                        })
-                        .collect(),
-                    _ => std::collections::BTreeMap::new(),
-                };
-                for (k, v) in &cfg.sub_tiers {
-                    mapping.insert(k.clone(), v.clone());
-                }
+                let mapping = llmtrim_core::config::sub_tiers_for("on");
                 let skip_login = llmtrim_core::config::sub_skip_anthropic_login();
                 let claude_auth = match llmtrim::statusline::sub_auth_env_presence() {
                     llmtrim::statusline::SubAuthEnvPresence::Ours => "dummy",

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -1230,11 +1230,7 @@ fn run_sub(action: SubCmd) -> Result<()> {
             println!("Installing/starting CLIProxyAPI…");
             llmtrim::reroute::cliproxy::ensure_running()?;
             llmtrim_core::config::enable_sub("on")?;
-            match provider
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-            {
+            match provider.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
                 None => {
                     llmtrim_core::config::write_sub_model(None)?;
                 }
@@ -1328,9 +1324,7 @@ fn run_sub(action: SubCmd) -> Result<()> {
                 }
             }
             if chain.is_empty() {
-                anyhow::bail!(
-                    "fallback chain is empty (e.g. anthropic,codex or codex,anthropic)"
-                );
+                anyhow::bail!("fallback chain is empty (e.g. anthropic,codex or codex,anthropic)");
             }
             llmtrim_core::config::write_sub_chain(&chain)?;
             println!("Fallback chain: {}.", chain.join(" -> "));

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -51,7 +51,7 @@ Get started:
   update     Update to the latest release and refresh integrations
   ensure     Bring this machine to the recommended current state
   wrap       Launch an agent (claude, codex, …) routed through the interceptor
-  sub        Reroute Claude Code to another subscription's backend (codex|kimi|grok)
+  sub        Reroute Claude Code through CLIProxyAPI (https://github.com/router-for-me/CLIProxyAPI)
   agents     Install routed Claude Code subagents (Grok, Codex/Terra, Kimi)
   tray       Open the desktop tray app (savings menu-bar / system-tray)
 
@@ -114,11 +114,10 @@ enum Commands {
         #[arg(long)]
         provider: Option<String>,
     },
-    /// Subscription reroute: use another subscription's backend for Claude Code
+    /// Subscription reroute: send Claude Code traffic through CLIProxyAPI
     ///
-    /// With `sub` enabled, intercepted Anthropic traffic is translated and sent to your
-    /// ChatGPT (codex) or Kimi subscription instead of Anthropic. Authenticate first with
-    /// `llmtrim sub auth codex login` / `llmtrim sub auth kimi login` / `llmtrim sub auth grok login`.
+    /// `sub on` installs/starts CLIProxyAPI and rewrites intercepted Anthropic traffic to it.
+    /// Sign in with `llmtrim sub auth` (CLIProxyAPI TUI). `sub models` lists what it can serve.
     Sub {
         #[command(subcommand)]
         action: SubCmd,
@@ -478,13 +477,13 @@ enum SubCmd {
         /// Provider to edit: codex|kimi|grok.
         provider: String,
     },
-    /// Enable reroute to a provider (writes `sub = <provider>` to the config).
+    /// Enable reroute through CLIProxyAPI (installs + starts the sidecar).
     ///
-    /// Omit the provider to re-enable the last provider you used. `sub use` and `sub start`
-    /// are accepted aliases.
+    /// An optional model id pins every turn to that CLIProxyAPI model. `sub use` and
+    /// `sub start` are accepted aliases.
     #[command(visible_alias = "use", alias = "start")]
     On {
-        /// Provider to route to: codex|kimi|grok. Omit to re-enable the last provider used.
+        /// Optional CLIProxyAPI model id to pin. Omit to pass Claude model ids through.
         provider: Option<String>,
         /// Don't restart a running interceptor to apply the change (just print the hint).
         #[arg(long)]
@@ -804,41 +803,27 @@ fn read_stdin() -> Result<String> {
     Ok(buf)
 }
 
-/// Resolve which subscription backend a window `/sub on [provider]` should use, and require it
-/// to be signed in. With an explicit name (`/sub on grok`), only that provider is considered.
-/// Without one (`/sub on`), fall back to the global/last-enabled `sub` config.
+/// Resolve which label a window `/sub on [model]` should store.
+/// Bare `/sub on` enables CLIProxyAPI for the window. An argument is a model pin
+/// (or a legacy provider alias, which just enables the sidecar).
 #[cfg(feature = "intercept")]
 fn window_sub_provider(requested: Option<&str>) -> Result<String> {
-    use llmtrim::reroute::SubProvider;
-    let configured = match requested {
+    match requested {
+        None => Ok("on".into()),
         Some(raw) => {
-            let p = SubProvider::parse(raw).ok_or_else(|| {
-                anyhow::anyhow!("unknown provider '{raw}' (codex|kimi|grok)")
-            })?;
-            p.as_str().to_string()
+            let raw = raw.trim();
+            if raw.is_empty() {
+                return Ok("on".into());
+            }
+            if llmtrim::reroute::SubProvider::parse(raw).is_some() {
+                return Ok("on".into());
+            }
+            if llmtrim::window_sub::valid_model_id(raw) {
+                return Ok(raw.to_string());
+            }
+            bail!("usage: /sub on [model-id] | off | status");
         }
-        None => llmtrim_core::config::RuntimeConfig::get()
-            .sub
-            .clone()
-            .or_else(llmtrim_core::config::sub_reenable_provider)
-            .context(
-                "no provider to re-enable — pass one (`/sub on grok`) or run `llmtrim sub on codex|kimi|grok` first",
-            )?,
-    };
-    let provider =
-        SubProvider::parse(&configured).context("configured subscription provider is invalid")?;
-    let logged_in = llmtrim::reroute::auth::auth_status_json(provider)
-        .get("logged_in")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
-    if !logged_in {
-        bail!(
-            "{} is not signed in — run `llmtrim sub auth {} login` first",
-            provider.as_str(),
-            provider.as_str()
-        );
     }
-    Ok(provider.as_str().to_string())
 }
 
 #[cfg(not(feature = "intercept"))]
@@ -945,7 +930,7 @@ fn run_window_sub(args: Vec<String>) -> Result<()> {
                     }
                     None => println!("This window follows the global subscription policy."),
                 },
-                _ => bail!("usage: /sub on [codex|kimi|grok] | off | status"),
+                _ => bail!("usage: /sub on [model-id] | off | status"),
             }
         }
         _ => bail!("unknown window-sub action"),
@@ -962,6 +947,7 @@ fn main() {
 
 /// Handle `llmtrim <codex|kimi|grok> auth <action>`.
 #[cfg(feature = "intercept")]
+#[allow(dead_code)] // first-party OAuth kept; live `sub auth` opens CLIProxyAPI TUI
 fn run_auth(provider: &str, action: AuthAction) -> Result<()> {
     use llmtrim::reroute::{SubProvider, auth};
     // `auth status --json` is provider-agnostic (reads the stored credential file).
@@ -996,6 +982,7 @@ fn run_auth(provider: &str, action: AuthAction) -> Result<()> {
 /// whether a token is present: when it isn't, the caller skips the daemon restart (routing can't
 /// work until sign-in, so applying it now is pointless).
 #[cfg(feature = "intercept")]
+#[allow(dead_code)] // first-party login nudge; live `sub on` starts CLIProxyAPI instead
 fn print_reroute_enabled(p: llmtrim::reroute::SubProvider) -> bool {
     let logged_in =
         llmtrim::reroute::auth::auth_status_json(p)["logged_in"].as_bool() == Some(true);
@@ -1051,6 +1038,11 @@ fn sync_claude_sub_auth() {
 /// up the new config on its own). Also reconciles the Claude Code dummy-auth env for always-on sub.
 #[cfg(feature = "intercept")]
 fn apply_sub_change(no_restart: bool) {
+    if llmtrim_core::config::sub_always_on()
+        && let Err(e) = llmtrim::reroute::cliproxy::ensure_running()
+    {
+        eprintln!("llmtrim: CLIProxyAPI: {e:#}");
+    }
     // Always reconcile Claude settings, even when the daemon isn't running / no_restart —
     // the auth env is independent of the interceptor process.
     sync_claude_sub_auth();
@@ -1234,58 +1226,32 @@ fn run_sub(action: SubCmd) -> Result<()> {
             provider,
             no_restart,
         } => {
-            let logged_in = match provider {
-                // Explicit provider: (re)write the default preset, as `use` always has.
-                Some(provider) => {
-                    let p = parse(&provider)?;
-                    let mut map = std::collections::BTreeMap::new();
-                    match p {
-                        SubProvider::Codex => {
-                            for t in Tier::ALL {
-                                map.insert(
-                                    t.as_str().to_string(),
-                                    default_codex_tier_model(t).to_string(),
-                                );
-                            }
-                        }
-                        SubProvider::Grok => {
-                            for t in Tier::ALL {
-                                map.insert(
-                                    t.as_str().to_string(),
-                                    llmtrim::reroute::default_grok_tier_model(t).to_string(),
-                                );
-                            }
-                        }
-                        SubProvider::Kimi => {}
-                        // SubProvider is non_exhaustive for semver; new backends need a map here.
-                        _ => {}
-                    }
-                    llmtrim_core::config::write_sub_mapping(p.as_str(), &map)?;
-                    print_reroute_enabled(p)
-                }
-                // Bare `sub on`: restore the last provider, keeping its saved mapping.
-                None => {
-                    let provider = llmtrim_core::config::sub_reenable_provider().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "no provider to re-enable — run `llmtrim sub on codex` (or kimi|grok) first"
-                        )
-                    })?;
-                    let p = parse(&provider)?;
-                    llmtrim_core::config::enable_sub(p.as_str())?;
-                    print_reroute_enabled(p)
-                }
-            };
-            // Claude auth-env sync always runs (independent of provider login). Daemon restart
-            // is still skipped when signed out — routing can't work until sign-in anyway.
-            if logged_in {
-                apply_sub_change(no_restart);
-            } else {
-                sync_claude_sub_auth();
+            println!("Installing/starting CLIProxyAPI…");
+            llmtrim::reroute::cliproxy::ensure_running()?;
+            llmtrim_core::config::enable_sub("on")?;
+            if let Some(model) = provider
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                && llmtrim::reroute::SubProvider::parse(model).is_none()
+            {
+                println!("Pinned model: {model} (window `/sub on {model}` to pin one session).");
             }
+            println!(
+                "Reroute enabled via CLIProxyAPI at {}.",
+                llmtrim::reroute::cliproxy::base_url()
+            );
+            println!("Sign in: `llmtrim sub auth`  ·  models: `llmtrim sub models`");
+            apply_sub_change(no_restart);
             Ok(())
         }
         SubCmd::Off { no_restart } => {
             llmtrim_core::config::disable_sub()?;
+            match llmtrim::reroute::cliproxy::stop() {
+                Ok(Some(pid)) => println!("Stopped CLIProxyAPI (pid {pid})."),
+                Ok(None) => {}
+                Err(e) => eprintln!("llmtrim: could not stop CLIProxyAPI: {e:#}"),
+            }
             println!("Reroute disabled — traffic goes to Anthropic (compression only).");
             // Always sync Claude auth env even if not logged in earlier paths skipped restart.
             apply_sub_change(no_restart);
@@ -1379,17 +1345,29 @@ fn run_sub(action: SubCmd) -> Result<()> {
             apply_sub_map_change(p, no_restart);
             Ok(())
         }
-        SubCmd::Models { provider, json } => {
-            let p = parse(&provider)?;
-            let ids: Vec<String> = llmtrim::reroute::catalog::models_for(p)
-                .into_iter()
-                .map(|e| e.id)
-                .collect();
+        SubCmd::Models { json, .. } => {
+            let models = llmtrim::reroute::cliproxy::list_models().map_err(|e| {
+                anyhow::anyhow!("{e} — is CLIProxyAPI running? Try `llmtrim sub on`.")
+            })?;
             if json {
-                println!("{}", serde_json::to_string(&ids)?);
+                println!(
+                    "{}",
+                    serde_json::to_string(
+                        &models
+                            .iter()
+                            .map(|m| serde_json::json!({"id": m.id, "owned_by": m.owned_by}))
+                            .collect::<Vec<_>>()
+                    )?
+                );
+            } else if models.is_empty() {
+                println!("No models yet — run `llmtrim sub auth` to sign in.");
             } else {
-                for id in ids {
-                    println!("{id}");
+                for m in models {
+                    if m.owned_by.is_empty() {
+                        println!("{}", m.id);
+                    } else {
+                        println!("{}\t{}", m.id, m.owned_by);
+                    }
                 }
             }
             Ok(())
@@ -1440,6 +1418,17 @@ fn run_sub(action: SubCmd) -> Result<()> {
                     "anthropic_login": if skip_login { "skip" } else { "keep" },
                     "claude_auth_token": claude_auth,
                     "mapping": mapping,
+                    "cliproxy": {
+                        "url": llmtrim::reroute::cliproxy::base_url(),
+                        "running": llmtrim::reroute::cliproxy::is_running(),
+                        "installed": llmtrim::reroute::cliproxy::is_installed(),
+                        "version": llmtrim::reroute::cliproxy::installed_version(),
+                        "models": llmtrim::reroute::cliproxy::list_models()
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(|m| m.id)
+                            .collect::<Vec<_>>(),
+                    },
                     "auth": {
                         "codex": llmtrim::reroute::auth::auth_status_json(SubProvider::Codex),
                         "kimi": llmtrim::reroute::auth::auth_status_json(SubProvider::Kimi),
@@ -1448,6 +1437,30 @@ fn run_sub(action: SubCmd) -> Result<()> {
                 });
                 println!("{}", serde_json::to_string_pretty(&out)?);
                 return Ok(());
+            }
+            let cp = llmtrim::reroute::cliproxy::status();
+            println!(
+                "CLIProxyAPI: {} ({}){}",
+                if cp.running { "running" } else { "stopped" },
+                cp.base_url,
+                cp.version
+                    .as_deref()
+                    .map(|v| format!(" v{v}"))
+                    .unwrap_or_default()
+            );
+            match llmtrim::reroute::cliproxy::list_models() {
+                Ok(models) if !models.is_empty() => {
+                    println!("Models:");
+                    for m in models {
+                        if m.owned_by.is_empty() {
+                            println!("  {}", m.id);
+                        } else {
+                            println!("  {} ({})", m.id, m.owned_by);
+                        }
+                    }
+                }
+                Ok(_) => println!("Models: none — run `llmtrim sub auth` to sign in."),
+                Err(e) => println!("Models: unavailable ({e})"),
             }
             match active {
                 None => println!("Reroute: off"),
@@ -1560,7 +1573,13 @@ fn run_sub(action: SubCmd) -> Result<()> {
             }
             Ok(())
         }
-        SubCmd::Auth { provider, action } => run_auth(&provider, action),
+        SubCmd::Auth { .. } => {
+            println!(
+                "Opening CLIProxyAPI TUI to sign in. Auth files: {}",
+                llmtrim::reroute::cliproxy::auth_dir().display()
+            );
+            llmtrim::reroute::cliproxy::auth_tui()
+        }
         SubCmd::AnthropicLogin { mode } => {
             let skip = match mode.trim().to_ascii_lowercase().as_str() {
                 "skip" | "dummy" | "none" => true,

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -1314,13 +1314,19 @@ fn run_sub(action: SubCmd) -> Result<()> {
                 if raw.is_empty() {
                     continue;
                 }
-                let p = parse(raw)?;
-                if !chain.contains(&p.as_str().to_string()) {
-                    chain.push(p.as_str().to_string());
+                let Some(hop) = llmtrim::reroute::cliproxy::parse_hop(raw) else {
+                    anyhow::bail!(
+                        "unknown hop '{raw}' (anthropic|codex|claude|gemini|grok|kimi|vertex|qwen|copilot)"
+                    );
+                };
+                if !chain.contains(&hop) {
+                    chain.push(hop);
                 }
             }
             if chain.is_empty() {
-                anyhow::bail!("fallback chain is empty (expected codex,kimi)");
+                anyhow::bail!(
+                    "fallback chain is empty (e.g. anthropic,codex or codex,anthropic)"
+                );
             }
             llmtrim_core::config::write_sub_chain(&chain)?;
             println!("Fallback chain: {}.", chain.join(" -> "));

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -808,12 +808,12 @@ fn read_stdin() -> Result<String> {
 /// or a model id is pinned for this window.
 #[cfg(feature = "intercept")]
 fn window_sub_provider(requested: Option<&str>) -> Result<String> {
-    use llmtrim::reroute::cliproxy::{PinRequest, parse_pin_request, resolve_pin_live};
+    use llmtrim::reroute::cliproxy::{PinRequest, parse_pin_request};
     match requested {
         None => Ok("on".into()),
         Some(raw) => match parse_pin_request(raw) {
             Some(PinRequest::Enable) => Ok("on".into()),
-            Some(PinRequest::Pin(pin)) => Ok(resolve_pin_live(&pin).unwrap_or(pin)),
+            Some(PinRequest::Pin(pin)) => Ok(pin),
             None => bail!(
                 "usage: /sub on [codex|claude|gemini|grok|kimi|vertex|qwen|copilot|model-id] | off | status"
             ),
@@ -1239,10 +1239,29 @@ fn run_sub(action: SubCmd) -> Result<()> {
                         llmtrim_core::config::write_sub_model(None)?;
                     }
                     Some(llmtrim::reroute::cliproxy::PinRequest::Pin(pin)) => {
-                        let wire = llmtrim::reroute::cliproxy::resolve_pin_live(&pin)
-                            .unwrap_or_else(|| pin.clone());
-                        llmtrim_core::config::write_sub_model(Some(&wire))?;
-                        println!("Pinned: {wire}.");
+                        llmtrim_core::config::write_sub_model(None)?;
+                        let catalog = llmtrim::reroute::cliproxy::official_models();
+                        let map = if let Some(backend) =
+                            llmtrim::reroute::cliproxy::backend_by_alias(&pin)
+                        {
+                            llmtrim::reroute::cliproxy::default_tier_map(Some(backend), &catalog)
+                        } else {
+                            let mut map = std::collections::BTreeMap::new();
+                            for t in llmtrim::reroute::Tier::ALL {
+                                map.insert(t.as_str().to_string(), pin.clone());
+                            }
+                            map
+                        };
+                        if map.is_empty() {
+                            anyhow::bail!(
+                                "no official CLIProxyAPI models matched '{pin}' — try `llmtrim sub models` or tab 4 search"
+                            );
+                        }
+                        llmtrim_core::config::write_sub_tiers("on", &map)?;
+                        println!("Tier map ({pin}):");
+                        for (k, v) in &map {
+                            println!("  {k:<7} → {v}");
+                        }
                     }
                     None => anyhow::bail!(
                         "unknown target '{raw}' (codex|claude|gemini|grok|kimi|vertex|qwen|copilot or a model id)"

--- a/crates/llmtrim-cli/src/reroute/auth.rs
+++ b/crates/llmtrim-cli/src/reroute/auth.rs
@@ -97,7 +97,9 @@ pub fn get_token(provider: SubProvider) -> Result<TokenSet> {
             })
         }
         SubProvider::CliProxy => {
-            anyhow::bail!("CLIProxyAPI auth is `llmtrim sub auth` (sidecar TUI), not a stored token")
+            anyhow::bail!(
+                "CLIProxyAPI auth is `llmtrim sub auth` (sidecar TUI), not a stored token"
+            )
         }
     }
 }

--- a/crates/llmtrim-cli/src/reroute/auth.rs
+++ b/crates/llmtrim-cli/src/reroute/auth.rs
@@ -96,6 +96,9 @@ pub fn get_token(provider: SubProvider) -> Result<TokenSet> {
                 account_id: None,
             })
         }
+        SubProvider::CliProxy => {
+            anyhow::bail!("CLIProxyAPI auth is `llmtrim sub auth` (sidecar TUI), not a stored token")
+        }
     }
 }
 
@@ -206,6 +209,7 @@ fn provider_lock(provider: SubProvider) -> &'static Mutex<()> {
         SubProvider::Codex => &CODEX_LOCK,
         SubProvider::Kimi => &KIMI_LOCK,
         SubProvider::Grok => &GROK_LOCK,
+        SubProvider::CliProxy => &CODEX_LOCK,
     }
 }
 
@@ -844,6 +848,7 @@ pub fn auth_status_json(provider: super::SubProvider) -> serde_json::Value {
         SubProvider::Codex => read_codex().ok().map(|s| (s.expires, s.account_id)),
         SubProvider::Kimi => read_kimi().ok().map(|s| (s.expires, None)),
         SubProvider::Grok => read_grok().ok().map(|s| (s.expires, None)),
+        SubProvider::CliProxy => None,
     };
     match stored {
         Some((expires, account_id)) => serde_json::json!({

--- a/crates/llmtrim-cli/src/reroute/catalog.rs
+++ b/crates/llmtrim-cli/src/reroute/catalog.rs
@@ -41,6 +41,7 @@ pub fn models_for(provider: SubProvider) -> Vec<CatalogEntry> {
             .iter()
             .map(|id| entry_for(id, &["x-ai/", "xai/"]))
             .collect(),
+        SubProvider::CliProxy => Vec::new(),
     }
 }
 

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -40,6 +40,151 @@ pub struct Status {
     pub base_url: String,
 }
 
+/// One CLIProxyAPI login / model family. Names match the sidecar's OAuth CLIs so
+/// `sub on gemini` / `/sub on antigravity` / tab 4 can address the same backends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Backend {
+    pub id: &'static str,
+    pub aliases: &'static [&'static str],
+    pub owned_by: &'static [&'static str],
+    pub model_prefixes: &'static [&'static str],
+}
+
+pub const BACKENDS: &[Backend] = &[
+    Backend {
+        id: "codex",
+        aliases: &["codex", "chatgpt", "openai"],
+        owned_by: &["openai", "codex"],
+        model_prefixes: &["gpt-"],
+    },
+    Backend {
+        id: "claude",
+        aliases: &["claude", "anthropic"],
+        owned_by: &["anthropic", "claude"],
+        model_prefixes: &["claude-"],
+    },
+    Backend {
+        id: "gemini",
+        aliases: &["gemini", "antigravity", "aistudio"],
+        owned_by: &["google", "gemini", "antigravity"],
+        model_prefixes: &["gemini-"],
+    },
+    Backend {
+        id: "grok",
+        aliases: &["grok", "xai", "x-ai"],
+        owned_by: &["xai", "x-ai", "grok"],
+        model_prefixes: &["grok-"],
+    },
+    Backend {
+        id: "kimi",
+        aliases: &["kimi", "moonshot"],
+        owned_by: &["kimi", "moonshot", "moonshotai"],
+        model_prefixes: &["kimi"],
+    },
+    Backend {
+        id: "vertex",
+        aliases: &["vertex"],
+        owned_by: &["vertex"],
+        model_prefixes: &[],
+    },
+    Backend {
+        id: "qwen",
+        aliases: &["qwen"],
+        owned_by: &["qwen"],
+        model_prefixes: &["qwen"],
+    },
+    Backend {
+        id: "copilot",
+        aliases: &["copilot", "github"],
+        owned_by: &["github", "copilot"],
+        model_prefixes: &[],
+    },
+];
+
+/// Enable sidecar with no model pin (`sub on` / `/sub on`).
+const PASSTHROUGH: &[&str] = &["on", "cliproxy", "cli-proxy", "cli-proxy-api", "cliproxyapi"];
+
+pub fn is_passthrough_label(raw: &str) -> bool {
+    let s = raw.trim().to_ascii_lowercase();
+    PASSTHROUGH.contains(&s.as_str())
+}
+
+pub fn backend_by_alias(raw: &str) -> Option<&'static Backend> {
+    let s = raw.trim().to_ascii_lowercase();
+    BACKENDS.iter().find(|b| b.id == s || b.aliases.contains(&s.as_str()))
+}
+
+impl Backend {
+    pub fn matches(&self, model: &Model) -> bool {
+        let owner = model.owned_by.to_ascii_lowercase();
+        if self.owned_by.iter().any(|o| owner.contains(o)) {
+            return true;
+        }
+        let id = model.id.to_ascii_lowercase();
+        self.model_prefixes
+            .iter()
+            .any(|p| !p.is_empty() && id.starts_with(p))
+    }
+}
+
+/// What `sub on X` / `/sub on X` means.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PinRequest {
+    /// Just turn the sidecar on; leave Claude model ids alone.
+    Enable,
+    /// Force this CLIProxyAPI model id (or a backend alias to expand later).
+    Pin(String),
+}
+
+pub fn parse_pin_request(raw: &str) -> Option<PinRequest> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw.eq_ignore_ascii_case("off") {
+        return None;
+    }
+    if is_passthrough_label(raw) {
+        return Some(PinRequest::Enable);
+    }
+    if backend_by_alias(raw).is_some() {
+        return Some(PinRequest::Pin(raw.trim().to_ascii_lowercase()));
+    }
+    let ok_chars = raw
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'/'));
+    if raw.len() <= 160
+        && ok_chars
+        && !raw.contains("..")
+        && (raw.contains('-') || raw.contains('/') || raw.contains('.'))
+    {
+        return Some(PinRequest::Pin(raw.to_string()));
+    }
+    None
+}
+
+/// Turn a stored pin (model id or backend alias) into a wire model id when the sidecar
+/// has published models. Backend aliases with no matching model stay unresolved so the
+/// Claude id is left alone.
+pub fn expand_pin(pin: &str, models: &[Model]) -> Option<String> {
+    if let Some(exact) = models.iter().find(|m| m.id.eq_ignore_ascii_case(pin)) {
+        return Some(exact.id.clone());
+    }
+    let backend = backend_by_alias(pin)?;
+    models
+        .iter()
+        .find(|m| backend.matches(m))
+        .map(|m| m.id.clone())
+}
+
+pub fn resolve_pin_live(pin: &str) -> Option<String> {
+    let models = list_models().unwrap_or_default();
+    expand_pin(pin, &models).or_else(|| {
+        if backend_by_alias(pin).is_some() {
+            None
+        } else {
+            Some(pin.to_string())
+        }
+    })
+}
+
 pub fn dir() -> Result<PathBuf> {
     Ok(crate::daemon::home_dir()?.join("cliproxy"))
 }
@@ -948,5 +1093,61 @@ mod tests {
         .unwrap();
         assert_eq!(grok["type"], "xai");
         assert_eq!(grok["auth_kind"], "oauth");
+    }
+
+    #[test]
+    fn parse_pin_accepts_every_cliproxy_backend() {
+        assert_eq!(parse_pin_request("on"), Some(PinRequest::Enable));
+        assert_eq!(
+            parse_pin_request("gemini"),
+            Some(PinRequest::Pin("gemini".into()))
+        );
+        assert_eq!(
+            parse_pin_request("antigravity"),
+            Some(PinRequest::Pin("antigravity".into()))
+        );
+        assert_eq!(
+            parse_pin_request("claude"),
+            Some(PinRequest::Pin("claude".into()))
+        );
+        assert_eq!(
+            parse_pin_request("vertex"),
+            Some(PinRequest::Pin("vertex".into()))
+        );
+        assert_eq!(
+            parse_pin_request("qwen"),
+            Some(PinRequest::Pin("qwen".into()))
+        );
+        assert_eq!(
+            parse_pin_request("copilot"),
+            Some(PinRequest::Pin("copilot".into()))
+        );
+        assert_eq!(
+            parse_pin_request("gpt-5.4"),
+            Some(PinRequest::Pin("gpt-5.4".into()))
+        );
+        assert!(parse_pin_request("off").is_none());
+        assert!(parse_pin_request("no spaces allowed here!").is_none());
+    }
+
+    #[test]
+    fn expand_pin_uses_owned_by_then_prefix() {
+        let models = vec![
+            Model {
+                id: "gemini-3-flash".into(),
+                owned_by: "google".into(),
+            },
+            Model {
+                id: "gpt-5.4".into(),
+                owned_by: "openai".into(),
+            },
+        ];
+        assert_eq!(
+            expand_pin("gemini", &models).as_deref(),
+            Some("gemini-3-flash")
+        );
+        assert_eq!(expand_pin("codex", &models).as_deref(), Some("gpt-5.4"));
+        assert_eq!(expand_pin("gpt-5.4", &models).as_deref(), Some("gpt-5.4"));
+        assert_eq!(expand_pin("kimi", &models), None);
     }
 }

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -686,6 +686,8 @@ pub fn rewrite(anthropic_body: &Value) -> Result<UpstreamRewrite> {
         .and_then(Value::as_str)
         .unwrap_or("unknown")
         .to_string();
+    let mut body = anthropic_body.clone();
+    strip_tiny_images(&mut body);
     let key = api_key()?;
     let url = base_url();
     let (host, path) = split_base_url(&url)?;
@@ -697,11 +699,125 @@ pub fn rewrite(anthropic_body: &Value) -> Result<UpstreamRewrite> {
             ("x-api-key".into(), key),
             ("content-type".into(), "application/json".into()),
         ],
-        body: serde_json::to_vec(anthropic_body)?,
+        body: serde_json::to_vec(&body)?,
         model,
         provider: SubProvider::CliProxy,
         insecure_http: url.starts_with("http://"),
     })
+}
+
+/// Grok (and some others) reject images under 8×8. Drop those blocks so a 2×2
+/// placeholder from Claude Code does not 400 the whole turn.
+const MIN_IMAGE_EDGE: u32 = 8;
+
+pub(crate) fn strip_tiny_images(body: &mut Value) -> usize {
+    let mut n = 0;
+    if let Some(msgs) = body.get_mut("messages").and_then(Value::as_array_mut) {
+        for msg in msgs {
+            n += strip_tiny_in_content(msg.get_mut("content"));
+        }
+    }
+    n
+}
+
+fn strip_tiny_in_content(content: Option<&mut Value>) -> usize {
+    let Some(content) = content else {
+        return 0;
+    };
+    match content {
+        Value::Array(blocks) => {
+            let mut n = 0;
+            let mut i = 0;
+            while i < blocks.len() {
+                n += strip_tiny_in_content(blocks[i].get_mut("content"));
+                if is_tiny_image(&blocks[i]) {
+                    blocks[i] = serde_json::json!({
+                        "type": "text",
+                        "text": "[image omitted: smaller than 8×8]"
+                    });
+                    n += 1;
+                }
+                i += 1;
+            }
+            n
+        }
+        _ => 0,
+    }
+}
+
+fn is_tiny_image(block: &Value) -> bool {
+    if block.get("type").and_then(Value::as_str) != Some("image") {
+        return false;
+    }
+    let Some(source) = block.get("source") else {
+        return false;
+    };
+    if source.get("type").and_then(Value::as_str) != Some("base64") {
+        return false;
+    }
+    let Some(data) = source.get("data").and_then(Value::as_str) else {
+        return false;
+    };
+    image_edges(data).is_some_and(|(w, h)| w < MIN_IMAGE_EDGE || h < MIN_IMAGE_EDGE)
+}
+
+fn image_edges(b64: &str) -> Option<(u32, u32)> {
+    use base64::Engine;
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(b64.trim())
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(b64.trim().replace('\n', "")))
+        .ok()?;
+    png_edges(&raw).or_else(|| jpeg_edges(&raw)).or_else(|| gif_edges(&raw))
+}
+
+fn png_edges(raw: &[u8]) -> Option<(u32, u32)> {
+    if raw.len() < 24 || &raw[0..8] != b"\x89PNG\r\n\x1a\n" {
+        return None;
+    }
+    if &raw[12..16] != b"IHDR" {
+        return None;
+    }
+    let w = u32::from_be_bytes(raw[16..20].try_into().ok()?);
+    let h = u32::from_be_bytes(raw[20..24].try_into().ok()?);
+    Some((w, h))
+}
+
+fn jpeg_edges(raw: &[u8]) -> Option<(u32, u32)> {
+    if raw.len() < 4 || raw[0] != 0xFF || raw[1] != 0xD8 {
+        return None;
+    }
+    let mut i = 2usize;
+    while i + 9 < raw.len() {
+        if raw[i] != 0xFF {
+            i += 1;
+            continue;
+        }
+        let marker = raw[i + 1];
+        if marker == 0xD8 || marker == 0xD9 || (0xD0..=0xD7).contains(&marker) {
+            i += 2;
+            continue;
+        }
+        if i + 4 > raw.len() {
+            break;
+        }
+        let len = u16::from_be_bytes([raw[i + 2], raw[i + 3]]) as usize;
+        if (0xC0..=0xC2).contains(&marker) && i + 9 < raw.len() {
+            let h = u16::from_be_bytes([raw[i + 5], raw[i + 6]]) as u32;
+            let w = u16::from_be_bytes([raw[i + 7], raw[i + 8]]) as u32;
+            return Some((w, h));
+        }
+        i += 2 + len;
+    }
+    None
+}
+
+fn gif_edges(raw: &[u8]) -> Option<(u32, u32)> {
+    if raw.len() < 10 || (&raw[0..6] != b"GIF87a" && &raw[0..6] != b"GIF89a") {
+        return None;
+    }
+    let w = u16::from_le_bytes([raw[6], raw[7]]) as u32;
+    let h = u16::from_le_bytes([raw[8], raw[9]]) as u32;
+    Some((w, h))
 }
 
 pub fn split_base_url(url: &str) -> Result<(String, String)> {
@@ -1399,5 +1515,37 @@ mod tests {
             Some("grok-composer-2.5-fast")
         );
         assert!(!map.values().any(|v| v == "claude-opus-5"));
+    }
+
+    const PNG_2X2: &str =
+        "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg==";
+
+    #[test]
+    fn png_2x2_is_tiny() {
+        assert_eq!(image_edges(PNG_2X2), Some((2, 2)));
+        assert!(image_edges(PNG_2X2).is_some_and(|(w, h)| w < 8 || h < 8));
+    }
+
+    #[test]
+    fn strip_tiny_images_replaces_2x2_keeps_text() {
+        let mut body = json!({
+            "model": "grok-4.6",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "see"},
+                    {"type": "image", "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": PNG_2X2
+                    }}
+                ]
+            }]
+        });
+        assert_eq!(strip_tiny_images(&mut body), 1);
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["text"], "see");
+        assert_eq!(content[1]["type"], "text");
+        assert!(content[1]["text"].as_str().unwrap().contains("8"));
     }
 }

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -1,0 +1,738 @@
+//! Managed [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) sidecar.
+//!
+//! `sub on` installs and starts this process. The interceptor then rewrites Anthropic
+//! `/v1/messages` to the sidecar (which already speaks the Claude API) instead of doing
+//! first-party Codex/Kimi/Grok protocol translation.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+
+use super::SubProvider;
+use super::UpstreamRewrite;
+
+pub const REPO: &str = "router-for-me/CLIProxyAPI";
+pub const DEFAULT_PORT: u16 = 18317;
+const DEFAULT_HOST: &str = "127.0.0.1";
+
+/// Override the sidecar base URL (`http://127.0.0.1:8317`). When set, llmtrim does not
+/// manage a private binary — it just redirects to this instance.
+pub const URL_ENV: &str = "LLMTRIM_CLIPROXY_URL";
+/// API key for [`URL_ENV`] (or for the managed sidecar when you want to pin one).
+pub const KEY_ENV: &str = "LLMTRIM_CLIPROXY_KEY";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Model {
+    pub id: String,
+    pub owned_by: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Status {
+    pub enabled: bool,
+    pub installed: bool,
+    pub running: bool,
+    pub managed: bool,
+    pub version: Option<String>,
+    pub base_url: String,
+}
+
+pub fn dir() -> Result<PathBuf> {
+    Ok(crate::daemon::home_dir()?.join("cliproxy"))
+}
+
+pub fn bin_path() -> Result<PathBuf> {
+    let name = if cfg!(windows) {
+        "CLIProxyAPI.exe"
+    } else {
+        "CLIProxyAPI"
+    };
+    Ok(dir()?.join(name))
+}
+
+pub fn config_path() -> Result<PathBuf> {
+    Ok(dir()?.join("config.yaml"))
+}
+
+pub fn version_path() -> Result<PathBuf> {
+    Ok(dir()?.join("version"))
+}
+
+fn pidfile() -> Result<PathBuf> {
+    Ok(crate::daemon::home_dir()?.join("cliproxy.pid"))
+}
+
+fn logfile() -> Result<PathBuf> {
+    Ok(crate::daemon::home_dir()?.join("cliproxy.log"))
+}
+
+fn key_path() -> Result<PathBuf> {
+    Ok(dir()?.join("api-key"))
+}
+
+pub fn is_installed() -> bool {
+    bin_path().ok().is_some_and(|p| p.is_file())
+}
+
+pub fn is_managed_user() -> bool {
+    is_installed() || is_enabled()
+}
+
+pub fn is_enabled() -> bool {
+    llmtrim_core::config::sub_always_on()
+}
+
+pub fn installed_version() -> Option<String> {
+    fs::read_to_string(version_path().ok()?).ok().map(|s| {
+        s.trim()
+            .trim_start_matches('v')
+            .trim()
+            .to_string()
+    })
+}
+
+/// Release asset name for this OS/arch (`None` if we do not ship that target).
+pub fn release_asset(version: &str) -> Option<String> {
+    release_asset_for(version, std::env::consts::OS, std::env::consts::ARCH)
+}
+
+pub fn release_asset_for(version: &str, os: &str, arch: &str) -> Option<String> {
+    let ver = version.trim_start_matches('v');
+    let (os, arch, ext) = match (os, arch) {
+        ("linux", "x86_64") => ("linux", "amd64", "tar.gz"),
+        ("linux", "aarch64") => ("linux", "aarch64", "tar.gz"),
+        ("macos", "x86_64") => ("darwin", "amd64", "tar.gz"),
+        ("macos", "aarch64") => ("darwin", "aarch64", "tar.gz"),
+        ("windows", "x86_64") => ("windows", "amd64", "zip"),
+        ("windows", "aarch64") => ("windows", "aarch64", "zip"),
+        _ => return None,
+    };
+    Some(format!("CLIProxyAPI_{ver}_{os}_{arch}.{ext}"))
+}
+
+pub fn default_base_url() -> String {
+    format!("http://{DEFAULT_HOST}:{DEFAULT_PORT}")
+}
+
+pub fn base_url() -> String {
+    std::env::var(URL_ENV)
+        .ok()
+        .map(|s| s.trim().trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(default_base_url)
+}
+
+pub fn is_externally_configured() -> bool {
+    std::env::var(URL_ENV)
+        .ok()
+        .is_some_and(|s| !s.trim().is_empty())
+}
+
+pub fn api_key() -> Result<String> {
+    if let Ok(k) = std::env::var(KEY_ENV) {
+        let k = k.trim().to_string();
+        if !k.is_empty() {
+            return Ok(k);
+        }
+    }
+    let path = key_path()?;
+    if let Ok(existing) = fs::read_to_string(&path) {
+        let k = existing.trim().to_string();
+        if !k.is_empty() {
+            return Ok(k);
+        }
+    }
+    let key = format!("llmtrim-{}", uuid::Uuid::new_v4().simple());
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&path, &key)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(key)
+}
+
+pub fn auth_dir() -> PathBuf {
+    if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+        let shared = PathBuf::from(home).join(".cli-proxy-api");
+        if shared.is_dir() {
+            return shared;
+        }
+    }
+    dir().map(|d| d.join("auth")).unwrap_or_else(|_| PathBuf::from("auth"))
+}
+
+pub fn config_yaml(port: u16, key: &str, auth: &Path) -> String {
+    format!(
+        "host: \"{DEFAULT_HOST}\"\n\
+         port: {port}\n\
+         auth-dir: \"{}\"\n\
+         api-keys:\n\
+           - \"{key}\"\n\
+         remote-management:\n\
+           allow-remote: false\n\
+           secret-key: \"\"\n\
+           disable-control-panel: true\n\
+         debug: false\n",
+        auth.display()
+    )
+}
+
+pub fn ensure_config() -> Result<()> {
+    if is_externally_configured() {
+        return Ok(());
+    }
+    let dir = dir()?;
+    fs::create_dir_all(dir.join("auth")).with_context(|| format!("create {}", dir.display()))?;
+    let path = config_path()?;
+    if path.is_file() {
+        return Ok(());
+    }
+    let yaml = config_yaml(DEFAULT_PORT, &api_key()?, &auth_dir());
+    fs::write(&path, yaml).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+pub fn pid_running() -> Option<u32> {
+    let raw = fs::read_to_string(pidfile().ok()?).ok()?;
+    let pid: u32 = raw.trim().parse().ok()?;
+    if process_alive(pid) {
+        Some(pid)
+    } else {
+        let _ = fs::remove_file(pidfile().ok()?);
+        None
+    }
+}
+
+fn process_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+    #[cfg(windows)]
+    {
+        std::process::Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+            .output()
+            .ok()
+            .is_some_and(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+pub fn is_healthy() -> bool {
+    probe_models().is_ok()
+}
+
+pub fn is_running() -> bool {
+    is_healthy() || pid_running().is_some()
+}
+
+fn ureq_agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(5)))
+        .http_status_as_error(false)
+        .build()
+        .into()
+}
+
+fn models_url() -> String {
+    format!("{}/v1/models", base_url())
+}
+
+fn probe_models() -> Result<Value> {
+    let key = api_key().unwrap_or_default();
+    let mut req = ureq_agent().get(models_url());
+    if !key.is_empty() {
+        req = req
+            .header("Authorization", format!("Bearer {key}"))
+            .header("x-api-key", &key);
+    }
+    let mut res = req.call().context("CLIProxyAPI /v1/models")?;
+    let status = res.status();
+    let body = res.body_mut().read_to_string().unwrap_or_default();
+    if !status.is_success() {
+        bail!("CLIProxyAPI /v1/models returned {status}: {body}");
+    }
+    serde_json::from_str(&body).context("parse CLIProxyAPI /v1/models")
+}
+
+pub fn parse_models(value: &Value) -> Vec<Model> {
+    let Some(arr) = value.get("data").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for item in arr {
+        let Some(id) = item.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        if id.is_empty() {
+            continue;
+        }
+        out.push(Model {
+            id: id.to_string(),
+            owned_by: item
+                .get("owned_by")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+        });
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out.dedup_by(|a, b| a.id == b.id);
+    out
+}
+
+pub fn list_models() -> Result<Vec<Model>> {
+    Ok(parse_models(&probe_models()?))
+}
+
+pub fn status() -> Status {
+    Status {
+        enabled: is_enabled(),
+        installed: is_installed(),
+        running: is_running(),
+        managed: !is_externally_configured(),
+        version: installed_version(),
+        base_url: base_url(),
+    }
+}
+
+/// Build the MITM rewrite that sends the (already Anthropic-shaped) body to CLIProxyAPI.
+pub fn rewrite(anthropic_body: &Value) -> Result<UpstreamRewrite> {
+    if !is_running() {
+        bail!("CLIProxyAPI is not running — run `llmtrim sub on`");
+    }
+    let model = anthropic_body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let key = api_key()?;
+    let url = base_url();
+    let (host, path) = split_base_url(&url)?;
+    Ok(UpstreamRewrite {
+        host,
+        path: format!("{path}/v1/messages"),
+        headers: vec![
+            ("authorization".into(), format!("Bearer {key}")),
+            ("x-api-key".into(), key),
+            ("content-type".into(), "application/json".into()),
+        ],
+        body: serde_json::to_vec(anthropic_body)?,
+        model,
+        provider: SubProvider::CliProxy,
+        insecure_http: url.starts_with("http://"),
+    })
+}
+
+pub fn split_base_url(url: &str) -> Result<(String, String)> {
+    let rest = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .context("CLIProxyAPI URL must be http(s)://host[:port]")?;
+    let (host, prefix) = rest.split_once('/').unwrap_or((rest, ""));
+    if host.is_empty() {
+        bail!("CLIProxyAPI URL has no host");
+    }
+    let prefix = prefix.trim_end_matches('/');
+    let prefix = if prefix.is_empty() {
+        String::new()
+    } else {
+        format!("/{prefix}")
+    };
+    Ok((host.to_string(), prefix))
+}
+
+pub fn fetch_latest_tag() -> Result<String> {
+    let url = format!("https://api.github.com/repos/{REPO}/releases/latest");
+    let mut req = ureq::get(&url)
+        .config()
+        .timeout_global(Some(Duration::from_secs(8)))
+        .http_status_as_error(false)
+        .build();
+    req = req.header("User-Agent", "llmtrim-cliproxy");
+    let body = req
+        .call()
+        .context("CLIProxyAPI releases")?
+        .body_mut()
+        .read_to_string()
+        .context("read CLIProxyAPI release")?;
+    let v: Value = serde_json::from_str(&body).context("parse CLIProxyAPI release")?;
+    let tag = v
+        .get("tag_name")
+        .and_then(Value::as_str)
+        .context("CLIProxyAPI release has no tag_name")?;
+    Ok(tag.trim_start_matches('v').to_string())
+}
+
+pub fn ensure_installed() -> Result<String> {
+    if is_externally_configured() {
+        return Ok("external".into());
+    }
+    if is_installed() {
+        return Ok(installed_version().unwrap_or_else(|| "unknown".into()));
+    }
+    install_latest()
+}
+
+pub fn install_latest() -> Result<String> {
+    if is_externally_configured() {
+        bail!("LLMTRIM_CLIPROXY_URL is set — I will not replace an external CLIProxyAPI");
+    }
+    let tag = fetch_latest_tag()?;
+    install_tag(&tag)?;
+    Ok(tag)
+}
+
+pub fn install_tag(tag: &str) -> Result<()> {
+    let asset = release_asset(tag)
+        .with_context(|| format!("no CLIProxyAPI build for {}/{}", std::env::consts::OS, std::env::consts::ARCH))?;
+    let url = format!("https://github.com/{REPO}/releases/download/v{tag}/{asset}");
+    let dest = dir()?;
+    fs::create_dir_all(&dest)?;
+    let archive = dest.join(&asset);
+    download(&url, &archive)?;
+    extract(&archive, &dest)?;
+    let _ = fs::remove_file(&archive);
+    locate_binary(&dest)?;
+    fs::write(version_path()?, tag)?;
+    ensure_config()?;
+    Ok(())
+}
+
+fn download(url: &str, dest: &Path) -> Result<()> {
+    let mut req = ureq::get(url)
+        .config()
+        .timeout_global(Some(Duration::from_secs(120)))
+        .http_status_as_error(true)
+        .build();
+    req = req.header("User-Agent", "llmtrim-cliproxy");
+    let mut res = req.call().with_context(|| format!("download {url}"))?;
+    let bytes = res
+        .body_mut()
+        .read_to_vec()
+        .context("read CLIProxyAPI archive")?;
+    fs::write(dest, bytes).with_context(|| format!("write {}", dest.display()))?;
+    Ok(())
+}
+
+fn extract(archive: &Path, dest: &Path) -> Result<()> {
+    let name = archive.file_name().and_then(|s| s.to_str()).unwrap_or("");
+    if name.ends_with(".zip") {
+        let status = if cfg!(windows) {
+            std::process::Command::new("powershell")
+                .args([
+                    "-NoProfile",
+                    "-Command",
+                    &format!(
+                        "Expand-Archive -Force -Path '{}' -DestinationPath '{}'",
+                        archive.display(),
+                        dest.display()
+                    ),
+                ])
+                .status()
+        } else {
+            std::process::Command::new("unzip")
+                .args(["-o", &archive.to_string_lossy(), "-d", &dest.to_string_lossy()])
+                .status()
+        }
+        .context("extract CLIProxyAPI zip")?;
+        if !status.success() {
+            bail!("failed to extract {}", archive.display());
+        }
+        return Ok(());
+    }
+    let status = std::process::Command::new("tar")
+        .args([
+            "-xzf",
+            &archive.to_string_lossy(),
+            "-C",
+            &dest.to_string_lossy(),
+        ])
+        .status()
+        .context("extract CLIProxyAPI tar.gz (tar required)")?;
+    if !status.success() {
+        bail!("failed to extract {}", archive.display());
+    }
+    Ok(())
+}
+
+fn locate_binary(dest: &Path) -> Result<PathBuf> {
+    let expected = bin_path()?;
+    if expected.is_file() {
+        chmod_exec(&expected);
+        return Ok(expected);
+    }
+    for entry in walkdir_bins(dest) {
+        let Some(name) = entry.file_name() else {
+            continue;
+        };
+        let name = name.to_string_lossy();
+        if name == "CLIProxyAPI" || name == "CLIProxyAPI.exe" || name == "cli-proxy-api" {
+            if entry != expected {
+                let _ = fs::copy(&entry, &expected);
+            }
+            chmod_exec(&expected);
+            return Ok(expected);
+        }
+    }
+    bail!("CLIProxyAPI binary not found in {}", dest.display());
+}
+
+fn walkdir_bins(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(rd) = fs::read_dir(root) else {
+        return out;
+    };
+    for entry in rd.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(walkdir_bins(&path));
+        } else {
+            out.push(path);
+        }
+    }
+    out
+}
+
+fn chmod_exec(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = fs::metadata(path) {
+            let mut mode = meta.permissions().mode();
+            mode |= 0o755;
+            let _ = fs::set_permissions(path, fs::Permissions::from_mode(mode));
+        }
+    }
+    let _ = path;
+}
+
+pub fn ensure_running() -> Result<()> {
+    if is_externally_configured() {
+        if is_healthy() {
+            return Ok(());
+        }
+        bail!(
+            "CLIProxyAPI at {} is not reachable — start it, or unset {URL_ENV}",
+            base_url()
+        );
+    }
+    ensure_installed()?;
+    ensure_config()?;
+    if is_healthy() {
+        return Ok(());
+    }
+    if pid_running().is_some() {
+        // Process up but not healthy yet — give it a moment.
+        for _ in 0..20 {
+            std::thread::sleep(Duration::from_millis(150));
+            if is_healthy() {
+                return Ok(());
+            }
+        }
+    }
+    start()?;
+    for _ in 0..40 {
+        if is_healthy() {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+    bail!(
+        "CLIProxyAPI started but {}/v1/models is not answering — see {}",
+        base_url(),
+        logfile().map(|p| p.display().to_string()).unwrap_or_else(|_| "cliproxy.log".into())
+    );
+}
+
+pub fn start() -> Result<u32> {
+    if is_externally_configured() {
+        bail!("LLMTRIM_CLIPROXY_URL is set — start that instance yourself");
+    }
+    if let Some(pid) = pid_running() {
+        return Ok(pid);
+    }
+    ensure_installed()?;
+    ensure_config()?;
+    let bin = bin_path()?;
+    let cfg = config_path()?;
+    let log = fs::File::create(logfile()?)?;
+    let err = log.try_clone()?;
+    let mut cmd = std::process::Command::new(&bin);
+    cmd.args(["--config", &cfg.to_string_lossy()])
+        .stdin(std::process::Stdio::null())
+        .stdout(log)
+        .stderr(err);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
+    }
+    let child = cmd.spawn().with_context(|| format!("spawn {}", bin.display()))?;
+    let pid = child.id();
+    fs::write(pidfile()?, pid.to_string())?;
+    Ok(pid)
+}
+
+pub fn stop() -> Result<Option<u32>> {
+    if is_externally_configured() {
+        return Ok(None);
+    }
+    let Some(pid) = pid_running() else {
+        return Ok(None);
+    };
+    #[cfg(unix)]
+    {
+        let _ = std::process::Command::new("kill")
+            .args([pid.to_string()])
+            .status();
+    }
+    #[cfg(windows)]
+    {
+        let _ = std::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .status();
+    }
+    for _ in 0..30 {
+        if !process_alive(pid) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let _ = fs::remove_file(pidfile()?);
+    Ok(Some(pid))
+}
+
+/// Launch the CLIProxyAPI TUI so the user can sign in to providers.
+pub fn auth_tui() -> Result<()> {
+    ensure_installed()?;
+    ensure_config()?;
+    let bin = bin_path()?;
+    let cfg = config_path()?;
+    let status = std::process::Command::new(&bin)
+        .args(["--tui", "--config", &cfg.to_string_lossy()])
+        .status()
+        .with_context(|| format!("run {} --tui", bin.display()))?;
+    if !status.success() {
+        bail!("CLIProxyAPI TUI exited non-zero");
+    }
+    Ok(())
+}
+
+pub fn update_if_used() -> Result<Option<String>> {
+    if !is_managed_user() || is_externally_configured() {
+        return Ok(None);
+    }
+    if !is_installed() {
+        return Ok(None);
+    }
+    let latest = fetch_latest_tag()?;
+    if installed_version().as_deref() == Some(latest.as_str()) {
+        return Ok(Some(format!("CLIProxyAPI already {latest}")));
+    }
+    let was_running = pid_running().is_some() || is_enabled();
+    if pid_running().is_some() {
+        let _ = stop();
+    }
+    install_tag(&latest)?;
+    if was_running {
+        let _ = ensure_running();
+    }
+    Ok(Some(format!("CLIProxyAPI updated to {latest}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn asset_name_linux_amd64() {
+        assert_eq!(
+            release_asset_for("7.2.130", "linux", "x86_64").as_deref(),
+            Some("CLIProxyAPI_7.2.130_linux_amd64.tar.gz")
+        );
+    }
+
+    #[test]
+    fn asset_name_darwin_arm() {
+        assert_eq!(
+            release_asset_for("v7.2.130", "macos", "aarch64").as_deref(),
+            Some("CLIProxyAPI_7.2.130_darwin_aarch64.tar.gz")
+        );
+    }
+
+    #[test]
+    fn asset_name_windows_zip() {
+        assert_eq!(
+            release_asset_for("7.2.130", "windows", "x86_64").as_deref(),
+            Some("CLIProxyAPI_7.2.130_windows_amd64.zip")
+        );
+    }
+
+    #[test]
+    fn asset_name_unknown_none() {
+        assert_eq!(release_asset_for("7.2.130", "linux", "riscv64"), None);
+    }
+
+    #[test]
+    fn split_url_strips_scheme_and_prefix() {
+        assert_eq!(
+            split_base_url("http://127.0.0.1:18317").unwrap(),
+            ("127.0.0.1:18317".into(), String::new())
+        );
+        assert_eq!(
+            split_base_url("http://127.0.0.1:8317/proxy").unwrap(),
+            ("127.0.0.1:8317".into(), "/proxy".into())
+        );
+    }
+
+    #[test]
+    fn config_yaml_is_localhost_only() {
+        let yaml = config_yaml(18317, "llmtrim-test", Path::new("/tmp/auth"));
+        assert!(yaml.contains("host: \"127.0.0.1\""));
+        assert!(yaml.contains("port: 18317"));
+        assert!(yaml.contains("llmtrim-test"));
+        assert!(yaml.contains("allow-remote: false"));
+    }
+
+    #[test]
+    fn parse_models_reads_openai_list() {
+        let v = json!({
+            "data": [
+                {"id": "gpt-5.4", "owned_by": "openai"},
+                {"id": "gemini-3-flash", "owned_by": "google"},
+                {"id": "gpt-5.4", "owned_by": "dup"},
+                {"owned_by": "skip-me"}
+            ]
+        });
+        let models = parse_models(&v);
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "gemini-3-flash");
+        assert_eq!(models[1].id, "gpt-5.4");
+        assert_eq!(models[1].owned_by, "openai");
+    }
+}

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -102,7 +102,13 @@ pub const BACKENDS: &[Backend] = &[
 ];
 
 /// Enable sidecar with no model pin (`sub on` / `/sub on`).
-const PASSTHROUGH: &[&str] = &["on", "cliproxy", "cli-proxy", "cli-proxy-api", "cliproxyapi"];
+const PASSTHROUGH: &[&str] = &[
+    "on",
+    "cliproxy",
+    "cli-proxy",
+    "cli-proxy-api",
+    "cliproxyapi",
+];
 
 /// A fallback-chain hop: real Anthropic, or a CLIProxyAPI CLI family.
 pub fn parse_hop(raw: &str) -> Option<String> {
@@ -120,7 +126,10 @@ pub fn parse_hop(raw: &str) -> Option<String> {
 }
 
 pub fn is_anthropic_hop(raw: &str) -> bool {
-    matches!(raw.trim().to_ascii_lowercase().as_str(), "anthropic" | "direct")
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "anthropic" | "direct"
+    )
 }
 
 pub fn is_passthrough_label(raw: &str) -> bool {
@@ -130,7 +139,9 @@ pub fn is_passthrough_label(raw: &str) -> bool {
 
 pub fn backend_by_alias(raw: &str) -> Option<&'static Backend> {
     let s = raw.trim().to_ascii_lowercase();
-    BACKENDS.iter().find(|b| b.id == s || b.aliases.contains(&s.as_str()))
+    BACKENDS
+        .iter()
+        .find(|b| b.id == s || b.aliases.contains(&s.as_str()))
 }
 
 impl Backend {
@@ -450,12 +461,9 @@ pub fn is_enabled() -> bool {
 }
 
 pub fn installed_version() -> Option<String> {
-    fs::read_to_string(version_path().ok()?).ok().map(|s| {
-        s.trim()
-            .trim_start_matches('v')
-            .trim()
-            .to_string()
-    })
+    fs::read_to_string(version_path().ok()?)
+        .ok()
+        .map(|s| s.trim().trim_start_matches('v').trim().to_string())
 }
 
 /// Release asset name for this OS/arch (`None` if we do not ship that target).
@@ -529,7 +537,9 @@ pub fn auth_dir() -> PathBuf {
             return shared;
         }
     }
-    dir().map(|d| d.join("auth")).unwrap_or_else(|_| PathBuf::from("auth"))
+    dir()
+        .map(|d| d.join("auth"))
+        .unwrap_or_else(|_| PathBuf::from("auth"))
 }
 
 pub fn config_yaml(port: u16, key: &str, auth: &Path) -> String {
@@ -767,7 +777,9 @@ fn image_edges(b64: &str) -> Option<(u32, u32)> {
         .decode(b64.trim())
         .or_else(|_| base64::engine::general_purpose::STANDARD.decode(b64.trim().replace('\n', "")))
         .ok()?;
-    png_edges(&raw).or_else(|| jpeg_edges(&raw)).or_else(|| gif_edges(&raw))
+    png_edges(&raw)
+        .or_else(|| jpeg_edges(&raw))
+        .or_else(|| gif_edges(&raw))
 }
 
 fn png_edges(raw: &[u8]) -> Option<(u32, u32)> {
@@ -880,8 +892,13 @@ pub fn install_latest() -> Result<String> {
 }
 
 pub fn install_tag(tag: &str) -> Result<()> {
-    let asset = release_asset(tag)
-        .with_context(|| format!("no CLIProxyAPI build for {}/{}", std::env::consts::OS, std::env::consts::ARCH))?;
+    let asset = release_asset(tag).with_context(|| {
+        format!(
+            "no CLIProxyAPI build for {}/{}",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )
+    })?;
     let url = format!("https://github.com/{REPO}/releases/download/v{tag}/{asset}");
     let dest = dir()?;
     fs::create_dir_all(&dest)?;
@@ -928,7 +945,12 @@ fn extract(archive: &Path, dest: &Path) -> Result<()> {
                 .status()
         } else {
             std::process::Command::new("unzip")
-                .args(["-o", &archive.to_string_lossy(), "-d", &dest.to_string_lossy()])
+                .args([
+                    "-o",
+                    &archive.to_string_lossy(),
+                    "-d",
+                    &dest.to_string_lossy(),
+                ])
                 .status()
         }
         .context("extract CLIProxyAPI zip")?;
@@ -1037,7 +1059,9 @@ pub fn ensure_running() -> Result<()> {
     bail!(
         "CLIProxyAPI started but {}/v1/models is not answering — see {}",
         base_url(),
-        logfile().map(|p| p.display().to_string()).unwrap_or_else(|_| "cliproxy.log".into())
+        logfile()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "cliproxy.log".into())
     );
 }
 
@@ -1071,7 +1095,9 @@ pub fn start() -> Result<u32> {
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
         cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
     }
-    let child = cmd.spawn().with_context(|| format!("spawn {}", bin.display()))?;
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("spawn {}", bin.display()))?;
     let pid = child.id();
     fs::write(pidfile()?, pid.to_string())?;
     Ok(pid)
@@ -1217,18 +1243,13 @@ pub fn migrate_legacy_tokens() -> Result<Vec<String>> {
     Ok(imported)
 }
 
-fn import_one(
-    src: &Path,
-    dest: &Path,
-    convert: fn(&Value) -> Option<Value>,
-) -> Result<bool> {
+fn import_one(src: &Path, dest: &Path, convert: fn(&Value) -> Option<Value>) -> Result<bool> {
     if dest.is_file() || !src.is_file() {
         return Ok(false);
     }
-    let raw = fs::read_to_string(src)
-        .with_context(|| format!("read {}", src.display()))?;
-    let src_val: Value = serde_json::from_str(&raw)
-        .with_context(|| format!("parse {}", src.display()))?;
+    let raw = fs::read_to_string(src).with_context(|| format!("read {}", src.display()))?;
+    let src_val: Value =
+        serde_json::from_str(&raw).with_context(|| format!("parse {}", src.display()))?;
     let Some(out) = convert(&src_val) else {
         return Ok(false);
     };
@@ -1517,8 +1538,7 @@ mod tests {
         assert!(!map.values().any(|v| v == "claude-opus-5"));
     }
 
-    const PNG_2X2: &str =
-        "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg==";
+    const PNG_2X2: &str = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg==";
 
     #[test]
     fn png_2x2_is_tiny() {

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -712,7 +712,6 @@ pub fn rewrite(anthropic_body: &Value) -> Result<UpstreamRewrite> {
         body: serde_json::to_vec(&body)?,
         model,
         provider: SubProvider::CliProxy,
-        insecure_http: url.starts_with("http://"),
     })
 }
 

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -104,6 +104,25 @@ pub const BACKENDS: &[Backend] = &[
 /// Enable sidecar with no model pin (`sub on` / `/sub on`).
 const PASSTHROUGH: &[&str] = &["on", "cliproxy", "cli-proxy", "cli-proxy-api", "cliproxyapi"];
 
+/// A fallback-chain hop: real Anthropic, or a CLIProxyAPI CLI family.
+pub fn parse_hop(raw: &str) -> Option<String> {
+    let s = raw.trim().to_ascii_lowercase();
+    if s.is_empty() || s == "off" {
+        return None;
+    }
+    if s == "anthropic" || s == "direct" {
+        return Some("anthropic".into());
+    }
+    if is_passthrough_label(&s) {
+        return Some("on".into());
+    }
+    backend_by_alias(&s).map(|b| b.id.to_string())
+}
+
+pub fn is_anthropic_hop(raw: &str) -> bool {
+    matches!(raw.trim().to_ascii_lowercase().as_str(), "anthropic" | "direct")
+}
+
 pub fn is_passthrough_label(raw: &str) -> bool {
     let s = raw.trim().to_ascii_lowercase();
     PASSTHROUGH.contains(&s.as_str())
@@ -1328,6 +1347,11 @@ mod tests {
         );
         assert!(parse_pin_request("off").is_none());
         assert!(parse_pin_request("no spaces allowed here!").is_none());
+        assert_eq!(parse_hop("anthropic").as_deref(), Some("anthropic"));
+        assert_eq!(parse_hop("codex").as_deref(), Some("codex"));
+        assert_eq!(parse_hop("gemini").as_deref(), Some("gemini"));
+        assert_eq!(parse_hop("on").as_deref(), Some("on"));
+        assert!(parse_hop("nope").is_none());
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -185,6 +185,206 @@ pub fn resolve_pin_live(pin: &str) -> Option<String> {
     })
 }
 
+const OFFICIAL_MODELS_URL: &str = "https://models.router-for.me/models.json";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OfficialModel {
+    pub id: String,
+    pub owned_by: String,
+    pub display_name: String,
+    pub family: String,
+}
+
+impl OfficialModel {
+    pub fn as_live(&self) -> Model {
+        Model {
+            id: self.id.clone(),
+            owned_by: self.owned_by.clone(),
+        }
+    }
+}
+
+fn official_cache_path() -> Result<PathBuf> {
+    Ok(dir()?.join("official-models.json"))
+}
+
+pub fn parse_official_models(raw: &Value) -> Vec<OfficialModel> {
+    let Some(obj) = raw.as_object() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for (family, arr) in obj {
+        let Some(list) = arr.as_array() else {
+            continue;
+        };
+        for item in list {
+            let Some(id) = item.get("id").and_then(Value::as_str) else {
+                continue;
+            };
+            if id.is_empty() || !seen.insert(id.to_string()) {
+                continue;
+            }
+            out.push(OfficialModel {
+                id: id.to_string(),
+                owned_by: item
+                    .get("owned_by")
+                    .and_then(Value::as_str)
+                    .unwrap_or(family)
+                    .to_string(),
+                display_name: item
+                    .get("display_name")
+                    .and_then(Value::as_str)
+                    .unwrap_or(id)
+                    .to_string(),
+                family: family.clone(),
+            });
+        }
+    }
+    out
+}
+
+pub fn search_official(catalog: &[OfficialModel], query: &str) -> Vec<OfficialModel> {
+    let q = query.trim().to_ascii_lowercase();
+    if q.is_empty() {
+        return catalog.to_vec();
+    }
+    catalog
+        .iter()
+        .filter(|m| {
+            m.id.to_ascii_lowercase().contains(&q)
+                || m.display_name.to_ascii_lowercase().contains(&q)
+                || m.family.to_ascii_lowercase().contains(&q)
+                || m.owned_by.to_ascii_lowercase().contains(&q)
+        })
+        .cloned()
+        .collect()
+}
+
+fn skip_aux_model(id: &str) -> bool {
+    let i = id.to_ascii_lowercase();
+    i.contains("imagine")
+        || i.contains("video")
+        || i.contains("image")
+        || i.contains("tts")
+        || i.contains("embed")
+}
+
+pub fn default_tier_map(
+    backend: Option<&Backend>,
+    catalog: &[OfficialModel],
+) -> std::collections::BTreeMap<String, String> {
+    let pool: Vec<&OfficialModel> = catalog
+        .iter()
+        .filter(|m| !skip_aux_model(&m.id))
+        .filter(|m| backend.is_none_or(|b| b.matches(&m.as_live())))
+        .collect();
+    if pool.is_empty() {
+        return std::collections::BTreeMap::new();
+    }
+    let is_small = |m: &OfficialModel| {
+        let i = m.id.to_ascii_lowercase();
+        i.contains("fast")
+            || i.contains("mini")
+            || i.contains("flash")
+            || i.contains("lite")
+            || i.contains("haiku")
+            || i.contains("composer")
+    };
+    let is_flagship = |m: &OfficialModel| {
+        let i = m.id.to_ascii_lowercase();
+        i.contains("opus") || i.contains("pro") || i.contains("terra") || i.contains("4.6")
+    };
+    let haiku = pool
+        .iter()
+        .copied()
+        .find(|m| is_small(m))
+        .unwrap_or(pool[pool.len() - 1]);
+    let opus = pool
+        .iter()
+        .copied()
+        .find(|m| is_flagship(m) && !is_small(m))
+        .or_else(|| pool.iter().copied().find(|m| !is_small(m)))
+        .unwrap_or(pool[0]);
+    let sonnet = pool
+        .iter()
+        .copied()
+        .find(|m| !is_small(m) && m.id != opus.id && !m.id.to_ascii_lowercase().contains("opus"))
+        .unwrap_or(opus);
+    let mut map = std::collections::BTreeMap::new();
+    map.insert("opus".into(), opus.id.clone());
+    map.insert("fable".into(), opus.id.clone());
+    map.insert("sonnet".into(), sonnet.id.clone());
+    map.insert("haiku".into(), haiku.id.clone());
+    map
+}
+
+pub fn official_models() -> Vec<OfficialModel> {
+    if let Some(cached) = read_official_cache() {
+        return cached;
+    }
+    match fetch_official_models() {
+        Ok(list) if !list.is_empty() => list,
+        _ => list_models()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|m| OfficialModel {
+                id: m.id,
+                owned_by: m.owned_by,
+                display_name: String::new(),
+                family: String::new(),
+            })
+            .collect(),
+    }
+}
+
+fn read_official_cache() -> Option<Vec<OfficialModel>> {
+    let path = official_cache_path().ok()?;
+    let raw = fs::read_to_string(path).ok()?;
+    let v: Value = serde_json::from_str(&raw).ok()?;
+    let at = v.get("fetched_at").and_then(Value::as_u64).unwrap_or(0);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    if now.saturating_sub(at) > 86_400 {
+        return None;
+    }
+    let models = parse_official_models(v.get("models").unwrap_or(&v));
+    (!models.is_empty()).then_some(models)
+}
+
+pub fn fetch_official_models() -> Result<Vec<OfficialModel>> {
+    let mut req = ureq::get(OFFICIAL_MODELS_URL)
+        .config()
+        .timeout_global(Some(Duration::from_secs(8)))
+        .http_status_as_error(true)
+        .build();
+    req = req.header("User-Agent", "llmtrim-cliproxy");
+    let body = req
+        .call()
+        .context("official CLIProxyAPI models")?
+        .body_mut()
+        .read_to_string()
+        .context("read official models")?;
+    let v: Value = serde_json::from_str(&body).context("parse official models")?;
+    let list = parse_official_models(&v);
+    if let Ok(path) = official_cache_path() {
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let _ = fs::write(
+            path,
+            serde_json::json!({ "fetched_at": now, "models": v }).to_string(),
+        );
+    }
+    Ok(list)
+}
+
 pub fn dir() -> Result<PathBuf> {
     Ok(crate::daemon::home_dir()?.join("cliproxy"))
 }
@@ -1149,5 +1349,31 @@ mod tests {
         assert_eq!(expand_pin("codex", &models).as_deref(), Some("gpt-5.4"));
         assert_eq!(expand_pin("gpt-5.4", &models).as_deref(), Some("gpt-5.4"));
         assert_eq!(expand_pin("kimi", &models), None);
+    }
+
+    #[test]
+    fn official_catalog_search_and_tier_defaults() {
+        let raw = json!({
+            "xai": [
+                {"id": "grok-4.6", "owned_by": "xai", "display_name": "Grok 4.6"},
+                {"id": "grok-composer-2.5-fast", "owned_by": "xai", "display_name": "Composer Fast"}
+            ],
+            "claude": [
+                {"id": "claude-opus-5", "owned_by": "anthropic", "display_name": "Opus 5"}
+            ]
+        });
+        let cat = parse_official_models(&raw);
+        assert_eq!(cat.len(), 3);
+        let hits = search_official(&cat, "composer");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "grok-composer-2.5-fast");
+        let grok = backend_by_alias("grok").unwrap();
+        let map = default_tier_map(Some(grok), &cat);
+        assert_eq!(map.get("opus").map(String::as_str), Some("grok-4.6"));
+        assert_eq!(
+            map.get("haiku").map(String::as_str),
+            Some("grok-composer-2.5-fast")
+        );
+        assert!(!map.values().any(|v| v == "claude-opus-5"));
     }
 }

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -647,21 +647,197 @@ pub fn update_if_used() -> Result<Option<String>> {
         return Ok(None);
     }
     if !is_installed() {
-        return Ok(None);
+        if !is_enabled() {
+            return Ok(None);
+        }
+        return ensure_for_existing_user().map(Some);
     }
     let latest = fetch_latest_tag()?;
     if installed_version().as_deref() == Some(latest.as_str()) {
-        return Ok(Some(format!("CLIProxyAPI already {latest}")));
+        let imported = migrate_legacy_tokens()?;
+        if is_enabled() {
+            let _ = ensure_running();
+        }
+        if imported.is_empty() {
+            return Ok(Some(format!("CLIProxyAPI already {latest}")));
+        }
+        return Ok(Some(format!(
+            "CLIProxyAPI already {latest}; imported {}",
+            imported.join(", ")
+        )));
     }
     let was_running = pid_running().is_some() || is_enabled();
     if pid_running().is_some() {
         let _ = stop();
     }
     install_tag(&latest)?;
+    let imported = migrate_legacy_tokens()?;
     if was_running {
         let _ = ensure_running();
     }
-    Ok(Some(format!("CLIProxyAPI updated to {latest}")))
+    let mut msg = format!("CLIProxyAPI updated to {latest}");
+    if !imported.is_empty() {
+        msg.push_str(&format!("; imported {}", imported.join(", ")));
+    }
+    Ok(Some(msg))
+}
+
+/// Install, import existing `sub` tokens, and start the sidecar. Used by `ensure` / `update`
+/// so a user who already had `sub = codex|kimi|grok` needs no extra command.
+pub fn ensure_for_existing_user() -> Result<String> {
+    if is_externally_configured() {
+        if is_healthy() {
+            return Ok(format!("CLIProxyAPI at {} reachable", base_url()));
+        }
+        bail!("CLIProxyAPI at {} is not reachable", base_url());
+    }
+    ensure_installed()?;
+    ensure_config()?;
+    let imported = migrate_legacy_tokens()?;
+    ensure_running()?;
+    if imported.is_empty() {
+        Ok(format!("CLIProxyAPI ready at {}", base_url()))
+    } else {
+        Ok(format!(
+            "CLIProxyAPI ready at {}; imported {}",
+            base_url(),
+            imported.join(", ")
+        ))
+    }
+}
+
+/// Copy first-party `~/.llmtrim/{{codex,kimi,grok}}/auth.json` into the CLIProxyAPI auth dir
+/// once. Existing sidecar files are left alone.
+pub fn migrate_legacy_tokens() -> Result<Vec<String>> {
+    let dest = auth_dir();
+    fs::create_dir_all(&dest)?;
+    let home = crate::daemon::home_dir()?;
+    let mut imported = Vec::new();
+    if import_one(
+        &home.join("codex").join("auth.json"),
+        &dest.join("codex-llmtrim.json"),
+        convert_codex_auth,
+    )? {
+        imported.push("codex".into());
+    }
+    if import_one(
+        &home.join("kimi").join("auth.json"),
+        &dest.join("kimi-llmtrim.json"),
+        convert_kimi_auth,
+    )? {
+        imported.push("kimi".into());
+    }
+    if import_one(
+        &home.join("grok").join("auth.json"),
+        &dest.join("xai-llmtrim.json"),
+        convert_grok_auth,
+    )? {
+        imported.push("grok".into());
+    }
+    Ok(imported)
+}
+
+fn import_one(
+    src: &Path,
+    dest: &Path,
+    convert: fn(&Value) -> Option<Value>,
+) -> Result<bool> {
+    if dest.is_file() || !src.is_file() {
+        return Ok(false);
+    }
+    let raw = fs::read_to_string(src)
+        .with_context(|| format!("read {}", src.display()))?;
+    let src_val: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parse {}", src.display()))?;
+    let Some(out) = convert(&src_val) else {
+        return Ok(false);
+    };
+    let bytes = serde_json::to_vec_pretty(&out)?;
+    fs::write(dest, bytes).with_context(|| format!("write {}", dest.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(dest, fs::Permissions::from_mode(0o600));
+    }
+    Ok(true)
+}
+
+fn epoch_ms_to_rfc3339(ms: u64) -> String {
+    use chrono::{TimeZone, Utc};
+    Utc.timestamp_millis_opt(ms as i64)
+        .single()
+        .unwrap_or_else(Utc::now)
+        .to_rfc3339()
+}
+
+fn json_str(v: &Value, keys: &[&str]) -> Option<String> {
+    for k in keys {
+        if let Some(s) = v.get(*k).and_then(Value::as_str).filter(|s| !s.is_empty()) {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+fn json_expires_ms(v: &Value) -> Option<u64> {
+    v.get("expires")
+        .and_then(Value::as_u64)
+        .or_else(|| v.get("expires").and_then(Value::as_i64).map(|n| n as u64))
+}
+
+pub(crate) fn convert_codex_auth(src: &Value) -> Option<Value> {
+    let access = json_str(src, &["access", "access_token"])?;
+    let refresh = json_str(src, &["refresh", "refresh_token"])?;
+    let account = json_str(src, &["accountId", "account_id"]).unwrap_or_default();
+    let expired = json_expires_ms(src)
+        .map(epoch_ms_to_rfc3339)
+        .unwrap_or_default();
+    Some(serde_json::json!({
+        "type": "codex",
+        "access_token": access,
+        "refresh_token": refresh,
+        "id_token": json_str(src, &["id_token"]).unwrap_or_default(),
+        "account_id": account,
+        "email": "llmtrim-migrated",
+        "last_refresh": chrono::Utc::now().to_rfc3339(),
+        "expired": expired,
+    }))
+}
+
+pub(crate) fn convert_kimi_auth(src: &Value) -> Option<Value> {
+    let access = json_str(src, &["access", "access_token"])?;
+    let refresh = json_str(src, &["refresh", "refresh_token"])?;
+    let expired = json_expires_ms(src)
+        .map(epoch_ms_to_rfc3339)
+        .unwrap_or_default();
+    Some(serde_json::json!({
+        "type": "kimi",
+        "access_token": access,
+        "refresh_token": refresh,
+        "token_type": "Bearer",
+        "scope": json_str(src, &["scope"]).unwrap_or_default(),
+        "device_id": json_str(src, &["device_id", "deviceId", "userId"]).unwrap_or_default(),
+        "expired": expired,
+    }))
+}
+
+pub(crate) fn convert_grok_auth(src: &Value) -> Option<Value> {
+    let access = json_str(src, &["access", "access_token"])?;
+    let refresh = json_str(src, &["refresh", "refresh_token"])?;
+    let expired = json_expires_ms(src)
+        .map(epoch_ms_to_rfc3339)
+        .unwrap_or_default();
+    Some(serde_json::json!({
+        "type": "xai",
+        "auth_kind": "oauth",
+        "access_token": access,
+        "refresh_token": refresh,
+        "id_token": json_str(src, &["id_token"]).unwrap_or_default(),
+        "token_type": "Bearer",
+        "expired": expired,
+        "last_refresh": chrono::Utc::now().to_rfc3339(),
+        "email": "llmtrim-migrated",
+    }))
 }
 
 #[cfg(test)]
@@ -734,5 +910,43 @@ mod tests {
         assert_eq!(models[0].id, "gemini-3-flash");
         assert_eq!(models[1].id, "gpt-5.4");
         assert_eq!(models[1].owned_by, "openai");
+    }
+
+    #[test]
+    fn convert_codex_maps_llmtrim_auth_json() {
+        let src = json!({
+            "access": "at-1",
+            "refresh": "rt-1",
+            "expires": 1_700_000_000_000u64,
+            "accountId": "acct-9"
+        });
+        let out = convert_codex_auth(&src).unwrap();
+        assert_eq!(out["type"], "codex");
+        assert_eq!(out["access_token"], "at-1");
+        assert_eq!(out["refresh_token"], "rt-1");
+        assert_eq!(out["account_id"], "acct-9");
+        assert!(out["expired"].as_str().unwrap().contains("2023"));
+    }
+
+    #[test]
+    fn convert_kimi_and_grok_require_refresh() {
+        assert!(convert_kimi_auth(&json!({"access": "a"})).is_none());
+        let kimi = convert_kimi_auth(&json!({
+            "access": "a",
+            "refresh": "r",
+            "expires": 1_700_000_000_000u64,
+            "userId": "u1"
+        }))
+        .unwrap();
+        assert_eq!(kimi["type"], "kimi");
+        assert_eq!(kimi["device_id"], "u1");
+        let grok = convert_grok_auth(&json!({
+            "access": "a",
+            "refresh": "r",
+            "expires": 1_700_000_000_000u64
+        }))
+        .unwrap();
+        assert_eq!(grok["type"], "xai");
+        assert_eq!(grok["auth_kind"], "oauth");
     }
 }

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -41,13 +41,16 @@ pub struct UpstreamRewrite {
     pub body: Vec<u8>,
     pub model: String,
     pub provider: SubProvider,
-    /// CLIProxyAPI is a local HTTP server. First-party translators speak HTTPS.
-    pub insecure_http: bool,
 }
 
 impl UpstreamRewrite {
     pub fn url(&self) -> String {
-        let scheme = if self.insecure_http { "http" } else { "https" };
+        let host = self.host.split(':').next().unwrap_or(self.host.as_str());
+        let scheme = if host == "127.0.0.1" || host == "localhost" {
+            "http"
+        } else {
+            "https"
+        };
         format!("{}://{}{}", scheme, self.host, self.path)
     }
 }
@@ -168,7 +171,6 @@ fn build_upstream_with_model(
         body,
         model,
         provider,
-        insecure_http: false,
     })
 }
 

--- a/crates/llmtrim-cli/src/reroute/mod.rs
+++ b/crates/llmtrim-cli/src/reroute/mod.rs
@@ -1,19 +1,18 @@
-//! Subscription reroute: send intercepted Anthropic `/v1/messages` traffic to a *different*
-//! subscription's backend (ChatGPT/Codex, Kimi, or Grok) instead of Anthropic, translating the
-//! request and streamed response between wire shapes.
+//! Subscription reroute: send intercepted Anthropic `/v1/messages` traffic through
+//! [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) instead of Anthropic.
 //!
-//! This is opt-in (`sub = "codex"|"kimi"|"grok"` in the config, off by default) and rides the
-//! existing MITM path: [`crate::serve`] rewrites the intercepted request's URI authority to the
-//! provider host and swaps in the translated body + provider auth, so hudsucker forwards it over
-//! the same client and `handle_response` streams the translated reply back. Nothing here opens its
-//! own socket except the one-time OAuth flows in [`auth`].
+//! This is opt-in (`sub = "on"` in the config, off by default). [`crate::serve`] rewrites the
+//! intercepted request onto the managed CLIProxyAPI sidecar (Anthropic-shaped in and out).
+//! First-party Codex/Kimi/Grok translators remain for tests and legacy helpers; the live path
+//! does not use them.
 //!
 //! **Terms of service:** driving a ChatGPT/Kimi/Grok *subscription* through a non-official client
-//! is a gray area and can get that account restricted. Reroute is off by default and the
-//! `auth login` commands print this warning. Use at your own risk.
+//! is a gray area and can get that account restricted. Reroute is off by default. Use at your
+//! own risk.
 
 pub mod auth;
 pub mod catalog;
+pub mod cliproxy;
 pub mod codex;
 pub mod context_limit;
 pub mod continuation;
@@ -42,6 +41,15 @@ pub struct UpstreamRewrite {
     pub body: Vec<u8>,
     pub model: String,
     pub provider: SubProvider,
+    /// CLIProxyAPI is a local HTTP server. First-party translators speak HTTPS.
+    pub insecure_http: bool,
+}
+
+impl UpstreamRewrite {
+    pub fn url(&self) -> String {
+        let scheme = if self.insecure_http { "http" } else { "https" };
+        format!("{}://{}{}", scheme, self.host, self.path)
+    }
 }
 
 /// Translate an intercepted Anthropic `/v1/messages` body into a provider-targeted request, using
@@ -79,6 +87,7 @@ pub(crate) fn build_upstream_for_model(
 
 /// Build a request for a concrete model selected by a routed custom agent. Unlike compact/tier
 /// routing, this never substitutes another model behind the explicit selection.
+#[allow(dead_code)] // first-party translators; live path uses cliproxy::rewrite
 pub(crate) fn build_upstream_for_explicit_model(
     provider: SubProvider,
     anthropic_body: &Value,
@@ -148,6 +157,9 @@ fn build_upstream_with_model(
             let h = grok::request_headers(&token.access, token.account_id.as_deref(), session_id);
             (grok::HOST, grok::PATH, serde_json::to_vec(&b)?, h)
         }
+        SubProvider::CliProxy => {
+            return cliproxy::rewrite(anthropic_body);
+        }
     };
     Ok(UpstreamRewrite {
         host: host.to_string(),
@@ -156,6 +168,7 @@ fn build_upstream_with_model(
         body,
         model,
         provider,
+        insecure_http: false,
     })
 }
 
@@ -174,6 +187,7 @@ impl StreamReducer {
             SubProvider::Codex => StreamReducer::Codex(codex::Reducer::new(model)),
             SubProvider::Kimi => StreamReducer::Kimi(kimi::Reducer::new(model)),
             SubProvider::Grok => StreamReducer::Grok(grok::Reducer::new(model)),
+            SubProvider::CliProxy => StreamReducer::Kimi(kimi::Reducer::new(model)),
         }
     }
 
@@ -263,6 +277,8 @@ pub enum SubProvider {
     Codex,
     Kimi,
     Grok,
+    /// Managed CLIProxyAPI sidecar. The live `sub on` path.
+    CliProxy,
 }
 
 impl SubProvider {
@@ -270,6 +286,9 @@ impl SubProvider {
     /// unknown value once; unknown never silently reroutes).
     pub fn parse(s: &str) -> Option<Self> {
         match s.trim().to_ascii_lowercase().as_str() {
+            "on" | "cliproxy" | "cli-proxy" | "cli-proxy-api" | "cliproxyapi" => {
+                Some(SubProvider::CliProxy)
+            }
             "codex" | "chatgpt" | "openai" => Some(SubProvider::Codex),
             "kimi" | "moonshot" => Some(SubProvider::Kimi),
             "grok" | "xai" | "x-ai" => Some(SubProvider::Grok),
@@ -282,6 +301,7 @@ impl SubProvider {
             SubProvider::Codex => "codex",
             SubProvider::Kimi => "kimi",
             SubProvider::Grok => "grok",
+            SubProvider::CliProxy => "on",
         }
     }
 }
@@ -401,6 +421,7 @@ pub fn resolve_model(
             SubProvider::Codex => default_codex_tier_model(tier).to_string(),
             SubProvider::Grok => default_grok_tier_model(tier).to_string(),
             SubProvider::Kimi => KIMI_MODEL.to_string(),
+            SubProvider::CliProxy => base,
         };
     }
     // 3. Not a Claude tier: pass through known provider ids; otherwise fall back to sonnet.
@@ -418,6 +439,7 @@ pub fn resolve_model(
             .cloned()
             .unwrap_or_else(|| default_grok_tier_model(Tier::Sonnet).to_string()),
         SubProvider::Kimi => KIMI_MODEL.to_string(),
+        SubProvider::CliProxy => base,
     }
 }
 
@@ -428,6 +450,7 @@ fn model_ok_for(provider: SubProvider, model: &str) -> bool {
         SubProvider::Codex => is_codex_model(model),
         SubProvider::Grok => is_grok_model(model),
         SubProvider::Kimi => model == KIMI_MODEL || model.starts_with("kimi"),
+        SubProvider::CliProxy => true,
     }
 }
 
@@ -609,6 +632,17 @@ mod tests {
             resolve_model(SubProvider::Grok, "grok-composer-2.5-fast", &ov),
             "grok-composer-2.5-fast"
         );
+    }
+
+    #[test]
+    fn parse_accepts_cliproxy_aliases() {
+        assert_eq!(SubProvider::parse("on"), Some(SubProvider::CliProxy));
+        assert_eq!(SubProvider::parse("cliproxy"), Some(SubProvider::CliProxy));
+        assert_eq!(
+            SubProvider::parse("CLI-Proxy-API"),
+            Some(SubProvider::CliProxy)
+        );
+        assert_eq!(SubProvider::CliProxy.as_str(), "on");
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/reroute/route.rs
+++ b/crates/llmtrim-cli/src/reroute/route.rs
@@ -137,11 +137,13 @@ pub fn resolve_explicit_model(provider: SubProvider, value: &str) -> Result<Stri
             "kimi" | "k2" | "kimik2" | "kimiforcoding" => super::KIMI_MODEL,
             _ => value,
         },
+        SubProvider::CliProxy => value,
     };
     let accepted = match provider {
         SubProvider::Codex => super::CODEX_MODELS.contains(&model),
         SubProvider::Grok => super::GROK_MODELS.contains(&model),
         SubProvider::Kimi => model == super::KIMI_MODEL,
+        SubProvider::CliProxy => true,
     };
     if accepted {
         return Ok(model.to_ascii_lowercase());
@@ -150,6 +152,7 @@ pub fn resolve_explicit_model(provider: SubProvider, value: &str) -> Result<Stri
         SubProvider::Codex => super::CODEX_MODELS.join(", "),
         SubProvider::Grok => super::GROK_MODELS.join(", "),
         SubProvider::Kimi => super::KIMI_MODEL.to_string(),
+        SubProvider::CliProxy => "any CLIProxyAPI model".to_string(),
     };
     bail!(
         "llmtrim: unknown {provider} route model `{value}`; supported models: {supported}",

--- a/crates/llmtrim-cli/src/reroute/tui.rs
+++ b/crates/llmtrim-cli/src/reroute/tui.rs
@@ -71,6 +71,7 @@ impl App {
                 .filter(|m| in_catalog(m) || m.starts_with("grok-"))
                 .cloned()
                 .unwrap_or_else(|| super::default_grok_tier_model(t).to_string()),
+            SubProvider::CliProxy => String::new(),
         });
         Self {
             provider,

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -2066,7 +2066,8 @@ mod imp {
                 );
                 let window_model_pin: Option<String> = match &window_intent {
                     Some(crate::window_sub::Intent::Enabled { provider })
-                        if !crate::reroute::cliproxy::is_passthrough_label(provider) =>
+                        if !crate::reroute::cliproxy::is_passthrough_label(provider)
+                            && crate::reroute::cliproxy::backend_by_alias(provider).is_none() =>
                     {
                         crate::reroute::cliproxy::resolve_pin_live(provider)
                     }
@@ -2639,16 +2640,29 @@ mod imp {
                 .map(|c| c.logical_model.as_str())
             {
                 translate_value["model"] = serde_json::Value::String(logical.to_string());
-            } else if sub != crate::reroute::SubProvider::CliProxy {
-                // Legacy `sub = codex|kimi|grok` keeps its tier map so existing users
-                // still land on the same upstream model through CLIProxyAPI.
-                let tiers = llmtrim_core::config::sub_tiers_for(sub.as_str());
+            } else {
+                // Legacy `sub = codex|kimi|grok` and `sub = on` both honor [sub.<active>.tiers]
+                // (opus/sonnet/haiku/fable → CLIProxyAPI model). No global single-model pin.
+                let key = if sub == crate::reroute::SubProvider::CliProxy {
+                    "on"
+                } else {
+                    sub.as_str()
+                };
+                let mut tiers = llmtrim_core::config::sub_tiers_for(key);
+                if let Some(win) = crate::window_sub::lookup(session_id.as_deref())
+                    && let crate::window_sub::Intent::Enabled { provider } = win
+                    && let Some(backend) = crate::reroute::cliproxy::backend_by_alias(&provider)
+                {
+                    let catalog = crate::reroute::cliproxy::official_models();
+                    let mapped = crate::reroute::cliproxy::default_tier_map(Some(backend), &catalog);
+                    if !mapped.is_empty() {
+                        tiers = mapped;
+                    }
+                }
                 let mapped = crate::reroute::resolve_model(sub, &client_model, &tiers);
-                translate_value["model"] = serde_json::Value::String(mapped);
-            } else if let Some(pin) = llmtrim_core::config::sub_model()
-                && let Some(mapped) = crate::reroute::cliproxy::resolve_pin_live(&pin)
-            {
-                translate_value["model"] = serde_json::Value::String(mapped);
+                if mapped != client_model {
+                    translate_value["model"] = serde_json::Value::String(mapped);
+                }
             }
             let rewrite = match crate::reroute::cliproxy::rewrite(&translate_value) {
                 Ok(r) => r,

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -477,12 +477,13 @@ mod imp {
     /// provider's session header).
     #[derive(Clone)]
     struct FallbackInfo {
-        /// Providers to try, in order. Never empty (the arming site drops the fallback otherwise).
-        providers: Vec<crate::reroute::SubProvider>,
+        /// Hops to try, in order (`anthropic`, `codex`, `gemini`, …).
+        providers: Vec<String>,
         anthropic_body: Vec<u8>,
         session_id: Option<String>,
     }
 
+    #[allow(dead_code)]
     struct FallbackAttempt {
         provider: crate::reroute::SubProvider,
         model: String,
@@ -1821,8 +1822,10 @@ mod imp {
         /// at construction. `None` = normal transparent compress-and-forward. When set, intercepted
         /// Anthropic `/v1/messages` traffic is rewritten to the CLIProxyAPI sidecar.
         sub: Option<crate::reroute::SubProvider>,
-        /// Ordered fallback providers. The active `sub` is used when this is empty.
-        sub_chain: Arc<Vec<crate::reroute::SubProvider>>,
+        /// Ordered fallback hops (`anthropic`, `codex`, `gemini`, …). First hop is primary.
+        sub_chain: Arc<Vec<String>>,
+        /// Per-request CLIProxyAPI CLI when fallback primary is not Anthropic.
+        request_backend: Option<String>,
         /// Tier→model overrides for the active `sub` (from `[sub.<provider>.tiers]`); empty = use
         /// the built-in preset. Shared across per-request handler clones.
         sub_tiers: Arc<std::collections::BTreeMap<String, String>>,
@@ -1997,6 +2000,24 @@ mod imp {
     }
 
     impl Interceptor {
+        fn fallback_hops(&self) -> Vec<String> {
+            if !self.sub_chain.is_empty() {
+                return (*self.sub_chain).clone();
+            }
+            let mut hops = vec!["anthropic".to_string()];
+            if let Some(sub) = self.sub {
+                let hop = if sub == crate::reroute::SubProvider::CliProxy {
+                    "on".to_string()
+                } else {
+                    sub.as_str().to_string()
+                };
+                if !hops.contains(&hop) {
+                    hops.push(hop);
+                }
+            }
+            hops
+        }
+
         /// Body of `handle_request`, factored out so tests can call it directly without
         /// constructing a `hudsucker::HttpContext` (which is `#[non_exhaustive]` and
         /// cannot be instantiated outside the hudsucker crate).
@@ -2038,7 +2059,7 @@ mod imp {
             // `ANTHROPIC_AUTH_TOKEN=llmtrim-sub`. Non-messages probes must not reach Anthropic
             // (401 → "Please run /login"). Messages that aren't rerouted (e.g. window `/sub off`)
             // must not reach Anthropic either — return a clear llmtrim error instead.
-            let mut fallback_arm: Option<(Vec<crate::reroute::SubProvider>, Option<String>)> = None;
+            let mut fallback_arm: Option<(Vec<String>, Option<String>)> = None;
             // A generated custom agent can carry one trusted, standalone system marker. Read and
             // remove it before every later stage so it never becomes prompt/cache/capture content.
             let (req, request_route) = if matches!(provider, Some(ProviderKind::Anthropic))
@@ -2108,20 +2129,25 @@ mod imp {
                     && req.method() == Method::POST
                     && path_kind == AnthropicApiPath::Messages
                 {
-                    // A chain is enough to arm the fallback: `sub` selects who serves *every* turn
-                    // in `always` mode, but in fallback mode the chain is the whole answer, so
-                    // `sub = off` + a chain is a valid configuration.
-                    let mut providers = self.sub_chain.as_ref().clone();
-                    if providers.is_empty() {
-                        providers.extend(self.sub);
-                    }
-                    if !providers.is_empty() {
+                    let hops = self.fallback_hops();
+                    if !hops.is_empty() {
                         let session_id = req
                             .headers()
                             .get("x-claude-code-session-id")
                             .and_then(|v| v.to_str().ok())
                             .map(str::to_string);
-                        fallback_arm = Some((providers, session_id));
+                        let (first, rest) = hops.split_first().unwrap();
+                        fallback_arm = Some((rest.to_vec(), session_id));
+                        if !crate::reroute::cliproxy::is_anthropic_hop(first) {
+                            self.request_backend = Some(first.clone());
+                            return self
+                                .reroute_messages(
+                                    req,
+                                    crate::reroute::SubProvider::CliProxy,
+                                    window_model_pin,
+                                )
+                                .await;
+                        }
                     }
                 }
                 // Dummy credential handling (token is global in settings.json, so it still
@@ -2649,7 +2675,23 @@ mod imp {
                     sub.as_str()
                 };
                 let mut tiers = llmtrim_core::config::sub_tiers_for(key);
-                if let Some(win) = crate::window_sub::lookup(session_id.as_deref())
+                if let Some(hop) = self.request_backend.take() {
+                    if let Some(backend) = crate::reroute::cliproxy::backend_by_alias(&hop) {
+                        let catalog = crate::reroute::cliproxy::official_models();
+                        let mapped =
+                            crate::reroute::cliproxy::default_tier_map(Some(backend), &catalog);
+                        if !mapped.is_empty() {
+                            tiers = mapped;
+                        }
+                    } else if hop != "on" {
+                        let catalog = crate::reroute::cliproxy::official_models();
+                        if let Some(id) =
+                            crate::reroute::cliproxy::expand_pin(&hop, &catalog.iter().map(|m| m.as_live()).collect::<Vec<_>>())
+                        {
+                            translate_value["model"] = serde_json::Value::String(id);
+                        }
+                    }
+                } else if let Some(win) = crate::window_sub::lookup(session_id.as_deref())
                     && let crate::window_sub::Intent::Enabled { provider } = win
                     && let Some(backend) = crate::reroute::cliproxy::backend_by_alias(&provider)
                 {
@@ -3535,7 +3577,6 @@ mod imp {
             mut pending: Pending,
             fb: FallbackInfo,
         ) -> Response<Body> {
-            use crate::reroute::sse::{AnthropicSseEncoder, ReduceEvent};
             let Some(mut anthropic) = std::str::from_utf8(&fb.anthropic_body)
                 .ok()
                 .and_then(|t| serde_json::from_str::<Value>(t).ok())
@@ -3553,123 +3594,100 @@ mod imp {
                 .to_string();
             apply_sub_effort(&mut anthropic, self.sub_effort.as_deref());
 
-            let mut providers = Vec::new();
-            for provider in fb.providers.iter().copied() {
-                if !providers.contains(&provider) {
-                    providers.push(provider);
+            let mut hops = Vec::new();
+            for hop in &fb.providers {
+                if !hops.contains(hop) {
+                    hops.push(hop.clone());
                 }
             }
-            // One wall-clock budget for the whole chain: per-provider backoff × N providers can
-            // otherwise outlast the client's own timeout, and a client that has already given up
-            // makes every further attempt pure waste (and pure spend).
             let deadline = std::time::Instant::now() + FALLBACK_CHAIN_BUDGET;
             let mut failures = Vec::new();
-            for provider in providers {
-                let attempt = match self
-                    .fallback_attempt(
-                        provider,
-                        &anthropic,
-                        None,
-                        fb.session_id.as_deref(),
-                        deadline,
-                    )
-                    .await
-                {
-                    Ok(attempt) => attempt,
-                    Err(error) => {
-                        if crate::reroute::context_limit::is_context_limit_text(&error) {
-                            crate::reroute::continuation::clear_continuation(
-                                fb.session_id.as_deref(),
-                            );
-                            crate::reroute::context_limit::mark_must_compact(
-                                fb.session_id.as_deref(),
-                            );
-                            return context_limit_guard_response(
-                                Some(pending),
-                                &self.ledger,
-                                &self.breakdown_ledger,
-                            );
+            for hop in hops {
+                if std::time::Instant::now() >= deadline {
+                    failures.push("fallback budget exhausted".into());
+                    break;
+                }
+                if crate::reroute::cliproxy::is_anthropic_hop(&hop) {
+                    if let Some(orig) = pending.original.as_ref()
+                        && let Some(res) = replay_original(orig, self.upstream_proxy.as_deref())
+                    {
+                        if res.status().as_u16() < 400 {
+                            return res;
                         }
-                        failures.push(format!("{}: {error}", provider.as_str()));
+                        failures.push(format!("anthropic: HTTP {}", res.status()));
+                        continue;
+                    }
+                    failures.push("anthropic: replay unavailable".into());
+                    continue;
+                }
+                let mut body = anthropic.clone();
+                if let Some(backend) = crate::reroute::cliproxy::backend_by_alias(&hop) {
+                    let catalog = crate::reroute::cliproxy::official_models();
+                    let map = crate::reroute::cliproxy::default_tier_map(Some(backend), &catalog);
+                    let mapped = crate::reroute::resolve_model(
+                        crate::reroute::SubProvider::CliProxy,
+                        &client_model,
+                        &map,
+                    );
+                    if mapped != client_model {
+                        body["model"] = serde_json::Value::String(mapped);
+                    }
+                } else if hop == "on" {
+                    let map = llmtrim_core::config::sub_tiers_for("on");
+                    let mapped = crate::reroute::resolve_model(
+                        crate::reroute::SubProvider::CliProxy,
+                        &client_model,
+                        &map,
+                    );
+                    if mapped != client_model {
+                        body["model"] = serde_json::Value::String(mapped);
+                    }
+                }
+                let rewrite = match crate::reroute::cliproxy::rewrite(&body) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        failures.push(format!("{hop}: {e}"));
                         continue;
                     }
                 };
-                let mut reducer =
-                    crate::reroute::StreamReducer::new(attempt.provider, &attempt.model);
-                let mut encoder = AnthropicSseEncoder::new(&client_model);
-                let mut output = String::new();
-                let mut stream_error = None;
-                let mut committed = false;
-                let mut events = reducer.push(&attempt.body);
-                events.extend(reducer.finish());
-                for event in &events {
-                    match event {
-                        ReduceEvent::Error { message } if !committed => {
-                            stream_error = Some(message.clone());
-                        }
-                        ReduceEvent::Error { .. } | ReduceEvent::Finish { .. } => {}
-                        _ => committed = true,
-                    }
-                    record_codex_continuation(
-                        event,
-                        &mut reducer,
-                        attempt.provider,
-                        attempt.logical_body.as_ref(),
-                        fb.session_id.as_deref(),
-                    );
-                    encoder.encode(event, &mut output);
-                }
-                if let Some(error) = stream_error {
-                    crate::reroute::continuation::clear_continuation(fb.session_id.as_deref());
-                    // Pre-output context-limit only — never latch after client-visible content.
-                    if crate::reroute::context_limit::is_context_limit_text(&error) && !committed {
-                        crate::reroute::context_limit::mark_must_compact(fb.session_id.as_deref());
-                        return context_limit_guard_response(
+                match self
+                    .reissue_reroute(&rewrite.url(), rewrite.headers.clone(), Arc::new(rewrite.body.clone()))
+                    .await
+                {
+                    Some((status, raw, _)) if (200..300).contains(&status) => {
+                        pending.model = Some(rewrite.model.clone());
+                        pending.reroute = Some(RerouteInfo {
+                            provider: crate::reroute::SubProvider::CliProxy,
+                            model: rewrite.model.clone(),
+                            client_model: client_model.clone(),
+                            replay: None,
+                            logical_body: None,
+                            session_id: fb.session_id.clone(),
+                            anthropic_snapshot: Some(body),
+                            passthrough: true,
+                        });
+                        crate::reroute::context_limit::record_accepted(
+                            fb.session_id.as_deref(),
+                            &anthropic,
+                        );
+                        let acc = Arc::new(Mutex::new(raw.clone()));
+                        let _finalize = Finalize::new(
+                            acc,
                             Some(pending),
-                            &self.ledger,
-                            &self.breakdown_ledger,
+                            self.ledger.clone(),
+                            self.breakdown_ledger.clone(),
+                        );
+                        return buffered_response(
+                            status,
+                            Some("text/event-stream".to_string()),
+                            raw,
                         );
                     }
-                    // Content already committed: do not surface as a clean next-provider attempt
-                    // (partial answer may already be in `output`); treat as terminal for this
-                    // provider and continue the chain only when nothing was committed.
-                    if committed {
-                        failures.push(format!("{}: {error}", attempt.provider.as_str()));
-                        continue;
-                    }
-                    failures.push(format!("{}: {error}", attempt.provider.as_str()));
-                    continue;
+                    Some((status, _, _)) => failures.push(format!("{hop}: HTTP {status}")),
+                    None => failures.push(format!("{hop}: no response")),
                 }
-                encoder.finish_if_open(&mut output);
-                pending.model = Some(attempt.model.clone());
-                pending.reroute = Some(RerouteInfo {
-                    provider: attempt.provider,
-                    model: attempt.model,
-                    client_model: client_model.clone(),
-                    replay: None,
-                    logical_body: attempt.logical_body,
-                    session_id: fb.session_id.clone(),
-                    anthropic_snapshot: Some(anthropic.clone()),
-                    passthrough: attempt.provider == crate::reroute::SubProvider::CliProxy,
-                });
-                if let Some(info) = pending.reroute.as_ref()
-                    && let Some(snap) = info.anthropic_snapshot.as_ref()
-                {
-                    crate::reroute::context_limit::record_accepted(
-                        info.session_id.as_deref(),
-                        snap,
-                    );
-                }
-                let acc = Arc::new(Mutex::new(output.clone().into_bytes()));
-                let _finalize = Finalize::new(
-                    acc,
-                    Some(pending),
-                    self.ledger.clone(),
-                    self.breakdown_ledger.clone(),
-                );
-                return sse_response(output);
             }
-            self.fallback_error(
+                        self.fallback_error(
                 pending,
                 &client_model,
                 &format!(
@@ -5388,18 +5406,17 @@ mod imp {
                     .sub_chain
                     .iter()
                     .filter_map(|p| {
-                        let parsed = crate::reroute::SubProvider::parse(p);
+                        let parsed = crate::reroute::cliproxy::parse_hop(p);
                         if parsed.is_none() {
-                            // Silently dropping it would leave a typo'd chain quietly shorter than
-                            // the user configured — and the fallback they think they have missing.
                             eprintln!(
-                                "llmtrim: unknown provider '{p}' in the sub fallback chain — ignored (expected on|cliproxy)"
+                                "llmtrim: unknown hop '{p}' in the sub fallback chain — ignored (anthropic|codex|claude|gemini|grok|kimi|vertex|qwen|copilot)"
                             );
                         }
                         parsed
                     })
                     .collect(),
             ),
+            request_backend: None,
             sub_tiers: Arc::new(RuntimeConfig::get().sub_tiers.clone()),
             sub_fallback: RuntimeConfig::get().sub_fallback,
             sub_effort: RuntimeConfig::get().sub_effort.clone(),
@@ -7429,6 +7446,7 @@ mod imp {
                 sub_fallback: false,
                 sub_effort: None,
                 compact_models: Arc::new(vec![]),
+                request_backend: None,
             };
             (handler, rx)
         }

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -453,6 +453,8 @@ mod imp {
         /// acceptance it becomes the session's last-known-good snapshot for the context-limit
         /// guard; never recorded when the backend rejects before any output is exposed.
         anthropic_snapshot: Option<Value>,
+        /// CLIProxyAPI already speaks Anthropic SSE — skip first-party reducers.
+        passthrough: bool,
     }
 
     /// Enough of the rewritten upstream request to re-issue it on a retryable failure. The body is
@@ -1815,9 +1817,9 @@ mod imp {
         /// forwarded verbatim (still intercepted, just not compressed).
         exclude_hosts: Arc<Vec<String>>,
         exclude_providers: Arc<Vec<String>>,
-        /// Subscription reroute target (`sub = codex|kimi|grok`), snapshotted from [`RuntimeConfig`] at
-        /// construction. `None` = normal transparent compress-and-forward. When set, intercepted
-        /// Anthropic `/v1/messages` traffic is translated and sent to that subscription's backend.
+        /// Subscription reroute target (`sub = on` / CLIProxyAPI), snapshotted from [`RuntimeConfig`]
+        /// at construction. `None` = normal transparent compress-and-forward. When set, intercepted
+        /// Anthropic `/v1/messages` traffic is rewritten to the CLIProxyAPI sidecar.
         sub: Option<crate::reroute::SubProvider>,
         /// Ordered fallback providers. The active `sub` is used when this is empty.
         sub_chain: Arc<Vec<crate::reroute::SubProvider>>,
@@ -2062,9 +2064,19 @@ mod imp {
                         .get("x-claude-code-session-id")
                         .and_then(|v| v.to_str().ok()),
                 );
+                let window_model_pin: Option<String> = match &window_intent {
+                    Some(crate::window_sub::Intent::Enabled { provider })
+                        if crate::reroute::SubProvider::parse(provider).is_none()
+                            && crate::window_sub::valid_model_id(provider) =>
+                    {
+                        Some(provider.clone())
+                    }
+                    _ => None,
+                };
                 let window_sub = match &window_intent {
                     Some(crate::window_sub::Intent::Enabled { provider }) => {
                         crate::reroute::SubProvider::parse(provider)
+                            .or(Some(crate::reroute::SubProvider::CliProxy))
                     }
                     _ => None,
                 };
@@ -2089,7 +2101,7 @@ mod imp {
                             return self.reroute_count_tokens(req).await;
                         }
                         if req.method() == Method::POST && path_kind == AnthropicApiPath::Messages {
-                            return self.reroute_messages(req, sub, None).await;
+                            return self.reroute_messages(req, sub, window_model_pin).await;
                         }
                     }
                 } else if !window_disabled
@@ -2621,66 +2633,18 @@ mod imp {
                 };
             apply_sub_effort(&mut translate_value, self.sub_effort.as_deref());
 
-            // Fetch the subscription token (OAuth refresh is blocking + single-flight).
-            let token = match tokio::task::spawn_blocking(move || {
-                crate::reroute::auth::get_token(sub)
-            })
-            .await
+            if let Some(model) = explicit_model.as_deref() {
+                translate_value["model"] = serde_json::Value::String(model.to_string());
+            } else if let Some(logical) = compact_current
+                .as_ref()
+                .map(|c| c.logical_model.as_str())
             {
-                Ok(Ok(t)) => t,
-                Ok(Err(e)) => {
-                    return anthropic_error(
-                        401,
-                        &format!(
-                            "llmtrim: {p} not authenticated ({e}). Run `llmtrim sub auth {p} login`.",
-                            p = sub.as_str()
-                        ),
-                    )
-                    .into();
-                }
-                Err(_) => return anthropic_error(500, "llmtrim: auth task failed").into(),
-            };
-
-            // Refresh the Codex plan's rate-limit windows for the status line (throttled,
-            // fire-and-forget). Claude Code's stdin blob only carries Anthropic quotas.
-            if sub == crate::reroute::SubProvider::Codex {
-                crate::reroute::quota::maybe_schedule_codex_poll(
-                    token.access.clone(),
-                    token.account_id.clone(),
-                );
+                translate_value["model"] = serde_json::Value::String(logical.to_string());
             }
-
-            // Tiers must match the provider actually serving this turn. A window `/sub on grok`
-            // with global `sub = codex` must use `[sub.grok.tiers]` (or Grok defaults), not the
-            // Codex mapping snapshotted into `self.sub_tiers` at daemon start.
-            let tiers = llmtrim_core::config::sub_tiers_for(sub.as_str());
-            let rewrite_result = if let Some(model) = explicit_model.as_deref() {
-                crate::reroute::build_upstream_for_explicit_model(
-                    sub,
-                    &translate_value,
-                    model,
-                    &tiers,
-                    &token,
-                    session_id.as_deref(),
-                )
-            } else {
-                crate::reroute::build_upstream_for_model(
-                    sub,
-                    &translate_value,
-                    compact_current.as_ref().map(|c| c.logical_model.as_str()),
-                    &tiers,
-                    &token,
-                    session_id.as_deref(),
-                )
-            };
-            let rewrite = match rewrite_result {
+            let rewrite = match crate::reroute::cliproxy::rewrite(&translate_value) {
                 Ok(r) => r,
                 Err(e) => {
-                    return anthropic_error(
-                        502,
-                        &format!("llmtrim: reroute translation failed: {e}"),
-                    )
-                    .into();
+                    return anthropic_error(502, &format!("llmtrim: {e}")).into();
                 }
             };
 
@@ -2688,25 +2652,9 @@ mod imp {
             // `logical_body` is the full pre-delta codex request (used for recording the
             // transcript and for re-issuing on continuation errors). `sent_body` may be a
             // delta version. This matches the proxy's handling (except transport specifics).
-            let mut sent_body = rewrite.body.clone();
-            let mut logical_body: Option<Value> = None;
-            if sub == crate::reroute::SubProvider::Codex
-                && let Ok(mut bval) = serde_json::from_slice::<Value>(&rewrite.body)
-            {
-                logical_body = Some(bval.clone());
-                let enabled =
-                    llmtrim_core::config::RuntimeConfig::get().sub_codex_previous_response_id;
-                let cand = crate::reroute::continuation::continuation_candidate(
-                    session_id.as_deref(),
-                    &bval,
-                    enabled,
-                );
-                crate::reroute::continuation::apply_codex_continuation(&mut bval, &cand);
-                if let Ok(serialized) = serde_json::to_vec(&bval) {
-                    sent_body = serialized;
-                }
-            }
-            capture_reroute(&sent_body, session_id.as_deref(), sub.as_str());
+            let sent_body = rewrite.body.clone();
+            let logical_body: Option<Value> = None;
+            capture_reroute(&sent_body, session_id.as_deref(), "cliproxy");
 
             // Record intent: provider stays Anthropic (we emit Anthropic SSE, which `Finalize`
             // measures); model is the resolved upstream model; `reroute` marks the response path.
@@ -2726,22 +2674,23 @@ mod imp {
                 frozen_input_tokens: None,
                 breakdown,
                 reroute: Some(RerouteInfo {
-                    provider: sub,
+                    provider: crate::reroute::SubProvider::CliProxy,
                     model: rewrite.model.clone(),
                     client_model: client_model.clone(),
                     replay: Some(RerouteReplay {
-                        url: format!("https://{}{}", rewrite.host, rewrite.path),
+                        url: rewrite.url(),
                         headers: rewrite.headers.clone(),
                         body: Arc::new(sent_body.clone()),
                     }),
                     logical_body,
                     session_id: session_id.clone(),
                     anthropic_snapshot: Some(translate_value.clone()),
+                    passthrough: true,
                 }),
                 fallback: None,
                 compact: compact_current.map(|_| CompactAttempt {
                     candidates: compact_candidates,
-                    url: format!("https://{}{}", rewrite.host, rewrite.path),
+                    url: rewrite.url(),
                     headers: rewrite.headers.clone(),
                     original_body: Arc::new(bytes.to_vec()),
                     max_tokens,
@@ -2751,10 +2700,8 @@ mod imp {
                 }),
             });
 
-            // Retarget the request onto the provider host + path.
-            if let Ok(uri) =
-                format!("https://{}{}", rewrite.host, rewrite.path).parse::<hudsucker::hyper::Uri>()
-            {
+            // Retarget the request onto CLIProxyAPI (HTTP localhost).
+            if let Ok(uri) = rewrite.url().parse::<hudsucker::hyper::Uri>() {
                 parts.uri = uri;
             }
             // Strip the client's Anthropic auth + hop headers; hyper sets host/content-length.
@@ -3680,6 +3627,7 @@ mod imp {
                     logical_body: attempt.logical_body,
                     session_id: fb.session_id.clone(),
                     anthropic_snapshot: Some(anthropic.clone()),
+                    passthrough: attempt.provider == crate::reroute::SubProvider::CliProxy,
                 });
                 if let Some(info) = pending.reroute.as_ref()
                     && let Some(snap) = info.anthropic_snapshot.as_ref()
@@ -3760,7 +3708,7 @@ mod imp {
                     sent_body = serialized;
                 }
             }
-            let url = format!("https://{}{}", rewrite.host, rewrite.path);
+            let url = rewrite.url();
             let headers = rewrite.headers.clone();
             let body = String::from_utf8_lossy(&sent_body).into_owned();
             let proxy = self.upstream_proxy.clone();
@@ -3980,6 +3928,7 @@ mod imp {
                     logical_body: attempt.logical_body,
                     session_id: state.session_id.clone(),
                     anthropic_snapshot: Some(body),
+                    passthrough: provider == crate::reroute::SubProvider::CliProxy,
                 });
                 let info = winner.reroute.clone().expect("reroute set above");
                 return Some(self.finish_buffered_reroute(winner, &info, attempt.body));
@@ -4127,10 +4076,11 @@ mod imp {
                 );
                 return buffered_response(status, content_type, body);
             }
-            // Subscription reroute: the upstream reply is the provider's SSE — translate it back to
-            // Anthropic SSE (the normal compress/replay/tee path below is for verbatim-forwarded
-            // Anthropic responses).
-            if let Some(info) = pending.reroute.clone() {
+            // Subscription reroute: first-party translators need an SSE reducer. CLIProxyAPI
+            // already speaks Anthropic, so those turns fall through to the normal tee path.
+            if let Some(info) = pending.reroute.clone()
+                && !info.passthrough
+            {
                 return self.reroute_response(res, pending, info).await;
             }
             // Fallback reroute: Anthropic could not serve the turn. On a *transient* status
@@ -5405,7 +5355,7 @@ mod imp {
                     && let Some(r) = raw
                 {
                     eprintln!(
-                        "llmtrim: unknown sub provider '{r}' — reroute disabled (expected codex|kimi|grok)"
+                        "llmtrim: unknown sub provider '{r}' — reroute disabled (expected on|cliproxy)"
                     );
                 }
                 parsed
@@ -5420,7 +5370,7 @@ mod imp {
                             // Silently dropping it would leave a typo'd chain quietly shorter than
                             // the user configured — and the fallback they think they have missing.
                             eprintln!(
-                                "llmtrim: unknown provider '{p}' in the sub fallback chain — ignored (expected codex|kimi|grok)"
+                                "llmtrim: unknown provider '{p}' in the sub fallback chain — ignored (expected on|cliproxy)"
                             );
                         }
                         parsed
@@ -5456,6 +5406,11 @@ mod imp {
             crate::recall::serve(recall).await?;
         }
 
+        if handler.sub.is_some()
+            && let Err(e) = crate::reroute::cliproxy::ensure_running()
+        {
+            eprintln!("llmtrim: CLIProxyAPI sidecar: {e}");
+        }
         eprintln!("llmtrim: MITM interceptor on http://{addr}");
         eprintln!("  export HTTPS_PROXY=http://{addr}");
         eprintln!(

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -2640,6 +2640,12 @@ mod imp {
                 .map(|c| c.logical_model.as_str())
             {
                 translate_value["model"] = serde_json::Value::String(logical.to_string());
+            } else if sub != crate::reroute::SubProvider::CliProxy {
+                // Legacy `sub = codex|kimi|grok` keeps its tier map so existing users
+                // still land on the same upstream model through CLIProxyAPI.
+                let tiers = llmtrim_core::config::sub_tiers_for(sub.as_str());
+                let mapped = crate::reroute::resolve_model(sub, &client_model, &tiers);
+                translate_value["model"] = serde_json::Value::String(mapped);
             }
             let rewrite = match crate::reroute::cliproxy::rewrite(&translate_value) {
                 Ok(r) => r,
@@ -5407,7 +5413,7 @@ mod imp {
         }
 
         if handler.sub.is_some()
-            && let Err(e) = crate::reroute::cliproxy::ensure_running()
+            && let Err(e) = crate::reroute::cliproxy::ensure_for_existing_user()
         {
             eprintln!("llmtrim: CLIProxyAPI sidecar: {e}");
         }

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -2661,9 +2661,7 @@ mod imp {
 
             if let Some(model) = explicit_model.as_deref() {
                 translate_value["model"] = serde_json::Value::String(model.to_string());
-            } else if let Some(logical) = compact_current
-                .as_ref()
-                .map(|c| c.logical_model.as_str())
+            } else if let Some(logical) = compact_current.as_ref().map(|c| c.logical_model.as_str())
             {
                 translate_value["model"] = serde_json::Value::String(logical.to_string());
             } else {
@@ -2685,9 +2683,10 @@ mod imp {
                         }
                     } else if hop != "on" {
                         let catalog = crate::reroute::cliproxy::official_models();
-                        if let Some(id) =
-                            crate::reroute::cliproxy::expand_pin(&hop, &catalog.iter().map(|m| m.as_live()).collect::<Vec<_>>())
-                        {
+                        if let Some(id) = crate::reroute::cliproxy::expand_pin(
+                            &hop,
+                            &catalog.iter().map(|m| m.as_live()).collect::<Vec<_>>(),
+                        ) {
                             translate_value["model"] = serde_json::Value::String(id);
                         }
                     }
@@ -2696,7 +2695,8 @@ mod imp {
                     && let Some(backend) = crate::reroute::cliproxy::backend_by_alias(&provider)
                 {
                     let catalog = crate::reroute::cliproxy::official_models();
-                    let mapped = crate::reroute::cliproxy::default_tier_map(Some(backend), &catalog);
+                    let mapped =
+                        crate::reroute::cliproxy::default_tier_map(Some(backend), &catalog);
                     if !mapped.is_empty() {
                         tiers = mapped;
                     }
@@ -3651,7 +3651,11 @@ mod imp {
                     }
                 };
                 match self
-                    .reissue_reroute(&rewrite.url(), rewrite.headers.clone(), Arc::new(rewrite.body.clone()))
+                    .reissue_reroute(
+                        &rewrite.url(),
+                        rewrite.headers.clone(),
+                        Arc::new(rewrite.body.clone()),
+                    )
                     .await
                 {
                     Some((status, raw, _)) if (200..300).contains(&status) => {
@@ -3687,7 +3691,7 @@ mod imp {
                     None => failures.push(format!("{hop}: no response")),
                 }
             }
-                        self.fallback_error(
+            self.fallback_error(
                 pending,
                 &client_model,
                 &format!(

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -2066,10 +2066,9 @@ mod imp {
                 );
                 let window_model_pin: Option<String> = match &window_intent {
                     Some(crate::window_sub::Intent::Enabled { provider })
-                        if crate::reroute::SubProvider::parse(provider).is_none()
-                            && crate::window_sub::valid_model_id(provider) =>
+                        if !crate::reroute::cliproxy::is_passthrough_label(provider) =>
                     {
-                        Some(provider.clone())
+                        crate::reroute::cliproxy::resolve_pin_live(provider)
                     }
                     _ => None,
                 };
@@ -2645,6 +2644,10 @@ mod imp {
                 // still land on the same upstream model through CLIProxyAPI.
                 let tiers = llmtrim_core::config::sub_tiers_for(sub.as_str());
                 let mapped = crate::reroute::resolve_model(sub, &client_model, &tiers);
+                translate_value["model"] = serde_json::Value::String(mapped);
+            } else if let Some(pin) = llmtrim_core::config::sub_model()
+                && let Some(mapped) = crate::reroute::cliproxy::resolve_pin_live(&pin)
+            {
                 translate_value["model"] = serde_json::Value::String(mapped);
             }
             let rewrite = match crate::reroute::cliproxy::rewrite(&translate_value) {

--- a/crates/llmtrim-cli/src/statusline.rs
+++ b/crates/llmtrim-cli/src/statusline.rs
@@ -578,6 +578,9 @@ fn reroute_real_window(
         "codex" => SubProvider::Codex,
         "kimi" => SubProvider::Kimi,
         "grok" => SubProvider::Grok,
+        "on" | "cliproxy" | "cli-proxy-api" => {
+            return upstream_window(incoming_model_id);
+        }
         _ => return None,
     };
     upstream_window(&crate::reroute::resolve_model(sp, incoming_model_id, tiers))

--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -291,6 +291,14 @@ pub fn run() -> Result<()> {
         }
     }
     // Package-manager channels: the panel already ends with `llmtrim ensure`.
+    #[cfg(feature = "intercept")]
+    {
+        match crate::reroute::cliproxy::update_if_used() {
+            Ok(Some(msg)) => println!("{msg}"),
+            Ok(None) => {}
+            Err(e) => eprintln!("llmtrim: CLIProxyAPI update skipped: {e:#}"),
+        }
+    }
     Ok(())
 }
 

--- a/crates/llmtrim-cli/src/update.rs
+++ b/crates/llmtrim-cli/src/update.rs
@@ -157,6 +157,7 @@ pub fn run() -> Result<()> {
                 "{}",
                 crate::ui::ok(color, &format!("Already up to date (v{CURRENT})."))
             );
+            update_cliproxy();
             return Ok(());
         }
         Some(v) => println!(
@@ -283,6 +284,8 @@ pub fn run() -> Result<()> {
                 if let Some(v) = latest {
                     write_cache(&v); // clear the `monitor` banner
                 }
+                // Sidecar first so the restarted daemon can bind to a running CLIProxyAPI.
+                update_cliproxy();
                 // Always finish on the new binary: in-process ensure would stamp the old
                 // CARGO_PKG_VERSION and rewrite Claude hooks with a ghost `(deleted)` path.
                 restart_daemon(color)?;
@@ -291,6 +294,11 @@ pub fn run() -> Result<()> {
         }
     }
     // Package-manager channels: the panel already ends with `llmtrim ensure`.
+    update_cliproxy();
+    Ok(())
+}
+
+fn update_cliproxy() {
     #[cfg(feature = "intercept")]
     {
         match crate::reroute::cliproxy::update_if_used() {
@@ -299,7 +307,6 @@ pub fn run() -> Result<()> {
             Err(e) => eprintln!("llmtrim: CLIProxyAPI update skipped: {e:#}"),
         }
     }
-    Ok(())
 }
 
 /// Path to the on-disk llmtrim to spawn after a self-replacing install (never a deleted path).

--- a/crates/llmtrim-cli/src/window_sub.rs
+++ b/crates/llmtrim-cli/src/window_sub.rs
@@ -66,7 +66,14 @@ fn valid(value: &str) -> bool {
         && !value.contains("..")
 }
 fn valid_provider(value: &str) -> bool {
-    crate::reroute::cliproxy::parse_pin_request(value).is_some()
+    #[cfg(feature = "intercept")]
+    {
+        crate::reroute::cliproxy::parse_pin_request(value).is_some()
+    }
+    #[cfg(not(feature = "intercept"))]
+    {
+        matches!(value, "codex" | "kimi" | "grok" | "on") || valid_model_id(value)
+    }
 }
 
 /// A CLIProxyAPI model id that `/sub on <id>` may pin for this window.

--- a/crates/llmtrim-cli/src/window_sub.rs
+++ b/crates/llmtrim-cli/src/window_sub.rs
@@ -66,10 +66,7 @@ fn valid(value: &str) -> bool {
         && !value.contains("..")
 }
 fn valid_provider(value: &str) -> bool {
-    matches!(
-        value,
-        "on" | "cliproxy" | "cli-proxy" | "cli-proxy-api" | "cliproxyapi" | "codex" | "kimi" | "grok"
-    ) || valid_model_id(value)
+    crate::reroute::cliproxy::parse_pin_request(value).is_some()
 }
 
 /// A CLIProxyAPI model id that `/sub on <id>` may pin for this window.
@@ -1186,8 +1183,15 @@ mod tests {
         assert!(valid_provider("codex"));
         assert!(valid_provider("kimi"));
         assert!(valid_provider("grok"));
-        assert!(!valid_provider("anthropic"));
-        assert!(!valid_provider("openai"));
+        assert!(valid_provider("gemini"));
+        assert!(valid_provider("claude"));
+        assert!(valid_provider("antigravity"));
+        assert!(valid_provider("qwen"));
+        assert!(valid_provider("copilot"));
+        assert!(valid_provider("vertex"));
+        assert!(valid_provider("openai"));
+        assert!(valid_provider("anthropic"));
+        assert!(!valid_provider("notaprovider"));
     }
 
     #[test]

--- a/crates/llmtrim-cli/src/window_sub.rs
+++ b/crates/llmtrim-cli/src/window_sub.rs
@@ -66,7 +66,23 @@ fn valid(value: &str) -> bool {
         && !value.contains("..")
 }
 fn valid_provider(value: &str) -> bool {
-    matches!(value, "codex" | "kimi" | "grok")
+    matches!(
+        value,
+        "on" | "cliproxy" | "cli-proxy" | "cli-proxy-api" | "cliproxyapi" | "codex" | "kimi" | "grok"
+    ) || valid_model_id(value)
+}
+
+/// A CLIProxyAPI model id that `/sub on <id>` may pin for this window.
+pub fn valid_model_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 160
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'/'))
+        && !value.contains("..")
+        && !value.eq_ignore_ascii_case("off")
+        && !value.eq_ignore_ascii_case("anthropic")
+        && (value.contains('-') || value.contains('/') || value.contains('.'))
 }
 
 pub fn registry_path() -> Result<PathBuf> {

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -926,9 +926,9 @@ pub struct RuntimeConfig {
     /// name (`mocha`/`macchiato`/`frappe`/`latte`). The `t` key persists the user's choice
     /// here via [`save_theme`]. The TUI validates the name and falls back to its default.
     pub theme: Option<String>,
-    /// Subscription reroute target (env `LLMTRIM_SUB` / file `sub`): `codex`, `kimi`, or `grok` reroutes
-    /// intercepted Anthropic `/v1/messages` traffic to that subscription's backend instead of
-    /// Anthropic (translating the request/response wire shapes). `off`/unset keeps the
+    /// Subscription reroute target (env `LLMTRIM_SUB` / file `sub`): `on` (or `cliproxy`)
+    /// rewrites intercepted Anthropic `/v1/messages` traffic to the managed CLIProxyAPI sidecar.
+    /// Legacy `codex`/`kimi`/`grok` values still enable the sidecar. `off`/unset keeps the
     /// transparent compress-and-forward behavior. Lowercased; an unknown value is left as-is
     /// for the serve layer to reject with a clear error.
     pub sub: Option<String>,

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1318,10 +1318,12 @@ fn resolve_sub_model(
 /// Persist or clear the global CLIProxyAPI model pin.
 pub fn write_sub_model(model: Option<&str>) -> Result<()> {
     let path = config_path().ok_or_else(|| anyhow::anyhow!("no config path (HOME/XDG unset)"))?;
-    edit_sub_table_at(&path, |t| match model.map(str::trim).filter(|s| !s.is_empty()) {
-        Some(m) => t["model"] = toml_edit::value(m),
-        None => {
-            t.remove("model");
+    edit_sub_table_at(&path, |t| {
+        match model.map(str::trim).filter(|s| !s.is_empty()) {
+            Some(m) => t["model"] = toml_edit::value(m),
+            None => {
+                t.remove("model");
+            }
         }
     })
 }

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1292,6 +1292,40 @@ fn resolve_sub_skip_anthropic_login(
         .unwrap_or(true) // default: skip Anthropic login while always-sub
 }
 
+/// Global CLIProxyAPI model pin (`sub.model` / `LLMTRIM_SUB_MODEL`). `None` = pass Claude ids
+/// through (or expand a backend alias at request time).
+pub fn sub_model() -> Option<String> {
+    let env = |k: &str| std::env::var(k).ok();
+    let file = load_config_file();
+    resolve_sub_model(&env, file.as_ref())
+}
+
+fn resolve_sub_model(
+    env: &impl Fn(&str) -> Option<String>,
+    file: Option<&toml::Value>,
+) -> Option<String> {
+    if let Some(v) = env("LLMTRIM_SUB_MODEL").filter(|s| !s.is_empty()) {
+        return Some(v.trim().to_string());
+    }
+    file.and_then(|v| v.get("sub"))
+        .and_then(|v| v.get("model"))
+        .and_then(toml::Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Persist or clear the global CLIProxyAPI model pin.
+pub fn write_sub_model(model: Option<&str>) -> Result<()> {
+    let path = config_path().ok_or_else(|| anyhow::anyhow!("no config path (HOME/XDG unset)"))?;
+    edit_sub_table_at(&path, |t| match model.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(m) => t["model"] = toml_edit::value(m),
+        None => {
+            t.remove("model");
+        }
+    })
+}
+
 /// Persist `sub.anthropic_login`: `skip` (dummy token, no Anthropic /login) or `keep` (claude.ai
 /// OAuth for connectors; Anthropic login still required).
 pub fn write_sub_anthropic_login(skip: bool) -> Result<()> {


### PR DESCRIPTION
## Summary

Replace the live first-party Codex/Kimi/Grok translators with a managed [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) sidecar.

- `llmtrim sub on` installs and starts CLIProxyAPI; intercepted Anthropic `/v1/messages` are rewritten to it.
- Existing `sub = codex|kimi|grok` users stay on after `update` / `ensure` (sidecar install + token import + old tier map).
- Tab 4 is Off / Always / Fallback plus a searchable input→output map against the official CLIProxyAPI catalog.
- Fallback is an ordered hop list (`sub chain anthropic,codex,…`); first hop can be what's in use or any CLI.
- Images smaller than 8×8 are omitted so Grok does not 400 on 2×2 placeholders.

## Test plan

- [x] `cargo test -p llmtrim --features intercept,breakdown --lib`
- [x] clippy `-D warnings` on the crate
- [x] Isolate MITM on :43219: 2×2 PNG request → 200, image replaced with omit text
- [ ] CI green