### PR TITLE
feat: add Codex localhost gateway without MITM proxy

### DIFF
--- a/.github/workflows/codex-gateway.yml
+++ b/.github/workflows/codex-gateway.yml
@@ -4,7 +4,7 @@ name: Codex gateway
 # executable, cuts a release or publishes a package.
 on:
   push:
-    branches: [main, master, feature/codex-local-gateway]
+    branches: [main, master]
   pull_request:
     paths:
       - "crates/llmtrim-cli/src/codex_gateway.rs"

--- a/.github/workflows/codex-gateway.yml
+++ b/.github/workflows/codex-gateway.yml
@@ -1,0 +1,224 @@
+name: Codex gateway
+
+# Validation only. This workflow builds and tests the Codex local gateway; it never uploads an
+# executable, cuts a release or publishes a package.
+on:
+  push:
+    branches: [main, master, feature/codex-local-gateway]
+  pull_request:
+    paths:
+      - "crates/llmtrim-cli/src/codex_gateway.rs"
+      - "crates/llmtrim-cli/src/lib.rs"
+      - "crates/llmtrim-core/**"
+      - "docs/codex-local-gateway.md"
+      - ".github/workflows/codex-gateway.yml"
+
+concurrency:
+  group: codex-gateway-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only. The gateway jobs need no token beyond checkout, no secret and no environment.
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  # Windows first: it is the platform where avoiding a local CA and a machine-wide proxy
+  # matters most. Linux runs the same suite as a portability check.
+  gateway:
+    name: gateway (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v7
+
+      # The channel is pinned repo-wide by rust-toolchain.toml; rustfmt and clippy come with
+      # it, so no toolchain arguments are needed here.
+      - name: Show toolchain
+        run: |
+          rustc --version
+          cargo --version
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: codex-gateway-${{ matrix.os }}
+
+      - name: WINDOWS_FMT / LINUX_FMT
+        run: cargo fmt --all -- --check
+
+      - name: WINDOWS_CHECK / LINUX_CHECK
+        run: cargo check -p llmtrim --lib --locked
+
+      - name: WINDOWS_TEST / LINUX_TEST
+        run: cargo test -p llmtrim --lib --locked codex_gateway
+
+      # Clippy runs on the whole crate, but this workflow answers a narrower question: did
+      # *this* contribution introduce a lint? The repository denies several clippy lints, so a
+      # pre-existing one in upstream code arrives as `level: "error"` even though it is not a
+      # compilation failure. The gate therefore classifies by the structured lint code rather
+      # than by level alone: a real compile error fails anywhere, a clippy lint fails only in
+      # the gateway module, and an upstream lint is reported without failing this workflow.
+      - name: WINDOWS_CLIPPY_GATE / LINUX_CLIPPY_GATE
+        shell: bash
+        env:
+          # Cleared for this step only, so the workflow-level `-D warnings` does not add a
+          # second promotion path on top of the repository's own deny configuration.
+          RUSTFLAGS: ""
+        run: |
+          set -uo pipefail
+          # GitHub runs `shell: bash` with `-e`, so a non-zero cargo exit would abort before
+          # the code could be captured. `|| CARGO_EXIT=$?` suppresses that and records it: a
+          # denied upstream lint makes cargo exit non-zero without being our failure.
+          CARGO_EXIT=0
+          cargo clippy -p llmtrim --lib --no-deps --locked --message-format=json > clippy.json || CARGO_EXIT=$?
+          PY=$(command -v python3 || command -v python)
+          "$PY" - clippy.json "$CARGO_EXIT" <<'PYEOF'
+          import json, sys
+
+          TARGET = "crates/llmtrim-cli/src/codex_gateway.rs"
+
+          def norm(path):
+              return path.replace("\\", "/")
+
+          def touches_target(message):
+              for span in message.get("spans") or []:
+                  if norm(span.get("file_name", "")).endswith(TARGET):
+                      return True
+              return False
+
+          diagnostics_path = sys.argv[1]
+          cargo_exit = int(sys.argv[2])
+
+          gateway_lints = 0
+          gateway_other = 0
+          upstream_lints = 0
+          upstream_denies = 0
+          non_clippy_errors = 0
+          parsed = 0
+          detail = []
+
+          with open(diagnostics_path, encoding="utf-8") as handle:
+              for raw in handle:
+                  raw = raw.strip()
+                  if not raw.startswith("{"):
+                      continue
+                  try:
+                      record = json.loads(raw)
+                  except ValueError:
+                      continue
+                  parsed += 1
+                  if record.get("reason") != "compiler-message":
+                      continue
+                  message = record.get("message") or {}
+                  level = message.get("level")
+                  code = (message.get("code") or {}).get("code")
+                  # Only the structured code identifies a clippy lint; the human text never does.
+                  is_clippy = bool(code) and code.startswith("clippy::")
+                  in_gateway = touches_target(message)
+                  span = (message.get("spans") or [{}])[0]
+                  where = "%s:%s" % (norm(span.get("file_name", "?")), span.get("line_start", "?"))
+                  head = (message.get("message") or "")[:120]
+                  label = code or "-"
+
+                  if is_clippy and in_gateway:
+                      gateway_lints += 1
+                      detail.append("FAIL gateway lint   %-28s %s %s" % (label, where, head))
+                  elif is_clippy:
+                      upstream_lints += 1
+                      if level == "error":
+                          upstream_denies += 1
+                      detail.append("     upstream lint   %-28s %s %s" % (label, where, head))
+                  elif level == "error":
+                      # A real compilation error fails the gate wherever it comes from.
+                      non_clippy_errors += 1
+                      detail.append("FAIL compile error  %-28s %s %s" % (label, where, head))
+                  elif level == "warning" and in_gateway:
+                      # Our own file must be clean of every diagnostic, not only clippy ones.
+                      gateway_other += 1
+                      detail.append("FAIL gateway warn   %-28s %s %s" % (label, where, head))
+
+          print("GATEWAY_CLIPPY_LINT_COUNT=%d" % gateway_lints)
+          print("GATEWAY_OTHER_DIAGNOSTIC_COUNT=%d" % gateway_other)
+          print("UPSTREAM_CLIPPY_LINT_COUNT=%d" % upstream_lints)
+          print("UPSTREAM_CLIPPY_DENY_COUNT=%d" % upstream_denies)
+          print("NON_CLIPPY_ERROR_COUNT=%d" % non_clippy_errors)
+          print("CARGO_EXIT=%d" % cargo_exit)
+          for line in detail:
+              print("  " + line)
+
+          fatal = gateway_lints or gateway_other or non_clippy_errors
+          # A non-zero cargo exit is tolerated only when a denied clippy lint outside the gateway
+          # fully explains it. An unexplained failure is a crash or an infrastructure problem and
+          # must never be reported as success.
+          if cargo_exit != 0 and not fatal and upstream_denies == 0:
+              print("::error::cargo clippy failed with no diagnostic that explains it")
+              fatal = 1
+          if parsed == 0 and cargo_exit != 0:
+              print("::error::cargo clippy produced no parsable diagnostics")
+              fatal = 1
+
+          if fatal:
+              print("::error::the gateway clippy gate failed")
+              sys.exit(1)
+          print("gateway clippy gate: clean")
+          PYEOF
+
+  # The security contract is expressed as tests inside the module, so it is enforced by the
+  # compiler and the test runner rather than by a grep over the whole repository — the legacy
+  # proxy legitimately contains every term this gateway must not use.
+  security-contract:
+    name: GATEWAY_SECURITY_CONTRACT
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: codex-gateway-contract
+
+      - name: Contract tests
+        run: |
+          cargo test -p llmtrim --lib --locked codex_gateway::tests::the_gateway_call_path_has_no_mitm_no_ca_and_no_proxy_env
+          cargo test -p llmtrim --lib --locked codex_gateway::tests::the_gateway_needs_no_api_key
+          cargo test -p llmtrim --lib --locked codex_gateway::tests::the_gateway_writes_nothing_to_disk
+          cargo test -p llmtrim --lib --locked codex_gateway::listener::tests
+
+      # A second, coarser net over the gateway module only. The in-module tests already pin
+      # these, but a reviewer reading the workflow can see the list without opening the source.
+      - name: Forbidden mechanisms in the gateway module
+        shell: bash
+        run: |
+          set -euo pipefail
+          module=crates/llmtrim-cli/src/codex_gateway.rs
+          # Strip comments and the test module: prose names what the design avoids, and the
+          # tests necessarily spell out what they forbid.
+          production=$(sed '/#\[cfg(test)\]/,$d' "$module" | grep -v '^\s*//')
+          fail=0
+          for term in HTTPS_PROXY HTTP_PROXY ALL_PROXY NODE_EXTRA_CA_CERTS SSL_CERT_FILE \
+                      CURL_CA_BUNDLE rcgen hudsucker ca.key certutil capture_dir \
+                      OPENAI_API_KEY ANTHROPIC_API_KEY fs::write File::create; do
+            if printf '%s' "$production" | grep -qF -- "$term"; then
+              echo "::error::gateway module must not use $term"
+              fail=1
+            fi
+          done
+          exit $fail
+
+  # Proves the whole exchange against a fake upstream on loopback. No external host is
+  # contacted: the production upstream is a constant, and the test reaches it through a seam.
+  e2e:
+    name: GATEWAY_E2E
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: codex-gateway-e2e
+      - name: Synthetic end-to-end
+        run: cargo test -p llmtrim --lib --locked codex_gateway::tests::synthetic_end_to_end_fake_codex_to_gateway_to_fake_upstream -- --nocapture

--- a/.github/workflows/codex-gateway.yml
+++ b/.github/workflows/codex-gateway.yml
@@ -8,7 +8,10 @@ on:
   pull_request:
     paths:
       - "crates/llmtrim-cli/src/codex_gateway.rs"
+      - "crates/llmtrim-cli/src/codex_gateway/**"
+      - "crates/llmtrim-cli/src/main.rs"
       - "crates/llmtrim-cli/src/lib.rs"
+      - "crates/llmtrim-cli/Cargo.toml"
       - "crates/llmtrim-core/**"
       - "docs/codex-local-gateway.md"
       - ".github/workflows/codex-gateway.yml"
@@ -54,7 +57,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: WINDOWS_CHECK / LINUX_CHECK
-        run: cargo check -p llmtrim --lib --locked
+        run: cargo check -p llmtrim --lib --bins --locked
 
       - name: WINDOWS_TEST / LINUX_TEST
         run: cargo test -p llmtrim --lib --locked codex_gateway
@@ -82,14 +85,18 @@ jobs:
           "$PY" - clippy.json "$CARGO_EXIT" <<'PYEOF'
           import json, sys
 
-          TARGET = "crates/llmtrim-cli/src/codex_gateway.rs"
+          # The gateway is a module *tree*: the policy file plus every submodule under it.
+          # A lint in a submodule is ours exactly as much as one in the parent file.
+          GATEWAY_FILE = "crates/llmtrim-cli/src/codex_gateway.rs"
+          GATEWAY_DIR = "crates/llmtrim-cli/src/codex_gateway/"
 
           def norm(path):
               return path.replace("\\", "/")
 
           def touches_target(message):
               for span in message.get("spans") or []:
-                  if norm(span.get("file_name", "")).endswith(TARGET):
+                  path = norm(span.get("file_name", ""))
+                  if path.endswith(GATEWAY_FILE) or GATEWAY_DIR in path:
                       return True
               return False
 

--- a/.github/workflows/codex-gateway.yml
+++ b/.github/workflows/codex-gateway.yml
@@ -195,6 +195,12 @@ jobs:
           cargo test -p llmtrim --lib --locked codex_gateway::tests::the_gateway_needs_no_api_key
           cargo test -p llmtrim --lib --locked codex_gateway::tests::the_gateway_writes_nothing_to_disk
           cargo test -p llmtrim --lib --locked codex_gateway::listener::tests
+          cargo test -p llmtrim --lib --locked codex_gateway::upstream::tests
+          cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::the_socket_layer_writes_nothing_and_carries_no_secret
+          cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::socket_binds_ipv4_loopback_only
+          cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::socket_rejects_non_loopback_configuration
+          cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::a_body_over_the_ceiling_is_refused_before_the_upstream_leg
+          cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::no_local_header_can_redirect_the_gateway
 
       # A second, coarser net over the gateway module only. The in-module tests already pin
       # these, but a reviewer reading the workflow can see the list without opening the source.
@@ -202,18 +208,27 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          module=crates/llmtrim-cli/src/codex_gateway.rs
-          # Strip comments and the test module: prose names what the design avoids, and the
-          # tests necessarily spell out what they forbid.
-          production=$(sed '/#\[cfg(test)\]/,$d' "$module" | grep -v '^\s*//')
+          # The whole module tree, not just the policy file: a mechanism moved into a
+          # submodule would still sit on the call path.
+          modules="crates/llmtrim-cli/src/codex_gateway.rs"
+          for submodule in crates/llmtrim-cli/src/codex_gateway/*.rs; do
+            modules="$modules $submodule"
+          done
+          echo "scanning: $modules"
           fail=0
-          for term in HTTPS_PROXY HTTP_PROXY ALL_PROXY NODE_EXTRA_CA_CERTS SSL_CERT_FILE \
-                      CURL_CA_BUNDLE rcgen hudsucker ca.key certutil capture_dir \
-                      OPENAI_API_KEY ANTHROPIC_API_KEY fs::write File::create; do
-            if printf '%s' "$production" | grep -qF -- "$term"; then
-              echo "::error::gateway module must not use $term"
-              fail=1
-            fi
+          for module in $modules; do
+            # Strip comments and the test module: prose names what the design avoids, and the
+            # tests necessarily spell out what they forbid.
+            production=$(sed '/#\[cfg(test)\]/,$d' "$module" | grep -v '^\s*//' || true)
+            for term in HTTPS_PROXY HTTP_PROXY ALL_PROXY NODE_EXTRA_CA_CERTS SSL_CERT_FILE \
+                        CURL_CA_BUNDLE rcgen hudsucker ca.key certutil capture_dir \
+                        OPENAI_API_KEY ANTHROPIC_API_KEY CODEX_API_KEY fs::write \
+                        File::create OpenOptions danger_accept_invalid; do
+              if printf '%s' "$production" | grep -qF -- "$term"; then
+                echo "::error::$module must not use $term"
+                fail=1
+              fi
+            done
           done
           exit $fail
 
@@ -229,3 +244,15 @@ jobs:
           key: codex-gateway-e2e
       - name: Synthetic end-to-end
         run: cargo test -p llmtrim --lib --locked codex_gateway::tests::synthetic_end_to_end_fake_codex_to_gateway_to_fake_upstream -- --nocapture
+
+      # SOCKET_E2E: the same exchange, but over a real loopback socket with a real HTTP client
+      # at both ends. The upstream is still the fake, so no external host is contacted.
+      - name: SOCKET_E2E
+        run: cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::socket_end_to_end_fake_codex_to_real_socket_to_fake_upstream -- --nocapture
+
+      - name: Streaming and lifecycle
+        run: |
+          cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::socket_sse_order_preserved
+          cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::socket_relays_incrementally_without_buffering_the_response
+          cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::socket_shutdown_releases_port
+          cargo test -p llmtrim --lib --locked codex_gateway::socket::tests::socket_shutdown_leaves_no_listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Codex local gateway (`llmtrim codex-gateway`).** Runs llmtrim in front of Codex with no
+  proxy, no local certificate authority and no change to the machine's trust configuration:
+  Codex is pointed at `127.0.0.1:43200` through its own `[model_providers]` block, and the
+  gateway relays one route to `https://chatgpt.com`. Loopback-only bind, a single route, a
+  destination built from constants, no API key and nothing written to disk. The `safe`
+  lossless preset is pinned for this version, and SSE bytes are relayed unparsed and in
+  order. Validated with synthetic socket end-to-end tests and against a live
+  ChatGPT-signed-in session on Codex 0.146.0. See `docs/codex-local-gateway.md`.
+
 ## [0.13.4] - 2026-09-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
  "flate2",
  "http-body-util",
  "hudsucker",
+ "hyper",
  "hyper-http-proxy",
  "hyper-rustls",
  "hyper-util",

--- a/crates/llmtrim-cli/Cargo.toml
+++ b/crates/llmtrim-cli/Cargo.toml
@@ -66,6 +66,7 @@ tokio = { version = "1.52", features = [
   "net",
   "io-util",
   "signal",
+  "sync",
   "time",
 ], optional = true }
 # The MITM interceptor (`serve`).
@@ -87,8 +88,16 @@ hyper-http-proxy = { version = "1.1", default-features = false, features = [
 hyper-util = { version = "0.1", default-features = false, features = [
   "client-legacy",
   "http2",
+  "tokio",
 ], optional = true }
 http-body-util = { version = "0.1", optional = true }
+# The Codex localhost gateway's HTTP server (`codex_gateway::socket`). Already in the tree as
+# hudsucker's own dependency, so this adds no package and no version to the lock — it only makes
+# the server side of hyper reachable directly, instead of hand-rolling request framing.
+hyper = { version = "1", default-features = false, features = [
+  "server",
+  "http1",
+], optional = true }
 bytes = { version = "1", optional = true }
 llm_providers = { version = "0.14", optional = true }
 # Subscription reroute (`sub` = codex|kimi): OAuth (PKCE/device) + provider request/response
@@ -162,6 +171,7 @@ live = ["dep:async-openai", "dep:reqwest", "dep:tokio"]
 breakdown = ["dep:ratatui", "dep:crossterm"]
 intercept = [
   "dep:hudsucker",
+  "dep:hyper",
   "dep:tokio",
   "dep:http-body-util",
   "dep:bytes",

--- a/crates/llmtrim-cli/src/codex_gateway.rs
+++ b/crates/llmtrim-cli/src/codex_gateway.rs
@@ -1,0 +1,825 @@
+//! A loopback HTTP gateway that Codex can be pointed at with its own native configuration.
+//!
+//! Codex supports a user-level `[model_providers.<name>]` block with a `base_url`. When that
+//! provider carries no `env_key` and no `auth` block, `auth_manager_for_provider` hands it the
+//! session's own auth manager, and `BearerAuthProvider::add_auth_headers` attaches
+//! `Authorization: Bearer <chatgpt token>` plus `ChatGPT-Account-ID` — regardless of where
+//! `base_url` points. So Codex will happily send its normal, ChatGPT-authenticated Responses
+//! request to `http://127.0.0.1:<port>` in plaintext.
+//!
+//! That removes the entire reason the legacy path needs a MITM proxy: no `HTTPS_PROXY`, no
+//! local CA, no leaf certificates, no trust-store or `NODE_EXTRA_CA_CERTS` wiring. The gateway
+//! reads a plain local request, compresses the body with the same `llmtrim_core` the proxy
+//! uses, and forwards it upstream over ordinary HTTPS.
+//!
+//! Everything in this module is a pure function or sits behind the [`GatewayUpstream`] seam, so
+//! the whole pipeline is exercised offline without opening a socket or reaching the network.
+
+use std::collections::BTreeMap;
+
+use llmtrim_core::config::DenseConfig;
+use llmtrim_core::ir::ProviderKind;
+
+/// The only origin this gateway will ever talk to. Not configurable, not derived from the
+/// request: a client that can reach the loopback port must not be able to choose a
+/// destination, or the gateway becomes an open SSRF relay.
+pub const UPSTREAM_ORIGIN: &str = "https://chatgpt.com";
+
+/// The only route the gateway serves, matching what Codex posts for `wire_api = "responses"`.
+pub const GATEWAY_ROUTE: &str = "/backend-api/codex/responses";
+
+/// The compression profile the first gateway version pins: llmtrim's lossless input-only
+/// preset. Not configurable here — a silently promoted profile would change what the model
+/// sees without anyone asking for it.
+pub const GATEWAY_PRESET: &str = "safe";
+
+/// Headers the gateway forwards verbatim. `Authorization` and `ChatGPT-Account-ID` are the
+/// credentials Codex attached; they are passed through in memory and never inspected for
+/// meaning, logged or written down.
+pub const FORWARDED_HEADERS: [&str; 5] = [
+    "authorization",
+    "chatgpt-account-id",
+    "content-type",
+    "accept",
+    "originator",
+];
+
+/// Hop-by-hop headers that must not be relayed, plus the ones the upstream leg recomputes.
+pub const DROPPED_HEADERS: [&str; 7] = [
+    "host",
+    "content-length",
+    "connection",
+    "proxy-authorization",
+    "proxy-connection",
+    "transfer-encoding",
+    "upgrade",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayError {
+    /// The request did not use the one method the route accepts.
+    MethodNotAllowed,
+    /// The request targeted something other than the single served route.
+    RouteNotFound,
+    /// Codex did not attach the credentials it normally attaches.
+    MissingAuthorization,
+    /// The `Authorization` header was present but not in the expected bearer form.
+    MalformedAuthorization,
+    /// Compression failed. The gateway fails closed rather than quietly forwarding the
+    /// original body, so a session never silently runs without llmtrim.
+    CompressionFailed,
+    /// The upstream leg failed. No fallback, no alternate provider, no retry.
+    UpstreamFailed,
+}
+
+impl std::fmt::Display for GatewayError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::MethodNotAllowed => "method not allowed",
+            Self::RouteNotFound => "route not served by the codex gateway",
+            Self::MissingAuthorization => "request carried no authorization header",
+            Self::MalformedAuthorization => "authorization header was not a bearer token",
+            Self::CompressionFailed => "compression failed; refusing to forward uncompressed",
+            Self::UpstreamFailed => "upstream request failed",
+        })
+    }
+}
+
+impl std::error::Error for GatewayError {}
+
+impl GatewayError {
+    /// The status the gateway answers Codex with. Kept coarse on purpose.
+    #[must_use]
+    pub fn status(&self) -> u16 {
+        match self {
+            Self::MethodNotAllowed => 405,
+            Self::RouteNotFound => 404,
+            Self::MissingAuthorization | Self::MalformedAuthorization => 401,
+            Self::CompressionFailed => 500,
+            Self::UpstreamFailed => 502,
+        }
+    }
+}
+
+/// A request as it arrived on the loopback listener. Header names are lowercase.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayRequest {
+    pub method: String,
+    pub path: String,
+    pub headers: BTreeMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+/// What the gateway sends upstream, and what a test asserts on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamRequest {
+    pub url: String,
+    pub headers: BTreeMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+/// The upstream answer, streamed back to Codex chunk by chunk and otherwise untouched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamResponse {
+    pub status: u16,
+    pub headers: BTreeMap<String, String>,
+    /// Response body in the order the upstream produced it. For an SSE stream each element is
+    /// one wire chunk; the gateway must not merge, reorder or rewrite them.
+    pub chunks: Vec<Vec<u8>>,
+}
+
+/// The network seam. Production implements it with an ordinary HTTPS client; tests implement
+/// it with a fake, which is what keeps the whole pipeline offline.
+pub trait GatewayUpstream {
+    fn send(&mut self, request: UpstreamRequest) -> Result<UpstreamResponse, GatewayError>;
+}
+
+/// Accept only the exact method and route Codex uses.
+pub fn validate_route(method: &str, path: &str) -> Result<(), GatewayError> {
+    // Compare the path only, never a caller-supplied absolute URL: an absolute-form target
+    // would carry a destination, which this gateway must never honour.
+    let path = path.split('?').next().unwrap_or(path);
+    if path != GATEWAY_ROUTE {
+        return Err(GatewayError::RouteNotFound);
+    }
+    if !method.eq_ignore_ascii_case("POST") {
+        return Err(GatewayError::MethodNotAllowed);
+    }
+    Ok(())
+}
+
+/// Require the credentials Codex attaches, by shape only.
+///
+/// The value is never parsed for meaning, decoded or compared against anything. This exists so
+/// the loopback port is not an anonymous relay: without the caller's own bearer, no
+/// authenticated upstream request happens.
+pub fn auth_gate(headers: &BTreeMap<String, String>) -> Result<(), GatewayError> {
+    let value = headers
+        .get("authorization")
+        .ok_or(GatewayError::MissingAuthorization)?;
+    let rest = value
+        .strip_prefix("Bearer ")
+        .or_else(|| value.strip_prefix("bearer "))
+        .ok_or(GatewayError::MalformedAuthorization)?;
+    if rest.trim().is_empty() {
+        return Err(GatewayError::MalformedAuthorization);
+    }
+    Ok(())
+}
+
+/// The upstream URL. Built from two constants — nothing from the request contributes.
+#[must_use]
+pub fn upstream_url() -> String {
+    format!("{UPSTREAM_ORIGIN}{GATEWAY_ROUTE}")
+}
+
+/// Select the headers to relay. Anything not on the forward list is dropped, so a client
+/// cannot smuggle routing or proxy directives through the gateway.
+#[must_use]
+pub fn forward_headers(incoming: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    incoming
+        .iter()
+        .filter(|(name, _)| {
+            let lowered = name.to_ascii_lowercase();
+            FORWARDED_HEADERS.contains(&lowered.as_str())
+                && !DROPPED_HEADERS.contains(&lowered.as_str())
+        })
+        .map(|(name, value)| (name.to_ascii_lowercase(), value.clone()))
+        .collect()
+}
+
+/// Compress the request body with the product's real transform.
+///
+/// Fail-closed by design, and deliberately different from the legacy proxy: there, a body that
+/// does not shrink is forwarded verbatim so a user never pays more. Here the point is to know
+/// the gateway is doing its job, so a failure surfaces instead of silently passing through.
+pub fn compress_body(body: &[u8]) -> Result<Vec<u8>, GatewayError> {
+    let text = std::str::from_utf8(body).map_err(|_| GatewayError::CompressionFailed)?;
+    let config = DenseConfig::preset(GATEWAY_PRESET).ok_or(GatewayError::CompressionFailed)?;
+    let result = llmtrim_core::compress_with_config(text, Some(ProviderKind::OpenAi), &config)
+        .map_err(|_| GatewayError::CompressionFailed)?;
+    Ok(result.request_json.into_bytes())
+}
+
+/// Byte counts for one exchange. Metadata only — no body, no header, no credential.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct GatewayMetrics {
+    pub local_request_bytes: u64,
+    pub upstream_request_bytes: u64,
+    pub response_chunks: u64,
+    pub status: u16,
+}
+
+impl GatewayMetrics {
+    /// Reduction in hundredths of a percent. Local estimate, not official Codex usage.
+    #[must_use]
+    pub fn reduction_basis_points(&self) -> i128 {
+        if self.local_request_bytes == 0 {
+            return 0;
+        }
+        let saved = i128::from(self.local_request_bytes) - i128::from(self.upstream_request_bytes);
+        saved * 10_000 / i128::from(self.local_request_bytes)
+    }
+}
+
+/// The whole pipeline: validate, gate, compress, forward, relay.
+pub fn handle<U: GatewayUpstream>(
+    request: &GatewayRequest,
+    upstream: &mut U,
+) -> Result<(UpstreamResponse, GatewayMetrics), GatewayError> {
+    validate_route(&request.method, &request.path)?;
+    auth_gate(&request.headers)?;
+
+    let compressed = compress_body(&request.body)?;
+    let outgoing = UpstreamRequest {
+        url: upstream_url(),
+        headers: forward_headers(&request.headers),
+        body: compressed,
+    };
+    let metrics = GatewayMetrics {
+        local_request_bytes: request.body.len() as u64,
+        upstream_request_bytes: outgoing.body.len() as u64,
+        ..GatewayMetrics::default()
+    };
+
+    let response = upstream.send(outgoing)?;
+    let metrics = GatewayMetrics {
+        response_chunks: response.chunks.len() as u64,
+        status: response.status,
+        ..metrics
+    };
+    Ok((response, metrics))
+}
+
+/// The loopback listener. Separated from [`handle`] so the pipeline stays testable without a
+/// socket, and so the bind policy is a value that can be asserted rather than a literal buried
+/// in a server call.
+pub mod listener {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    /// The only address family and host the gateway will bind. A MITM-free local gateway that
+    /// answered on a routable address would hand every machine on the network a way to spend
+    /// the user's ChatGPT quota.
+    pub const BIND_HOST: Ipv4Addr = Ipv4Addr::LOCALHOST;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum BindError {
+        /// Anything that is not IPv4 loopback.
+        NotLoopback,
+    }
+
+    impl std::fmt::Display for BindError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("the codex gateway only binds 127.0.0.1")
+        }
+    }
+
+    impl std::error::Error for BindError {}
+
+    /// Resolve the address the gateway may listen on. The host is not configurable: only the
+    /// port is, and an explicitly requested non-loopback host is refused rather than silently
+    /// corrected, so a misconfiguration is visible.
+    pub fn bind_address(
+        requested_host: Option<IpAddr>,
+        port: u16,
+    ) -> Result<SocketAddr, BindError> {
+        match requested_host {
+            None => Ok(SocketAddr::from((BIND_HOST, port))),
+            Some(IpAddr::V4(host)) if host == Ipv4Addr::LOCALHOST => {
+                Ok(SocketAddr::from((BIND_HOST, port)))
+            }
+            Some(_) => Err(BindError::NotLoopback),
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{BIND_HOST, BindError, bind_address};
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+        #[test]
+        fn the_default_bind_is_ipv4_loopback() {
+            let address = bind_address(None, 43117).expect("default binds");
+            assert_eq!(address.ip(), IpAddr::V4(BIND_HOST));
+            assert!(address.ip().is_loopback());
+            assert_eq!(address.port(), 43117);
+        }
+
+        #[test]
+        fn an_all_interfaces_bind_is_refused() {
+            assert_eq!(
+                bind_address(Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED)), 43117),
+                Err(BindError::NotLoopback)
+            );
+        }
+
+        #[test]
+        fn a_public_ipv6_bind_is_refused() {
+            for host in [
+                IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
+                IpAddr::V6("::1".parse().expect("v6")),
+            ] {
+                assert_eq!(
+                    bind_address(Some(host), 43117),
+                    Err(BindError::NotLoopback),
+                    "{host}"
+                );
+            }
+        }
+
+        #[test]
+        fn a_routable_address_is_refused() {
+            for host in ["192.168.1.10", "10.0.0.5", "8.8.8.8"] {
+                assert_eq!(
+                    bind_address(Some(host.parse().expect("ip")), 43117),
+                    Err(BindError::NotLoopback),
+                    "{host}"
+                );
+            }
+        }
+
+        #[test]
+        fn explicit_loopback_is_accepted_and_normalized() {
+            let address = bind_address(Some(IpAddr::V4(Ipv4Addr::LOCALHOST)), 0).expect("loopback");
+            assert!(address.ip().is_loopback());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DROPPED_HEADERS, GATEWAY_PRESET, GATEWAY_ROUTE, GatewayError, GatewayRequest,
+        GatewayUpstream, UPSTREAM_ORIGIN, UpstreamRequest, UpstreamResponse, auth_gate,
+        compress_body, forward_headers, handle, upstream_url, validate_route,
+    };
+    use std::collections::BTreeMap;
+
+    /// The production half of this file — everything before the test module. The scans below
+    /// must not read their own assertion lists, which necessarily name what they forbid.
+    fn production_source() -> String {
+        let whole = include_str!("codex_gateway.rs");
+        let marker = concat!("#[cfg(", "test)]");
+        let production = whole.split(marker).next().expect("production half");
+        // Comments are prose: the module doc names the very mechanisms this architecture
+        // avoids, and scanning them would forbid explaining the design.
+        production
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join(
+                "
+",
+            )
+    }
+
+    /// Fictitious sentinels. Any real credential would be a bug in the test, not a secret.
+    const FAKE_BEARER: &str = "Bearer SUPER_SECRET_DO_NOT_LEAK";
+    const FAKE_ACCOUNT: &str = "FAKE_ACCOUNT_DO_NOT_LEAK";
+
+    /// Stands in for chatgpt.com. Records exactly what the gateway tried to send, so the test
+    /// can assert on the wire without a socket or a network.
+    #[derive(Default)]
+    struct FakeUpstream {
+        seen: Vec<UpstreamRequest>,
+        reply: Option<UpstreamResponse>,
+        fail: bool,
+    }
+
+    impl FakeUpstream {
+        fn streaming() -> Self {
+            Self {
+                reply: Some(UpstreamResponse {
+                    status: 200,
+                    headers: BTreeMap::from([(
+                        "content-type".to_string(),
+                        "text/event-stream".to_string(),
+                    )]),
+                    chunks: vec![
+                        b"event: response.created\ndata: {\"a\":1}\n\n".to_vec(),
+                        b"event: response.output_text.delta\ndata: {\"d\":\"x\"}\n\n".to_vec(),
+                        b"event: response.completed\ndata: {\"done\":true}\n\n".to_vec(),
+                    ],
+                }),
+                ..Self::default()
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                fail: true,
+                ..Self::default()
+            }
+        }
+    }
+
+    impl GatewayUpstream for FakeUpstream {
+        fn send(&mut self, request: UpstreamRequest) -> Result<UpstreamResponse, GatewayError> {
+            self.seen.push(request);
+            if self.fail {
+                return Err(GatewayError::UpstreamFailed);
+            }
+            Ok(self.reply.clone().unwrap_or(UpstreamResponse {
+                status: 200,
+                headers: BTreeMap::new(),
+                chunks: vec![b"{}".to_vec()],
+            }))
+        }
+    }
+
+    /// A Responses-shaped body carrying repetitive tool output — the shape llmtrim shrinks.
+    fn codex_body() -> Vec<u8> {
+        let records: Vec<String> = (0..80)
+            .map(|i| {
+                format!(
+                    r#"{{"requestId":"REQ-{i:06}","service":"billing","level":"INFO","latencyMs":{},"route":"/api/v1/billing/items","region":"sa-east-1","message":"request completed"}}"#,
+                    12 + i
+                )
+            })
+            .collect();
+        // Pretty-printed, like real tool output: whitespace and repeated keys are exactly
+        // what the lossless `safe` preset removes. A pre-minified fixture would leave it
+        // nothing to do and prove nothing.
+        let parsed: Vec<serde_json::Value> = records
+            .iter()
+            .map(|r| serde_json::from_str(r).expect("record"))
+            .collect();
+        let tool_output = serde_json::to_string_pretty(&parsed).expect("pretty tool output");
+        let content = format!(
+            "PRIVATE_PROMPT_DO_NOT_LEAK Read the log tool output and reply with the requestId of REQ-000057.\n\n{tool_output}"
+        );
+        serde_json::to_vec(&serde_json::json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{ "role": "user", "content": content }],
+        }))
+        .expect("serialize body")
+    }
+
+    fn codex_request() -> GatewayRequest {
+        GatewayRequest {
+            method: "POST".to_string(),
+            path: GATEWAY_ROUTE.to_string(),
+            headers: BTreeMap::from([
+                ("authorization".to_string(), FAKE_BEARER.to_string()),
+                ("chatgpt-account-id".to_string(), FAKE_ACCOUNT.to_string()),
+                ("content-type".to_string(), "application/json".to_string()),
+                ("host".to_string(), "127.0.0.1:45999".to_string()),
+                ("content-length".to_string(), "999".to_string()),
+            ]),
+            body: codex_body(),
+        }
+    }
+
+    // ----- route and method -------------------------------------------------------------
+
+    #[test]
+    fn the_gateway_serves_exactly_one_route() {
+        validate_route("POST", GATEWAY_ROUTE).expect("the codex route is served");
+        assert_eq!(
+            validate_route("POST", "/v1/responses"),
+            Err(GatewayError::RouteNotFound)
+        );
+        assert_eq!(
+            validate_route("POST", "/"),
+            Err(GatewayError::RouteNotFound)
+        );
+        assert_eq!(
+            validate_route("GET", GATEWAY_ROUTE),
+            Err(GatewayError::MethodNotAllowed)
+        );
+    }
+
+    #[test]
+    fn an_absolute_form_target_is_not_a_destination() {
+        // A proxy would treat this as "go to example.com". The gateway must not: it only ever
+        // compares the path, and an absolute URL is simply not the served route.
+        for hostile in [
+            "http://example.com/backend-api/codex/responses",
+            "https://api.openai.com/v1/responses",
+            "//evil.example/backend-api/codex/responses",
+        ] {
+            assert_eq!(
+                validate_route("POST", hostile),
+                Err(GatewayError::RouteNotFound),
+                "{hostile}"
+            );
+        }
+    }
+
+    // ----- auth -------------------------------------------------------------------------
+
+    #[test]
+    fn a_request_without_the_callers_own_bearer_never_reaches_upstream() {
+        let mut request = codex_request();
+        request.headers.remove("authorization");
+        let mut upstream = FakeUpstream::default();
+        assert_eq!(
+            handle(&request, &mut upstream),
+            Err(GatewayError::MissingAuthorization)
+        );
+        assert!(
+            upstream.seen.is_empty(),
+            "the loopback port must not be an anonymous relay"
+        );
+    }
+
+    #[test]
+    fn a_malformed_authorization_is_rejected_by_shape_alone() {
+        for value in ["", "Token abc", "Bearer ", "Bearer    "] {
+            let mut headers = BTreeMap::new();
+            headers.insert("authorization".to_string(), value.to_string());
+            assert!(auth_gate(&headers).is_err(), "{value:?}");
+        }
+        // Shape only: any non-empty bearer passes, because the gateway never interprets it.
+        let mut ok = BTreeMap::new();
+        ok.insert("authorization".to_string(), FAKE_BEARER.to_string());
+        auth_gate(&ok).expect("a well-formed bearer passes");
+    }
+
+    // ----- upstream is fixed ------------------------------------------------------------
+
+    #[test]
+    fn the_upstream_is_two_constants_and_nothing_from_the_request() {
+        assert_eq!(upstream_url(), format!("{UPSTREAM_ORIGIN}{GATEWAY_ROUTE}"));
+        assert!(upstream_url().starts_with("https://chatgpt.com"));
+    }
+
+    #[test]
+    fn no_header_can_redirect_the_gateway() {
+        let mut request = codex_request();
+        for (name, value) in [
+            ("x-upstream", "https://evil.example"),
+            ("host", "evil.example"),
+            ("x-forwarded-host", "evil.example"),
+            ("forwarded", "host=evil.example"),
+        ] {
+            request.headers.insert(name.to_string(), value.to_string());
+        }
+        let mut upstream = FakeUpstream::default();
+        handle(&request, &mut upstream).expect("still handled");
+        let sent = &upstream.seen[0];
+        assert_eq!(
+            sent.url,
+            upstream_url(),
+            "the destination is not negotiable"
+        );
+        for leaked in ["x-upstream", "x-forwarded-host", "forwarded", "host"] {
+            assert!(!sent.headers.contains_key(leaked), "{leaked} was relayed");
+        }
+    }
+
+    #[test]
+    fn hop_by_hop_headers_are_not_relayed() {
+        let mut request = codex_request();
+        for name in DROPPED_HEADERS {
+            request.headers.insert(name.to_string(), "x".to_string());
+        }
+        let forwarded = forward_headers(&request.headers);
+        for name in DROPPED_HEADERS {
+            assert!(!forwarded.contains_key(name), "{name}");
+        }
+    }
+
+    // ----- credentials pass through, untouched ------------------------------------------
+
+    #[test]
+    fn the_callers_credentials_reach_upstream_byte_for_byte() {
+        let request = codex_request();
+        let mut upstream = FakeUpstream::default();
+        handle(&request, &mut upstream).expect("handled");
+        let sent = &upstream.seen[0];
+        assert_eq!(
+            sent.headers.get("authorization").map(String::as_str),
+            Some(FAKE_BEARER)
+        );
+        assert_eq!(
+            sent.headers.get("chatgpt-account-id").map(String::as_str),
+            Some(FAKE_ACCOUNT)
+        );
+    }
+
+    // ----- compression ------------------------------------------------------------------
+
+    #[test]
+    fn the_body_is_compressed_by_the_products_real_transform() {
+        let request = codex_request();
+        let mut upstream = FakeUpstream::default();
+        let (_, metrics) = handle(&request, &mut upstream).expect("handled");
+        let sent = &upstream.seen[0];
+        assert!(
+            sent.body.len() < request.body.len(),
+            "upstream body {} must be smaller than the local body {}",
+            sent.body.len(),
+            request.body.len()
+        );
+        assert_eq!(metrics.local_request_bytes, request.body.len() as u64);
+        assert_eq!(metrics.upstream_request_bytes, sent.body.len() as u64);
+        assert!(metrics.reduction_basis_points() > 0);
+    }
+
+    #[test]
+    fn the_compressed_body_keeps_what_the_task_needs() {
+        let request = codex_request();
+        let mut upstream = FakeUpstream::default();
+        handle(&request, &mut upstream).expect("handled");
+        let sent = String::from_utf8(upstream.seen[0].body.clone()).expect("utf-8");
+        for marker in ["REQ-000057", "gpt-5.6-sol", "billing"] {
+            assert!(sent.contains(marker), "transform dropped {marker}");
+        }
+    }
+
+    #[test]
+    fn the_gateway_pins_the_safe_profile() {
+        assert_eq!(GATEWAY_PRESET, "safe");
+        assert!(llmtrim_core::config::DenseConfig::preset(GATEWAY_PRESET).is_some());
+    }
+
+    #[test]
+    fn compression_failure_is_closed_not_open() {
+        // Invalid UTF-8 cannot be compressed. The legacy proxy would forward the original;
+        // this gateway must refuse, so a session never silently runs without llmtrim.
+        let mut request = codex_request();
+        request.body = vec![0xff, 0xfe, 0xfd];
+        let mut upstream = FakeUpstream::default();
+        assert_eq!(
+            handle(&request, &mut upstream),
+            Err(GatewayError::CompressionFailed)
+        );
+        assert!(
+            upstream.seen.is_empty(),
+            "nothing may be forwarded when compression fails"
+        );
+        assert!(compress_body(&[0xff, 0xfe]).is_err());
+    }
+
+    // ----- response ---------------------------------------------------------------------
+
+    #[test]
+    fn a_streamed_response_is_relayed_chunk_for_chunk_in_order() {
+        let request = codex_request();
+        let mut upstream = FakeUpstream::streaming();
+        let expected = upstream.reply.clone().expect("reply");
+        let (response, metrics) = handle(&request, &mut upstream).expect("handled");
+        assert_eq!(
+            response.chunks, expected.chunks,
+            "SSE order must be preserved"
+        );
+        assert_eq!(response.status, 200);
+        assert_eq!(
+            response.headers.get("content-type").map(String::as_str),
+            Some("text/event-stream")
+        );
+        assert_eq!(metrics.response_chunks, 3);
+    }
+
+    #[test]
+    fn an_upstream_failure_is_reported_not_worked_around() {
+        let request = codex_request();
+        let mut upstream = FakeUpstream::failing();
+        assert_eq!(
+            handle(&request, &mut upstream),
+            Err(GatewayError::UpstreamFailed)
+        );
+        assert_eq!(upstream.seen.len(), 1, "no retry, no second provider");
+    }
+
+    // ----- what the gateway must not do -------------------------------------------------
+
+    #[test]
+    fn errors_never_render_a_credential() {
+        for error in [
+            GatewayError::MissingAuthorization,
+            GatewayError::MalformedAuthorization,
+            GatewayError::CompressionFailed,
+            GatewayError::UpstreamFailed,
+            GatewayError::RouteNotFound,
+            GatewayError::MethodNotAllowed,
+        ] {
+            let rendered = format!("{error} {error:?}");
+            for sentinel in [
+                "SUPER_SECRET_DO_NOT_LEAK",
+                "FAKE_ACCOUNT_DO_NOT_LEAK",
+                "Bearer ",
+            ] {
+                assert!(!rendered.contains(sentinel), "{error:?} leaked {sentinel}");
+            }
+        }
+    }
+
+    #[test]
+    fn metrics_carry_no_content() {
+        let request = codex_request();
+        let mut upstream = FakeUpstream::streaming();
+        let (_, metrics) = handle(&request, &mut upstream).expect("handled");
+        let rendered = format!("{metrics:?}");
+        for sentinel in [
+            "SUPER_SECRET_DO_NOT_LEAK",
+            "FAKE_ACCOUNT_DO_NOT_LEAK",
+            "REQ-",
+            "billing",
+        ] {
+            assert!(!rendered.contains(sentinel), "metrics leaked {sentinel}");
+        }
+    }
+
+    // ----- synthetic end-to-end ---------------------------------------------------------
+
+    #[test]
+    fn synthetic_end_to_end_fake_codex_to_gateway_to_fake_upstream() {
+        let request = codex_request();
+        let mut upstream = FakeUpstream::streaming();
+        let expected_stream = upstream.reply.clone().expect("reply").chunks;
+
+        let (response, metrics) = handle(&request, &mut upstream).expect("the exchange completes");
+
+        // A: the client sent a controlled payload; B: the gateway received it.
+        assert_eq!(metrics.local_request_bytes, request.body.len() as u64);
+        // C + D: real compression happened and the upstream body is smaller.
+        let sent = &upstream.seen[0];
+        assert!(sent.body.len() < request.body.len());
+        // E: the semantic marker survived.
+        let sent_text = String::from_utf8(sent.body.clone()).expect("utf-8");
+        assert!(sent_text.contains("REQ-000057"));
+        // F + G: credentials arrived identical.
+        assert_eq!(
+            sent.headers.get("authorization").map(String::as_str),
+            Some(FAKE_BEARER)
+        );
+        assert_eq!(
+            sent.headers.get("chatgpt-account-id").map(String::as_str),
+            Some(FAKE_ACCOUNT)
+        );
+        // H: nothing observable carries the sentinel.
+        let observable = format!("{metrics:?} {:?} {}", response.status, upstream_url());
+        assert!(!observable.contains("SUPER_SECRET_DO_NOT_LEAK"));
+        // J: the stream came back unchanged, in order.
+        assert_eq!(response.chunks, expected_stream);
+
+        // Reported for the delivery; a local estimate, never official Codex usage.
+        println!("LOCAL_REQUEST_BYTES={}", metrics.local_request_bytes);
+        println!("UPSTREAM_REQUEST_BYTES={}", metrics.upstream_request_bytes);
+        println!(
+            "LOCAL_PAYLOAD_REDUCTION_PERCENT={:.2}",
+            metrics.reduction_basis_points() as f64 / 100.0
+        );
+    }
+
+    #[test]
+    fn the_gateway_writes_nothing_to_disk() {
+        // I: no capture file, no ledger, no log. The module has no filesystem surface at all,
+        // which this test pins by construction: a future `fs::write` in the call path would
+        // have to be added here to be reachable.
+        let source = production_source();
+        let source = source.as_str();
+        for forbidden in [
+            "fs::write",
+            "File::create",
+            "OpenOptions",
+            "capture_dir",
+            "remove_dir_all",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "the gateway call path must not touch the filesystem: {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_gateway_call_path_has_no_mitm_no_ca_and_no_proxy_env() {
+        let source = production_source();
+        let source = source.as_str();
+        for forbidden in [
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+            "ALL_PROXY",
+            "NODE_EXTRA_CA_CERTS",
+            "SSL_CERT_FILE",
+            "CURL_CA_BUNDLE",
+            "rcgen",
+            "hudsucker",
+            "ca.key",
+            "CONNECT",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "the new architecture must not reintroduce {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_gateway_needs_no_api_key() {
+        let source = production_source();
+        let source = source.as_str();
+        for forbidden in [
+            "OPENAI_API_KEY",
+            "CODEX_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "env_key",
+        ] {
+            assert!(!source.contains(forbidden), "{forbidden} must not appear");
+        }
+    }
+}

--- a/crates/llmtrim-cli/src/codex_gateway.rs
+++ b/crates/llmtrim-cli/src/codex_gateway.rs
@@ -47,6 +47,10 @@ pub const FORWARDED_HEADERS: [&str; 5] = [
     "originator",
 ];
 
+/// The one header that survives only when the body is forwarded untransformed. See
+/// [`prepare`] for why it is handled there instead of in [`FORWARDED_HEADERS`].
+pub const CONTENT_ENCODING: &str = "content-encoding";
+
 /// Hop-by-hop headers that must not be relayed, plus the ones the upstream leg recomputes.
 pub const DROPPED_HEADERS: [&str; 7] = [
     "host",
@@ -72,8 +76,10 @@ pub enum GatewayError {
     MalformedRequest,
     /// The `Authorization` header was present but not in the expected bearer form.
     MalformedAuthorization,
-    /// Compression failed. The gateway fails closed rather than quietly forwarding the
-    /// original body, so a session never silently runs without llmtrim.
+    /// The transform could not run over this body. Reported by [`compress_body`] so the
+    /// caller can decide; [`prepare`] treats it as a failed *optimisation* and forwards the
+    /// original request unchanged, because losing a turn is worse than losing a reduction.
+    /// The security gates — route, method, bearer, destination — still fail closed.
     CompressionFailed,
     /// The upstream leg failed. No fallback, no alternate provider, no retry.
     UpstreamFailed,
@@ -88,7 +94,7 @@ impl std::fmt::Display for GatewayError {
             Self::RequestTooLarge => "request body exceeded the gateway limit",
             Self::MalformedRequest => "request body could not be read",
             Self::MalformedAuthorization => "authorization header was not a bearer token",
-            Self::CompressionFailed => "compression failed; refusing to forward uncompressed",
+            Self::CompressionFailed => "compression failed",
             Self::UpstreamFailed => "upstream request failed",
         })
     }
@@ -201,9 +207,12 @@ pub fn forward_headers(incoming: &BTreeMap<String, String>) -> BTreeMap<String, 
 
 /// Compress the request body with the product's real transform.
 ///
-/// Fail-closed by design, and deliberately different from the legacy proxy: there, a body that
-/// does not shrink is forwarded verbatim so a user never pays more. Here the point is to know
-/// the gateway is doing its job, so a failure surfaces instead of silently passing through.
+/// Reports failure to the caller rather than deciding what to do about it: [`prepare`] owns
+/// that policy. Whether a failure is fatal is not a property of the transform.
+///
+/// # Errors
+///
+/// A body that is not UTF-8, a preset that will not resolve, or a transform that fails.
 pub fn compress_body(body: &[u8]) -> Result<Vec<u8>, GatewayError> {
     let text = std::str::from_utf8(body).map_err(|_| GatewayError::CompressionFailed)?;
     let config = DenseConfig::preset(GATEWAY_PRESET).ok_or(GatewayError::CompressionFailed)?;
@@ -219,6 +228,10 @@ pub struct GatewayMetrics {
     pub upstream_request_bytes: u64,
     pub response_chunks: u64,
     pub status: u16,
+    /// The original body went upstream because the transform failed. Equal byte counts alone
+    /// cannot say this — a body that simply did not shrink looks identical — so the fact is
+    /// carried rather than inferred, and the operator is told which one happened.
+    pub compression_failed: bool,
 }
 
 impl GatewayMetrics {
@@ -242,22 +255,49 @@ pub type PreparedRequest = (UpstreamRequest, GatewayMetrics);
 /// Split out so the offline [`handle`] and the real [`socket`] server run the *same* policy. A
 /// rule added here cannot be enforced on one path and quietly forgotten on the other.
 ///
+/// Compression is the one step that fails *open*: a body llmtrim cannot transform is
+/// forwarded unchanged, so a failed optimisation never costs the user their turn. The
+/// security gates above it stay fail-closed — route, method and bearer are refusals, and the
+/// destination is still built from constants, so failing open here widens nothing.
+///
 /// # Errors
 ///
-/// The first gate the request fails: route, method, authorization shape, or compression.
+/// The first *security* gate the request fails: route, method, or authorization shape.
 pub fn prepare(request: &GatewayRequest) -> Result<PreparedRequest, GatewayError> {
     validate_route(&request.method, &request.path)?;
     auth_gate(&request.headers)?;
 
-    let compressed = compress_body(&request.body)?;
+    let (body, compression_failed) = match compress_body(&request.body) {
+        Ok(compressed) => (compressed, false),
+        Err(_) => (request.body.clone(), true),
+    };
+    let mut headers = forward_headers(&request.headers);
+    if compression_failed {
+        // The body goes out exactly as it arrived, so whatever encodes it has to travel with
+        // it. Dropping the header here would forward a still-encoded body labelled as plain
+        // JSON — bytes preserved, meaning destroyed, which is not the original request.
+        //
+        // This mirrors the interceptor rather than inventing a policy: it strips
+        // `content-encoding` only after a *successful* decode, and on any decode failure
+        // "the header stays and the still-encoded body is forwarded verbatim"
+        // (`serve.rs`, `decode_request_body` and its caller).
+        //
+        // Deliberately not added to `FORWARDED_HEADERS`: on the success path the body really
+        // is plain JSON llmtrim just wrote, and claiming an encoding there would be a lie in
+        // the other direction. The header is relayed on this one path and no other.
+        if let Some(encoding) = request.headers.get(CONTENT_ENCODING) {
+            headers.insert(CONTENT_ENCODING.to_string(), encoding.clone());
+        }
+    }
     let outgoing = UpstreamRequest {
         url: upstream_url(),
-        headers: forward_headers(&request.headers),
-        body: compressed,
+        headers,
+        body,
     };
     let metrics = GatewayMetrics {
         local_request_bytes: request.body.len() as u64,
         upstream_request_bytes: outgoing.body.len() as u64,
+        compression_failed,
         ..GatewayMetrics::default()
     };
     Ok((outgoing, metrics))
@@ -377,9 +417,9 @@ pub mod listener {
 #[cfg(test)]
 mod tests {
     use super::{
-        DROPPED_HEADERS, GATEWAY_PRESET, GATEWAY_ROUTE, GatewayError, GatewayRequest,
-        GatewayUpstream, UPSTREAM_ORIGIN, UpstreamRequest, UpstreamResponse, auth_gate,
-        compress_body, forward_headers, handle, upstream_url, validate_route,
+        CONTENT_ENCODING, DROPPED_HEADERS, GATEWAY_PRESET, GATEWAY_ROUTE, GatewayError,
+        GatewayRequest, GatewayUpstream, UPSTREAM_ORIGIN, UpstreamRequest, UpstreamResponse,
+        auth_gate, compress_body, forward_headers, handle, prepare, upstream_url, validate_route,
     };
     use std::collections::BTreeMap;
 
@@ -675,21 +715,105 @@ mod tests {
     }
 
     #[test]
-    fn compression_failure_is_closed_not_open() {
-        // Invalid UTF-8 cannot be compressed. The legacy proxy would forward the original;
-        // this gateway must refuse, so a session never silently runs without llmtrim.
+    fn compression_failure_forwards_the_original_body() {
+        // Invalid UTF-8 cannot be compressed. The turn must still happen: a failed
+        // optimisation is not a reason to take the user's session away from them.
         let mut request = codex_request();
-        request.body = vec![0xff, 0xfe, 0xfd];
-        let mut upstream = FakeUpstream::default();
-        assert_eq!(
-            handle(&request, &mut upstream),
-            Err(GatewayError::CompressionFailed)
-        );
-        assert!(
-            upstream.seen.is_empty(),
-            "nothing may be forwarded when compression fails"
-        );
+        let original = vec![0xff, 0xfe, 0xfd];
+        request.body = original.clone();
+        let mut upstream = FakeUpstream::streaming();
+        let (_, metrics) = handle(&request, &mut upstream).expect("the turn still happens");
+        assert_eq!(upstream.seen.len(), 1, "one attempt, still no retry");
+        assert_eq!(upstream.seen[0].body, original, "byte for byte, untouched");
+        assert!(metrics.compression_failed, "the operator is told");
+        assert_eq!(metrics.local_request_bytes, metrics.upstream_request_bytes);
         assert!(compress_body(&[0xff, 0xfe]).is_err());
+    }
+
+    #[test]
+    fn an_untransformed_body_keeps_the_encoding_that_describes_it() {
+        // A zstd body: not UTF-8, so the transform cannot run. What reaches the upstream must
+        // be the original request in full — the same bytes AND the header that says how to
+        // read them.
+        let mut request = codex_request();
+        let original = vec![0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x58, 0x99, 0x00, 0x00];
+        request.body = original.clone();
+        request
+            .headers
+            .insert(CONTENT_ENCODING.to_string(), "zstd".to_string());
+
+        let mut upstream = FakeUpstream::streaming();
+        let (_, metrics) = handle(&request, &mut upstream).expect("the turn still happens");
+        let sent = &upstream.seen[0];
+        assert_eq!(sent.body, original, "byte for byte");
+        assert_eq!(
+            sent.headers.get(CONTENT_ENCODING).map(String::as_str),
+            Some("zstd"),
+            "a still-encoded body must not be presented as plain JSON"
+        );
+        assert!(metrics.compression_failed);
+    }
+
+    #[test]
+    fn a_transformed_body_never_claims_an_encoding() {
+        // The other direction, and the reason this is not on the forward list: after a
+        // successful transform the body is plain JSON llmtrim just serialised. Relaying an
+        // inherited `content-encoding` would describe bytes that no longer exist.
+        let mut request = codex_request();
+        request
+            .headers
+            .insert(CONTENT_ENCODING.to_string(), "zstd".to_string());
+
+        let mut upstream = FakeUpstream::streaming();
+        let (_, metrics) = handle(&request, &mut upstream).expect("handled");
+        assert!(!metrics.compression_failed, "this body does compress");
+        assert!(
+            !upstream.seen[0].headers.contains_key(CONTENT_ENCODING),
+            "plain JSON must not be labelled encoded"
+        );
+    }
+
+    #[test]
+    fn no_stale_content_length_is_ever_forwarded() {
+        // The gateway changes the body length on the success path and preserves it on the
+        // fail-open path. Either way it never forwards a length of its own: `content-length`
+        // is dropped, and `HttpsUpstream::send` hands ureq the body slice, which sets the
+        // header from the bytes actually sent. Same rule as the interceptor, which removes
+        // `CONTENT_LENGTH` so hyper recomputes it.
+        for body in [codex_request().body, vec![0xff, 0xfe, 0xfd]] {
+            let mut request = codex_request();
+            request.body = body;
+            request
+                .headers
+                .insert("content-length".to_string(), "999999".to_string());
+            let (outgoing, _) = prepare(&request).expect("prepared");
+            assert!(
+                !outgoing.headers.contains_key("content-length"),
+                "the client must compute this from the body it sends"
+            );
+        }
+        assert!(DROPPED_HEADERS.contains(&"content-length"));
+    }
+
+    #[test]
+    fn failing_open_is_only_the_compression_step() {
+        // The gates that keep the port from being an anonymous relay are untouched by the
+        // change above: each still refuses, and refusing still means nothing goes upstream.
+        let gates: [(&str, fn(&mut GatewayRequest)); 3] = [
+            ("route", |r| r.path = "/v1/responses".into()),
+            ("method", |r| r.method = "GET".into()),
+            ("bearer", |r| {
+                r.headers.remove("authorization");
+            }),
+        ];
+        for (name, mutate) in gates {
+            let mut request = codex_request();
+            request.body = vec![0xff, 0xfe, 0xfd];
+            mutate(&mut request);
+            let mut upstream = FakeUpstream::streaming();
+            assert!(handle(&request, &mut upstream).is_err(), "{name}");
+            assert!(upstream.seen.is_empty(), "{name}: nothing forwarded");
+        }
     }
 
     // ----- response ---------------------------------------------------------------------

--- a/crates/llmtrim-cli/src/codex_gateway.rs
+++ b/crates/llmtrim-cli/src/codex_gateway.rs
@@ -20,6 +20,9 @@ use std::collections::BTreeMap;
 use llmtrim_core::config::DenseConfig;
 use llmtrim_core::ir::ProviderKind;
 
+pub mod socket;
+pub mod upstream;
+
 /// The only origin this gateway will ever talk to. Not configurable, not derived from the
 /// request: a client that can reach the loopback port must not be able to choose a
 /// destination, or the gateway becomes an open SSRF relay.
@@ -356,22 +359,34 @@ mod tests {
     };
     use std::collections::BTreeMap;
 
-    /// The production half of this file — everything before the test module. The scans below
-    /// must not read their own assertion lists, which necessarily name what they forbid.
+    /// The production half of the whole gateway — this file and every submodule under it,
+    /// each cut at its own test module. The scans below must cover the entire call path: a
+    /// forbidden mechanism moved into `socket` or `upstream` would otherwise slip past them.
     fn production_source() -> String {
-        let whole = include_str!("codex_gateway.rs");
+        [
+            include_str!("codex_gateway.rs"),
+            include_str!("codex_gateway/socket.rs"),
+            include_str!("codex_gateway/upstream.rs"),
+        ]
+        .into_iter()
+        .map(production_half)
+        .collect::<Vec<_>>()
+        .join("\n")
+    }
+
+    /// Everything before the test module, minus the comments. The scans must not read their
+    /// own assertion lists, and comments are prose: the module docs name the very mechanisms
+    /// this architecture avoids, so scanning them would forbid explaining the design.
+    fn production_half(whole: &str) -> String {
         let marker = concat!("#[cfg(", "test)]");
-        let production = whole.split(marker).next().expect("production half");
-        // Comments are prose: the module doc names the very mechanisms this architecture
-        // avoids, and scanning them would forbid explaining the design.
-        production
+        whole
+            .split(marker)
+            .next()
+            .expect("production half")
             .lines()
             .filter(|line| !line.trim_start().starts_with("//"))
             .collect::<Vec<_>>()
-            .join(
-                "
-",
-            )
+            .join("\n")
     }
 
     /// Fictitious sentinels. Any real credential would be a bug in the test, not a secret.

--- a/crates/llmtrim-cli/src/codex_gateway.rs
+++ b/crates/llmtrim-cli/src/codex_gateway.rs
@@ -66,6 +66,10 @@ pub enum GatewayError {
     RouteNotFound,
     /// Codex did not attach the credentials it normally attaches.
     MissingAuthorization,
+    /// The local request body was larger than the gateway is willing to hold.
+    RequestTooLarge,
+    /// The local request could not be read as an HTTP body at all.
+    MalformedRequest,
     /// The `Authorization` header was present but not in the expected bearer form.
     MalformedAuthorization,
     /// Compression failed. The gateway fails closed rather than quietly forwarding the
@@ -81,6 +85,8 @@ impl std::fmt::Display for GatewayError {
             Self::MethodNotAllowed => "method not allowed",
             Self::RouteNotFound => "route not served by the codex gateway",
             Self::MissingAuthorization => "request carried no authorization header",
+            Self::RequestTooLarge => "request body exceeded the gateway limit",
+            Self::MalformedRequest => "request body could not be read",
             Self::MalformedAuthorization => "authorization header was not a bearer token",
             Self::CompressionFailed => "compression failed; refusing to forward uncompressed",
             Self::UpstreamFailed => "upstream request failed",
@@ -98,6 +104,8 @@ impl GatewayError {
             Self::MethodNotAllowed => 405,
             Self::RouteNotFound => 404,
             Self::MissingAuthorization | Self::MalformedAuthorization => 401,
+            Self::MalformedRequest => 400,
+            Self::RequestTooLarge => 413,
             Self::CompressionFailed => 500,
             Self::UpstreamFailed => 502,
         }
@@ -225,11 +233,19 @@ impl GatewayMetrics {
     }
 }
 
-/// The whole pipeline: validate, gate, compress, forward, relay.
-pub fn handle<U: GatewayUpstream>(
-    request: &GatewayRequest,
-    upstream: &mut U,
-) -> Result<(UpstreamResponse, GatewayMetrics), GatewayError> {
+/// What the request half of the pipeline produces: the one upstream request it will send,
+/// and the byte counts describing it.
+pub type PreparedRequest = (UpstreamRequest, GatewayMetrics);
+
+/// The request half of the pipeline: validate, gate, compress, select headers.
+///
+/// Split out so the offline [`handle`] and the real [`socket`] server run the *same* policy. A
+/// rule added here cannot be enforced on one path and quietly forgotten on the other.
+///
+/// # Errors
+///
+/// The first gate the request fails: route, method, authorization shape, or compression.
+pub fn prepare(request: &GatewayRequest) -> Result<PreparedRequest, GatewayError> {
     validate_route(&request.method, &request.path)?;
     auth_gate(&request.headers)?;
 
@@ -244,7 +260,15 @@ pub fn handle<U: GatewayUpstream>(
         upstream_request_bytes: outgoing.body.len() as u64,
         ..GatewayMetrics::default()
     };
+    Ok((outgoing, metrics))
+}
 
+/// The whole pipeline: validate, gate, compress, forward, relay.
+pub fn handle<U: GatewayUpstream>(
+    request: &GatewayRequest,
+    upstream: &mut U,
+) -> Result<(UpstreamResponse, GatewayMetrics), GatewayError> {
+    let (outgoing, metrics) = prepare(request)?;
     let response = upstream.send(outgoing)?;
     let metrics = GatewayMetrics {
         response_chunks: response.chunks.len() as u64,
@@ -710,6 +734,8 @@ mod tests {
             GatewayError::UpstreamFailed,
             GatewayError::RouteNotFound,
             GatewayError::MethodNotAllowed,
+            GatewayError::RequestTooLarge,
+            GatewayError::MalformedRequest,
         ] {
             let rendered = format!("{error} {error:?}");
             for sentinel in [

--- a/crates/llmtrim-cli/src/codex_gateway.rs
+++ b/crates/llmtrim-cli/src/codex_gateway.rs
@@ -36,15 +36,33 @@ pub const GATEWAY_ROUTE: &str = "/backend-api/codex/responses";
 /// sees without anyone asking for it.
 pub const GATEWAY_PRESET: &str = "safe";
 
-/// Headers the gateway forwards verbatim. `Authorization` and `ChatGPT-Account-ID` are the
-/// credentials Codex attached; they are passed through in memory and never inspected for
-/// meaning, logged or written down.
-pub const FORWARDED_HEADERS: [&str; 5] = [
+/// Headers the gateway forwards verbatim.
+///
+/// `Authorization` and `ChatGPT-Account-ID` are the credentials Codex attached; they are
+/// passed through in memory and never inspected for meaning, logged or written down.
+///
+/// The rest are Codex's identity to the backend, and dropping them is not neutral. The
+/// interceptor's own notes (`reroute::codex`) record that this exact URL answers 404 for the
+/// GPT-5.6 models unless `originator` is `codex_cli_rs` *and* `user-agent` starts with
+/// `codex_cli_rs`; `ureq` supplies its own `user-agent` only when the request carries none, so
+/// relaying Codex's is what keeps the client identity intact instead of announcing `ureq/3.x`.
+/// `openai-beta`, `session_id`, `x-client-request-id` and `x-codex-window-id` complete the set
+/// `request_headers_with_mode` sets for this route.
+///
+/// This stays an allowlist rather than becoming a hop-by-hop denylist. The gateway attaches
+/// the user's ChatGPT credential to whatever it forwards, so the default for a header nobody
+/// named has to be "dropped" — not "relayed because no one thought to ban it".
+pub const FORWARDED_HEADERS: [&str; 10] = [
     "authorization",
     "chatgpt-account-id",
     "content-type",
     "accept",
     "originator",
+    "user-agent",
+    "openai-beta",
+    "session_id",
+    "x-client-request-id",
+    "x-codex-window-id",
 ];
 
 /// The one header that survives only when the body is forwarded untransformed. See
@@ -417,9 +435,10 @@ pub mod listener {
 #[cfg(test)]
 mod tests {
     use super::{
-        CONTENT_ENCODING, DROPPED_HEADERS, GATEWAY_PRESET, GATEWAY_ROUTE, GatewayError,
-        GatewayRequest, GatewayUpstream, UPSTREAM_ORIGIN, UpstreamRequest, UpstreamResponse,
-        auth_gate, compress_body, forward_headers, handle, prepare, upstream_url, validate_route,
+        CONTENT_ENCODING, DROPPED_HEADERS, FORWARDED_HEADERS, GATEWAY_PRESET, GATEWAY_ROUTE,
+        GatewayError, GatewayRequest, GatewayUpstream, UPSTREAM_ORIGIN, UpstreamRequest,
+        UpstreamResponse, auth_gate, compress_body, forward_headers, handle, prepare, upstream_url,
+        validate_route,
     };
     use std::collections::BTreeMap;
 
@@ -528,9 +547,19 @@ mod tests {
         let content = format!(
             "PRIVATE_PROMPT_DO_NOT_LEAK Read the log tool output and reply with the requestId of REQ-000057.\n\n{tool_output}"
         );
+        // The shape this route actually serves: Responses `input` items carrying `input_text`
+        // parts, the same body `reroute::codex` builds. Chat Completions `messages` would not
+        // reach this endpoint at all, so a fixture in that shape proved nothing about it.
         serde_json::to_vec(&serde_json::json!({
             "model": "gpt-5.6-sol",
-            "messages": [{ "role": "user", "content": content }],
+            "instructions": "You are a terse log assistant.",
+            "input": [{
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": content }],
+            }],
+            "store": false,
+            "stream": true,
         }))
         .expect("serialize body")
     }
@@ -675,6 +704,72 @@ mod tests {
         assert_eq!(
             sent.headers.get("chatgpt-account-id").map(String::as_str),
             Some(FAKE_ACCOUNT)
+        );
+    }
+
+    #[test]
+    fn codex_identity_headers_reach_the_upstream() {
+        // Not cosmetic. `reroute::codex` records that this exact URL answers 404 for the
+        // GPT-5.6 models unless `originator` is `codex_cli_rs` *and* `user-agent` starts with
+        // it, and `ureq` supplies its own `user-agent` whenever the request carries none. A
+        // gateway that drops these turns a working turn into a 404 that looks like an outage.
+        // The full set is what `request_headers_with_mode` sets for this route.
+        let identity = [
+            ("originator", "codex_cli_rs"),
+            ("user-agent", "codex_cli_rs/0.146.0 (Windows 11; x86_64)"),
+            ("openai-beta", "responses=experimental"),
+            ("session_id", "11111111-2222-3333-4444-555555555555"),
+            (
+                "x-client-request-id",
+                "11111111-2222-3333-4444-555555555555",
+            ),
+            (
+                "x-codex-window-id",
+                "11111111-2222-3333-4444-555555555555:0",
+            ),
+        ];
+        let mut request = codex_request();
+        for (name, value) in identity {
+            request.headers.insert(name.to_string(), value.to_string());
+        }
+
+        let mut upstream = FakeUpstream::default();
+        handle(&request, &mut upstream).expect("handled");
+        let sent = &upstream.seen[0];
+        for (name, value) in identity {
+            assert_eq!(
+                sent.headers.get(name).map(String::as_str),
+                Some(value),
+                "{name} did not reach the upstream"
+            );
+        }
+    }
+
+    #[test]
+    fn widening_the_list_did_not_turn_it_into_a_denylist() {
+        // The gateway attaches the user's ChatGPT credential to whatever it forwards, so the
+        // default for a header nobody named must stay "dropped". This is the test that fails
+        // if someone later swaps the allowlist for "everything except hop-by-hop".
+        let unnamed = [
+            "cookie",
+            "x-api-key",
+            "referer",
+            "origin",
+            "x-forwarded-for",
+        ];
+        let mut request = codex_request();
+        for name in unnamed {
+            request.headers.insert(name.to_string(), "x".to_string());
+        }
+        let forwarded = forward_headers(&request.headers);
+        for name in unnamed {
+            assert!(!forwarded.contains_key(name), "{name} was relayed");
+        }
+        assert!(
+            forwarded
+                .keys()
+                .all(|name| FORWARDED_HEADERS.contains(&name.as_str())),
+            "only listed headers may be forwarded"
         );
     }
 

--- a/crates/llmtrim-cli/src/codex_gateway/socket.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/socket.rs
@@ -16,7 +16,9 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use anyhow::Context;
+// Imported anonymously: the trait is only needed for `.context()`, and its name would
+// collide with the `std::task::Context` the body's `poll_frame` takes.
+use anyhow::Context as _;
 use http_body_util::{BodyExt, LengthLimitError, Limited};
 use hyper::body::{Body, Bytes, Frame, Incoming};
 use hyper::service::service_fn;

--- a/crates/llmtrim-cli/src/codex_gateway/socket.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/socket.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
+use anyhow::Context;
 use http_body_util::{BodyExt, LengthLimitError, Limited};
 use hyper::body::{Body, Bytes, Frame, Incoming};
 use hyper::service::service_fn;
@@ -26,8 +27,8 @@ use tokio::sync::{Semaphore, mpsc, oneshot};
 use tokio::task::JoinSet;
 
 use super::listener::{BindError, bind_address};
-use super::upstream::{StreamingUpstream, UpstreamStream};
-use super::{GatewayError, GatewayRequest, UpstreamRequest, prepare};
+use super::upstream::{HttpsUpstream, StreamingUpstream, UpstreamStream};
+use super::{GATEWAY_PRESET, GatewayError, GatewayRequest, UpstreamRequest, prepare};
 
 /// The port the gateway listens on unless the caller names another one. Picked high and
 /// unassigned; nothing else in the product uses it.
@@ -196,6 +197,40 @@ pub async fn serve<U: StreamingUpstream>(
         stop: Some(stop),
         task,
     })
+}
+
+/// Run the gateway in the foreground until Ctrl-C, talking to the real upstream.
+///
+/// It builds its own Tokio runtime so the rest of the CLI stays synchronous. There is no
+/// daemon, no autostart and no background service: the gateway lives exactly as long as this
+/// process, and nothing it does outlives it.
+///
+/// # Errors
+///
+/// If the async runtime cannot start, or the loopback port cannot be bound.
+pub fn run(port: u16) -> anyhow::Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("failed to start async runtime")?;
+    runtime.block_on(run_async(port))
+}
+
+async fn run_async(port: u16) -> anyhow::Result<()> {
+    let upstream = Arc::new(HttpsUpstream::new());
+    let server = serve(None, port, ServerLimits::default(), upstream)
+        .await
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let address = server.local_addr();
+    // Metadata only: an address and a profile name. Never a header, a token or a payload.
+    println!("Codex gateway listening on {address}");
+    println!("Compressing with the `{GATEWAY_PRESET}` preset.");
+    println!("Point Codex at http://{address}/backend-api/codex");
+    println!("Press Ctrl-C to stop.");
+    let _ = tokio::signal::ctrl_c().await;
+    println!("Stopping the Codex gateway.");
+    server.shutdown().await;
+    Ok(())
 }
 
 async fn accept_loop<U: StreamingUpstream>(

--- a/crates/llmtrim-cli/src/codex_gateway/socket.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/socket.rs
@@ -34,7 +34,7 @@ use super::{GATEWAY_PRESET, GatewayError, GatewayRequest, UpstreamRequest, prepa
 
 /// The port the gateway listens on unless the caller names another one. Picked high and
 /// unassigned; nothing else in the product uses it.
-pub const DEFAULT_PORT: u16 = 43117;
+pub const DEFAULT_PORT: u16 = 43200;
 
 /// Ceiling on one local request body.
 ///
@@ -365,8 +365,13 @@ async fn relay<U: StreamingUpstream>(
 
     // Metadata only, and only once the exchange is under way: byte counts and a status. No
     // header, no body, nothing written down.
+    let note = if metrics.compression_failed {
+        " (compression failed; original body forwarded)"
+    } else {
+        ""
+    };
     println!(
-        "codex-gateway: {} -> {} bytes upstream ({:.2}% smaller), status {status}",
+        "codex-gateway: {} -> {} bytes upstream ({:.2}% smaller), status {status}{note}",
         metrics.local_request_bytes,
         metrics.upstream_request_bytes,
         metrics.reduction_basis_points() as f64 / 100.0
@@ -708,7 +713,18 @@ mod tests {
 
     #[test]
     fn the_default_port_is_the_documented_one() {
-        assert_eq!(DEFAULT_PORT, 43117);
+        assert_eq!(DEFAULT_PORT, 43200);
+    }
+
+    #[test]
+    fn the_default_port_is_clear_of_the_interceptor() {
+        // `setup` wires the interceptor at 43117 and, when that is busy, scans the 64 ports
+        // above it. A gateway default inside that window would race the interceptor for a
+        // port on the same machine.
+        assert!(
+            !(43117..=43181).contains(&DEFAULT_PORT),
+            "{DEFAULT_PORT} sits in the interceptor's scan window"
+        );
     }
 
     // ----- the served exchange ----------------------------------------------------------
@@ -772,16 +788,46 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn socket_compression_failure_returns_500() {
+    async fn socket_compression_failure_forwards_the_original_body() {
         let upstream = Arc::new(FakeUpstream::replying(sse()));
         let server = start(&upstream).await;
         let address = server.local_addr();
-        // Not UTF-8, so the product's real transform cannot run. The gateway fails closed
-        // rather than forwarding a body llmtrim never touched.
+        // Not UTF-8, so the product's real transform cannot run. The turn still completes;
+        // the body goes out exactly as it arrived.
         let broken = vec![0x80, 0x81, 0xfe, 0xff];
-        let reply = post(address, GATEWAY_ROUTE, auth_headers(), broken).await;
-        assert_eq!(reply.status, 500);
-        assert!(upstream.seen().is_empty(), "nothing uncompressed goes out");
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), broken.clone()).await;
+        assert_eq!(reply.status, 200, "a failed transform is not a failed turn");
+        let seen = upstream.seen();
+        assert_eq!(seen.len(), 1, "one attempt, no retry");
+        assert_eq!(seen[0].body, broken, "forwarded byte for byte");
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_forwards_an_encoded_body_with_its_encoding() {
+        // The whole fail-open path over a real socket: a zstd-framed body arrives with its
+        // `Content-Encoding`, the transform cannot run, and the upstream receives the
+        // original request intact — the same bytes, still described as zstd.
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let encoded = vec![0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x58, 0x99, 0x00, 0x00];
+        let mut headers = auth_headers();
+        headers.push(("content-encoding".to_string(), "zstd".to_string()));
+
+        let reply = post(address, GATEWAY_ROUTE, headers, encoded.clone()).await;
+        assert_eq!(reply.status, 200);
+        let seen = upstream.seen();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].body, encoded, "no transformation applied");
+        assert_eq!(
+            seen[0].headers.get("content-encoding").map(String::as_str),
+            Some("zstd")
+        );
+        assert!(
+            !seen[0].headers.contains_key("content-length"),
+            "the client sets this from the body it sends"
+        );
         server.shutdown().await;
     }
 

--- a/crates/llmtrim-cli/src/codex_gateway/socket.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/socket.rs
@@ -1,0 +1,720 @@
+//! The loopback HTTP server Codex actually talks to.
+//!
+//! The parent module decides *what* the gateway does with a request; this file is the part
+//! that speaks HTTP. It frames nothing by hand — hyper owns the local side of the wire and
+//! ureq owns the upstream side — and it never buffers a reply: bytes reach Codex as the
+//! upstream produces them, through a queue whose depth is fixed.
+//!
+//! The server is generic over the upstream seam, so the whole exchange — a real socket, a
+//! real HTTP client, the product's real compression — is exercised without a network.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, VecDeque};
+    use std::io::Read;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+    use std::sync::mpsc;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use super::{
+        DEFAULT_PORT, GatewayServer, MAX_LOCAL_CLIENTS, MAX_REQUEST_BODY_BYTES,
+        RESPONSE_QUEUE_DEPTH, ServeError, ServerLimits, serve,
+    };
+
+    use crate::codex_gateway::listener::BindError;
+    use crate::codex_gateway::upstream::{StreamingUpstream, UpstreamStream};
+    use crate::codex_gateway::{GATEWAY_ROUTE, GatewayError, UpstreamRequest, upstream_url};
+
+    /// Fictitious sentinels. A real credential here would be a bug in the test, not a secret.
+    const FAKE_BEARER: &str = "Bearer SUPER_SECRET_DO_NOT_LEAK";
+    const FAKE_ACCOUNT: &str = "FAKE_ACCOUNT_DO_NOT_LEAK";
+    const MARKER: &str = "REQ-000057";
+
+    // ----- the fake upstream ------------------------------------------------------------
+
+    /// Stands in for the fixed origin: records what the gateway sent and replies with a
+    /// scripted stream, one chunk per `read`.
+    struct FakeUpstream {
+        seen: Mutex<Vec<UpstreamRequest>>,
+        status: u16,
+        chunks: Vec<Vec<u8>>,
+        gate: Mutex<Option<mpsc::Receiver<()>>>,
+        fail: bool,
+    }
+
+    impl FakeUpstream {
+        fn replying(chunks: Vec<Vec<u8>>) -> Self {
+            Self {
+                seen: Mutex::new(Vec::new()),
+                status: 200,
+                chunks,
+                gate: Mutex::new(None),
+                fail: false,
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                fail: true,
+                ..Self::replying(Vec::new())
+            }
+        }
+
+        fn gated(chunks: Vec<Vec<u8>>, gate: mpsc::Receiver<()>) -> Self {
+            Self {
+                gate: Mutex::new(Some(gate)),
+                ..Self::replying(chunks)
+            }
+        }
+
+        fn seen(&self) -> Vec<UpstreamRequest> {
+            self.seen.lock().expect("upstream log").clone()
+        }
+    }
+
+    impl StreamingUpstream for FakeUpstream {
+        fn send(&self, request: UpstreamRequest) -> Result<UpstreamStream, GatewayError> {
+            self.seen.lock().expect("upstream log").push(request);
+            if self.fail {
+                return Err(GatewayError::UpstreamFailed);
+            }
+            let gate = self.gate.lock().expect("gate").take();
+            Ok(UpstreamStream {
+                status: self.status,
+                headers: BTreeMap::from([(
+                    "content-type".to_string(),
+                    "text/event-stream".to_string(),
+                )]),
+                body: Box::new(ScriptedBody {
+                    chunks: self.chunks.clone().into(),
+                    gate,
+                    delivered: 0,
+                }),
+            })
+        }
+    }
+
+    /// Hands back one scripted chunk per `read`. With a gate, the second chunk waits until the
+    /// test confirms the first one already reached the client — which is how the suite proves
+    /// the relay is incremental instead of buffered.
+    struct ScriptedBody {
+        chunks: VecDeque<Vec<u8>>,
+        gate: Option<mpsc::Receiver<()>>,
+        delivered: usize,
+    }
+
+    impl Read for ScriptedBody {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let gate = if self.delivered == 1 {
+                self.gate.take()
+            } else {
+                None
+            };
+            if let Some(gate) = gate {
+                gate.recv().expect("the test releases the gate");
+            }
+            let Some(chunk) = self.chunks.pop_front() else {
+                return Ok(0);
+            };
+            assert!(chunk.len() <= buffer.len(), "test chunks fit one read");
+            buffer[..chunk.len()].copy_from_slice(&chunk);
+            self.delivered += 1;
+            Ok(chunk.len())
+        }
+    }
+
+    // ----- the fake Codex ---------------------------------------------------------------
+
+    struct Reply {
+        status: u16,
+        body: Vec<u8>,
+    }
+
+    /// A real HTTP client on the loopback port. Blocking, so it runs on the blocking pool
+    /// while the runtime keeps driving the server.
+    fn client() -> ureq::Agent {
+        ureq::Agent::config_builder()
+            .proxy(None)
+            .http_status_as_error(false)
+            .timeout_global(Some(Duration::from_secs(30)))
+            .build()
+            .into()
+    }
+
+    fn blocking_post(
+        address: SocketAddr,
+        path: &str,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    ) -> Result<Reply, String> {
+        let url = format!("http://{address}{path}");
+        let mut request = client().post(&url);
+        for (name, value) in &headers {
+            request = request.header(name.as_str(), value.as_str());
+        }
+        let mut response = request.send(&body[..]).map_err(|error| error.to_string())?;
+        let status = response.status().as_u16();
+        let body = response
+            .body_mut()
+            .read_to_vec()
+            .map_err(|error| error.to_string())?;
+        Ok(Reply { status, body })
+    }
+
+    async fn try_post(
+        address: SocketAddr,
+        path: &str,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    ) -> Result<Reply, String> {
+        let path = path.to_string();
+        tokio::task::spawn_blocking(move || blocking_post(address, &path, headers, body))
+            .await
+            .expect("the client task runs")
+    }
+
+    async fn post(
+        address: SocketAddr,
+        path: &str,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    ) -> Reply {
+        try_post(address, path, headers, body)
+            .await
+            .expect("the gateway answers")
+    }
+
+    async fn get(address: SocketAddr, path: &str) -> Reply {
+        let path = path.to_string();
+        tokio::task::spawn_blocking(move || {
+            let url = format!("http://{address}{path}");
+            let mut response = client().get(&url).call().expect("the gateway answers");
+            let status = response.status().as_u16();
+            let body = response.body_mut().read_to_vec().expect("body");
+            Reply { status, body }
+        })
+        .await
+        .expect("the client task runs")
+    }
+
+    fn auth_headers() -> Vec<(String, String)> {
+        vec![
+            ("authorization".to_string(), FAKE_BEARER.to_string()),
+            ("chatgpt-account-id".to_string(), FAKE_ACCOUNT.to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]
+    }
+
+    fn sse() -> Vec<Vec<u8>> {
+        vec![
+            b"event: response.created\ndata: {\"a\":1}\n\n".to_vec(),
+            b"event: response.output_text.delta\ndata: {\"d\":\"x\"}\n\n".to_vec(),
+            b"event: response.completed\ndata: {\"done\":true}\n\n".to_vec(),
+        ]
+    }
+
+    /// A Responses-shaped body carrying repetitive tool output — the shape llmtrim shrinks.
+    /// Pretty-printed on purpose: a pre-minified fixture would leave the lossless `safe`
+    /// preset nothing to do and prove nothing.
+    fn codex_body() -> Vec<u8> {
+        let records: Vec<serde_json::Value> = (0..80)
+            .map(|i| {
+                serde_json::json!({
+                    "requestId": format!("REQ-{i:06}"),
+                    "service": "billing",
+                    "level": "INFO",
+                    "latencyMs": 12 + i,
+                    "route": "/api/v1/billing/items",
+                    "region": "sa-east-1",
+                    "message": "request completed",
+                })
+            })
+            .collect();
+        let tool_output = serde_json::to_string_pretty(&records).expect("pretty tool output");
+        let content = format!(
+            "PRIVATE_PROMPT_DO_NOT_LEAK Read the log tool output and reply with the requestId \
+             of {MARKER}.\n\n{tool_output}"
+        );
+        serde_json::to_vec(&serde_json::json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{ "role": "user", "content": content }],
+        }))
+        .expect("serialize body")
+    }
+
+    async fn start(upstream: &Arc<FakeUpstream>) -> GatewayServer {
+        serve(None, 0, ServerLimits::default(), Arc::clone(upstream))
+            .await
+            .expect("the gateway binds loopback")
+    }
+
+    // ----- bind policy ------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_binds_ipv4_loopback_only() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        assert_eq!(address.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert!(address.ip().is_loopback());
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_port_zero_returns_actual_loopback_port() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        assert_ne!(address.port(), 0, "the caller must learn the real port");
+        TcpStream::connect(address).expect("the port is open");
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_rejects_non_loopback_configuration() {
+        for host in [
+            Ipv4Addr::UNSPECIFIED,
+            Ipv4Addr::new(192, 168, 1, 10),
+            Ipv4Addr::new(8, 8, 8, 8),
+        ] {
+            let upstream = Arc::new(FakeUpstream::replying(sse()));
+            let host = IpAddr::V4(host);
+            let outcome = serve(Some(host), 0, ServerLimits::default(), upstream).await;
+            let error = outcome.err().expect("a non-loopback host is refused");
+            assert!(
+                matches!(error, ServeError::Bind(BindError::NotLoopback)),
+                "{host}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_default_port_is_the_documented_one() {
+        assert_eq!(DEFAULT_PORT, 43117);
+    }
+
+    // ----- the served exchange ----------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_post_valid_route_reaches_pipeline() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), codex_body()).await;
+        assert_eq!(reply.status, 200);
+        let seen = upstream.seen();
+        assert_eq!(seen.len(), 1, "one request, no retry, no second provider");
+        assert_eq!(seen[0].url, upstream_url());
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_wrong_route_returns_404() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        for path in ["/v1/responses", "/", "/backend-api/codex/other"] {
+            let reply = post(address, path, auth_headers(), codex_body()).await;
+            assert_eq!(reply.status, 404, "{path}");
+        }
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_wrong_method_returns_405() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let reply = get(server.local_addr(), GATEWAY_ROUTE).await;
+        assert_eq!(reply.status, 405);
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_missing_auth_returns_401() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let headers = vec![("content-type".to_string(), "application/json".to_string())];
+        let reply = post(address, GATEWAY_ROUTE, headers, codex_body()).await;
+        assert_eq!(reply.status, 401);
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_malformed_auth_returns_401() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        for value in ["Token abc", "Bearer ", "SUPER_SECRET_DO_NOT_LEAK"] {
+            let headers = vec![("authorization".to_string(), value.to_string())];
+            let reply = post(address, GATEWAY_ROUTE, headers, codex_body()).await;
+            assert_eq!(reply.status, 401, "{value}");
+        }
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_compression_failure_returns_500() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        // Not UTF-8, so the product's real transform cannot run. The gateway fails closed
+        // rather than forwarding a body llmtrim never touched.
+        let broken = vec![0x80, 0x81, 0xfe, 0xff];
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), broken).await;
+        assert_eq!(reply.status, 500);
+        assert!(upstream.seen().is_empty(), "nothing uncompressed goes out");
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_upstream_failure_returns_502() {
+        let upstream = Arc::new(FakeUpstream::failing());
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), codex_body()).await;
+        assert_eq!(reply.status, 502);
+        assert_eq!(upstream.seen().len(), 1, "one attempt, no retry");
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_does_not_forward_on_auth_failure() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let reply = post(address, GATEWAY_ROUTE, Vec::new(), codex_body()).await;
+        assert_eq!(reply.status, 401);
+        assert!(
+            upstream.seen().is_empty(),
+            "the loopback port is not an anonymous relay"
+        );
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_does_not_forward_on_route_failure() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let reply = post(address, "/v1/chat/completions", auth_headers(), codex_body()).await;
+        assert_eq!(reply.status, 404);
+        assert!(upstream.seen().is_empty(), "a refused route costs nothing");
+        server.shutdown().await;
+    }
+
+    // ----- compression ------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_real_compression_reduces_body() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let body = codex_body();
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), body.clone()).await;
+        assert_eq!(reply.status, 200);
+        let sent = upstream.seen();
+        assert!(
+            sent[0].body.len() < body.len(),
+            "{} is not smaller than {}",
+            sent[0].body.len(),
+            body.len()
+        );
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_semantic_marker_survives() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), codex_body()).await;
+        assert_eq!(reply.status, 200);
+        let sent = upstream.seen();
+        let text = String::from_utf8(sent[0].body.clone()).expect("utf-8");
+        assert!(text.contains(MARKER), "the task's identifier must survive");
+        server.shutdown().await;
+    }
+
+    // ----- streaming --------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_sse_order_preserved() {
+        let chunks = sse();
+        let upstream = Arc::new(FakeUpstream::replying(chunks.clone()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), codex_body()).await;
+        assert_eq!(reply.status, 200);
+        assert_eq!(reply.body, chunks.concat(), "bytes relayed in order");
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_relays_incrementally_without_buffering_the_response() {
+        let chunks = sse();
+        let (release, gate) = mpsc::channel();
+        let upstream = Arc::new(FakeUpstream::gated(chunks.clone(), gate));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let first = chunks[0].len();
+        let expected = chunks.concat();
+
+        // The upstream refuses to produce its second chunk until the client says the first one
+        // already arrived. A gateway that collected the whole response before answering would
+        // deadlock here, which the timeout turns into a failure rather than a hang.
+        let exchange = tokio::task::spawn_blocking(move || {
+            let url = format!("http://{address}{GATEWAY_ROUTE}");
+            let mut request = client().post(&url);
+            for (name, value) in auth_headers() {
+                request = request.header(name.as_str(), value.as_str());
+            }
+            let body = codex_body();
+            let mut response = request.send(&body[..]).expect("the gateway answers");
+            let mut reader = response.body_mut().as_reader();
+            let mut head = vec![0_u8; first];
+            reader.read_exact(&mut head).expect("the first chunk");
+            release.send(()).expect("release the upstream");
+            let mut rest = Vec::new();
+            reader.read_to_end(&mut rest).expect("the rest of the stream");
+            head.extend_from_slice(&rest);
+            head
+        });
+
+        let relayed = tokio::time::timeout(Duration::from_secs(30), exchange)
+            .await
+            .expect("the relay starts before the upstream finishes")
+            .expect("the client task runs");
+        assert_eq!(relayed, expected);
+        server.shutdown().await;
+    }
+
+    #[test]
+    fn the_response_queue_is_bounded() {
+        // Bounded on purpose: the blocking reader parks on a full queue, so memory tracks the
+        // queue depth rather than the length of the generation.
+        assert!(RESPONSE_QUEUE_DEPTH > 0);
+        assert!(RESPONSE_QUEUE_DEPTH <= 64);
+        assert!(MAX_LOCAL_CLIENTS > 0);
+        assert!(MAX_LOCAL_CLIENTS <= 1024);
+    }
+
+    // ----- limits -----------------------------------------------------------------------
+
+    #[test]
+    fn the_default_request_ceiling_is_the_products_own() {
+        assert_eq!(MAX_REQUEST_BODY_BYTES, 64 * 1024 * 1024);
+        assert_eq!(
+            ServerLimits::default().max_request_body_bytes,
+            MAX_REQUEST_BODY_BYTES
+        );
+        assert_eq!(ServerLimits::default().max_connections, MAX_LOCAL_CLIENTS);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_body_over_the_ceiling_is_refused_before_the_upstream_leg() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let limits = ServerLimits {
+            max_request_body_bytes: 4096,
+            ..ServerLimits::default()
+        };
+        let server = serve(None, 0, limits, Arc::clone(&upstream))
+            .await
+            .expect("the gateway binds loopback");
+        let address = server.local_addr();
+        let oversized = vec![b'x'; 8192];
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), oversized).await;
+        assert_eq!(reply.status, 413);
+        assert!(upstream.seen().is_empty(), "no partial body is forwarded");
+        server.shutdown().await;
+    }
+
+    // ----- the client cannot pick a destination -----------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn no_local_header_can_redirect_the_gateway() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let mut headers = auth_headers();
+        for name in ["x-forwarded-host", "forwarded", "x-upstream", "origin"] {
+            headers.push((name.to_string(), "evil.example".to_string()));
+        }
+        let reply = post(address, GATEWAY_ROUTE, headers, codex_body()).await;
+        assert_eq!(reply.status, 200);
+        let sent = upstream.seen();
+        assert_eq!(sent[0].url, upstream_url());
+        for name in [
+            "x-forwarded-host",
+            "forwarded",
+            "x-upstream",
+            "origin",
+            "host",
+            "content-length",
+        ] {
+            assert!(!sent[0].headers.contains_key(name), "{name} was relayed");
+        }
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_callers_credentials_reach_the_upstream_byte_for_byte() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), codex_body()).await;
+        assert_eq!(reply.status, 200);
+        let sent = upstream.seen();
+        assert_eq!(
+            sent[0].headers.get("authorization").map(String::as_str),
+            Some(FAKE_BEARER)
+        );
+        assert_eq!(
+            sent[0].headers.get("chatgpt-account-id").map(String::as_str),
+            Some(FAKE_ACCOUNT)
+        );
+        server.shutdown().await;
+    }
+
+    // ----- concurrency and lifecycle ----------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn several_connections_are_served_without_unbounded_work() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let mut calls = Vec::new();
+        for _ in 0..3 {
+            calls.push(post(address, GATEWAY_ROUTE, auth_headers(), codex_body()));
+        }
+        for call in calls {
+            assert_eq!(call.await.status, 200);
+        }
+        assert_eq!(upstream.seen().len(), 3);
+        server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_shutdown_releases_port() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        server.shutdown().await;
+        let rebound = TcpListener::bind(address).expect("the port is free again");
+        drop(rebound);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_shutdown_leaves_no_listener() {
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        server.shutdown().await;
+        assert!(
+            TcpStream::connect(address).is_err(),
+            "nothing is still listening on {address}"
+        );
+    }
+
+    // ----- nothing leaks ----------------------------------------------------------------
+
+    #[test]
+    fn the_socket_layer_writes_nothing_and_carries_no_secret() {
+        let whole = include_str!("socket.rs");
+        let marker = concat!("#[cfg(", "test)]");
+        let source = whole
+            .split(marker)
+            .next()
+            .expect("production half")
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for forbidden in [
+            "fs::write",
+            "File::create",
+            "OpenOptions",
+            "capture_dir",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "CODEX_API_KEY",
+            "env_key",
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+            "ALL_PROXY",
+            "NODE_EXTRA_CA_CERTS",
+            "SSL_CERT_FILE",
+            "CURL_CA_BUNDLE",
+            "rcgen",
+            "hudsucker",
+            "ca.key",
+        ] {
+            assert!(!source.contains(forbidden), "{forbidden} must not appear");
+        }
+    }
+
+    #[test]
+    fn a_start_up_error_renders_no_credential() {
+        let errors = [
+            ServeError::Bind(BindError::NotLoopback),
+            ServeError::Listen(std::io::Error::other("address in use")),
+        ];
+        for error in errors {
+            let rendered = format!("{error} {error:?}");
+            for sentinel in [
+                "SUPER_SECRET_DO_NOT_LEAK",
+                "FAKE_ACCOUNT_DO_NOT_LEAK",
+                "PRIVATE_PROMPT_DO_NOT_LEAK",
+                "Bearer ",
+            ] {
+                assert!(!rendered.contains(sentinel), "{error:?} leaked {sentinel}");
+            }
+        }
+    }
+
+    // ----- socket end-to-end ------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn socket_end_to_end_fake_codex_to_real_socket_to_fake_upstream() {
+        let chunks = sse();
+        let upstream = Arc::new(FakeUpstream::replying(chunks.clone()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+        let body = codex_body();
+
+        let reply = post(address, GATEWAY_ROUTE, auth_headers(), body.clone()).await;
+
+        // A: a real client spoke HTTP to a real loopback socket.
+        assert!(address.ip().is_loopback());
+        assert_eq!(reply.status, 200);
+        // B: exactly one upstream request, to the one destination that exists.
+        let sent = upstream.seen();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].url, upstream_url());
+        // C: the product's real compression ran and the payload shrank.
+        assert!(sent[0].body.len() < body.len());
+        // D: the semantic marker survived it.
+        let text = String::from_utf8(sent[0].body.clone()).expect("utf-8");
+        assert!(text.contains(MARKER));
+        // E: the caller's own credentials went upstream untouched.
+        assert_eq!(
+            sent[0].headers.get("authorization").map(String::as_str),
+            Some(FAKE_BEARER)
+        );
+        // F: the stream came back byte for byte, in order.
+        assert_eq!(reply.body, chunks.concat());
+
+        let saved = body.len() - sent[0].body.len();
+        println!("SOCKET_E2E=PASS");
+        println!("SOCKET_LOCAL_REQUEST_BYTES={}", body.len());
+        println!("SOCKET_UPSTREAM_REQUEST_BYTES={}", sent[0].body.len());
+        println!(
+            "SOCKET_LOCAL_PAYLOAD_REDUCTION_PERCENT={:.2}",
+            saved as f64 * 100.0 / body.len() as f64
+        );
+        println!("SOCKET_RESPONSE_BYTES={}", reply.body.len());
+
+        server.shutdown().await;
+    }
+}

