### PR TITLE
chore(deps): land Dependabot bumps with API migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: kotlin-smoke
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: temurin
           java-version: "17"

--- a/.github/workflows/release-bindings.yml
+++ b/.github/workflows/release-bindings.yml
@@ -185,7 +185,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-java@v5.6.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: temurin
           java-version: "17"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. The format follows
 
 ### Changed
 
+- **Dependencies.** MITM proxy crate `hudsucker` 0.25 (SNI hostnames plus key-usage/AKI on
+  generated certificates), `comfy-table` 8 for status/eval tables, `actions/setup-java` v6
+  for Kotlin CI, and cargo patch updates including `rmcp` 3.1.4.
+
 - **Statusline, cold-cache guard, and cheaper `/compact` are off by default.** `setup` /
   `ensure` no longer first-install them. New machines get `/sub` (and routed subagents)
   only. An already-owned status line or guard is still refreshed on upgrade; compact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.41.1"
+version = "0.41.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3007014661d5b98168b7b6f1014147bce8b1362a194783543eeb9f6117a20be9"
+checksum = "d72db2750faea2ca5edbf6d0c50277a89dc8f75f5e6ddd695ef30f75e335019b"
 dependencies = [
  "async-openai-macros",
  "base64 0.22.1",
@@ -497,9 +497,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "basic-toml"
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
 dependencies = [
  "ansi-str",
  "console",
@@ -1249,6 +1249,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1286,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1318,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1580,7 +1614,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -1745,12 +1779,13 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1949,7 +1984,7 @@ dependencies = [
  "fnv",
  "itertools",
  "num-traits",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_pcg 0.3.1",
  "random_choice",
  "rayon",
@@ -2379,7 +2414,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -2447,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2472,9 +2507,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hudsucker"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2dca99d166caa6658eb3842ab0c6672241e47027dcf6f407aa0cf61755b480"
+checksum = "3a1d7c1c828ff6db12ddafb16768ecbac920df6301778d0eb78e95da0e44d94b"
 dependencies = [
  "bstr",
  "futures",
@@ -2485,7 +2520,7 @@ dependencies = [
  "hyper-tungstenite",
  "hyper-util",
  "moka",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rcgen",
  "thiserror 2.0.18",
  "time",
@@ -2529,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-http-proxy"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8021e0ae20c08eadc94d0bdafdeda66d4f0858541c146ae6e46b219bfe58497e"
+checksum = "bd1d471ea2f65ba45eddb1d6ab7d58ac2671d2d4ac14da5c6516ae1d97e1327a"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2566,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-tungstenite"
-version = "0.19.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc778da281a749ed28d2be73a9f2cd13030680a1574bc729debd1195e44f00e9"
+checksum = "aee7ba11c4933715ee2c2fea1d8932f19356d31648c0a1bb65223ef5d7962c4c"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3154,7 +3189,7 @@ dependencies = [
  "anyhow",
  "async-openai",
  "auto-launch",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "clap",
@@ -3174,7 +3209,7 @@ dependencies = [
  "nix",
  "once_cell",
  "owo-colors",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ratatui",
  "regex",
  "reqwest",
@@ -3187,7 +3222,7 @@ dependencies = [
  "statrs",
  "time",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "unicode-width",
  "ureq",
  "uuid",
@@ -3202,7 +3237,7 @@ name = "llmtrim-core"
 version = "0.13.3-dev"
 dependencies = [
  "anyhow",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bm25",
  "csv",
  "gaoya",
@@ -3216,7 +3251,7 @@ dependencies = [
  "serde_json",
  "stop-words 0.10.0",
  "tiktoken-rs",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "toml_edit 0.25.13+spec-1.1.0",
  "toon-format",
  "tree-sitter",
@@ -3404,6 +3439,16 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3916,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
 
 [[package]]
 name = "palette"
@@ -4180,7 +4225,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -4193,7 +4238,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -4363,7 +4408,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_pcg 0.10.2",
  "ring",
  "rustc-hash",
@@ -4457,9 +4502,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -4810,13 +4855,13 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd2b6dd3b18129368955f32661a7718969e8c152c7d8866434c09cf15a512e0"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
- "async-trait",
  "chrono",
  "futures",
+ "indexmap 2.14.0",
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
@@ -4833,15 +4878,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5410,6 +5455,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6129,7 +6185,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -6144,7 +6200,7 @@ checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
 ]
 
 [[package]]
@@ -6245,9 +6301,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "libc",
@@ -6363,9 +6419,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
@@ -6419,9 +6475,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -6656,9 +6712,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",
@@ -6858,21 +6914,20 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.10.2",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.11.0",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -7024,7 +7079,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -7069,7 +7124,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "uniffi_meta",
 ]
 
@@ -7118,11 +7173,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -7135,11 +7190,11 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "http",
  "httparse",
  "log",
@@ -7196,9 +7251,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -8425,6 +8480,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -44,7 +44,7 @@ llmtrim-ledger = { path = "../llmtrim-ledger", version = "0.13.3-dev" }
 anyhow.workspace = true
 chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive"] }
-comfy-table = { version = "7.2.2", default-features = false, features = ["custom_styling"] }
+comfy-table = { version = "8.0.0", default-features = false, features = ["custom_styling"] }
 dotenvy = "0.15.7"
 once_cell.workspace = true
 owo-colors = "4.3.0"
@@ -69,7 +69,7 @@ tokio = { version = "1.52", features = [
   "time",
 ], optional = true }
 # The MITM interceptor (`serve`).
-hudsucker = { version = "0.24", default-features = false, features = [
+hudsucker = { version = "0.25", default-features = false, features = [
   "rcgen-ca",
   "rustls-client",
   "http2",
@@ -109,7 +109,7 @@ flate2 = { version = "1", optional = true }
 # Not used directly — caps the transitive `time` (via hudsucker → rcgen) below 0.3.48,
 # whose new blanket impl collides with rcgen 0.14's `impl<T: Into<String>> From<T>`
 # (E0119), breaking un-`--locked` `cargo install`. Drop when rcgen ships a fix.
-time = { version = ">=0.3.36, <0.3.55", default-features = false, optional = true }
+time = { version = ">=0.3.36, <0.3.56", default-features = false, optional = true }
 # MCP server over stdio (`mcp`). rmcp is the official Model Context Protocol Rust SDK;
 # `transport-io` is the stdio transport, `macros` derives each tool's JSON Schema.
 rmcp = { version = "3.0", default-features = false, features = [

--- a/crates/llmtrim-cli/src/serve.rs
+++ b/crates/llmtrim-cli/src/serve.rs
@@ -1863,7 +1863,11 @@ mod imp {
     impl HttpHandler for Interceptor {
         /// Only MITM (forge a cert for) the LLM provider hosts; everything else is
         /// blind-tunneled, so the CA is never used outside its purpose.
-        async fn should_intercept(&mut self, _ctx: &HttpContext, req: &Request<Body>) -> bool {
+        async fn should_intercept_connect(
+            &mut self,
+            _ctx: &HttpContext,
+            req: &Request<Body>,
+        ) -> bool {
             host_of(req)
                 .map(|h| host_covered(&h.to_ascii_lowercase(), &self.domains))
                 .unwrap_or(false)
@@ -3815,21 +3819,22 @@ mod imp {
         /// One bounded retry of the turn against Anthropic before the chain takes over. A 503 or a
         /// short 429 is usually a blip, and a blip should not move a turn (and its spend) to a
         /// different provider. Returns the `Pending` back when no retry was possible or the retry
-        /// failed, so the caller falls through to the chain. The retry sends the *original*
-        /// (uncompressed) request — the compressed body isn't retained past the forward — so the
-        /// row is recorded honestly as a no-savings turn.
+        /// failed, so the caller falls through to the chain. `Pending` is boxed on `Err` because
+        /// clippy 1.98's `result_large_err` rejects it on the stack (~816 bytes). The retry sends
+        /// the *original* (uncompressed) request — the compressed body isn't retained past the
+        /// forward — so the row is recorded honestly as a no-savings turn.
         async fn retry_anthropic_once(
             &self,
             mut pending: Pending,
             retry_after_secs: Option<u64>,
-        ) -> Result<Response<Body>, Pending> {
+        ) -> Result<Response<Body>, Box<Pending>> {
             let Some(original) = pending.original.clone() else {
-                return Err(pending);
+                return Err(Box::new(pending));
             };
             // A reset hint beyond the backoff cap (a usage limit hours away) means "don't wait" —
             // go straight to the chain, which is the whole point of fallback mode.
             let Some(wait_ms) = reroute_backoff_ms(0, retry_after_secs) else {
-                return Err(pending);
+                return Err(Box::new(pending));
             };
             tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
             let proxy = self.upstream_proxy.clone();
@@ -3837,10 +3842,10 @@ mod imp {
                 tokio::task::spawn_blocking(move || fetch_original(&original, proxy.as_deref()))
                     .await;
             let Ok(Some((status, content_type, body))) = fetched else {
-                return Err(pending);
+                return Err(Box::new(pending));
             };
             if !(200..300).contains(&status) || is_sub_fallback_body(&body) {
-                return Err(pending);
+                return Err(Box::new(pending));
             }
             pending.input_after = pending.input_before;
             pending.output_shaped = false;
@@ -4146,7 +4151,7 @@ mod imp {
                     let hint = reroute_retry_after_from_headers(&parts.headers, &bytes);
                     match self.retry_anthropic_once(pending, hint).await {
                         Ok(response) => return response,
-                        Err(returned) => pending = returned,
+                        Err(returned) => pending = *returned,
                     }
                 }
                 return self.fallback_to_chain(pending, fb).await;

--- a/crates/llmtrim-cli/src/ui.rs
+++ b/crates/llmtrim-cli/src/ui.rs
@@ -259,11 +259,10 @@ pub fn kv_rows(color: bool, rows: &[(&str, String, String)]) -> Vec<String> {
 /// Cells may carry ANSI when `color` is true — the `custom_styling` feature keeps
 /// the width math correct.
 pub fn table(color: bool, headers: &[&str]) -> comfy_table::Table {
-    use comfy_table::{Cell, ContentArrangement, Table, modifiers, presets};
+    use comfy_table::{Cell, ContentArrangement, Table, presets};
     let mut t = Table::new();
     // Outer border + header rule only — column separators would fight the panel chrome.
-    t.load_preset(presets::UTF8_BORDERS_ONLY);
-    t.apply_modifier(modifiers::UTF8_ROUND_CORNERS);
+    t.load_style(presets::UTF8_BORDERS_ONLY.with_rounded_corners());
     t.set_content_arrangement(ContentArrangement::Disabled);
     t.set_header(
         headers
@@ -482,6 +481,17 @@ mod tests {
         assert!(out.starts_with("error: failed to read corpus"));
         assert!(out.contains("caused by: io fail"));
         assert!(!out.contains('\x1b'));
+    }
+
+    #[test]
+    fn table_uses_rounded_utf8_borders() {
+        let mut t = table(false, &["a", "b"]);
+        t.add_row(vec!["1", "2"]);
+        let out = t.to_string();
+        assert!(
+            out.contains('╭') && out.contains('╰'),
+            "expected rounded corners: {out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Lands the four open Dependabot PRs with the code changes they need to compile and pass clippy 1.98.

| PR | Update | Extra work |
| --- | --- | --- |
| #274 | `actions/setup-java` 5.6.0 → 6.0.0 | none (Kotlin CI / release-bindings) |
| #275 | cargo patch group (rmcp 3.1.4, clap 4.6.6, …) | raise `time` pin to `<0.3.56` (already in that PR) |
| #276 | `comfy-table` 7.2.2 → 8.0.0 | `load_style(UTF8_BORDERS_ONLY.with_rounded_corners())` |
| #277 | `hudsucker` 0.24 → 0.25 | `HttpHandler::should_intercept` → `should_intercept_connect` |

Also boxes `Pending` on `retry_anthropic_once`'s `Err` path. Clippy 1.98's `result_large_err` (~816 byte `Err`) was failing **every** PR's Test jobs, including the workflow-only Java bump.

Local verification: `cargo clippy --all-targets -- -D warnings` and `cargo nextest run --profile ci` (1349 passed, 1 skipped) on rustc 1.98.0.

Closes #274
Closes #275
Closes #276
Closes #277