### PR TITLE
wrap: launch Windows .cmd/.ps1 shims generically

### DIFF
--- a/crates/llmtrim-cli/src/wrap.rs
+++ b/crates/llmtrim-cli/src/wrap.rs
@@ -5,7 +5,10 @@
 //!   1. Confirm the interceptor is wired (the same `HTTPS_PROXY` mechanism `setup`
 //!      installs and `start` checks), so the agent's HTTPS to LLM hosts routes through
 //!      llmtrim — there is **no** per-agent quirk handling, no base-URL writing, no
-//!      allow-list of "supported" agents. Any binary on PATH works.
+//!      allow-list of "supported" agents. Any binary on PATH works. One exception:
+//!      on Windows, the DeepSeek Harness CLI (`dsh`) is an npm `.cmd`/`.ps1` shim that
+//!      `Command` cannot exec directly, so `wrap` resolves it to
+//!      `node <shimDir>\node_modules\@deepseek-ai\dsh\lib\bin.js` (see `resolve_launch`).
 //!   2. Exec the named binary as a subprocess that inherits the current environment
 //!      (which, post-`setup` + a fresh shell, already carries `HTTPS_PROXY` and the CA
 //!      trust vars), forwarding the passthrough args and propagating its exit code.
@@ -32,7 +35,9 @@ pub struct WrapInvocation {
 
 /// A few well-known agent names, used *only* to enrich the "not found" hint. This is NOT
 /// an allow-list: any binary on PATH is accepted. Kept tiny and advisory on purpose.
-const KNOWN_AGENTS: &[&str] = &["claude", "codex", "cursor", "aider", "copilot", "gemini"];
+const KNOWN_AGENTS: &[&str] = &[
+    "claude", "codex", "cursor", "aider", "copilot", "gemini", "dsh",
+];
 
 /// Split the raw `wrap` arguments into the agent and its passthrough args. The first token
 /// is the agent; everything after it is forwarded as-is. A leading `--` separator (clap
@@ -89,6 +94,10 @@ pub fn run(raw: Vec<String>) -> Result<()> {
     let inv = parse_invocation(&raw)?;
     let color = ui::color_stdout();
 
+    // Resolve the real launch command up front (Windows `dsh` → node + bin.js), so
+    // readiness hints and the "not found" error talk about the agent the user typed.
+    let (program, final_args) = resolve_launch(&inv.agent, &inv.args, None)?;
+
     // Reuse the exact helpers `start`/`setup` use — do not reimplement the checks.
     let daemon_running = crate::daemon::running().is_some();
     let env_wired = https_proxy_is_local();
@@ -136,7 +145,7 @@ pub fn run(raw: Vec<String>) -> Result<()> {
         ui::paint(color, Tone::Dim, &format!("llmtrim wrap → {}", inv.agent))
     );
 
-    exec_agent(&inv)
+    exec_agent(&program, &final_args, &inv.agent)
 }
 
 /// True when the agent binary looks like Claude Code (not Codex/Gemini/etc.).
@@ -149,17 +158,87 @@ fn agent_is_claude(agent: &str) -> bool {
     base == "claude" || base.starts_with("claude-") || base == "claude.exe"
 }
 
-/// Launch the agent and propagate its exit code. This is the real-IO entrypoint (it spawns
-/// a subprocess), so it is left uncovered by unit tests — the testable logic lives in
-/// `parse_invocation` / `readiness`, which are tested below.
-fn exec_agent(inv: &WrapInvocation) -> Result<()> {
-    let mut cmd = std::process::Command::new(&inv.agent);
-    cmd.args(&inv.args);
+/// True when the agent binary is the DeepSeek Harness CLI. On Windows `dsh` is an
+/// npm `.cmd`/`.ps1` shim that `Command` cannot exec directly (see `resolve_launch`).
+fn agent_is_dsh(agent: &str) -> bool {
+    let base = agent
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(agent)
+        .to_ascii_lowercase();
+    let base = base.as_str();
+    matches!(base, "dsh" | "dsh.exe" | "dsh.cmd" | "dsh.ps1")
+}
+
+/// First directory on `PATH` that contains a shim named `bin` (bare, `.exe`, `.cmd`,
+/// or `.ps1`). `path_env` is a seam for tests; `None` reads the live environment.
+fn shim_dir_on_path(bin: &str, path_env: Option<&str>) -> Option<std::path::PathBuf> {
+    let path = match path_env {
+        Some(p) => p.to_string(),
+        None => std::env::var_os("PATH")?.to_string_lossy().into_owned(),
+    };
+    let names = [
+        bin.to_string(),
+        format!("{bin}.exe"),
+        format!("{bin}.cmd"),
+        format!("{bin}.ps1"),
+    ];
+    std::env::split_paths(&path).find(|dir| names.iter().any(|n| dir.join(n).is_file()))
+}
+
+/// Derive the npm-installed entry script next to a `dsh` shim, if present.
+fn dsh_node_entry(path_env: Option<&str>) -> Option<std::path::PathBuf> {
+    let dir = shim_dir_on_path("dsh", path_env)?;
+    let entry = dir
+        .join("node_modules")
+        .join("@deepseek-ai")
+        .join("dsh")
+        .join("lib")
+        .join("bin.js");
+    entry.is_file().then_some(entry)
+}
+
+/// Rewrite a `wrap` invocation into the real (program, args) to launch.
+///
+/// Only Windows `dsh` is special: npm ships `dsh` as `.cmd`/`.ps1` shims that Rust's
+/// `Command` cannot exec directly, so we resolve the shim's directory on PATH and
+/// launch `node <shimDir>\node_modules\@deepseek-ai\dsh\lib\bin.js`. Every other
+/// agent resolves to itself (today's generic behavior). `path_env` is a seam for
+/// tests; `None` reads the live environment.
+fn resolve_launch(
+    agent: &str,
+    args: &[String],
+    path_env: Option<&str>,
+) -> Result<(String, Vec<String>)> {
+    if cfg!(windows) && agent_is_dsh(agent) {
+        if let Some(entry) = dsh_node_entry(path_env) {
+            let mut final_args = Vec::with_capacity(args.len() + 1);
+            final_args.push(entry.to_string_lossy().into_owned());
+            final_args.extend(args.iter().cloned());
+            return Ok(("node".to_string(), final_args));
+        }
+        // dsh shim present but entry missing → actionable hint.
+        if shim_dir_on_path("dsh", path_env).is_some() {
+            anyhow::bail!(
+                "found the `dsh` shim but no `node_modules\\@deepseek-ai\\dsh\\lib\\bin.js` \
+                 beside it — run `npm install -g @deepseek-ai/dsh` and try again"
+            );
+        }
+    }
+    Ok((agent.to_string(), args.to_vec()))
+}
+
+/// Launch the resolved program and propagate its exit code. This is the real-IO
+/// entrypoint (it spawns a subprocess), so it is left uncovered by unit tests — the
+/// testable logic lives in `parse_invocation` / `readiness` / `resolve_launch`.
+fn exec_agent(program: &str, args: &[String], display: &str) -> Result<()> {
+    let mut cmd = std::process::Command::new(program);
+    cmd.args(args);
     // Always-sub skip-login: Claude Code must not require a live Anthropic OAuth session.
     // Only inject for Claude-ish binaries — never pollute codex/gemini/etc.
     // Prefer an already-set user value; only inject when missing so a real key still wins.
     if llmtrim_core::config::sub_skip_anthropic_login()
-        && agent_is_claude(&inv.agent)
+        && agent_is_claude(display)
         && std::env::var_os("ANTHROPIC_AUTH_TOKEN").is_none()
     {
         cmd.env(
@@ -168,16 +247,12 @@ fn exec_agent(inv: &WrapInvocation) -> Result<()> {
         );
     }
     let status = cmd.status().with_context(|| {
-        if KNOWN_AGENTS.contains(&inv.agent.as_str()) {
-            format!(
-                "failed to launch `{}`: is it installed and on your PATH?",
-                inv.agent
-            )
+        if KNOWN_AGENTS.contains(&display) {
+            format!("failed to launch `{display}`: is it installed and on your PATH?")
         } else {
             format!(
-                "failed to launch `{}`: not found on PATH (pass an installed binary, \
+                "failed to launch `{display}`: not found on PATH (pass an installed binary, \
                  e.g. one of: {})",
-                inv.agent,
                 KNOWN_AGENTS.join(", ")
             )
         }
@@ -258,5 +333,85 @@ mod tests {
         assert!(!agent_is_claude("codex"));
         assert!(!agent_is_claude("gemini"));
         assert!(!agent_is_claude("/usr/bin/aider"));
+    }
+
+    #[test]
+    fn agent_is_dsh_matches_dsh_binaries_only() {
+        assert!(agent_is_dsh("dsh"));
+        assert!(agent_is_dsh("dsh.exe"));
+        assert!(agent_is_dsh("dsh.cmd"));
+        assert!(agent_is_dsh("dsh.ps1"));
+        assert!(agent_is_dsh(r"C:\Tools\dsh.exe"));
+        assert!(agent_is_dsh("/usr/bin/dsh"));
+        assert!(!agent_is_dsh("claude"));
+        assert!(!agent_is_dsh("codex"));
+        assert!(!agent_is_dsh("dsh-custom"));
+    }
+
+    #[test]
+    fn non_dsh_agents_resolve_to_themselves() {
+        let out = resolve_launch("claude", &s(&["--x"]), Some("C:\\bin")).expect("generic");
+        assert_eq!(out, ("claude".to_string(), s(&["--x"])));
+        let out = resolve_launch("codex", &[], Some("C:\\bin")).expect("generic");
+        assert_eq!(out, ("codex".to_string(), Vec::<String>::new()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn dsh_resolves_to_node_entry_when_shim_and_entry_present() {
+        let dir = std::env::temp_dir().join(format!("llmtrim-wrap-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(
+            dir.join("node_modules")
+                .join("@deepseek-ai")
+                .join("dsh")
+                .join("lib"),
+        )
+        .expect("mkdir");
+        std::fs::write(dir.join("dsh.cmd"), "@echo off\r\nexit /b 0\r\n").expect("shim");
+        std::fs::write(
+            dir.join("node_modules")
+                .join("@deepseek-ai")
+                .join("dsh")
+                .join("lib")
+                .join("bin.js"),
+            "#!/usr/bin/env node\r\n",
+        )
+        .expect("entry");
+
+        let path = dir.to_string_lossy().into_owned();
+        let out = resolve_launch("dsh", &s(&["web"]), Some(path.as_str())).expect("resolve");
+        assert_eq!(out.0, "node");
+        assert_eq!(out.1.len(), 2);
+        assert!(
+            out.1[0].ends_with("node_modules\\@deepseek-ai\\dsh\\lib\\bin.js")
+                || out.1[0].ends_with("node_modules/@deepseek-ai/dsh/lib/bin.js")
+        );
+        assert_eq!(out.1[1], "web");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn dsh_with_shim_but_no_entry_returns_npm_install_hint() {
+        let dir = std::env::temp_dir().join(format!("llmtrim-wrap-missing-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(dir.join("dsh.cmd"), "@echo off\r\nexit /b 0\r\n").expect("shim");
+
+        let path = dir.to_string_lossy().into_owned();
+        let err = resolve_launch("dsh", &[], Some(path.as_str())).expect_err("should error");
+        assert!(err.to_string().contains("npm install -g @deepseek-ai/dsh"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dsh_not_on_path_resolves_to_itself() {
+        // No dsh shim anywhere on PATH → generic behavior (the later exec error
+        // handles the not-found case, matching today's semantics for any agent).
+        let out = resolve_launch("dsh", &[], Some("C:\\other")).expect("generic");
+        assert_eq!(out, ("dsh".to_string(), Vec::<String>::new()));
     }
 }

--- a/crates/llmtrim-cli/src/wrap.rs
+++ b/crates/llmtrim-cli/src/wrap.rs
@@ -21,6 +21,7 @@
 //! wired (trivially safe: the contract — port + CA — is already in place, same as `start`).
 
 use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
 
 use crate::ui::{self, Tone};
 
@@ -172,7 +173,7 @@ fn agent_is_dsh(agent: &str) -> bool {
 
 /// First directory on `PATH` that contains a shim named `bin` (bare, `.exe`, `.cmd`,
 /// or `.ps1`). `path_env` is a seam for tests; `None` reads the live environment.
-fn shim_dir_on_path(bin: &str, path_env: Option<&str>) -> Option<std::path::PathBuf> {
+fn shim_dir_on_path(bin: &str, path_env: Option<&str>) -> Option<PathBuf> {
     let path = match path_env {
         Some(p) => p.to_string(),
         None => std::env::var_os("PATH")?.to_string_lossy().into_owned(),
@@ -186,9 +187,23 @@ fn shim_dir_on_path(bin: &str, path_env: Option<&str>) -> Option<std::path::Path
     std::env::split_paths(&path).find(|dir| names.iter().any(|n| dir.join(n).is_file()))
 }
 
+/// Directory of an explicitly passed shim path such as `C:\Users\me\npm\dsh.cmd`.
+fn explicit_shim_dir(agent: &str) -> Option<PathBuf> {
+    let path = Path::new(agent);
+    if path.components().count() <= 1 || !path.is_file() {
+        return None;
+    }
+    path.parent().map(Path::to_path_buf)
+}
+
+/// Resolve either an explicit shim path or the first PATH shim directory.
+fn dsh_shim_dir(agent: &str, path_env: Option<&str>) -> Option<PathBuf> {
+    explicit_shim_dir(agent).or_else(|| shim_dir_on_path("dsh", path_env))
+}
+
 /// Derive the npm-installed entry script next to a `dsh` shim, if present.
-fn dsh_node_entry(path_env: Option<&str>) -> Option<std::path::PathBuf> {
-    let dir = shim_dir_on_path("dsh", path_env)?;
+fn dsh_node_entry(agent: &str, path_env: Option<&str>) -> Option<PathBuf> {
+    let dir = dsh_shim_dir(agent, path_env)?;
     let entry = dir
         .join("node_modules")
         .join("@deepseek-ai")
@@ -210,15 +225,24 @@ fn resolve_launch(
     args: &[String],
     path_env: Option<&str>,
 ) -> Result<(String, Vec<String>)> {
-    if cfg!(windows) && agent_is_dsh(agent) {
-        if let Some(entry) = dsh_node_entry(path_env) {
+    resolve_launch_for_platform(agent, args, path_env, cfg!(windows))
+}
+
+fn resolve_launch_for_platform(
+    agent: &str,
+    args: &[String],
+    path_env: Option<&str>,
+    is_windows: bool,
+) -> Result<(String, Vec<String>)> {
+    if is_windows && agent_is_dsh(agent) {
+        if let Some(entry) = dsh_node_entry(agent, path_env) {
             let mut final_args = Vec::with_capacity(args.len() + 1);
             final_args.push(entry.to_string_lossy().into_owned());
             final_args.extend(args.iter().cloned());
             return Ok(("node".to_string(), final_args));
         }
         // dsh shim present but entry missing → actionable hint.
-        if shim_dir_on_path("dsh", path_env).is_some() {
+        if dsh_shim_dir(agent, path_env).is_some() {
             anyhow::bail!(
                 "found the `dsh` shim but no `node_modules\\@deepseek-ai\\dsh\\lib\\bin.js` \
                  beside it — run `npm install -g @deepseek-ai/dsh` and try again"
@@ -356,7 +380,6 @@ mod tests {
         assert_eq!(out, ("codex".to_string(), Vec::<String>::new()));
     }
 
-    #[cfg(windows)]
     #[test]
     fn dsh_resolves_to_node_entry_when_shim_and_entry_present() {
         let dir = std::env::temp_dir().join(format!("llmtrim-wrap-test-{}", std::process::id()));
@@ -380,7 +403,8 @@ mod tests {
         .expect("entry");
 
         let path = dir.to_string_lossy().into_owned();
-        let out = resolve_launch("dsh", &s(&["web"]), Some(path.as_str())).expect("resolve");
+        let out = resolve_launch_for_platform("dsh", &s(&["web"]), Some(path.as_str()), true)
+            .expect("resolve");
         assert_eq!(out.0, "node");
         assert_eq!(out.1.len(), 2);
         assert!(
@@ -392,7 +416,48 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    #[cfg(windows)]
+    #[test]
+    fn dsh_resolves_explicit_shim_path_to_adjacent_node_entry() {
+        let dir =
+            std::env::temp_dir().join(format!("llmtrim-wrap-explicit-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(
+            dir.join("node_modules")
+                .join("@deepseek-ai")
+                .join("dsh")
+                .join("lib"),
+        )
+        .expect("mkdir");
+        let shim = dir.join("dsh.cmd");
+        std::fs::write(&shim, "@echo off\r\nexit /b 0\r\n").expect("shim");
+        std::fs::write(
+            dir.join("node_modules")
+                .join("@deepseek-ai")
+                .join("dsh")
+                .join("lib")
+                .join("bin.js"),
+            "#!/usr/bin/env node\r\n",
+        )
+        .expect("entry");
+
+        let out = resolve_launch_for_platform(
+            shim.to_string_lossy().as_ref(),
+            &s(&["web"]),
+            Some(""),
+            true,
+        )
+        .expect("resolve");
+        assert_eq!(out.0, "node");
+        assert_eq!(out.1.len(), 2);
+        assert!(
+            out.1[0].ends_with("node_modules\\@deepseek-ai\\dsh\\lib\\bin.js")
+                || out.1[0].ends_with("node_modules/@deepseek-ai/dsh/lib/bin.js")
+        );
+        assert_eq!(out.1[1], "web");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn dsh_with_shim_but_no_entry_returns_npm_install_hint() {
         let dir = std::env::temp_dir().join(format!("llmtrim-wrap-missing-{}", std::process::id()));
@@ -401,7 +466,26 @@ mod tests {
         std::fs::write(dir.join("dsh.cmd"), "@echo off\r\nexit /b 0\r\n").expect("shim");
 
         let path = dir.to_string_lossy().into_owned();
-        let err = resolve_launch("dsh", &[], Some(path.as_str())).expect_err("should error");
+        let err = resolve_launch_for_platform("dsh", &[], Some(path.as_str()), true)
+            .expect_err("should error");
+        assert!(err.to_string().contains("npm install -g @deepseek-ai/dsh"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn explicit_dsh_shim_without_entry_returns_npm_install_hint() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmtrim-wrap-explicit-missing-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let shim = dir.join("dsh.cmd");
+        std::fs::write(&shim, "@echo off\r\nexit /b 0\r\n").expect("shim");
+
+        let err = resolve_launch_for_platform(shim.to_string_lossy().as_ref(), &[], Some(""), true)
+            .expect_err("should error");
         assert!(err.to_string().contains("npm install -g @deepseek-ai/dsh"));
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -411,7 +495,8 @@ mod tests {
     fn dsh_not_on_path_resolves_to_itself() {
         // No dsh shim anywhere on PATH → generic behavior (the later exec error
         // handles the not-found case, matching today's semantics for any agent).
-        let out = resolve_launch("dsh", &[], Some("C:\\other")).expect("generic");
+        let out =
+            resolve_launch_for_platform("dsh", &[], Some("C:\\other"), true).expect("generic");
         assert_eq!(out, ("dsh".to_string(), Vec::<String>::new()));
     }
 }


### PR DESCRIPTION
## The problem

`llmtrim wrap dsh` fails on Windows. Rust's `Command` never consults `PATHEXT`, so a bare `dsh` resolves to `dsh.exe` and never finds the `.cmd` shim npm actually installs — the same hole for every npm-installed CLI (`tsc`, `vite`, `dsh`), not just one.

Two later findings, both from review, are why the launcher looks the way it does now:

- A first revision added a `dsh`-specific resolver. Wrong layer: it hardcoded `node_modules\@deepseek-ai\dsh\lib\bin.js` beside the shim, which only matches a classic `npm i -g` layout and breaks pnpm/Volta installs.
- The generic replacement built a `cmd.exe` command line by hand. `cmd /c "<shim>" "web"` loses both quotes, so `wrap dsh web` ran the shim with **no arguments** while `wrap dsh` survived — and the tests, which asserted the string instead of spawning, could not see it.

## The change

- `resolve_candidate` picks the candidate the shell would run: a path is used as given, a bare name is probed along PATH, and within each directory in the order `.com`, `.exe`, `.bat`, `.cmd`, `.ps1` — so a native `tool.exe` beside a `tool.cmd` wins instead of being shadowed.
- `.cmd`/`.bat` are launched by resolved path through `std::process::Command`, which wraps batch files in `cmd.exe` and escapes their arguments itself (Rust ≥ 1.77.2, CVE-2024-24576), refusing ones it cannot escape rather than mangling them.
- `.ps1` goes through `powershell -NoProfile -ExecutionPolicy Bypass -File`.
- Everything else — native binaries, unknown names, POSIX shims (shebang scripts) — passes through exactly as before.
- `cmd_escape`, `cmd_line` and the `raw_arg` plumbing are deleted; `dsh` stays in the advisory "not found" hint list.

## Verified

- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test -p llmtrim --lib` — 24 `wrap::` tests, including three that **spawn a real `.cmd`** fixture and assert its arguments arrive (plain, space-containing, and a cmd metacharacter).
- Mutation check: reverting the launcher to the old `cmd /c "<shim>" "arg"` form makes the spawn test fail with an empty stdout — the failure mode this PR exists to fix.
- `cargo check -p llmtrim --no-default-features --lib` and `cargo check -p llmtrim --features live` clean (the no-default-features build is the one that failed on #270).
- `CHANGELOG.md` has an `[Unreleased]` entry.

The fork PR's workflow runs are still `action_required`, so the above are local runs rather than CI.