--- a/crates/llmtrim-cli/src/codex_gateway/socket.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/socket.rs
@@ -398,7 +398,13 @@ mod tests {
         let upstream = Arc::new(FakeUpstream::replying(sse()));
         let server = start(&upstream).await;
         let address = server.local_addr();
-        let reply = post(address, "/v1/chat/completions", auth_headers(), codex_body()).await;
+        let reply = post(
+            address,
+            "/v1/chat/completions",
+            auth_headers(),
+            codex_body(),
+        )
+        .await;
         assert_eq!(reply.status, 404);
         assert!(upstream.seen().is_empty(), "a refused route costs nothing");
         server.shutdown().await;
@@ -477,7 +483,9 @@ mod tests {
             reader.read_exact(&mut head).expect("the first chunk");
             release.send(()).expect("release the upstream");
             let mut rest = Vec::new();
-            reader.read_to_end(&mut rest).expect("the rest of the stream");
+            reader
+                .read_to_end(&mut rest)
+                .expect("the rest of the stream");
             head.extend_from_slice(&rest);
             head
         });
@@ -571,7 +579,10 @@ mod tests {
             Some(FAKE_BEARER)
         );
         assert_eq!(
-            sent[0].headers.get("chatgpt-account-id").map(String::as_str),
+            sent[0]
+                .headers
+                .get("chatgpt-account-id")
+                .map(String::as_str),
             Some(FAKE_ACCOUNT)
         );
         server.shutdown().await;

