### PR TITLE
windows: use Windows store roots for upstream-proxy origin TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,7 @@ dependencies = [
  "statrs",
  "time",
  "tokio",
+ "tokio-rustls",
  "toml 1.1.2+spec-1.1.0",
  "unicode-width",
  "ureq",

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -147,6 +147,10 @@ hyper-rustls = { version = "0.27", default-features = false, features = [
   "http1",
   "http2",
 ], optional = true }
+# Re-seeds the UPSTREAM-PROXY origin TLS leg from the Windows store builder
+# (a stock ProxyConnector::from_proxy origin TLS would honor inherited
+# SSL_CERT_FILE / SSL_CERT_DIR instead — see #259).
+tokio-rustls = { version = "0.26", optional = true }
 schannel = { version = "0.1.29", optional = true }
 winreg = "0.56"
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Pipes"] }
@@ -169,6 +173,7 @@ intercept = [
   "dep:time",
   "dep:hyper-http-proxy",
   "dep:hyper-rustls",
+  "dep:tokio-rustls",
   "dep:hyper-util",
   "dep:schannel",
   "dep:uuid",

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -5500,9 +5500,30 @@ mod imp {
             // verification. The tokio-rustls ClientConfig uses whatever CryptoProvider is
             // installed at process start — we call aws_lc_rs::default_provider() at startup,
             // so origin TLS automatically uses aws-lc-rs throughout.
-            let proxy_connector =
+            #[allow(unused_mut)] // the cfg(windows) block re-seeds the origin TLS via set_tls
+            let mut proxy_connector =
                 ProxyConnector::from_proxy(HttpConnector::new(), upstream_proxy_spec)
                     .map_err(|e| anyhow::anyhow!("failed to build upstream ProxyConnector: {e}"))?;
+            #[cfg(windows)]
+            {
+                // Parity with the direct Windows path (#257): `from_proxy` builds the origin
+                // TLS leg via rustls-native-certs `load_native_certs()`, which preferentially
+                // reads inherited `SSL_CERT_FILE` / `SSL_CERT_DIR` and skips the OS stores —
+                // leaving an enterprise user whose TLS is inspected by both a proxy AND a
+                // corporate CA back on `UnknownIssuer`. Replace the origin trust set with the
+                // same Windows store builder the direct path uses (CurrentUser + optional
+                // LocalMachine ROOT, serverAuth EKU, time-valid). rustls verification itself
+                // is untouched; only which roots are trusted changes.
+                let tls_config = hudsucker::rustls::ClientConfig::builder_with_provider(Arc::new(
+                    aws_lc_rs::default_provider(),
+                ))
+                .with_safe_default_protocol_versions()
+                .context("failed to configure Windows upstream-proxy origin TLS protocol versions")?
+                .with_root_certificates(windows_root_store()?)
+                .with_no_client_auth();
+                proxy_connector
+                    .set_tls(Some(tokio_rustls::TlsConnector::from(Arc::new(tls_config))));
+            }
             Proxy::builder()
                 .with_addr(addr)
                 .with_ca(ca)


### PR DESCRIPTION
## Problem

PR #257 fixed the **direct** Windows outbound path: native roots from the Windows cert stores, rustls verification kept, inherited `SSL_CERT_FILE` / `SSL_CERT_DIR` ignored. The **`LLMTRIM_UPSTREAM_PROXY` path was left unchanged**.

When `LLMTRIM_UPSTREAM_PROXY` is set, origin TLS goes through `hyper-http-proxy`'s `ProxyConnector::from_proxy` with the `rustls-tls-native-roots` feature → hyper-rustls `with_native_roots()` → `rustls-native-certs::load_native_certs()`. That loader:

1. Preferentially reads **only** `SSL_CERT_FILE` / `SSL_CERT_DIR` when either is set (OS store skipped).
2. On Windows without those vars, opens **only** `CurrentUser\ROOT` (no LocalMachine).

So an enterprise user behind both HTTPS inspection AND an upstream proxy can still get `UnknownIssuer` / Claude Code 529.

## Fix

On Windows only, re-seed the origin `TlsConnector` with the same `windows_root_store()` builder the direct path uses (`set_tls` after `from_proxy`):

- Same trust set as the direct Windows path (#257): CurrentUser + optional LocalMachine ROOT, serverAuth EKU, time-valid.
- Full rustls verification stays on (no verify-off).
- Inherited `SSL_CERT_FILE` / `SSL_CERT_DIR` are ignored on this path too.
- Non-Windows behavior is byte-for-byte unchanged (the old `from_proxy` construction).

## Verification

- `cargo check -p llmtrim` (host) and `cargo check -p llmtrim --no-default-features --lib` (CI variant)
- `cargo clippy -p llmtrim --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `taplo fmt --check`
- Existing `proxy_connector_origin_tls_is_active` regression (still guards the construction path)
- Microsoft Windows SDK not present on this runner, so the `cfg(windows)` arm could not be type-checked end-to-end here; the API usage mirrors the already-shipped `windows_native_roots_connector` (#257) and `set_tls`'s `Option<tokio_rustls::TlsConnector>` signature in `hyper-http-proxy` 1.1.1 (`rustls-tls-native-roots` → `__rustls`).

Fixes #259
