### PR TITLE
fix(sub): inherit pre-0.13 grok/codex/kimi maps under sub=on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **0.13 upgrade keeps the old `sub` map.** Status tab 4 and `sub = on` were
+  reading only `[sub.on.tiers]`. A pre-0.13 `[sub.grok.tiers]` (or
+  codex/kimi) pin such as opus → `grok-4.6` looked like empty
+  `(pass through)` and the output picker had no models if the official
+  catalog fetch failed. The live `on` table now inherits the last
+  legacy map, and the picker falls back to a small built-in list.
+
 ## [0.13.1] - 2026-08-16
 
 ### Fixed

--- a/crates/llmtrim-cli/src/reroute/cliproxy.rs
+++ b/crates/llmtrim-cli/src/reroute/cliproxy.rs
@@ -355,17 +355,49 @@ pub fn official_models() -> Vec<OfficialModel> {
     }
     match fetch_official_models() {
         Ok(list) if !list.is_empty() => list,
-        _ => list_models()
-            .unwrap_or_default()
-            .into_iter()
-            .map(|m| OfficialModel {
-                id: m.id,
-                owned_by: m.owned_by,
-                display_name: String::new(),
-                family: String::new(),
-            })
-            .collect(),
+        _ => {
+            let live = list_models()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|m| OfficialModel {
+                    id: m.id,
+                    owned_by: m.owned_by,
+                    display_name: String::new(),
+                    family: String::new(),
+                })
+                .collect::<Vec<_>>();
+            if live.is_empty() {
+                fallback_official_models()
+            } else {
+                live
+            }
+        }
     }
+}
+
+/// Offline / failed-catalog picker so tab 4 is not empty after a 0.13 upgrade.
+fn fallback_official_models() -> Vec<OfficialModel> {
+    const ROWS: &[(&str, &str, &str, &str)] = &[
+        ("grok-4.6", "xai", "Grok 4.6", "grok"),
+        (
+            "grok-composer-2.5-fast",
+            "xai",
+            "Grok Composer 2.5 Fast",
+            "grok",
+        ),
+        ("gpt-5.6-terra", "openai", "GPT-5.6 Terra", "codex"),
+        ("gpt-5.6-luna", "openai", "GPT-5.6 Luna", "codex"),
+        ("gpt-5.4-mini", "openai", "GPT-5.4 Mini", "codex"),
+        ("kimi-k2.5", "moonshot", "Kimi K2.5", "kimi"),
+    ];
+    ROWS.iter()
+        .map(|(id, owned_by, display_name, family)| OfficialModel {
+            id: (*id).into(),
+            owned_by: (*owned_by).into(),
+            display_name: (*display_name).into(),
+            family: (*family).into(),
+        })
+        .collect()
 }
 
 fn read_official_cache() -> Option<Vec<OfficialModel>> {
@@ -1544,6 +1576,13 @@ mod tests {
             Some("grok-composer-2.5-fast")
         );
         assert!(!map.values().any(|v| v == "claude-opus-5"));
+    }
+
+    #[test]
+    fn fallback_catalog_lists_grok_46() {
+        let cat = fallback_official_models();
+        assert!(cat.iter().any(|m| m.id == "grok-4.6"));
+        assert!(cat.iter().any(|m| m.id == "grok-composer-2.5-fast"));
     }
 
     const PNG_2X2: &str = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg==";

--- a/crates/llmtrim-core/src/config.rs
+++ b/crates/llmtrim-core/src/config.rs
@@ -1146,14 +1146,18 @@ pub fn sub_tiers_for(provider: &str) -> std::collections::BTreeMap<String, Strin
     sub_tiers_from_file(file.as_ref(), &provider)
 }
 