--- a/crates/llmtrim-cli/src/codex_gateway/socket.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/socket.rs
@@ -8,6 +8,386 @@
 //! The server is generic over the upstream seam, so the whole exchange — a real socket, a
 //! real HTTP client, the product's real compression — is exercised without a network.
 
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use http_body_util::{BodyExt, LengthLimitError, Limited};
+use hyper::body::{Body, Bytes, Frame, Incoming};
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::{TokioIo, TokioTimer};
+use tokio::net::TcpListener;
+use tokio::sync::{Semaphore, mpsc, oneshot};
+use tokio::task::JoinSet;
+
+use super::listener::{BindError, bind_address};
+use super::upstream::{StreamingUpstream, UpstreamStream};
+use super::{GatewayError, GatewayRequest, UpstreamRequest, prepare};
+
+/// The port the gateway listens on unless the caller names another one. Picked high and
+/// unassigned; nothing else in the product uses it.
+pub const DEFAULT_PORT: u16 = 43117;
+
+/// Ceiling on one local request body.
+///
+/// The gateway has to hold a whole body to compress it, so this is what stops a local client
+/// from turning the loopback port into an out-of-memory switch. 64 MiB is not a new number:
+/// it is the ceiling the rest of the product already uses wherever it must materialise a
+/// payload (`ensure`, `recall`, the CLIProxyAPI download).
+pub const MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
+
+/// Connections served at once. Codex opens one; the bound exists so nothing can make the
+/// gateway spawn tasks without limit.
+pub const MAX_LOCAL_CLIENTS: usize = 32;
+
+/// Response chunks that may sit between the upstream reader and the local writer.
+///
+/// This is the backpressure. The reader is a blocking thread using `blocking_send`, so when
+/// Codex reads slower than the upstream sends, the thread parks and the upstream connection
+/// stops being drained. Memory tracks this depth, never the length of the generation.
+pub const RESPONSE_QUEUE_DEPTH: usize = 8;
+
+/// Bytes taken from the upstream per relay step.
+pub const RESPONSE_READ_SIZE: usize = 16 * 1024;
+
+/// How long a local client may take to send its request headers before hyper drops it.
+pub const LOCAL_HEADER_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// What the server bounds. Not a configuration surface: the command line cannot reach it,
+/// [`ServerLimits::default`] is what production uses, and the only reason it is a value at all
+/// is so a test can shrink a ceiling instead of shipping 64 MiB over a socket to prove it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServerLimits {
+    pub max_request_body_bytes: usize,
+    pub max_connections: usize,
+}
+
+impl Default for ServerLimits {
+    fn default() -> Self {
+        Self {
+            max_request_body_bytes: MAX_REQUEST_BODY_BYTES,
+            max_connections: MAX_LOCAL_CLIENTS,
+        }
+    }
+}
+
+/// Status and relayed headers, handed back the moment the upstream answers — before its body
+/// has finished arriving, which is what makes the relay incremental.
+type UpstreamHead = Result<(u16, BTreeMap<String, String>), GatewayError>;
+
+/// One piece of the upstream body, in the order it came off the wire.
+type ResponseChunk = Result<Bytes, std::io::Error>;
+
+/// Why the gateway could not start listening.
+#[derive(Debug)]
+pub enum ServeError {
+    /// The requested host was not IPv4 loopback.
+    Bind(BindError),
+    /// The operating system refused the bind — almost always a port already in use.
+    Listen(std::io::Error),
+}
+
+impl std::fmt::Display for ServeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bind(error) => write!(formatter, "{error}"),
+            Self::Listen(error) => write!(formatter, "could not listen on 127.0.0.1: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ServeError {}
+
+/// The body the gateway hands hyper: either nothing at all, or the bounded queue the upstream
+/// reader feeds. There is no third case — the gateway never composes a body of its own.
+pub struct GatewayBody {
+    inner: BodyInner,
+}
+
+enum BodyInner {
+    Empty,
+    Streaming(mpsc::Receiver<ResponseChunk>),
+}
+
+impl GatewayBody {
+    fn empty() -> Self {
+        Self {
+            inner: BodyInner::Empty,
+        }
+    }
+
+    fn streaming(chunks: mpsc::Receiver<ResponseChunk>) -> Self {
+        Self {
+            inner: BodyInner::Streaming(chunks),
+        }
+    }
+}
+
+impl Body for GatewayBody {
+    type Data = Bytes;
+    type Error = std::io::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match &mut self.get_mut().inner {
+            BodyInner::Empty => Poll::Ready(None),
+            BodyInner::Streaming(chunks) => match chunks.poll_recv(context) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Ready(Some(Ok(chunk))) => Poll::Ready(Some(Ok(Frame::data(chunk)))),
+                Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(error))),
+            },
+        }
+    }
+}
+
+/// A running gateway. Dropping this leaves the server running; [`GatewayServer::shutdown`] is
+/// how it stops, and it does not return until the port is free.
+pub struct GatewayServer {
+    local_addr: SocketAddr,
+    stop: Option<oneshot::Sender<()>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl GatewayServer {
+    /// The address actually bound. With port 0 this is how the caller learns the real port.
+    #[must_use]
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Stop accepting, drop the listener, end the connections still open, release the port.
+    pub async fn shutdown(mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+        let _ = self.task.await;
+    }
+}
+
+/// Start the gateway on loopback. Returns once the port is bound, so the caller can read the
+/// real port before anything connects.
+///
+/// # Errors
+///
+/// [`ServeError::Bind`] for any host that is not IPv4 loopback, [`ServeError::Listen`] if the
+/// port cannot be opened.
+pub async fn serve<U: StreamingUpstream>(
+    requested_host: Option<IpAddr>,
+    port: u16,
+    limits: ServerLimits,
+    upstream: Arc<U>,
+) -> Result<GatewayServer, ServeError> {
+    let address = bind_address(requested_host, port).map_err(ServeError::Bind)?;
+    let bound = TcpListener::bind(address).await;
+    let listener = bound.map_err(ServeError::Listen)?;
+    let local_addr = listener.local_addr().map_err(ServeError::Listen)?;
+    let (stop, stopped) = oneshot::channel();
+    let task = tokio::spawn(accept_loop(listener, limits, upstream, stopped));
+    Ok(GatewayServer {
+        local_addr,
+        stop: Some(stop),
+        task,
+    })
+}
+
+async fn accept_loop<U: StreamingUpstream>(
+    listener: TcpListener,
+    limits: ServerLimits,
+    upstream: Arc<U>,
+    mut stopped: oneshot::Receiver<()>,
+) {
+    let permits = Arc::new(Semaphore::new(limits.max_connections));
+    let mut connections = JoinSet::new();
+    loop {
+        // Taking the permit before accepting is what bounds the work: with every permit out,
+        // the loop waits here instead of queuing connections it cannot serve.
+        let Ok(permit) = Arc::clone(&permits).acquire_owned().await else {
+            break;
+        };
+        let accepted = tokio::select! {
+            _ = &mut stopped => break,
+            accepted = listener.accept() => accepted,
+        };
+        let (stream, _) = match accepted {
+            Ok(accepted) => accepted,
+            Err(_) => continue,
+        };
+        let upstream = Arc::clone(&upstream);
+        connections.spawn(async move {
+            let service = service_fn(move |request: Request<Incoming>| {
+                serve_request(request, limits, Arc::clone(&upstream))
+            });
+            let io = TokioIo::new(stream);
+            let mut builder = hyper::server::conn::http1::Builder::new();
+            builder.timer(TokioTimer::new());
+            builder.header_read_timeout(LOCAL_HEADER_TIMEOUT);
+            let _ = builder.serve_connection(io, service).await;
+            drop(permit);
+        });
+    }
+    // Dropping the listener is what frees the port; the connection tasks are then ended so a
+    // shutdown cannot outlive the handle that asked for it.
+    drop(listener);
+    connections.shutdown().await;
+}
+
+async fn serve_request<U: StreamingUpstream>(
+    request: Request<Incoming>,
+    limits: ServerLimits,
+    upstream: Arc<U>,
+) -> Result<Response<GatewayBody>, std::convert::Infallible> {
+    let response = match relay(request, limits, upstream).await {
+        Ok(response) => response,
+        Err(error) => refuse(&error),
+    };
+    Ok(response)
+}
+
+/// Which refusal a failed body read is. Only an over-length body is a 413; anything else is a
+/// request the gateway could not read at all, and neither answer says anything about content.
+fn body_error(error: Box<dyn std::error::Error + Send + Sync>) -> GatewayError {
+    if error.downcast_ref::<LengthLimitError>().is_some() {
+        GatewayError::RequestTooLarge
+    } else {
+        GatewayError::MalformedRequest
+    }
+}
+
+/// A refusal carries a status and nothing else: no body, no echoed header, no reason text.
+/// An error path is exactly where a credential or a prompt fragment would leak if it could.
+fn refuse(error: &GatewayError) -> Response<GatewayBody> {
+    Response::builder()
+        .status(error.status())
+        .body(GatewayBody::empty())
+        .expect("a status-only response is always well formed")
+}
+
+async fn relay<U: StreamingUpstream>(
+    request: Request<Incoming>,
+    limits: ServerLimits,
+    upstream: Arc<U>,
+) -> Result<Response<GatewayBody>, GatewayError> {
+    let (parts, body) = request.into_parts();
+
+    // A target in absolute or authority form carries a destination. This gateway has exactly
+    // one, so anything but an origin-form path is simply not a route it serves.
+    if parts.uri.authority().is_some() || parts.uri.scheme().is_some() {
+        return Err(GatewayError::RouteNotFound);
+    }
+
+    let method = parts.method.as_str().to_string();
+    let path = parts.uri.path().to_string();
+    let mut headers = BTreeMap::new();
+    for (name, value) in &parts.headers {
+        if let Ok(value) = value.to_str() {
+            headers
+                .entry(name.as_str().to_ascii_lowercase())
+                .or_insert_with(|| value.to_string());
+        }
+    }
+
+    // The cheap gates first: a request that will be refused must not cost a body read, and
+    // must never reach the upstream leg.
+    super::validate_route(&method, &path)?;
+    super::auth_gate(&headers)?;
+
+    let collected = Limited::new(body, limits.max_request_body_bytes)
+        .collect()
+        .await
+        .map_err(body_error)?
+        .to_bytes();
+
+    let local = GatewayRequest {
+        method,
+        path,
+        headers,
+        body: collected.to_vec(),
+    };
+    // Both entry points run the same policy. `prepare` re-checks the two gates above; that is
+    // two comparisons, and one guarantee that the socket path cannot drift away from it.
+    let (outgoing, metrics) = prepare(&local)?;
+
+    let (head_sender, head_receiver) = oneshot::channel();
+    let (chunk_sender, chunk_receiver) = mpsc::channel(RESPONSE_QUEUE_DEPTH);
+    tokio::task::spawn_blocking(move || {
+        pump(upstream.as_ref(), outgoing, head_sender, chunk_sender);
+    });
+
+    let head = head_receiver
+        .await
+        .map_err(|_| GatewayError::UpstreamFailed)?;
+    let (status, upstream_headers) = head?;
+
+    // Metadata only, and only once the exchange is under way: byte counts and a status. No
+    // header, no body, nothing written down.
+    println!(
+        "codex-gateway: {} -> {} bytes upstream ({:.2}% smaller), status {status}",
+        metrics.local_request_bytes,
+        metrics.upstream_request_bytes,
+        metrics.reduction_basis_points() as f64 / 100.0
+    );
+
+    let mut response = Response::builder().status(status);
+    for (name, value) in &upstream_headers {
+        response = response.header(name.as_str(), value.as_str());
+    }
+    response
+        .body(GatewayBody::streaming(chunk_receiver))
+        .map_err(|_| GatewayError::UpstreamFailed)
+}
+
+/// The upstream leg, start to finish, on one blocking thread.
+///
+/// Sending, reading the head and pumping the body all happen here, so the upstream reader
+/// never crosses a thread boundary and `blocking_send` can park it when the local client is
+/// the slower of the two.
+fn pump<U: StreamingUpstream>(
+    upstream: &U,
+    outgoing: UpstreamRequest,
+    head: oneshot::Sender<UpstreamHead>,
+    chunks: mpsc::Sender<ResponseChunk>,
+) {
+    let stream = match upstream.send(outgoing) {
+        Ok(stream) => stream,
+        Err(error) => {
+            let _ = head.send(Err(error));
+            return;
+        }
+    };
+    let UpstreamStream {
+        status,
+        headers,
+        mut body,
+    } = stream;
+    if head.send(Ok((status, headers))).is_err() {
+        return;
+    }
+    let mut buffer = vec![0_u8; RESPONSE_READ_SIZE];
+    loop {
+        match body.read(&mut buffer) {
+            Ok(0) => return,
+            Ok(read) => {
+                let chunk = Bytes::copy_from_slice(&buffer[..read]);
+                if chunks.blocking_send(Ok(chunk)).is_err() {
+                    return;
+                }
+            }
+            Err(error) => {
+                let _ = chunks.blocking_send(Err(error));
+                return;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, VecDeque};

--- a/crates/llmtrim-cli/src/codex_gateway/socket.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/socket.rs
@@ -300,9 +300,20 @@ fn body_error(error: Box<dyn std::error::Error + Send + Sync>) -> GatewayError {
 
 /// A refusal carries a status and nothing else: no body, no echoed header, no reason text.
 /// An error path is exactly where a credential or a prompt fragment would leak if it could.
+///
+/// It also ends the connection. The gates run *before* the body is read, which is what keeps a
+/// refused request cheap, and that leaves the unread body in the stream. hyper does drain a
+/// small one to reuse the connection, but that is its choice and not a promise this gateway
+/// makes: `Connection: close` turns "probably drained" into "cannot be re-read", and costs a
+/// connection nobody wanted to keep anyway.
 fn refuse(error: &GatewayError) -> Response<GatewayBody> {
     Response::builder()
         .status(error.status())
+        // A lowercase literal, like every other header name in this module. hyper's typed
+        // constant would work, but its name contains a substring the security-contract test
+        // forbids anywhere in the production source, and tripping that test over a header
+        // name is a false alarm nobody should have to diagnose twice.
+        .header("connection", "close")
         .body(GatewayBody::empty())
         .expect("a status-only response is always well formed")
 }
@@ -658,9 +669,19 @@ mod tests {
             "PRIVATE_PROMPT_DO_NOT_LEAK Read the log tool output and reply with the requestId \
              of {MARKER}.\n\n{tool_output}"
         );
+        // The shape this route actually serves: Responses `input` items carrying `input_text`
+        // parts, the same body `reroute::codex` builds. Chat Completions `messages` would not
+        // reach this endpoint at all, so a fixture in that shape proved nothing about it.
         serde_json::to_vec(&serde_json::json!({
             "model": "gpt-5.6-sol",
-            "messages": [{ "role": "user", "content": content }],
+            "instructions": "You are a terse log assistant.",
+            "input": [{
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": content }],
+            }],
+            "store": false,
+            "stream": true,
         }))
         .expect("serialize body")
     }
@@ -785,6 +806,74 @@ mod tests {
             assert_eq!(reply.status, 401, "{value}");
         }
         server.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_refusal_cannot_poison_the_next_request_on_the_same_socket() {
+        // The gateway refuses before reading the body — deliberately, so a refused request
+        // costs nothing. On a keep-alive connection that leaves the unread body sitting in
+        // the stream, where the next parse would read it as a request line. The contract is
+        // that the refusal ends the connection, so those bytes can never be re-read.
+        let upstream = Arc::new(FakeUpstream::replying(sse()));
+        let server = start(&upstream).await;
+        let address = server.local_addr();
+
+        let transcript = tokio::task::spawn_blocking(move || {
+            use std::io::Write;
+            let mut socket = TcpStream::connect(address).expect("the port is open");
+            socket
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .expect("read timeout");
+
+            // First request: no `Authorization`, so it is refused with 401. The body is real
+            // and non-empty; these are the bytes that would poison the next parse.
+            let poison = br#"{"input":"POISON"}"#;
+            let head = format!(
+                "POST {GATEWAY_ROUTE} HTTP/1.1\r\n\
+                 Host: {address}\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\r\n",
+                poison.len()
+            );
+            socket.write_all(head.as_bytes()).expect("write first head");
+            socket.write_all(poison).expect("write first body");
+
+            // A second, well-formed request on the same connection.
+            let second = format!("GET /nope HTTP/1.1\r\nHost: {address}\r\n\r\n");
+            // Both of these may fail once the server has closed: that is the passing case,
+            // not an error, so neither result is asserted on.
+            let _ = socket.write_all(second.as_bytes());
+            let _ = socket.flush();
+
+            let mut raw = Vec::new();
+            let _ = socket.read_to_end(&mut raw);
+            String::from_utf8_lossy(&raw).into_owned()
+        })
+        .await
+        .expect("the client task runs");
+
+        server.shutdown().await;
+
+        assert!(
+            transcript.starts_with("HTTP/1.1 401"),
+            "the first request is refused: {transcript:?}"
+        );
+        assert!(
+            transcript
+                .to_ascii_lowercase()
+                .contains("connection: close"),
+            "a refusal must announce that the connection ends: {transcript:?}"
+        );
+        assert_eq!(
+            transcript.matches("HTTP/1.1 ").count(),
+            1,
+            "one answer, then EOF — a second answer means the poison body was parsed as a \
+             request: {transcript:?}"
+        );
+        assert!(
+            upstream.seen().is_empty(),
+            "a refused request never reaches the upstream"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/llmtrim-cli/src/codex_gateway/upstream.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/upstream.rs
@@ -33,7 +33,10 @@ mod tests {
 
     #[test]
     fn the_upstream_url_is_the_one_https_destination() {
-        assert_eq!(upstream_url(), "https://chatgpt.com/backend-api/codex/responses");
+        assert_eq!(
+            upstream_url(),
+            "https://chatgpt.com/backend-api/codex/responses"
+        );
     }
 
     #[test]
@@ -106,7 +109,12 @@ mod tests {
     #[test]
     fn only_the_content_type_comes_back_to_codex() {
         assert_eq!(RELAYED_RESPONSE_HEADERS, ["content-type"]);
-        for never in ["set-cookie", "content-length", "transfer-encoding", "content-encoding"] {
+        for never in [
+            "set-cookie",
+            "content-length",
+            "transfer-encoding",
+            "content-encoding",
+        ] {
             assert!(!RELAYED_RESPONSE_HEADERS.contains(&never), "{never}");
         }
     }

--- a/crates/llmtrim-cli/src/codex_gateway/upstream.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/upstream.rs
@@ -1,0 +1,138 @@
+//! The upstream leg: one fixed HTTPS destination, no proxy, no redirects.
+//!
+//! Kept apart from the policy module so the one place that opens a network connection is a
+//! small file a reviewer can read in a minute. Every setting on the client below is a
+//! security property rather than a tuning knob, and each one is pinned by a test.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
+    use super::{
+        BODY_TIMEOUT, HANDSHAKE_TIMEOUT, HttpsUpstream, MAX_REDIRECTS, RELAYED_RESPONSE_HEADERS,
+        RESPONSE_TIMEOUT, StreamingUpstream, agent,
+    };
+
+    use crate::codex_gateway::{GatewayError, UpstreamRequest, upstream_url};
+
+    /// The production half of this file. The scans below must not read their own lists, and
+    /// the prose necessarily names the mechanisms this leg avoids.
+    fn production_source() -> String {
+        let whole = include_str!("upstream.rs");
+        let marker = concat!("#[cfg(", "test)]");
+        whole
+            .split(marker)
+            .next()
+            .expect("production half")
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn the_upstream_url_is_the_one_https_destination() {
+        assert_eq!(upstream_url(), "https://chatgpt.com/backend-api/codex/responses");
+    }
+
+    #[test]
+    fn the_production_upstream_refuses_every_url_but_the_constant() {
+        let upstream = HttpsUpstream::new();
+        for hostile in [
+            "https://api.openai.com/v1/responses",
+            "http://127.0.0.1:43117/backend-api/codex/responses",
+            "https://chatgpt.example.com/backend-api/codex/responses",
+        ] {
+            let request = UpstreamRequest {
+                url: hostile.to_string(),
+                headers: BTreeMap::new(),
+                body: Vec::new(),
+            };
+            assert_eq!(
+                upstream.send(request).err(),
+                Some(GatewayError::UpstreamFailed),
+                "{hostile}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_upstream_client_never_adopts_an_ambient_proxy() {
+        // ureq's own default is to take the proxy from the environment. That default would
+        // route the user's ChatGPT traffic wherever the environment points, so the gateway
+        // turns it off explicitly rather than hoping the variables are unset.
+        assert!(agent().config().proxy().is_none());
+    }
+
+    #[test]
+    fn the_upstream_client_does_not_follow_redirects() {
+        assert_eq!(MAX_REDIRECTS, 0);
+        let agent = agent();
+        assert_eq!(agent.config().max_redirects(), 0);
+        // A 3xx comes back as a response to relay, not as a hop the client takes on its own.
+        assert!(!agent.config().max_redirects_will_error());
+    }
+
+    #[test]
+    fn the_upstream_client_keeps_ordinary_tls_verification() {
+        assert!(agent().config().https_only());
+        let source = production_source();
+        for forbidden in [
+            "danger",
+            "accept_invalid",
+            "insecure",
+            "tls_config",
+            "add_root",
+            "root_store",
+        ] {
+            assert!(!source.contains(forbidden), "{forbidden} must not appear");
+        }
+    }
+
+    #[test]
+    fn every_upstream_timeout_is_bounded() {
+        let agent = agent();
+        let timeouts = agent.config().timeouts();
+        assert_eq!(timeouts.connect, Some(HANDSHAKE_TIMEOUT));
+        assert_eq!(timeouts.recv_response, Some(RESPONSE_TIMEOUT));
+        assert_eq!(timeouts.recv_body, Some(BODY_TIMEOUT));
+        for bound in [HANDSHAKE_TIMEOUT, RESPONSE_TIMEOUT, BODY_TIMEOUT] {
+            assert!(bound > Duration::ZERO, "{bound:?}");
+            assert!(bound <= Duration::from_secs(3600), "{bound:?}");
+        }
+    }
+
+    #[test]
+    fn only_the_content_type_comes_back_to_codex() {
+        assert_eq!(RELAYED_RESPONSE_HEADERS, ["content-type"]);
+        for never in ["set-cookie", "content-length", "transfer-encoding", "content-encoding"] {
+            assert!(!RELAYED_RESPONSE_HEADERS.contains(&never), "{never}");
+        }
+    }
+
+    #[test]
+    fn the_upstream_leg_writes_nothing_and_needs_no_key() {
+        let source = production_source();
+        for forbidden in [
+            "fs::write",
+            "File::create",
+            "OpenOptions",
+            "capture_dir",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "CODEX_API_KEY",
+            "env_key",
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+            "ALL_PROXY",
+            "NODE_EXTRA_CA_CERTS",
+            "SSL_CERT_FILE",
+            "CURL_CA_BUNDLE",
+            "rcgen",
+            "hudsucker",
+        ] {
+            assert!(!source.contains(forbidden), "{forbidden} must not appear");
+        }
+    }
+}

--- a/crates/llmtrim-cli/src/codex_gateway/upstream.rs
+++ b/crates/llmtrim-cli/src/codex_gateway/upstream.rs
@@ -4,6 +4,126 @@
 //! small file a reviewer can read in a minute. Every setting on the client below is a
 //! security property rather than a tuning knob, and each one is pinned by a test.
 
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::time::Duration;
+
+use super::{GatewayError, UpstreamRequest, upstream_url};
+
+/// Time allowed to resolve, connect and finish the TLS handshake.
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Time allowed for the upstream to return its response *headers*. Only the first byte is
+/// bounded here — a generation may take far longer than this to finish.
+pub const RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Ceiling on receiving the whole response body: long enough for a slow streamed generation,
+/// short enough that a wedged connection cannot hold a thread forever.
+pub const BODY_TIMEOUT: Duration = Duration::from_secs(1800);
+
+/// Redirects followed: none. The destination is a constant, and a `Location` header is the
+/// network asking to change it.
+pub const MAX_REDIRECTS: u32 = 0;
+
+/// Response headers relayed back to Codex. An allowlist, so the default for anything new is
+/// to be dropped: cookies, framing the local leg recomputes, and the upstream's own transfer
+/// encoding all stay out by construction.
+pub const RELAYED_RESPONSE_HEADERS: [&str; 1] = ["content-type"];
+
+/// An upstream response whose body is still arriving. The reader yields bytes as the upstream
+/// produces them, which is what lets the gateway relay a stream instead of collecting one.
+pub struct UpstreamStream {
+    pub status: u16,
+    pub headers: BTreeMap<String, String>,
+    pub body: Box<dyn Read>,
+}
+
+/// The streaming network seam. Production dials the fixed origin; a test hands back a scripted
+/// reader, which is what keeps the socket suite offline.
+pub trait StreamingUpstream: Send + Sync + 'static {
+    /// Blocking. Returns once the response head is in, with the body still on the wire.
+    ///
+    /// # Errors
+    ///
+    /// [`GatewayError::UpstreamFailed`] for anything that went wrong on the network. There is
+    /// no retry and no alternate provider: one attempt, one destination.
+    fn send(&self, request: UpstreamRequest) -> Result<UpstreamStream, GatewayError>;
+}
+
+/// The one HTTP client the gateway uses.
+///
+/// `proxy(None)` is the important line: ureq's default is to adopt the ambient proxy
+/// variables, which would route the user's ChatGPT traffic through whatever the environment
+/// names. `https_only` and ureq's ordinary rustls verification keep the upstream leg a normal,
+/// verified TLS connection — there is no custom root, no pinning bypass and nothing to install.
+#[must_use]
+pub fn agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .proxy(None)
+        .https_only(true)
+        .max_redirects(MAX_REDIRECTS)
+        .max_redirects_will_error(false)
+        .http_status_as_error(false)
+        .timeout_connect(Some(HANDSHAKE_TIMEOUT))
+        .timeout_recv_response(Some(RESPONSE_TIMEOUT))
+        .timeout_recv_body(Some(BODY_TIMEOUT))
+        .build()
+        .into()
+}
+
+/// The gateway's real upstream: HTTPS to one constant URL.
+pub struct HttpsUpstream {
+    agent: ureq::Agent,
+}
+
+impl HttpsUpstream {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { agent: agent() }
+    }
+}
+
+impl Default for HttpsUpstream {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StreamingUpstream for HttpsUpstream {
+    fn send(&self, request: UpstreamRequest) -> Result<UpstreamStream, GatewayError> {
+        // The caller does not get to pick a destination. `prepare` builds this URL out of two
+        // constants; re-checking it here means a later refactor cannot quietly make it a
+        // parameter without a test noticing.
+        if request.url != upstream_url() {
+            return Err(GatewayError::UpstreamFailed);
+        }
+        let mut outgoing = self.agent.post(upstream_url());
+        for (name, value) in &request.headers {
+            outgoing = outgoing.header(name.as_str(), value.as_str());
+        }
+        let response = outgoing
+            .send(&request.body[..])
+            .map_err(|_| GatewayError::UpstreamFailed)?;
+        let (parts, body) = response.into_parts();
+        let headers = parts
+            .headers
+            .iter()
+            .filter(|(name, _)| RELAYED_RESPONSE_HEADERS.contains(&name.as_str()))
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_string(), value.to_string()))
+            })
+            .collect();
+        Ok(UpstreamStream {
+            status: parts.status.as_u16(),
+            headers,
+            body: Box::new(body.into_reader()),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/crates/llmtrim-cli/src/lib.rs
+++ b/crates/llmtrim-cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod bench;
 #[cfg(feature = "breakdown")]
 pub mod breakdown;
 #[cfg(feature = "intercept")]
+pub mod codex_gateway;
 pub mod compact;
 pub mod daemon;
 pub mod discover;

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -163,6 +163,19 @@ enum Commands {
         #[arg(long, hide = true)]
         hide_console: bool,
     },
+    /// Run the Codex localhost gateway in the foreground
+    ///
+    /// A reverse gateway for Codex alone: point a `[model_providers.*]` `base_url` at it and
+    /// Codex sends its normal, ChatGPT-authenticated request to 127.0.0.1 in plaintext. No
+    /// proxy variable, no local CA, no API key. It compresses the request body with the
+    /// `safe` preset and streams the answer straight back. Ctrl-C stops it; nothing is left
+    /// running afterwards.
+    #[cfg(feature = "intercept")]
+    CodexGateway {
+        /// Port to listen on. The host is not configurable — it is always 127.0.0.1.
+        #[arg(long, default_value_t = llmtrim::codex_gateway::socket::DEFAULT_PORT)]
+        port: u16,
+    },
     /// Set everything up and start saving (CA, environment, autostart, daemon)
     ///
     /// The fastest path from install to compressing: ensures the local CA, sets
@@ -1737,6 +1750,10 @@ fn run() -> Result<()> {
             } else {
                 llmtrim::serve::run(port, force)?;
             }
+        }
+        #[cfg(feature = "intercept")]
+        Commands::CodexGateway { port } => {
+            llmtrim::codex_gateway::socket::run(port)?;
         }
         Commands::Setup { port, force, env } => {
             if env {

--- a/crates/llmtrim-cli/src/main.rs
+++ b/crates/llmtrim-cli/src/main.rs
@@ -65,11 +65,13 @@ When something's wrong:
   uninstall  Undo everything `setup` did
 
 Pipes & one-shots:
-  compress   Compress a request from stdin to stdout
-  send       Compress a request, send it to the provider, print the response
-  recall     Recover raw bytes from an ephemeral recall handle
-  serve      Run the HTTPS interceptor in the foreground
-  ca         Print the local CA certificate path and how to trust it
+  compress       Compress a request from stdin to stdout
+  send           Compress a request, send it to the provider, print the response
+  recall         Recover raw bytes from an ephemeral recall handle
+  serve          Run the HTTPS interceptor in the foreground
+  codex-gateway  Run llmtrim in front of Codex on loopback (no proxy, no CA)
+  mcp            Run an MCP server over stdio (`mcp install` registers it)
+  ca             Print the local CA certificate path and how to trust it
 
 Measurement (dev):
   eval       Measure retrieval recall + token savings on a corpus
@@ -3329,6 +3331,26 @@ fn run_monitor(
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    // The comment on `HELP_TEMPLATE` asks for it to be kept in sync with `Commands`, and
+    // nothing enforced that: `codex-gateway` and `mcp` were both absent, so a user reading
+    // `llmtrim --help` could not discover either. Hidden commands stay out by design, and
+    // clap's generated `help` is not a listed entry.
+    #[test]
+    fn every_visible_command_is_listed_in_the_help_template() {
+        let command = <Cli as clap::CommandFactory>::command();
+        let missing: Vec<&str> = command
+            .get_subcommands()
+            .filter(|sub| !sub.is_hide_set())
+            .map(clap::Command::get_name)
+            .filter(|name| *name != "help")
+            .filter(|name| !HELP_TEMPLATE.contains(&format!("\n  {name} ")))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "commands missing from HELP_TEMPLATE: {missing:?}"
+        );
+    }
 
     // `--watch` is a deprecated no-op, but it must still parse: removing it outright would
     // break existing `llmtrim status --watch` scripts and aliases.

--- a/docs/codex-local-gateway.md
+++ b/docs/codex-local-gateway.md
@@ -6,7 +6,7 @@ using its own native configuration, and llmtrim serves that address as an ordina
 endpoint.
 
 ```
-Codex  ──HTTP──▶  127.0.0.1:43117  (llmtrim gateway)  ──HTTPS──▶  chatgpt.com
+Codex  ──HTTP──▶  127.0.0.1:43200  (llmtrim gateway)  ──HTTPS──▶  chatgpt.com
 ```
 
 ## Motivation
@@ -42,9 +42,13 @@ credentials attached. No API key is involved at any point.
 ## Running it
 
 ```
-llmtrim codex-gateway            # 127.0.0.1:43117
+llmtrim codex-gateway            # 127.0.0.1:43200
 llmtrim codex-gateway --port 8123
 ```
+
+The default is **43200**, deliberately not 43117. That one belongs to the interceptor, which
+also scans the 64 ports above it when the default is busy — so a gateway default inside
+`43117..=43181` would race the interceptor for a port on the same machine.
 
 Foreground only. There is no daemon, no autostart, no background service and no supervision:
 the gateway lives exactly as long as the process, and Ctrl-C stops accepting, ends the
@@ -66,7 +70,7 @@ and warns about it at startup — a sensible guard against a hostile repository.
 ```toml
 [model_providers.llmtrim_local]
 name = "LLMTrim Local"
-base_url = "http://127.0.0.1:43117/backend-api/codex"
+base_url = "http://127.0.0.1:43200/backend-api/codex"
 wire_api = "responses"
 requires_openai_auth = true
 
@@ -75,6 +79,41 @@ model_provider = "llmtrim_local"
 
 Nothing here is secret. llmtrim does not write this file and does not read `auth.json`;
 configuring Codex stays the user's decision.
+
+Two details in that snippet are easy to get wrong:
+
+- **`base_url` stops at `/backend-api/codex`.** Codex appends the operation itself, so
+  `wire_api = "responses"` turns it into `POST /backend-api/codex/responses` — which is the
+  one route the gateway serves. Writing the full path with `/responses` already on it yields
+  `/backend-api/codex/responses/responses` and a `404` from the gateway.
+- **`chatgpt_base_url` is not this setting.** That one points at the ChatGPT *login* host
+  used during authentication. Pointing it at the gateway breaks sign-in and does not route a
+  single turn through llmtrim.
+
+### Provider name and first-party capabilities
+
+Codex gates some first-party features on `provider.name` being exactly `"OpenAI"` —
+`ModelProviderInfo::is_openai()` compares that string, not the endpoint or the credentials.
+With any other name the turn works and the ChatGPT session is used normally, but the built-in
+web-search tool is not offered to the model. Measured against Codex 0.146.0, that tool is
+worth about 2.4k input tokens per turn; dropping it is a capability change, not a saving.
+
+Naming the provider `"OpenAI"` restores it, and also lets Codex compress its request bodies
+with zstd. This version does not decode that, so such a request is forwarded exactly as it
+arrived — original body, matching `Content-Encoding` — and the turn completes normally; it
+simply gets no llmtrim reduction. The per-request line says which happened.
+
+To let the gateway see readable JSON and try the `safe` preset on it:
+
+```toml
+[features]
+enable_request_compression = false
+```
+
+All three combinations were exercised against a live session and none of them costs you a
+turn. What changes is how often llmtrim has anything to work with — and even when it does,
+the reduction depends on the payload: structured JSON shrinks, prose and diffs may not shrink
+at all.
 
 ## Security properties
 
@@ -93,7 +132,7 @@ configuring Codex stays the user's decision.
 | Auth gate | A well-formed bearer must be present, checked by shape only, before any body is read. |
 | Request size | 64 MiB, the ceiling the rest of the product already uses. Over it: `413`, and no upstream request. |
 | Compression | `llmtrim_core::compress_with_config`, `safe` preset. |
-| Failure mode | Fail closed: a body that cannot be compressed is refused, not forwarded. |
+| Failure mode | Security gates fail closed. Compression fails **open**: a body llmtrim cannot transform is forwarded unchanged — same bytes, and the `Content-Encoding` that describes them — and the log line says so. |
 | Response | Relayed incrementally, byte for byte and in order (SSE). Nothing is parsed or rewritten. |
 | Memory | Bounded by a fixed relay queue, not by the length of the generation. |
 | Timeouts | Connect 30 s, response head 120 s, response body 30 min. Nothing unbounded. |
@@ -113,17 +152,37 @@ the last.
 
 ## Limitations
 
-- **No gateway authentication.** Any process on the machine can reach the port. The mitigation
-  is structural rather than added: the gateway stores no credential, and it refuses a request
-  that does not carry the caller's own bearer.
-- **The local hop is plaintext.** That is why it is loopback-only.
-- **Fail-closed compression** differs from the interceptor, which forwards the original body
-  when compression does not help. Here a failure surfaces, so a session is never silently
-  running without llmtrim.
+- **No separate gateway authentication.** The gateway has no credential of its own and
+  persists none: `Authorization` and `ChatGPT-Account-ID` exist in memory for the length of one
+  request and are never parsed, logged or written down. It requires a non-empty bearer before
+  forwarding, but that check is on the header's shape — it is not authentication of the local
+  process. Reaching the port does not by itself yield a valid ChatGPT credential, and a bearer
+  that is merely well-formed is still rejected upstream.
+- **The local hop is plaintext.** Credentials transit the loopback hop unencrypted. Binding to
+  loopback reduces network exposure; it does not isolate the port from other processes on the
+  same machine. Confirm the gateway started and bound the port you configured before pointing
+  Codex at it: if another process already holds that port, Codex is talking to that process,
+  not to the gateway.
+- **Compression fails open.** A body llmtrim cannot transform is forwarded unchanged rather
+  than refused: a failed optimisation should not cost the user their turn. It is not silent —
+  the per-request line ends with `(compression failed; original body forwarded)`. The security
+  gates around it stay fail-closed.
+- **No zstd decoding.** Codex compresses request bodies when it considers the provider
+  first-party. This gateway does not decode them, so the transform cannot run and the request
+  is relayed exactly as it arrived: the turn works, llmtrim simply does nothing for it. The
+  interceptor *does* decode zstd and gzip; to have those turns compressed here instead, use
+  the `enable_request_compression = false` configuration above.
+- **`llmtrim status` does not count these turns.** The gateway writes no ledger entry — it has
+  no filesystem surface at all, which is a property the security-contract test enforces. Its
+  only accounting is the two byte counts printed per request, and those are local estimates of
+  request bytes, not billed usage.
+- **The README's savings figures do not describe this path.** They come from the interceptor
+  across mixed traffic. Here the preset is `safe` (lossless, input-only) and the measured
+  effect depends entirely on payload shape: structured JSON pasted into a prompt shrinks;
+  prose, diffs and logs with no exact repetition do not shrink at all. No output-token claim
+  applies to this path.
 - **Codex only.** One route, one upstream. This is not a general reverse proxy and is not
   meant to become one.
-- **Not yet exercised against a live Codex session.** Everything below is validated with a
-  synthetic socket end-to-end test; the first real Codex run has not happened.
 - **Smart App Control** still applies to a locally compiled, unsigned binary on Windows, and
   can block it from running. That is a property of the build, not of this gateway.
 
@@ -137,6 +196,13 @@ The policy layer is pure functions; the socket and upstream layers sit behind a 
 seam. So the whole exchange is **validated with synthetic socket end-to-end tests**: a real
 HTTP client, a real loopback socket, the product's real compression, and a scripted fake
 upstream. No external host is contacted at any point.
+
+Those tests are necessary but not sufficient, so the path is also **exercised against a live
+ChatGPT-signed-in session**: `codex exec` posting to the loopback listener, llmtrim
+compressing, the request reaching `https://chatgpt.com/backend-api/codex/responses`, and the
+turn completing with the expected answer. Pinned to **Codex 0.146.0**
+(`rust-v0.146.0`, `e363b08c9175ac1cbe5893615dd2cb9ddf95043b`); a different Codex version can
+change what it sends and is a different claim.
 
 The suite covers the bind policy and the refusal of any non-loopback host, the route and
 method allowlist, the auth gate and the fact that a refused request never reaches the upstream

--- a/docs/codex-local-gateway.md
+++ b/docs/codex-local-gateway.md
@@ -1,0 +1,107 @@
+# Codex local gateway
+
+Run llmtrim in front of Codex without a proxy, without a local certificate authority and
+without touching the machine's trust configuration. Codex is pointed at a loopback address
+using its own native configuration, and llmtrim serves that address as an ordinary HTTP
+endpoint.
+
+```
+Codex  ──HTTP──▶  127.0.0.1:PORT  (llmtrim gateway)  ──HTTPS──▶  chatgpt.com
+```
+
+## Motivation
+
+The interceptor is a capable, general solution: it can compress traffic from any client that
+honours `HTTPS_PROXY`. The cost is a fair amount of machinery — a proxy variable exported into
+the environment, a locally generated CA, leaf certificates minted per host, and
+`NODE_EXTRA_CA_CERTS` / `SSL_CERT_FILE` / `CURL_CA_BUNDLE` wired up so clients trust it.
+
+For Codex specifically, none of that is necessary. Codex already supports pointing at a custom
+endpoint, and it keeps its ChatGPT session authentication when it does. A dedicated gateway is
+therefore a much smaller thing to reason about: one route, one fixed destination, no
+certificates and no environment-wide side effects.
+
+## Why Codex accepts it
+
+Codex supports a user-level `[model_providers.<name>]` block with a `base_url`. When that
+provider defines no `env_key` and no `auth` block, it inherits the session's own auth manager:
+
+- `model-provider/src/auth.rs` — `auth_manager_for_provider` returns the session auth manager
+  when the provider carries no custom `auth`.
+- `model-provider/src/auth.rs` — `auth_provider_from_auth` maps a ChatGPT auth snapshot to a
+  bearer provider.
+- `model-provider/src/bearer_auth_provider.rs` — that provider inserts
+  `Authorization: Bearer <token>` and `ChatGPT-Account-ID`.
+
+None of this depends on where `base_url` points, so Codex sends its normal,
+ChatGPT-authenticated Responses request to the loopback address with the subscription
+credentials attached. No API key is involved at any point.
+
+(References are to the Codex Rust sources at the version this was checked against, 0.146.0.)
+
+## Configuration
+
+In the **user-level** `~/.codex/config.toml`. Codex deliberately ignores `model_provider`,
+`model_providers` and `*_base_url` when they come from a project-local `.codex/config.toml`,
+and warns about it at startup — a sensible guard against a hostile repository.
+
+```toml
+[model_providers.llmtrim_local]
+name = "LLMTrim Local"
+base_url = "http://127.0.0.1:43117/backend-api/codex"
+wire_api = "responses"
+requires_openai_auth = true
+
+model_provider = "llmtrim_local"
+```
+
+Nothing here is secret. llmtrim does not write this file; configuring Codex stays the user's
+decision.
+
+## Security properties
+
+| | |
+|---|---|
+| Listener | `127.0.0.1` only. A non-loopback bind is refused, not silently corrected. |
+| Routes | `POST /backend-api/codex/responses` and nothing else. |
+| Upstream | `https://chatgpt.com` + that route, built from two constants. |
+| SSRF | No input reaches the destination — no `?url=`, no `X-Upstream`, no `Host` routing. |
+| Credentials | `Authorization` and `ChatGPT-Account-ID` relayed byte for byte, in memory. |
+| Credential handling | Never parsed for meaning, never logged, never written to disk. |
+| Auth gate | A well-formed bearer must be present, checked by shape only. |
+| Compression | `llmtrim_core::compress_with_config`, `safe` preset. |
+| Failure mode | Fail closed: a body that cannot be compressed is refused, not forwarded. |
+| Response | Status, headers and chunks relayed unchanged and in order (SSE). |
+| Persistence | None. No capture directory, no prompt or response written anywhere. |
+| Keys | No API key, no paid API, no provider fallback. |
+
+The auth gate deserves a note: it exists so the loopback port is not an anonymous relay. The
+gateway holds no credential of its own, so a caller that does not present a bearer cannot
+cause an authenticated upstream request.
+
+## Limitations
+
+- **No gateway authentication.** Any process on the machine can reach the port. The mitigation
+  is structural rather than added: the gateway stores no credential.
+- **The local hop is plaintext.** That is why it is loopback-only.
+- **Fail-closed compression** differs from the interceptor, which forwards the original body
+  when compression does not help. Here a failure surfaces, so a session is never silently
+  running without llmtrim.
+- **Codex only.** This is not a general reverse proxy and is not meant to become one.
+
+As a side benefit on Windows, the absence of a local CA and of machine-wide proxy variables
+avoids the certificate and environment plumbing that modern application-control policies tend
+to interact badly with.
+
+## Testing
+
+Everything in the module is either a pure function or sits behind an upstream seam, so the
+pipeline is exercised offline with a fake upstream — no socket, no external host. The suite
+covers the bind policy, the route allowlist, the fixed upstream, the absence of any
+client-controlled destination, the auth gate, credential passthrough, real compression through
+`llmtrim_core`, fail-closed behaviour, SSE ordering, and redaction: fictitious sentinels are
+asserted absent from every error and every metric.
+
+CI runs the suite on `windows-latest` and `ubuntu-latest`, plus a security-contract job that
+fails if the gateway module ever gains a proxy variable, a CA dependency, a capture path or an
+API key.

--- a/docs/codex-local-gateway.md
+++ b/docs/codex-local-gateway.md
@@ -6,7 +6,7 @@ using its own native configuration, and llmtrim serves that address as an ordina
 endpoint.
 
 ```
-Codex  ──HTTP──▶  127.0.0.1:PORT  (llmtrim gateway)  ──HTTPS──▶  chatgpt.com
+Codex  ──HTTP──▶  127.0.0.1:43117  (llmtrim gateway)  ──HTTPS──▶  chatgpt.com
 ```
 
 ## Motivation
@@ -39,6 +39,24 @@ credentials attached. No API key is involved at any point.
 
 (References are to the Codex Rust sources at the version this was checked against, 0.146.0.)
 
+## Running it
+
+```
+llmtrim codex-gateway            # 127.0.0.1:43117
+llmtrim codex-gateway --port 8123
+```
+
+Foreground only. There is no daemon, no autostart, no background service and no supervision:
+the gateway lives exactly as long as the process, and Ctrl-C stops accepting, ends the
+connections still open and releases the port before returning.
+
+`--port` is the whole configuration surface. The host is not a flag — it is always
+`127.0.0.1`, and a non-loopback bind is refused rather than silently corrected. There is no
+`--upstream`, no `--proxy`, no `--ca`, no `--api-key` and no `--capture`.
+
+On startup it prints its address and the compression preset. It never prints a header, a
+token, a prompt or a response; per request it prints two byte counts and a status.
+
 ## Configuration
 
 In the **user-level** `~/.codex/config.toml`. Codex deliberately ignores `model_provider`,
@@ -55,8 +73,8 @@ requires_openai_auth = true
 model_provider = "llmtrim_local"
 ```
 
-Nothing here is secret. llmtrim does not write this file; configuring Codex stays the user's
-decision.
+Nothing here is secret. llmtrim does not write this file and does not read `auth.json`;
+configuring Codex stays the user's decision.
 
 ## Security properties
 
@@ -64,30 +82,50 @@ decision.
 |---|---|
 | Listener | `127.0.0.1` only. A non-loopback bind is refused, not silently corrected. |
 | Routes | `POST /backend-api/codex/responses` and nothing else. |
+| Request framing | hyper parses the local request; nothing is framed by hand. |
 | Upstream | `https://chatgpt.com` + that route, built from two constants. |
 | SSRF | No input reaches the destination — no `?url=`, no `X-Upstream`, no `Host` routing. |
+| Redirects | Not followed. A `3xx` is relayed as a status, never as a new destination. |
+| Upstream proxy | Explicitly disabled, so no ambient `*_PROXY` variable can reroute the leg. |
+| TLS | Ordinary certificate verification. No custom root, no pinning bypass, nothing installed. |
 | Credentials | `Authorization` and `ChatGPT-Account-ID` relayed byte for byte, in memory. |
 | Credential handling | Never parsed for meaning, never logged, never written to disk. |
-| Auth gate | A well-formed bearer must be present, checked by shape only. |
+| Auth gate | A well-formed bearer must be present, checked by shape only, before any body is read. |
+| Request size | 64 MiB, the ceiling the rest of the product already uses. Over it: `413`, and no upstream request. |
 | Compression | `llmtrim_core::compress_with_config`, `safe` preset. |
 | Failure mode | Fail closed: a body that cannot be compressed is refused, not forwarded. |
-| Response | Status, headers and chunks relayed unchanged and in order (SSE). |
-| Persistence | None. No capture directory, no prompt or response written anywhere. |
-| Keys | No API key, no paid API, no provider fallback. |
+| Response | Relayed incrementally, byte for byte and in order (SSE). Nothing is parsed or rewritten. |
+| Memory | Bounded by a fixed relay queue, not by the length of the generation. |
+| Timeouts | Connect 30 s, response head 120 s, response body 30 min. Nothing unbounded. |
+| Retry | None. One attempt, one destination, no provider fallback. |
+| Persistence | None. No capture directory, no ledger, no prompt or response written anywhere. |
+| Keys | No API key, no paid API. |
 
 The auth gate deserves a note: it exists so the loopback port is not an anonymous relay. The
 gateway holds no credential of its own, so a caller that does not present a bearer cannot
 cause an authenticated upstream request.
 
+The relay deserves one too. The upstream leg runs on a blocking thread that hands back the
+response head as soon as it arrives and then pushes the body into a fixed-depth queue. When
+Codex reads more slowly than the upstream sends, that thread parks — so memory tracks the
+queue, never the size of the answer, and the first token reaches Codex without waiting for
+the last.
+
 ## Limitations
 
 - **No gateway authentication.** Any process on the machine can reach the port. The mitigation
-  is structural rather than added: the gateway stores no credential.
+  is structural rather than added: the gateway stores no credential, and it refuses a request
+  that does not carry the caller's own bearer.
 - **The local hop is plaintext.** That is why it is loopback-only.
 - **Fail-closed compression** differs from the interceptor, which forwards the original body
   when compression does not help. Here a failure surfaces, so a session is never silently
   running without llmtrim.
-- **Codex only.** This is not a general reverse proxy and is not meant to become one.
+- **Codex only.** One route, one upstream. This is not a general reverse proxy and is not
+  meant to become one.
+- **Not yet exercised against a live Codex session.** Everything below is validated with a
+  synthetic socket end-to-end test; the first real Codex run has not happened.
+- **Smart App Control** still applies to a locally compiled, unsigned binary on Windows, and
+  can block it from running. That is a property of the build, not of this gateway.
 
 As a side benefit on Windows, the absence of a local CA and of machine-wide proxy variables
 avoids the certificate and environment plumbing that modern application-control policies tend
@@ -95,13 +133,20 @@ to interact badly with.
 
 ## Testing
 
-Everything in the module is either a pure function or sits behind an upstream seam, so the
-pipeline is exercised offline with a fake upstream — no socket, no external host. The suite
-covers the bind policy, the route allowlist, the fixed upstream, the absence of any
-client-controlled destination, the auth gate, credential passthrough, real compression through
-`llmtrim_core`, fail-closed behaviour, SSE ordering, and redaction: fictitious sentinels are
-asserted absent from every error and every metric.
+The policy layer is pure functions; the socket and upstream layers sit behind a streaming
+seam. So the whole exchange is **validated with synthetic socket end-to-end tests**: a real
+HTTP client, a real loopback socket, the product's real compression, and a scripted fake
+upstream. No external host is contacted at any point.
+
+The suite covers the bind policy and the refusal of any non-loopback host, the route and
+method allowlist, the auth gate and the fact that a refused request never reaches the upstream
+leg, the request-size ceiling, real compression through `llmtrim_core` with the task's
+identifier surviving it, fail-closed behaviour, SSE ordering, incremental relay (the upstream
+withholds its second chunk until the client confirms the first one arrived), graceful shutdown
+with the port released and no listener left behind, and the static contract on the production
+upstream client: fixed URL, no proxy, no redirects, standard TLS verification and bounded
+timeouts. Fictitious sentinels are asserted absent from every error and every metric.
 
 CI runs the suite on `windows-latest` and `ubuntu-latest`, plus a security-contract job that
-fails if the gateway module ever gains a proxy variable, a CA dependency, a capture path or an
-API key.
+fails if any file in the gateway module tree ever gains a proxy variable, a CA dependency, a
+capture path, a filesystem write or an API key.


### PR DESCRIPTION
# Summary

Adds a Codex-only localhost gateway that runs llmtrim in front of Codex
without HTTPS interception.

Codex points its native `model_provider.base_url` at a loopback HTTP endpoint:

    Codex
      -> HTTP 127.0.0.1:43200
      -> llmtrim `safe`
      -> HTTPS https://chatgpt.com/backend-api/codex/responses

The existing interceptor is unchanged.

Closes #273.

# Security model

- binds only to `127.0.0.1`
- one exact route: `POST /backend-api/codex/responses`
- fixed upstream: `https://chatgpt.com`
- caller cannot choose or redirect the destination
- no API key
- no paid API path
- no `HTTPS_PROXY` / `HTTP_PROXY`
- no local CA or trust-store changes
- ordinary TLS certificate verification upstream
- redirects disabled
- request size and connection count bounded
- no prompt/response persistence
- no filesystem writes in the gateway path
- bearer/account headers are relayed in memory and never logged
- security gates fail closed
- compression fails open and forwards the original request faithfully
- encoded fail-open bodies retain their matching `Content-Encoding`
- stale `Content-Length` is never forwarded

The local hop is intentionally plaintext loopback. The docs explicitly note
that loopback reduces network exposure but is not process isolation.

# Codex compatibility

Validated against:

- Codex CLI `0.146.0`
- tag `rust-v0.146.0`
- commit `e363b08c9175ac1cbe5893615dd2cb9ddf95043b`

The user-level `~/.codex/config.toml` setup and `/responses` suffix behavior are
documented. `chatgpt_base_url` remains the authentication host and is not
modified.

# Live validation

Two ChatGPT-signed-in live canaries were run against the real Codex backend.

## 1. Readable JSON / real llmtrim compression

- loopback POST: PASS
- upstream: `https://chatgpt.com/backend-api/codex/responses`
- upstream status: `200`
- turn completed: PASS
- semantic check: PASS
- request bytes: `212,906 -> 194,285`
- reduction for that structured fixture: `8.74%`

This is fixture-specific and is not presented as a universal savings claim.

## 2. Codex zstd request / compression fail-open

Codex sent a zstd-encoded request.

- gateway could not transform the encoded body
- original body forwarded byte-for-byte
- matching `Content-Encoding` preserved
- upstream status: `200`
- turn completed: PASS
- semantic check: PASS

This exercised the fail-open path against the real backend.

# Testing

Local validation:

- `cargo fmt --all -- --check`
- `cargo check -p llmtrim --lib --bins --locked`
- 67 gateway tests passing
- synthetic socket E2E
- SSE order/incremental relay tests
- shutdown / port-release tests
- route / auth / SSRF gates
- encoded-body fail-open tests
- security-contract tests
- gateway-scoped Clippy gate

The PR workflow runs the gateway suite on `windows-latest` and `ubuntu-latest`.

# Scope

This PR intentionally does not:

- modify the existing interceptor behavior
- modify the public `llmtrim-core` API
- add the gateway to `setup` or `ensure`
- add daemon/autostart behavior
- implement zstd decoding in the gateway
- add Windows code signing
- write Codex configuration for the user

The gateway is foreground-only for v1.
