### PR TITLE
fix(sub): stream CLIProxyAPI archives past ureq's 10 MiB cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ensure` / `sub on` can install CLIProxyAPI again.** The sidecar download used
+  ureq's `read_to_vec()` (10 MiB default). Current CLIProxyAPI archives are ~20 MiB,
+  so `llmtrim ensure` warned `the response body is larger than request limit: 10485760`.
+  The install now streams the archive to disk (64 MiB cap), matching the tray download.
+
 ## [0.13.0] - 2026-08-16
 
 ### Changed

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
 use super::SubProvider;

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use serde_json::Value;
 
 use super::SubProvider;
@@ -911,6 +911,11 @@ pub fn install_tag(tag: &str) -> Result<()> {
     Ok(())
 }
 
+/// Bound so a runaway response cannot fill the disk. Must be above current
+/// CLIProxyAPI archives (~20 MiB); ureq `read_to_vec` defaults to 10 MiB and
+/// rejects them (`the response body is larger than request limit: 10485760`).
+const MAX_ARCHIVE_BYTES: u64 = 64 * 1024 * 1024;
+
 fn download(url: &str, dest: &Path) -> Result<()> {
     let mut req = ureq::get(url)
         .config()
@@ -919,11 +924,15 @@ fn download(url: &str, dest: &Path) -> Result<()> {
         .build();
     req = req.header("User-Agent", "llmtrim-cliproxy");
     let mut res = req.call().with_context(|| format!("download {url}"))?;
-    let bytes = res
-        .body_mut()
-        .read_to_vec()
-        .context("read CLIProxyAPI archive")?;
-    fs::write(dest, bytes).with_context(|| format!("write {}", dest.display()))?;
+    use std::io::Read;
+    // `as_reader()` is unlimited by default; `read_to_vec()` is not (10 MiB).
+    let mut reader = res.body_mut().as_reader();
+    let mut file = fs::File::create(dest).with_context(|| format!("create {}", dest.display()))?;
+    let mut limited = Read::take(&mut reader, MAX_ARCHIVE_BYTES);
+    let n = std::io::copy(&mut limited, &mut file).context("read CLIProxyAPI archive")?;
+    if n >= MAX_ARCHIVE_BYTES {
+        bail!("CLIProxyAPI archive exceeded 64 MiB size limit");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## What & why

`llmtrim ensure` / `sub on` fail to install CLIProxyAPI:

```
⚠ CLIProxyAPI  read CLIProxyAPI archive: the response body is larger than request limit: 10485760 — `llmtrim sub on` to retry
```

The sidecar download used ureq 3's `read_to_vec()`, which is capped at 10 MiB. Current CLIProxyAPI archives are ~20 MiB (linux_amd64 21.0 MB, darwin_aarch64 19.4 MB, windows_amd64 21.3 MB).

Stream the archive to disk with `as_reader()` and a 64 MiB bound, matching the tray download in `ensure.rs`.

## Linked issue

No issue — regression on current CLIProxyAPI releases after the 0.13.0 sidecar switch.

## How it was verified

- [x] `cargo fmt` is clean
- [x] `cargo test -p llmtrim --lib reroute::cliproxy::tests` — 14 passed
- [ ] `cargo clippy --all-targets` (CI)
- [ ] `cargo nextest run --profile ci` (CI)
- [ ] New behavior is covered by a test — download is a live GitHub GET; the 10 MiB failure is ureq's default, not app logic we can unit-test without a mock server
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`
- [x] Commits are signed off (`git commit -s`, DCO)

## Notes

Needed in 0.13.1 so existing `sub` users can `ensure` again.