-fn sub_tiers_from_file(
-    file: Option<&toml::Value>,
+fn is_cliproxy_provider(provider: &str) -> bool {
+    matches!(
+        provider,
+        "on" | "cliproxy" | "cli-proxy" | "cli-proxy-api" | "cliproxyapi"
+    )
+}
+
+fn provider_tiers_table(
+    file: &toml::Value,
     provider: &str,
 ) -> std::collections::BTreeMap<String, String> {
     let mut map = std::collections::BTreeMap::new();
-    let Some(file) = file else {
-        return map;
-    };
     if let Some(tiers) = file
         .get("sub")
         .and_then(|v| v.get(provider))
@@ -1167,6 +1171,49 @@ fn sub_tiers_from_file(
         }
     }
     map
+}
+
+/// Pre-0.13 configs stored opus/sonnet/haiku/fable under `[sub.grok.tiers]` (or
+/// codex/kimi). 0.13 writes the live map at `[sub.on.tiers]`. When that table is
+/// missing, keep using the old one so an upgrade does not wipe the user's pin.
+fn inherit_legacy_sub_tiers(file: &toml::Value) -> std::collections::BTreeMap<String, String> {
+    const LEGACY: &[&str] = &[
+        "grok", "codex", "kimi", "claude", "gemini", "vertex", "qwen", "copilot",
+    ];
+    if let Some(last) = file
+        .get("sub")
+        .and_then(|v| v.get("last"))
+        .and_then(toml::Value::as_str)
+    {
+        let last = last.trim().to_ascii_lowercase();
+        if !last.is_empty() && !is_cliproxy_provider(&last) {
+            let map = provider_tiers_table(file, &last);
+            if !map.is_empty() {
+                return map;
+            }
+        }
+    }
+    for provider in LEGACY {
+        let map = provider_tiers_table(file, provider);
+        if !map.is_empty() {
+            return map;
+        }
+    }
+    std::collections::BTreeMap::new()
+}
+
+fn sub_tiers_from_file(
+    file: Option<&toml::Value>,
+    provider: &str,
+) -> std::collections::BTreeMap<String, String> {
+    let Some(file) = file else {
+        return std::collections::BTreeMap::new();
+    };
+    let map = provider_tiers_table(file, provider);
+    if !map.is_empty() || !is_cliproxy_provider(provider) {
+        return map;
+    }
+    inherit_legacy_sub_tiers(file)
 }
 
 /// Codex reasoning effort for the active provider: env `LLMTRIM_CODEX_EFFORT` wins, else the file
@@ -2083,6 +2130,68 @@ mod tests {
         std::fs::write(&path, "preset = \"auto\"\n").unwrap();
         assert_eq!(sub_reenable_provider_at(&path), None);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cliproxy_on_inherits_legacy_grok_tiers() {
+        let no_env = |_: &str| None;
+        let file: toml::Value = toml::from_str(
+            r#"
+[sub]
+active = "on"
+[sub.grok.tiers]
+opus = "grok-4.6"
+sonnet = "grok-4.6"
+fable = "grok-4.6"
+haiku = "grok-composer-2.5-fast"
+"#,
+        )
+        .unwrap();
+        let tiers = resolve_sub_tiers(&no_env, Some(&file));
+        assert_eq!(tiers.get("opus").map(String::as_str), Some("grok-4.6"));
+        assert_eq!(
+            tiers.get("haiku").map(String::as_str),
+            Some("grok-composer-2.5-fast")
+        );
+        let on_only = sub_tiers_from_file(Some(&file), "on");
+        assert_eq!(on_only.get("sonnet").map(String::as_str), Some("grok-4.6"));
+        let grok = sub_tiers_from_file(Some(&file), "grok");
+        assert_eq!(grok.get("fable").map(String::as_str), Some("grok-4.6"));
+    }
+
+    #[test]
+    fn cliproxy_on_table_wins_over_legacy_grok() {
+        let file: toml::Value = toml::from_str(
+            r#"
+[sub]
+active = "on"
+[sub.on.tiers]
+opus = "gpt-5.6-terra"
+[sub.grok.tiers]
+opus = "grok-4.6"
+"#,
+        )
+        .unwrap();
+        let on = sub_tiers_from_file(Some(&file), "on");
+        assert_eq!(on.get("opus").map(String::as_str), Some("gpt-5.6-terra"));
+    }
+
+    #[test]
+    fn cliproxy_on_prefers_sub_last_legacy_table() {
+        let file: toml::Value = toml::from_str(
+            r#"
+[sub]
+active = "on"
+last = "codex"
+[sub.grok.tiers]
+opus = "grok-4.6"
+[sub.codex.tiers]
+opus = "gpt-5.6-terra"
+"#,
+        )
+        .unwrap();
+        let on = sub_tiers_from_file(Some(&file), "on");
+        assert_eq!(on.get("opus").map(String::as_str), Some("gpt-5.6-terra"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

0.13.0 moved the live remap to `[sub.on.tiers]` and tab 4 only reads that table. After upgrade, a pre-0.13 `[sub.grok.tiers]` pin (e.g. opus → `grok-4.6`) showed as empty `(pass through)` and the output picker was empty if `models.router-for.me` failed.

This keeps the old map working without a reconfigure:

- `sub = on` / tab 4 inherit `[sub.grok|codex|kimi.tiers]` (or `sub.last`) when `[sub.on.tiers]` is empty
- an explicit `[sub.on.tiers]` still wins
- tab 4 falls back to a small built-in model list if the official catalog and sidecar `/v1/models` are both empty

Changelog: Unreleased.

## Test plan

- [x] `cargo test -p llmtrim-core cliproxy_on`
- [x] `cargo test -p llmtrim fallback_catalog_lists_grok`
- [ ] After install: tab 4 shows grok-4.6 from an existing `[sub.grok.tiers]` without saving a new map
- [ ] Saving tab 4 writes `[sub.on.tiers]` and does not wipe the legacy table